### PR TITLE
cdc_msc_hid: Limit number of endpoints used by STM32F4 for demo.

### DIFF
--- a/examples/device/cdc_msc_hid/src/tusb_config.h
+++ b/examples/device/cdc_msc_hid/src/tusb_config.h
@@ -74,7 +74,14 @@
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1
 #define CFG_TUD_MSC              1
+#if CFG_TUSB_MCU == OPT_MCU_STM32F4
+// STM32F4 does not have enough endpoints (4, including hardcoded control
+// endpoint) to enable CDC, MSC, and HID simultaneously, so disable HID as a
+// compromise.
+#define CFG_TUD_HID              0
+#else
 #define CFG_TUD_HID              1
+#endif
 
 #define CFG_TUD_MIDI             0
 #define CFG_TUD_VENDOR           0


### PR DESCRIPTION
Since I last checked, the default options to the `cdc_msc_hid` demo have changed. The default options allocate more endpoints than exist on the STM32 used on the STM32F4DISC. I [guard](https://github.com/hathach/tinyusb/blob/master/src/portable/st/stm32f4/dcd_stm32f4.c#L221-L223) against this, but ultimately tinyusb will end up triggering an assert because the endpoint open failed.

As a compromise, I add an `#if` guard to avoid allocating too many endpoints on STM32F4DISC in `tusb_config.h`.