### PR TITLE
add uf2 target for uf2 bootloader boards

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "hw/mcu/nxp/lpcopen"]
 	path = hw/mcu/nxp/lpcopen
 	url = https://github.com/hathach/lpcopen.git
+[submodule "tools/uf2"]
+	path = tools/uf2
+	url = https://github.com/microsoft/uf2.git

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -12,6 +12,7 @@ MKDIR = mkdir
 SED = sed
 CP = cp
 RM = rm
+PYTHON ?= python
 
 # Select the board to build for.
 ifeq ($(BOARD),)

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -43,6 +43,8 @@ endif
 .DEFAULT_GOAL := all
 all: $(BUILD)/$(BOARD)-firmware.bin size
 
+uf2: $(BUILD)/$(BOARD)-firmware.uf2
+
 OBJ_DIRS = $(sort $(dir $(OBJ)))
 $(OBJ): | $(OBJ_DIRS)
 $(OBJ_DIRS):
@@ -59,6 +61,11 @@ $(BUILD)/$(BOARD)-firmware.bin: $(BUILD)/$(BOARD)-firmware.elf
 $(BUILD)/$(BOARD)-firmware.hex: $(BUILD)/$(BOARD)-firmware.elf	
 	@echo CREATE $@
 	@$(OBJCOPY) -O ihex $^ $@
+
+UF2_FAMILY ?= 0x00
+$(BUILD)/$(BOARD)-firmware.uf2: $(BUILD)/$(BOARD)-firmware.hex
+	@echo CREATE $@
+	$(PYTHON) $(TOP)/tools/uf2/utils/uf2conv.py -f $(UF2_FAMILY) -c -o $@ $^
 
 # We set vpath to point to the top of the tree so that the source files
 # can be located. By following this scheme, it allows a single build rule

--- a/hw/bsp/feather_nrf52840_express/board.mk
+++ b/hw/bsp/feather_nrf52840_express/board.mk
@@ -12,7 +12,7 @@ CFLAGS += \
 CFLAGS += -Wno-error=undef 
 
 # All source paths should be relative to the top level.
-LD_FILE = hw/mcu/nordic/nrfx/mdk/nrf52840_xxaa.ld
+LD_FILE = hw/bsp/feather_nrf52840_express/nrf52840_s140_v6.ld
 
 LDFLAGS += -L$(TOP)/hw/mcu/nordic/nrfx/mdk
 
@@ -46,6 +46,9 @@ FREERTOS_PORT = ARM_CM4F
 # For flash-jlink target
 JLINK_DEVICE = nRF52840_xxAA
 JLINK_IF = swd
+
+# For uf2 conversion
+UF2_FAMILY = 0xADA52840
 
 # flash using jlink
 flash: flash-jlink

--- a/hw/bsp/feather_nrf52840_express/nrf52840_s140_v6.ld
+++ b/hw/bsp/feather_nrf52840_express/nrf52840_s140_v6.ld
@@ -1,0 +1,38 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx)     : ORIGIN = 0x26000, LENGTH = 0xED000 - 0x26000
+
+  /* SRAM required by S132 depend on
+   * - Attribute Table Size
+   * - Vendor UUID count
+   * - Max ATT MTU
+   * - Concurrent connection peripheral + central + secure links
+   * - Event Len, HVN queue, Write CMD queue
+   */ 
+  RAM (rwx) :  ORIGIN = 0x20003400, LENGTH = 0x20040000 - 0x20003400
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .svc_data :
+  {
+    PROVIDE(__start_svc_data = .);
+    KEEP(*(.svc_data))
+    PROVIDE(__stop_svc_data = .);
+  } > RAM
+  
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf52_common.ld"

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -131,33 +131,32 @@
 #endif
 
 #ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN          ATTR_ALIGNED(4)
+#define CFG_TUSB_MEM_ALIGN        ATTR_ALIGNED(4)
 #endif
 
 #ifndef CFG_TUSB_OS
-#define CFG_TUSB_OS OPT_OS_NONE
+#define CFG_TUSB_OS               OPT_OS_NONE
 #endif
 
 //--------------------------------------------------------------------
 // DEVICE OPTIONS
 //--------------------------------------------------------------------
-#if TUSB_OPT_DEVICE_ENABLED
 
-  #ifndef CFG_TUD_ENDOINT0_SIZE
-    #define CFG_TUD_ENDOINT0_SIZE    64
-  #endif
+#ifndef CFG_TUD_ENDOINT0_SIZE
+  #define CFG_TUD_ENDOINT0_SIZE   64
+#endif
 
-  #ifndef CFG_TUD_CTRL_BUFSIZE
-    #define CFG_TUD_CTRL_BUFSIZE 256
-  #endif
+#ifndef CFG_TUD_CDC
+  #define CFG_TUD_CDC             0
+#endif
 
-  #ifndef CFG_TUD_CDC
-    #define CFG_TUD_CDC            0
-  #endif
+#ifndef CFG_TUD_MSC
+  #define CFG_TUD_MSC             0
+#endif
 
-  #ifndef CFG_TUD_MSC
-    #define CFG_TUD_MSC          0
-  #endif
+#ifndef CFG_TUD_HID
+  #define CFG_TUD_HID             0
+#endif
 
 #ifndef CFG_TUD_MIDI
   #define CFG_TUD_MIDI            0
@@ -167,7 +166,6 @@
   #define CFG_TUD_CUSTOM_CLASS    0
 #endif
 
-#endif // TUSB_OPT_DEVICE_ENABLED
 
 //--------------------------------------------------------------------
 // HOST OPTIONS


### PR DESCRIPTION
- follow up to #68  and should fix #69 
- metro m0/m4 and feather nrf52840
- only add uf2 as submodule at tools/uf2
