### PR TITLE
add callback for descriptors device/configuration/string/hid

### DIFF
--- a/examples/device/cdc_msc_hid/src/usb_descriptors.c
+++ b/examples/device/cdc_msc_hid/src/usb_descriptors.c
@@ -79,25 +79,34 @@ uint8_t const desc_hid_report[] =
   TUD_HID_REPORT_DESC_KEYBOARD( HID_REPORT_ID(REPORT_ID_KEYBOARD), ),
   TUD_HID_REPORT_DESC_MOUSE   ( HID_REPORT_ID(REPORT_ID_MOUSE), )
 };
+
+// Invoked when received GET HID REPORT DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_hid_descriptor_report_cb(void)
+{
+  return desc_hid_report;
+}
+
 #endif
 
 //------------- Configuration Descriptor -------------//
 enum
 {
-  #if CFG_TUD_CDC
-    ITF_NUM_CDC = 0,
-    ITF_NUM_CDC_DATA,
-  #endif
+#if CFG_TUD_CDC
+  ITF_NUM_CDC = 0,
+  ITF_NUM_CDC_DATA,
+#endif
 
-  #if CFG_TUD_MSC
-    ITF_NUM_MSC,
-  #endif
+#if CFG_TUD_MSC
+  ITF_NUM_MSC,
+#endif
 
-  #if CFG_TUD_HID
-    ITF_NUM_HID,
-  #endif
+#if CFG_TUD_HID
+  ITF_NUM_HID,
+#endif
 
-    ITF_NUM_TOTAL
+  ITF_NUM_TOTAL
 };
 
 enum
@@ -136,17 +145,20 @@ uint8_t const desc_configuration[] =
 #endif
 };
 
-
-// tud_desc_set is required by tinyusb stack
-tud_desc_set_t tud_desc_set =
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const * tud_descriptor_device_cb(void)
 {
-  .device     = &desc_device,
-  .config     = desc_configuration,
+  return (uint8_t const *) &desc_device;
+}
 
-#if CFG_TUD_HID
-  .hid_report = desc_hid_report,
-#endif
-};
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_descriptor_configuration_cb(void)
+{
+  return desc_configuration;
+}
 
 //------------- String Descriptors -------------//
 

--- a/examples/device/cdc_msc_hid/src/usb_descriptors.c
+++ b/examples/device/cdc_msc_hid/src/usb_descriptors.c
@@ -136,31 +136,6 @@ uint8_t const desc_configuration[] =
 #endif
 };
 
-//------------- String Descriptors -------------//
-// array of pointer to string descriptors
-uint16_t const * const string_desc_arr [] =
-{
-  // 0: is supported language = English
-  TUD_DESC_STRCONV(0x0409),
-
-  // 1: Manufacturer
-  TUD_DESC_STRCONV('t', 'i', 'n', 'y', 'u', 's', 'b', '.', 'o', 'r', 'g'),
-
-  // 2: Product
-  TUD_DESC_STRCONV('t', 'i', 'n', 'y', 'u', 's', 'b', ' ', 'd', 'e', 'v', 'i', 'c', 'e'),
-
-  // 3: Serials, should use chip ID
-  TUD_DESC_STRCONV('1', '2', '3', '4', '5', '6'),
-
-  // 4: CDC Interface
-  TUD_DESC_STRCONV('t','u','s','b',' ','c','d','c'),
-
-  // 5: MSC Interface
-  TUD_DESC_STRCONV('t','u','s','b',' ','m','s','c'),
-
-  // 6: HID
-  TUD_DESC_STRCONV('t','u','s','b',' ','h','i','d')
-};
 
 // tud_desc_set is required by tinyusb stack
 tud_desc_set_t tud_desc_set =
@@ -168,10 +143,49 @@ tud_desc_set_t tud_desc_set =
   .device     = &desc_device,
   .config     = desc_configuration,
 
-  .string_arr   = (uint8_t const **) string_desc_arr,
-  .string_count = sizeof(string_desc_arr)/sizeof(string_desc_arr[0]),
-
 #if CFG_TUD_HID
   .hid_report = desc_hid_report,
 #endif
 };
+
+//------------- String Descriptors -------------//
+
+// array of pointer to string descriptors
+char const* string_desc_arr [] =
+{
+  (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
+  "TinyUSB",                     // 1: Manufacturer
+  "TinyUSB Device",              // 2: Product
+  "123456",                      // 3: Serials, should use chip ID
+  "TinyUSB CDC",                 // 4: CDC Interface
+  "TinyUSB MSC",                 // 5: MSC Interface
+  "TinyUSB HID"                  // 6: HID
+};
+
+// Invoked when received GET_STRING_DESC request
+// max_char is CFG_TUD_ENDOINT0_SIZE/2 -1, typically max_char = 31 if Endpoint0 size is 64
+// Return number of characters. Note usb string is in 16-bits unicode format
+uint8_t tud_descriptor_string_cb(uint8_t index, uint16_t* desc, uint8_t max_char)
+{
+  if ( index == 0)
+  {
+    memcpy(desc, string_desc_arr[0], 2);
+    return 1;
+  }else
+  {
+    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return 0;
+
+    const char* str = string_desc_arr[index];
+
+    // Cap at max char
+    uint8_t count = strlen(str);
+    if ( count > max_char ) count = max_char;
+
+    for(uint8_t i=0; i<count; i++)
+    {
+      *desc++ = str[i];
+    }
+
+    return count;
+  }
+}

--- a/examples/device/cdc_msc_hid_freertos/src/usb_descriptors.c
+++ b/examples/device/cdc_msc_hid_freertos/src/usb_descriptors.c
@@ -79,25 +79,34 @@ uint8_t const desc_hid_report[] =
   TUD_HID_REPORT_DESC_KEYBOARD( HID_REPORT_ID(REPORT_ID_KEYBOARD), ),
   TUD_HID_REPORT_DESC_MOUSE   ( HID_REPORT_ID(REPORT_ID_MOUSE), )
 };
+
+// Invoked when received GET HID REPORT DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_hid_descriptor_report_cb(void)
+{
+  return desc_hid_report;
+}
+
 #endif
 
 //------------- Configuration Descriptor -------------//
 enum
 {
-  #if CFG_TUD_CDC
-    ITF_NUM_CDC = 0,
-    ITF_NUM_CDC_DATA,
-  #endif
+#if CFG_TUD_CDC
+  ITF_NUM_CDC = 0,
+  ITF_NUM_CDC_DATA,
+#endif
 
-  #if CFG_TUD_MSC
-    ITF_NUM_MSC,
-  #endif
+#if CFG_TUD_MSC
+  ITF_NUM_MSC,
+#endif
 
-  #if CFG_TUD_HID
-    ITF_NUM_HID,
-  #endif
+#if CFG_TUD_HID
+  ITF_NUM_HID,
+#endif
 
-    ITF_NUM_TOTAL
+  ITF_NUM_TOTAL
 };
 
 enum
@@ -136,16 +145,20 @@ uint8_t const desc_configuration[] =
 #endif
 };
 
-// tud_desc_set is required by tinyusb stack
-tud_desc_set_t tud_desc_set =
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const * tud_descriptor_device_cb(void)
 {
-    .device     = &desc_device,
-    .config     = desc_configuration,
+  return (uint8_t const *) &desc_device;
+}
 
-#if CFG_TUD_HID
-    .hid_report = desc_hid_report,
-#endif
-};
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_descriptor_configuration_cb(void)
+{
+  return desc_configuration;
+}
 
 //------------- String Descriptors -------------//
 

--- a/examples/device/hid_generic_inout/src/usb_descriptors.c
+++ b/examples/device/hid_generic_inout/src/usb_descriptors.c
@@ -88,30 +88,53 @@ uint8_t const desc_configuration[] =
   TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, 0, HID_PROTOCOL_NONE, sizeof(desc_hid_report), 0x80 | EPNUM_HID, EPNUM_HID, 16, 10)
 };
 
-//------------- String Descriptors -------------//
-// array of pointer to string descriptors
-uint16_t const * const string_desc_arr [] =
-{
-  // 0: is supported language = English
-  TUD_DESC_STRCONV(0x0409),
-
-  // 1: Manufacturer
-  TUD_DESC_STRCONV('t', 'i', 'n', 'y', 'u', 's', 'b', '.', 'o', 'r', 'g'),
-
-  // 2: Product
-  TUD_DESC_STRCONV('t', 'i', 'n', 'y', 'u', 's', 'b', ' ', 'd', 'e', 'v', 'i', 'c', 'e'),
-
-  // 3: Serials, should use chip ID
-  TUD_DESC_STRCONV('1', '2', '3', '4', '5', '6'),
-};
 
 // tud_desc_set is required by tinyusb stack
 tud_desc_set_t tud_desc_set =
 {
-  .device       = &desc_device,
-  .config       = desc_configuration,
+    .device     = &desc_device,
+    .config     = desc_configuration,
 
-  .string_arr   = (uint8_t const **) string_desc_arr,
-  .string_count = sizeof(string_desc_arr)/sizeof(string_desc_arr[0]),
-  .hid_report   = desc_hid_report,
+#if CFG_TUD_HID
+    .hid_report = desc_hid_report,
+#endif
 };
+
+//------------- String Descriptors -------------//
+
+// array of pointer to string descriptors
+char const* string_desc_arr [] =
+{
+  (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
+  "TinyUSB",                     // 1: Manufacturer
+  "TinyUSB Device",              // 2: Product
+  "123456",                      // 3: Serials, should use chip ID
+};
+
+// Invoked when received GET_STRING_DESC request
+// max_char is CFG_TUD_ENDOINT0_SIZE/2 -1, typically max_char = 31 if Endpoint0 size is 64
+// Return number of characters. Note usb string is in 16-bits unicode format
+uint8_t tud_descriptor_string_cb(uint8_t index, uint16_t* desc, uint8_t max_char)
+{
+  if ( index == 0)
+  {
+    memcpy(desc, string_desc_arr[0], 2);
+    return 1;
+  }else
+  {
+    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return 0;
+
+    const char* str = string_desc_arr[index];
+
+    // Cap at max char
+    uint8_t count = strlen(str);
+    if ( count > max_char ) count = max_char;
+
+    for(uint8_t i=0; i<count; i++)
+    {
+      *desc++ = str[i];
+    }
+
+    return count;
+  }
+}

--- a/examples/device/hid_generic_inout/src/usb_descriptors.c
+++ b/examples/device/hid_generic_inout/src/usb_descriptors.c
@@ -89,16 +89,28 @@ uint8_t const desc_configuration[] =
 };
 
 
-// tud_desc_set is required by tinyusb stack
-tud_desc_set_t tud_desc_set =
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const * tud_descriptor_device_cb(void)
 {
-    .device     = &desc_device,
-    .config     = desc_configuration,
+  return (uint8_t const *) &desc_device;
+}
 
-#if CFG_TUD_HID
-    .hid_report = desc_hid_report,
-#endif
-};
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_descriptor_configuration_cb(void)
+{
+  return desc_configuration;
+}
+
+// Invoked when received GET HID REPORT DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_hid_descriptor_report_cb(void)
+{
+  return desc_hid_report;
+}
 
 //------------- String Descriptors -------------//
 

--- a/examples/device/hid_generic_inout/src/usb_descriptors.c
+++ b/examples/device/hid_generic_inout/src/usb_descriptors.c
@@ -123,30 +123,36 @@ char const* string_desc_arr [] =
   "123456",                      // 3: Serials, should use chip ID
 };
 
-// Invoked when received GET_STRING_DESC request
-// max_char is CFG_TUD_ENDOINT0_SIZE/2 -1, typically max_char = 31 if Endpoint0 size is 64
-// Return number of characters. Note usb string is in 16-bits unicode format
-uint8_t tud_descriptor_string_cb(uint8_t index, uint16_t* desc, uint8_t max_char)
+static uint16_t _desc_str[32];
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+uint16_t const* tud_descriptor_string_cb(uint8_t index)
 {
+  uint8_t chr_count;
+
   if ( index == 0)
   {
-    memcpy(desc, string_desc_arr[0], 2);
-    return 1;
+    memcpy(&_desc_str[1], string_desc_arr[0], 2);
+    chr_count = 1;
   }else
   {
-    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return 0;
+    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
 
     const char* str = string_desc_arr[index];
 
     // Cap at max char
-    uint8_t count = strlen(str);
-    if ( count > max_char ) count = max_char;
+    chr_count = strlen(str);
+    if ( chr_count > 31 ) chr_count = 31;
 
-    for(uint8_t i=0; i<count; i++)
+    for(uint8_t i=0; i<chr_count; i++)
     {
-      *desc++ = str[i];
+      _desc_str[1+i] = str[i];
     }
-
-    return count;
   }
+
+  // first byte is len, second byte is string type
+  _desc_str[0] = TUD_DESC_STR_HEADER(chr_count);
+
+  return _desc_str;
 }

--- a/examples/device/msc_dual_lun/src/usb_descriptors.c
+++ b/examples/device/msc_dual_lun/src/usb_descriptors.c
@@ -82,17 +82,20 @@ uint8_t const desc_configuration[] =
   TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 0, EPNUM_MSC, 0x80 | EPNUM_MSC, 64), // highspeed 512
 };
 
-
-// tud_desc_set is required by tinyusb stack
-tud_desc_set_t tud_desc_set =
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const * tud_descriptor_device_cb(void)
 {
-    .device     = &desc_device,
-    .config     = desc_configuration,
+  return (uint8_t const *) &desc_device;
+}
 
-#if CFG_TUD_HID
-    .hid_report = desc_hid_report,
-#endif
-};
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_descriptor_configuration_cb(void)
+{
+  return desc_configuration;
+}
 
 //------------- String Descriptors -------------//
 

--- a/examples/device/msc_dual_lun/src/usb_descriptors.c
+++ b/examples/device/msc_dual_lun/src/usb_descriptors.c
@@ -82,29 +82,53 @@ uint8_t const desc_configuration[] =
   TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 0, EPNUM_MSC, 0x80 | EPNUM_MSC, 64), // highspeed 512
 };
 
-//------------- String Descriptors -------------//
-// array of pointer to string descriptors
-uint16_t const * const string_desc_arr [] =
-{
-  // 0: is supported language = English
-  TUD_DESC_STRCONV(0x0409),
-
-  // 1: Manufacturer
-  TUD_DESC_STRCONV('t', 'i', 'n', 'y', 'u', 's', 'b', '.', 'o', 'r', 'g'),
-
-  // 2: Product
-  TUD_DESC_STRCONV('t', 'i', 'n', 'y', 'u', 's', 'b', ' ', 'd', 'e', 'v', 'i', 'c', 'e'),
-
-  // 3: Serials, should use chip ID
-  TUD_DESC_STRCONV('1', '2', '3', '4', '5', '6')
-};
 
 // tud_desc_set is required by tinyusb stack
 tud_desc_set_t tud_desc_set =
 {
-  .device       = &desc_device,
-  .config       = desc_configuration,
-  .string_arr   = (uint8_t const **) string_desc_arr,
-  .string_count = sizeof(string_desc_arr)/sizeof(string_desc_arr[0]),
-  .hid_report   = NULL,
+    .device     = &desc_device,
+    .config     = desc_configuration,
+
+#if CFG_TUD_HID
+    .hid_report = desc_hid_report,
+#endif
 };
+
+//------------- String Descriptors -------------//
+
+// array of pointer to string descriptors
+char const* string_desc_arr [] =
+{
+  (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
+  "TinyUSB",                     // 1: Manufacturer
+  "TinyUSB Device",              // 2: Product
+  "123456",                      // 3: Serials, should use chip ID
+};
+
+// Invoked when received GET_STRING_DESC request
+// max_char is CFG_TUD_ENDOINT0_SIZE/2 -1, typically max_char = 31 if Endpoint0 size is 64
+// Return number of characters. Note usb string is in 16-bits unicode format
+uint8_t tud_descriptor_string_cb(uint8_t index, uint16_t* desc, uint8_t max_char)
+{
+  if ( index == 0)
+  {
+    memcpy(desc, string_desc_arr[0], 2);
+    return 1;
+  }else
+  {
+    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return 0;
+
+    const char* str = string_desc_arr[index];
+
+    // Cap at max char
+    uint8_t count = strlen(str);
+    if ( count > max_char ) count = max_char;
+
+    for(uint8_t i=0; i<count; i++)
+    {
+      *desc++ = str[i];
+    }
+
+    return count;
+  }
+}

--- a/examples/device/msc_dual_lun/src/usb_descriptors.c
+++ b/examples/device/msc_dual_lun/src/usb_descriptors.c
@@ -108,30 +108,36 @@ char const* string_desc_arr [] =
   "123456",                      // 3: Serials, should use chip ID
 };
 
-// Invoked when received GET_STRING_DESC request
-// max_char is CFG_TUD_ENDOINT0_SIZE/2 -1, typically max_char = 31 if Endpoint0 size is 64
-// Return number of characters. Note usb string is in 16-bits unicode format
-uint8_t tud_descriptor_string_cb(uint8_t index, uint16_t* desc, uint8_t max_char)
+static uint16_t _desc_str[32];
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+uint16_t const* tud_descriptor_string_cb(uint8_t index)
 {
+  uint8_t chr_count;
+
   if ( index == 0)
   {
-    memcpy(desc, string_desc_arr[0], 2);
-    return 1;
+    memcpy(&_desc_str[1], string_desc_arr[0], 2);
+    chr_count = 1;
   }else
   {
-    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return 0;
+    if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
 
     const char* str = string_desc_arr[index];
 
     // Cap at max char
-    uint8_t count = strlen(str);
-    if ( count > max_char ) count = max_char;
+    chr_count = strlen(str);
+    if ( chr_count > 31 ) chr_count = 31;
 
-    for(uint8_t i=0; i<count; i++)
+    for(uint8_t i=0; i<chr_count; i++)
     {
-      *desc++ = str[i];
+      _desc_str[1+i] = str[i];
     }
-
-    return count;
   }
+
+  // first byte is len, second byte is string type
+  _desc_str[0] = TUD_DESC_STR_HEADER(chr_count);
+
+  return _desc_str;
 }

--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -201,7 +201,8 @@ bool hidd_control_request(uint8_t rhport, tusb_control_request_t const * p_reque
 
     if (p_request->bRequest == TUSB_REQ_GET_DESCRIPTOR && desc_type == HID_DESC_TYPE_REPORT)
     {
-      usbd_control_xfer(rhport, p_request, (void*) tud_desc_set.hid_report, p_hid->reprot_desc_len);
+      uint8_t const * desc_report = tud_hid_descriptor_report_cb();
+      usbd_control_xfer(rhport, p_request, (void*) desc_report, p_hid->reprot_desc_len);
     }else
     {
       return false; // stall unsupported request

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -68,6 +68,11 @@ bool tud_hid_mouse_report(uint8_t report_id, uint8_t buttons, int8_t x, int8_t y
 // Callbacks (Weak is optional)
 //--------------------------------------------------------------------+
 
+// Invoked when received GET HID REPORT DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_hid_descriptor_report_cb(void);
+
 // Invoked when received GET_REPORT control request
 // Application must fill buffer report's content and return its length.
 // Return zero will cause the stack to STALL request

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -68,9 +68,8 @@ bool tud_hid_mouse_report(uint8_t report_id, uint8_t buttons, int8_t x, int8_t y
 // Callbacks (Weak is optional)
 //--------------------------------------------------------------------+
 
-// Invoked when received GET HID REPORT DESCRIPTOR
-// Application return pointer to descriptor
-// Descriptor contents must exist long enough for transfer to complete
+// Invoked when received GET HID REPORT DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
 uint8_t const * tud_hid_descriptor_report_cb(void);
 
 // Invoked when received GET_REPORT control request

--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -142,6 +142,11 @@ static inline uint32_t tu_u32_from_u8(uint8_t b1, uint8_t b2, uint8_t b3, uint8_
   return ( ((uint32_t) b1) << 24) + ( ((uint32_t) b2) << 16) + ( ((uint32_t) b3) << 8) + b4;
 }
 
+static inline uint16_t tu_u16_from_u8(uint8_t high, uint8_t low)
+{
+  return (((uint16_t) high) << 8) + low;
+}
+
 static inline uint8_t tu_u16_high(uint16_t u16)
 {
   return (uint8_t) ( ((uint16_t) (u16 >> 8)) & 0x00ff);

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -403,10 +403,10 @@ static inline uint8_t tu_desc_len(void const* desc)
 }
 
 // Length of the string descriptors in bytes with slen characters
-#define TUD_DESC_STRLEN(_slen)      (2*(_slen) + 2)
+#define TUD_DESC_STRLEN(_chr_count)      (2*(_chr_count) + 2)
 
 // Header of string descriptors with len + string type
-#define TUD_DESC_STR_HEADER(_slen)  ( (uint16_t) ( (TUSB_DESC_STRING << 8 ) | TUD_DESC_STRLEN(_slen)) )
+#define TUD_DESC_STR_HEADER(_chr_count)  ( (uint16_t) ( (TUSB_DESC_STRING << 8 ) | TUD_DESC_STRLEN(_chr_count)) )
 
 // Convert comma-separated string to descriptor unicode format
 #define TUD_DESC_STRCONV( ... )     (const uint16_t[]) { TUD_DESC_STR_HEADER(VA_ARGS_NUM_(__VA_ARGS__)), __VA_ARGS__ }

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -479,7 +479,7 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
 // This function parse configuration descriptor & open drivers accordingly
 static bool process_set_config(uint8_t rhport)
 {
-  tusb_desc_configuration_t const * desc_cfg = (tusb_desc_configuration_t const *) tud_desc_set.config;
+  tusb_desc_configuration_t const * desc_cfg = (tusb_desc_configuration_t const *) tud_descriptor_configuration_cb();
   TU_ASSERT(desc_cfg != NULL && desc_cfg->bDescriptorType == TUSB_DESC_CONFIGURATION);
 
   // Parse configuration descriptor
@@ -558,11 +558,14 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
   switch(desc_type)
   {
     case TUSB_DESC_DEVICE:
-      return usbd_control_xfer(rhport, p_request, (void*) tud_desc_set.device, sizeof(tusb_desc_device_t));
+      return usbd_control_xfer(rhport, p_request, (void*) tud_descriptor_device_cb(), sizeof(tusb_desc_device_t));
     break;
 
     case TUSB_DESC_CONFIGURATION:
-      return usbd_control_xfer(rhport, p_request, (void*) tud_desc_set.config, ((tusb_desc_configuration_t const*) tud_desc_set.config)->wTotalLength);
+    {
+      tusb_desc_configuration_t const* desc_config = (tusb_desc_configuration_t const*) tud_descriptor_configuration_cb();
+      return usbd_control_xfer(rhport, p_request, (void*) desc_config, desc_config->wTotalLength);
+    }
     break;
 
     case TUSB_DESC_STRING:

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -577,16 +577,11 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
         return false;
       }else
       {
-        uint16_t desc_str[CFG_TUD_ENDOINT0_SIZE/2]; // up to endpoint0 size only
-        uint8_t len = 2*tud_descriptor_string_cb(desc_index, desc_str+1, CFG_TUD_ENDOINT0_SIZE/2-1);
+        uint8_t const* desc_str = (uint8_t const*) tud_descriptor_string_cb(desc_index);
+        TU_ASSERT(desc_str);
 
-        TU_ASSERT(len > 0);
-
-        // first byte of descriptor is size, second byte is string type
-        len += 2; // header len
-        desc_str[0] = tu_u16_from_u8(TUSB_DESC_STRING, len);
-
-        return usbd_control_xfer(rhport, p_request, desc_str, len);
+        // first byte of descriptor is its size
+        return usbd_control_xfer(rhport, p_request, (void*) desc_str, desc_str[0]);
       }
     break;
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -160,7 +160,7 @@ static osal_queue_t _usbd_q;
 static void mark_interface_endpoint(uint8_t ep2drv[8][2], uint8_t const* p_desc, uint16_t desc_len, uint8_t driver_id);
 static bool process_control_request(uint8_t rhport, tusb_control_request_t const * p_request);
 static bool process_set_config(uint8_t rhport);
-static void const* get_descriptor(tusb_control_request_t const * p_request, uint16_t* desc_len);
+static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const * p_request);
 
 void usbd_control_reset (uint8_t rhport);
 bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t xferred_bytes);
@@ -382,13 +382,7 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
         break;
 
         case TUSB_REQ_GET_DESCRIPTOR:
-        {
-          uint16_t len = 0;
-          void* buf = (void*) get_descriptor(p_request, &len);
-          if ( buf == NULL || len == 0 ) return false;
-
-          usbd_control_xfer(rhport, p_request, buf, len);
-        }
+          TU_ASSERT( process_get_descriptor(rhport, p_request) );
         break;
 
         case TUSB_REQ_SET_FEATURE:
@@ -556,56 +550,53 @@ static void mark_interface_endpoint(uint8_t ep2drv[8][2], uint8_t const* p_desc,
 }
 
 // return descriptor's buffer and update desc_len
-static void const* get_descriptor(tusb_control_request_t const * p_request, uint16_t* desc_len)
+static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const * p_request)
 {
   tusb_desc_type_t const desc_type = (tusb_desc_type_t) tu_u16_high(p_request->wValue);
   uint8_t const desc_index = tu_u16_low( p_request->wValue );
 
-  uint8_t const * desc_data = NULL;
-  uint16_t len = 0;
-
-  *desc_len = 0;
-
   switch(desc_type)
   {
     case TUSB_DESC_DEVICE:
-      desc_data = (uint8_t const *) tud_desc_set.device;
-      len       = sizeof(tusb_desc_device_t);
+      return usbd_control_xfer(rhport, p_request, (void*) tud_desc_set.device, sizeof(tusb_desc_device_t));
     break;
 
     case TUSB_DESC_CONFIGURATION:
-      desc_data = (uint8_t const *) tud_desc_set.config;
-      len       = ((tusb_desc_configuration_t const*) desc_data)->wTotalLength;
+      return usbd_control_xfer(rhport, p_request, (void*) tud_desc_set.config, ((tusb_desc_configuration_t const*) tud_desc_set.config)->wTotalLength);
     break;
 
     case TUSB_DESC_STRING:
       // String Descriptor always uses the desc set from user
-      if ( desc_index < tud_desc_set.string_count )
+      if ( desc_index == 0xEE )
       {
-        desc_data = tud_desc_set.string_arr[desc_index];
-        TU_VERIFY( desc_data != NULL, NULL );
-
-        len  = desc_data[0];  // first byte of descriptor is its size
-      }else
-      {
-        // out of range
         // The 0xEE index string is a Microsoft USB extension.
         // It can be used to tell Windows what driver it should use for the device !!!
-        return NULL;
+        return false;
+      }else
+      {
+        uint16_t desc_str[CFG_TUD_ENDOINT0_SIZE/2]; // up to endpoint0 size only
+        uint8_t len = 2*tud_descriptor_string_cb(desc_index, desc_str+1, CFG_TUD_ENDOINT0_SIZE/2-1);
+
+        TU_ASSERT(len > 0);
+
+        // first byte of descriptor is size, second byte is string type
+        len += 2; // header len
+        desc_str[0] = tu_u16_from_u8(TUSB_DESC_STRING, len);
+
+        return usbd_control_xfer(rhport, p_request, desc_str, len);
       }
     break;
 
     case TUSB_DESC_DEVICE_QUALIFIER:
       // TODO If not highspeed capable stall this request otherwise
       // return the descriptor that could work in highspeed
-      return NULL;
+      return false;
     break;
 
-    default: return NULL;
+    default: return false;
   }
 
-  *desc_len = len;
-  return desc_data;
+  return true;
 }
 
 //--------------------------------------------------------------------+

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -39,12 +39,8 @@
 
 /// \brief Descriptor pointer collector to all the needed.
 typedef struct {
-  void const * device;            ///< pointer to device descriptor \ref tusb_desc_device_t
-  void const * config;            ///< pointer to the whole configuration descriptor, starting by \ref tusb_desc_configuration_t
-
-  uint8_t const** string_arr;     ///< a array of pointers to string descriptors
-  uint16_t        string_count;
-
+  void const * device;        ///< pointer to device descriptor \ref tusb_desc_device_t
+  void const * config;        ///< pointer to the whole configuration descriptor, starting by \ref tusb_desc_configuration_t
   uint8_t const*  hid_report;
 
 }tud_desc_set_t;
@@ -77,6 +73,11 @@ bool tud_remote_wakeup(void);
 //--------------------------------------------------------------------+
 // Application Callbacks (WEAK is optional)
 //--------------------------------------------------------------------+
+
+// Invoked when received GET_STRING_DESC request
+// max_char is CFG_TUD_ENDOINT0_SIZE/2 -1, typically max_char = 31 if Endpoint0 size is 64
+// Return number of characters. Note usb string is in 16-bits unicode format
+uint8_t tud_descriptor_string_cb(uint8_t index, uint16_t* desc, uint8_t max_char);
 
 // Invoked when device is mounted (configured)
 ATTR_WEAK void tud_mount_cb(void);

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -63,19 +63,17 @@ bool tud_remote_wakeup(void);
 // Application Callbacks (WEAK is optional)
 //--------------------------------------------------------------------+
 
-// Invoked when received GET DEVICE DESCRIPTOR
+// Invoked when received GET DEVICE DESCRIPTOR request
 // Application return pointer to descriptor
 uint8_t const * tud_descriptor_device_cb(void);
 
-// Invoked when received GET CONFIGURATION DESCRIPTOR
-// Application return pointer to descriptor
-// Descriptor contents must exist long enough for transfer to complete
+// Invoked when received GET CONFIGURATION DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
 uint8_t const * tud_descriptor_configuration_cb(void);
 
-// Invoked when received GET STRING DESC request
-// max_char is CFG_TUD_ENDOINT0_SIZE/2 -1, typically max_char = 31 if Endpoint0 size is 64
-// Return number of characters. Note usb string is in UTF-16 format
-uint8_t tud_descriptor_string_cb(uint8_t index, uint16_t* desc, uint8_t max_char);
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+uint16_t const* tud_descriptor_string_cb(uint8_t index);
 
 // Invoked when device is mounted (configured)
 ATTR_WEAK void tud_mount_cb(void);

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -37,17 +37,6 @@
 #include "common/tusb_common.h"
 #include "device/dcd.h"
 
-/// \brief Descriptor pointer collector to all the needed.
-typedef struct {
-  void const * device;        ///< pointer to device descriptor \ref tusb_desc_device_t
-  void const * config;        ///< pointer to the whole configuration descriptor, starting by \ref tusb_desc_configuration_t
-  uint8_t const*  hid_report;
-
-}tud_desc_set_t;
-
-// Descriptor collection set, must be defined by application
-extern tud_desc_set_t tud_desc_set;
-
 //--------------------------------------------------------------------+
 // Application API
 //--------------------------------------------------------------------+
@@ -74,9 +63,18 @@ bool tud_remote_wakeup(void);
 // Application Callbacks (WEAK is optional)
 //--------------------------------------------------------------------+
 
-// Invoked when received GET_STRING_DESC request
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const * tud_descriptor_device_cb(void);
+
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const * tud_descriptor_configuration_cb(void);
+
+// Invoked when received GET STRING DESC request
 // max_char is CFG_TUD_ENDOINT0_SIZE/2 -1, typically max_char = 31 if Endpoint0 size is 64
-// Return number of characters. Note usb string is in 16-bits unicode format
+// Return number of characters. Note usb string is in UTF-16 format
 uint8_t tud_descriptor_string_cb(uint8_t index, uint16_t* desc, uint8_t max_char);
 
 // Invoked when device is mounted (configured)

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -93,8 +93,10 @@ bool usbd_control_xfer(uint8_t rhport, tusb_control_request_t const * request, v
   _control_state.total_len = tu_min16(len, request->wLength);
   _control_state.total_transferred = 0;
 
-  if ( (buffer != NULL) && len )
+  if ( len )
   {
+    TU_ASSERT(buffer);
+
     // Data stage
     TU_ASSERT( start_control_data_xact(rhport) );
   }else

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -93,7 +93,7 @@ bool usbd_control_xfer(uint8_t rhport, tusb_control_request_t const * request, v
   _control_state.total_len = tu_min16(len, request->wLength);
   _control_state.total_transferred = 0;
 
-  if ( buffer != NULL && len )
+  if ( (buffer != NULL) && len )
   {
     // Data stage
     TU_ASSERT( start_control_data_xact(rhport) );


### PR DESCRIPTION
tud_desc_set_t is removed and replaced by following callbacks:
- tud_descriptor_device_cb()
- tud_descriptor_configuration_cb()
- tud_descriptor_string_cb()
- tud_hid_descriptor_report_cb()