### PR TITLE
Fixes #33: Remove invalid use of strncpy()

### DIFF
--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -265,14 +265,20 @@ int32_t proc_builtin_scsi(msc_cbw_t const * p_cbw, uint8_t* buffer, uint32_t buf
           .is_removable         = 1,
           .version              = 2,
           .response_data_format = 2,
-          .vendor_id            = "Adafruit",
-          .product_id           = "Feather52840",
-          .product_rev          = "1.0"
+          .vendor_id            = "        ",
+          .product_id           = "                ",
+          .product_rev          = "    ",
       };
+      size_t len;
 
-      strncpy((char*) inquiry_rsp.vendor_id  , CFG_TUD_MSC_VENDOR     , sizeof(inquiry_rsp.vendor_id));
-      strncpy((char*) inquiry_rsp.product_id , CFG_TUD_MSC_PRODUCT    , sizeof(inquiry_rsp.product_id));
-      strncpy((char*) inquiry_rsp.product_rev, CFG_TUD_MSC_PRODUCT_REV, sizeof(inquiry_rsp.product_rev));
+      #define _min(a,b) ((a) < (b) ? (a) : (b))
+      len = strlen(CFG_TUD_MSC_VENDOR);
+      memcpy(inquiry_rsp.vendor_id  , CFG_TUD_MSC_VENDOR     , _min(len, sizeof(inquiry_rsp.vendor_id)));
+      len = strlen(CFG_TUD_MSC_PRODUCT);
+      memcpy(inquiry_rsp.product_id , CFG_TUD_MSC_PRODUCT    , _min(len, sizeof(inquiry_rsp.product_id)));
+      len = strlen(CFG_TUD_MSC_PRODUCT_REV);
+      memcpy(inquiry_rsp.product_rev, CFG_TUD_MSC_PRODUCT_REV, _min(len, sizeof(inquiry_rsp.product_rev)));
+      #undef _min
 
       ret = sizeof(inquiry_rsp);
       memcpy(buffer, &inquiry_rsp, ret);


### PR DESCRIPTION
This was causing a stringop-truncation compiler warning in gcc 8 when
the #defined values being copied from were string literals.
 `error: 'strncpy' output truncated before terminating nul copying 8 bytes from a string of the same length [-Werror=stringop-truncation]`

These fields aren't NUL terminated C strings, they are a fixed width buffer
that is supposed to be space (0x20) padded.

See #33 .

I initialized the values to raw space filled constants.  that could instead be done as a post memcpy step based on the difference between len and the sizeof if you want to preserve your initial adafruit/feather/1.0 values in there (though i don't see why you would - everything should be defining the `CFG_TUD_` macros and using the copies)

It compiles on gcc-8.  i haven't run the code yet.  you'll know much better how to test this than I will.