### PR TITLE
A few more updates

### DIFF
--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -418,7 +418,8 @@ bool hidd_control_request(uint8_t rhport, tusb_control_request_t const * p_reque
 
     if (p_request->bRequest == TUSB_REQ_GET_DESCRIPTOR && desc_type == HID_DESC_TYPE_REPORT)
     {
-      usbd_control_xfer(rhport, p_request, p_hid->desc_report, p_hid->desc_len);
+      // Cast away the const on p_hid->desc_report because we know it won't be modified.
+      usbd_control_xfer(rhport, p_request, (void *)p_hid->desc_report, p_hid->desc_len);
     }else
     {
       return false; // stall unsupported request

--- a/src/portable/microchip/samd21/dcd_samd21.c
+++ b/src/portable/microchip/samd21/dcd_samd21.c
@@ -71,10 +71,19 @@ static void bus_reset(void) {
  *------------------------------------------------------------------*/
 bool dcd_init (uint8_t rhport)
 {
+  // Reset to get in a clean state.
+  USB->DEVICE.CTRLA.bit.SWRST = true;
+  while (USB->DEVICE.SYNCBUSY.bit.SWRST == 0) {
+
+  }
+  while (USB->DEVICE.SYNCBUSY.bit.SWRST == 1) {}
+
   (void) rhport;
   USB->DEVICE.DESCADD.reg = (uint32_t) &sram_registers;
   USB->DEVICE.CTRLB.reg = USB_DEVICE_CTRLB_SPDCONF_FS;
-  USB->DEVICE.CTRLA.reg = USB_CTRLA_MODE_DEVICE | USB_CTRLA_ENABLE;
+  USB->DEVICE.CTRLA.reg = USB_CTRLA_MODE_DEVICE | USB_CTRLA_ENABLE | USB_CTRLA_RUNSTDBY;
+  while (USB->DEVICE.SYNCBUSY.bit.ENABLE == 1) {}
+
   USB->DEVICE.INTENSET.reg = USB_DEVICE_INTENSET_SOF | USB_DEVICE_INTENSET_EORST;
 
   return true;

--- a/src/portable/microchip/samd21/dcd_samd21.c
+++ b/src/portable/microchip/samd21/dcd_samd21.c
@@ -164,6 +164,12 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
   UsbDeviceDescBank* bank = &sram_registers[epnum][dir];
   UsbDeviceEndpoint* ep = &USB->DEVICE.DeviceEndpoint[epnum];
 
+  // A setup token can occur immediately after an OUT STATUS packet so make sure we have a valid
+  // buffer for the control endpoint.
+  if (epnum == 0 && dir == 0 && buffer == NULL) {
+      buffer = _setup_packet;
+  }
+
   bank->ADDR.reg = (uint32_t) buffer;
   if ( dir == TUSB_DIR_OUT )
   {

--- a/src/portable/microchip/samd51/dcd_samd51.c
+++ b/src/portable/microchip/samd51/dcd_samd51.c
@@ -72,9 +72,17 @@ static void bus_reset(void) {
 bool dcd_init (uint8_t rhport)
 {
   (void) rhport;
+  // Reset to get in a clean state.
+  USB->DEVICE.CTRLA.bit.SWRST = true;
+  while (USB->DEVICE.SYNCBUSY.bit.SWRST == 0) {
+
+  }
+  while (USB->DEVICE.SYNCBUSY.bit.SWRST == 1) {}
+
   USB->DEVICE.DESCADD.reg = (uint32_t) &sram_registers;
   USB->DEVICE.CTRLB.reg = USB_DEVICE_CTRLB_SPDCONF_FS;
-  USB->DEVICE.CTRLA.reg = USB_CTRLA_MODE_DEVICE | USB_CTRLA_ENABLE;
+  USB->DEVICE.CTRLA.reg = USB_CTRLA_MODE_DEVICE | USB_CTRLA_ENABLE | USB_CTRLA_RUNSTDBY;
+  while (USB->DEVICE.SYNCBUSY.bit.ENABLE == 1) {}
   USB->DEVICE.INTENSET.reg = USB_DEVICE_INTENSET_SOF | USB_DEVICE_INTENSET_EORST;
 
   return true;

--- a/src/portable/microchip/samd51/dcd_samd51.c
+++ b/src/portable/microchip/samd51/dcd_samd51.c
@@ -163,6 +163,12 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
   UsbDeviceDescBank* bank = &sram_registers[epnum][dir];
   UsbDeviceEndpoint* ep = &USB->DEVICE.DeviceEndpoint[epnum];
 
+  // A setup token can occur immediately after an OUT STATUS packet so make sure we have a valid
+  // buffer for the control endpoint.
+  if (epnum == 0 && dir == 0 && buffer == NULL) {
+    buffer = _setup_packet;
+  }
+
   bank->ADDR.reg = (uint32_t) buffer;
   if ( dir == TUSB_DIR_OUT )
   {


### PR DESCRIPTION
This does a few things:
* Fixes one warning about dropping a cast
* Enables interrupt protection of the queue. If nrf doesn't want this we should change its interrupt enable/disable. We probably want usb at a lesser nvic priority than the SD.
* Changes samd USB start up to wait for sync.
* Ensures that the samd control endpoint always has a valid buffer to write to.

CircuitPython now uses this branch as of https://github.com/adafruit/circuitpython/pull/1353