### PR TITLE
Fix missing section in binary output

### DIFF
--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -54,7 +54,7 @@ $(BUILD)/$(BOARD)-firmware.elf: $(OBJ)
 
 $(BUILD)/$(BOARD)-firmware.bin: $(BUILD)/$(BOARD)-firmware.elf
 	@echo CREATE $@
-	@$(OBJCOPY) -O binary -j .vectors -j .text -j .data $^ $@
+	@$(OBJCOPY) -O binary $^ $@
 	
 $(BUILD)/$(BOARD)-firmware.hex: $(BUILD)/$(BOARD)-firmware.elf	
 	@echo CREATE $@


### PR DESCRIPTION
The binary outputs of examples are not working, the global variables initialization section was missing.