### PR TITLE
fix tud_cdc_read_char()/tud_cdc_peek() to return signed char

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -126,9 +126,9 @@ uint32_t tud_cdc_n_available(uint8_t itf)
   return tu_fifo_count(&_cdcd_itf[itf].rx_ff);
 }
 
-char tud_cdc_n_read_char(uint8_t itf)
+signed char tud_cdc_n_read_char(uint8_t itf)
 {
-  char ch;
+  signed char ch;
   return tud_cdc_n_read(itf, &ch, 1) ? ch : (-1);
 }
 
@@ -139,9 +139,9 @@ uint32_t tud_cdc_n_read(uint8_t itf, void* buffer, uint32_t bufsize)
   return num_read;
 }
 
-char tud_cdc_n_peek(uint8_t itf, int pos)
+signed char tud_cdc_n_peek(uint8_t itf, int pos)
 {
-  char ch;
+  signed char ch;
   return tu_fifo_peek_at(&_cdcd_itf[itf].rx_ff, pos, &ch) ? ch : (-1);
 }
 

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -51,40 +51,40 @@
 // APPLICATION API (Multiple Interfaces)
 // CFG_TUD_CDC > 1
 //--------------------------------------------------------------------+
-bool     tud_cdc_n_connected       (uint8_t itf);
-uint8_t  tud_cdc_n_get_line_state  (uint8_t itf);
-void     tud_cdc_n_get_line_coding (uint8_t itf, cdc_line_coding_t* coding);
-void     tud_cdc_n_set_wanted_char (uint8_t itf, char wanted);
+bool        tud_cdc_n_connected       (uint8_t itf);
+uint8_t     tud_cdc_n_get_line_state  (uint8_t itf);
+void        tud_cdc_n_get_line_coding (uint8_t itf, cdc_line_coding_t* coding);
+void        tud_cdc_n_set_wanted_char (uint8_t itf, char wanted);
 
-uint32_t tud_cdc_n_available       (uint8_t itf);
-char     tud_cdc_n_read_char       (uint8_t itf);
-uint32_t tud_cdc_n_read            (uint8_t itf, void* buffer, uint32_t bufsize);
-void     tud_cdc_n_read_flush      (uint8_t itf);
-char     tud_cdc_n_peek            (uint8_t itf, int pos);
+uint32_t    tud_cdc_n_available       (uint8_t itf);
+signed char tud_cdc_n_read_char       (uint8_t itf);
+uint32_t    tud_cdc_n_read            (uint8_t itf, void* buffer, uint32_t bufsize);
+void        tud_cdc_n_read_flush      (uint8_t itf);
+signed char tud_cdc_n_peek            (uint8_t itf, int pos);
 
-uint32_t tud_cdc_n_write_char      (uint8_t itf, char ch);
-uint32_t tud_cdc_n_write           (uint8_t itf, void const* buffer, uint32_t bufsize);
-uint32_t tud_cdc_n_write_str       (uint8_t itf, char const* str);
-bool     tud_cdc_n_write_flush     (uint8_t itf);
+uint32_t    tud_cdc_n_write_char      (uint8_t itf, char ch);
+uint32_t    tud_cdc_n_write           (uint8_t itf, void const* buffer, uint32_t bufsize);
+uint32_t    tud_cdc_n_write_str       (uint8_t itf, char const* str);
+bool        tud_cdc_n_write_flush     (uint8_t itf);
 
 //--------------------------------------------------------------------+
 // APPLICATION API (Interface0)
 //--------------------------------------------------------------------+
-static inline bool     tud_cdc_connected       (void)                                 { return tud_cdc_n_connected(0);              }
-static inline uint8_t  tud_cdc_get_line_state  (void)                                 { return tud_cdc_n_get_line_state(0);         }
-static inline void     tud_cdc_get_line_coding (cdc_line_coding_t* coding)            { return tud_cdc_n_get_line_coding(0, coding);}
-static inline void     tud_cdc_set_wanted_char (char wanted)                          { tud_cdc_n_set_wanted_char(0, wanted);       }
+static inline bool        tud_cdc_connected       (void)                                 { return tud_cdc_n_connected(0);              }
+static inline uint8_t     tud_cdc_get_line_state  (void)                                 { return tud_cdc_n_get_line_state(0);         }
+static inline void        tud_cdc_get_line_coding (cdc_line_coding_t* coding)            { return tud_cdc_n_get_line_coding(0, coding);}
+static inline void        tud_cdc_set_wanted_char (char wanted)                          { tud_cdc_n_set_wanted_char(0, wanted);       }
 
-static inline uint32_t tud_cdc_available       (void)                                 { return tud_cdc_n_available(0);              }
-static inline char     tud_cdc_read_char       (void)                                 { return tud_cdc_n_read_char(0);              }
-static inline uint32_t tud_cdc_read            (void* buffer, uint32_t bufsize)       { return tud_cdc_n_read(0, buffer, bufsize);  }
-static inline void     tud_cdc_read_flush      (void)                                 { tud_cdc_n_read_flush(0);                    }
-static inline char     tud_cdc_peek            (int pos)                              { return tud_cdc_n_peek(0, pos);              }
+static inline uint32_t    tud_cdc_available       (void)                                 { return tud_cdc_n_available(0);              }
+static inline signed char tud_cdc_read_char       (void)                                 { return tud_cdc_n_read_char(0);              }
+static inline uint32_t    tud_cdc_read            (void* buffer, uint32_t bufsize)       { return tud_cdc_n_read(0, buffer, bufsize);  }
+static inline void        tud_cdc_read_flush      (void)                                 { tud_cdc_n_read_flush(0);                    }
+static inline signed char tud_cdc_peek            (int pos)                              { return tud_cdc_n_peek(0, pos);              }
 
-static inline uint32_t tud_cdc_write_char      (char ch)                              { return tud_cdc_n_write_char(0, ch);         }
-static inline uint32_t tud_cdc_write           (void const* buffer, uint32_t bufsize) { return tud_cdc_n_write(0, buffer, bufsize); }
-static inline uint32_t tud_cdc_write_str       (char const* str)                      { return tud_cdc_n_write_str(0, str);         }
-static inline bool     tud_cdc_write_flush     (void)                                 { return tud_cdc_n_write_flush(0);            }
+static inline uint32_t    tud_cdc_write_char      (char ch)                              { return tud_cdc_n_write_char(0, ch);         }
+static inline uint32_t    tud_cdc_write           (void const* buffer, uint32_t bufsize) { return tud_cdc_n_write(0, buffer, bufsize); }
+static inline uint32_t    tud_cdc_write_str       (char const* str)                      { return tud_cdc_n_write_str(0, str);         }
+static inline bool        tud_cdc_write_flush     (void)                                 { return tud_cdc_n_write_flush(0);            }
 
 //--------------------------------------------------------------------+
 // APPLICATION CALLBACK API (WEAK is optional)


### PR DESCRIPTION
- depending on compiler option "char" can be intepreted as unsigned char