### PR TITLE
Fix write protected MSC. The bits were flipped.

### DIFF
--- a/src/class/msc/msc.h
+++ b/src/class/msc/msc.h
@@ -284,8 +284,8 @@ typedef struct ATTR_PACKED
 {
   uint8_t data_len;
   uint8_t medium_type;
-  bool write_protected : 1;
   uint8_t reserved : 7;
+  bool write_protected : 1;
   uint8_t block_descriptor_len;
 } scsi_mode_sense6_resp_t;
 


### PR DESCRIPTION
I'm not exactly sure the CSW response is correct. It doesn't happen on Mac when the right Mode 6 bit is set.