### PR TITLE
midi_device: Send message classes C and D as 2 bytes

### DIFF
--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -161,6 +161,9 @@ uint32_t tud_midi_n_write(uint8_t itf, uint8_t jack_id, uint8_t const* buffer, u
         } else if ((msg >= 0x8 && msg <= 0xB) || msg == 0xE) {
             midi->message_buffer[0] = jack_id << 4 | msg;
             midi->message_target_length = 4;
+        } else if (msg == 0xC || msg == 0xD) {
+            midi->message_buffer[0] = jack_id << 4 | msg;
+            midi->message_target_length = 3;
         } else if (msg == 0xf) {
             if (data == 0xf0) {
                 midi->message_buffer[0] = 0x4;


### PR DESCRIPTION
.. sending these as two 1-byte messages with CIN of 0xF is misinterpreted by OSes including Windows 10 and (reportedly) Mac.

Testing performed: Ran the reproducer script, which sends Program Change (0xCx) messages.  I did not check with Change Pressure (0xDx) messages, but expect the same thing.

Closes: #98