### PR TITLE
TI compiler quirks, and LE byte swapping functions.

### DIFF
--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -80,7 +80,7 @@
     return __builtin_bswap16(u16);
   }
 
-  static inline uint16_t tu_bswap32(uint16_t u32)
+  static inline uint32_t tu_bswap32(uint32_t u32)
   {
     return __builtin_bswap32(u32);
   }
@@ -108,7 +108,7 @@
     return __builtin_bswap16(u16);
   }
 
-  static inline uint16_t tu_bswap32(uint16_t u32)
+  static inline uint32_t tu_bswap32(uint32_t u32)
   {
     return __builtin_bswap32(u32);
   }

--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -75,17 +75,8 @@
     #define TU_BYTE_ORDER TU_BIG_ENDIAN
   #endif
 
-  static inline uint16_t tu_bswap16(uint16_t u16)
-  {
-    return __builtin_bswap16(u16);
-  }
-
-  static inline uint32_t tu_bswap32(uint32_t u32)
-  {
-    return __builtin_bswap32(u32);
-  }
-
-  #define TU_BSWAP16
+#define TU_BSWAP16(u16) (__builtin_bswap16(u16))
+#define TU_BSWAP32(u32) (__builtin_bswap32(u32))
 
 #elif defined(__TI_COMPILER_VERSION__)
   #define TU_ATTR_ALIGNED(Bytes)        __attribute__ ((aligned(Bytes)))
@@ -103,44 +94,41 @@
     #define TU_BYTE_ORDER TU_BIG_ENDIAN
   #endif
 
-  static inline uint16_t tu_bswap16(uint16_t u16)
-  {
-    return __builtin_bswap16(u16);
-  }
+  #define TU_BSWAP16(u16) (__builtin_bswap16(u16))
+  #define TU_BSWAP32(u32) (__builtin_bswap32(u32))
 
-  static inline uint32_t tu_bswap32(uint32_t u32)
-  {
-    return __builtin_bswap32(u32);
-  }
 #else
   #error "Compiler attribute porting is required"
 #endif
 
 #if (TU_BYTE_ORDER == TU_LITTLE_ENDIAN)
-  #define tu_htonl(u32)  tu_bswap32(u32)
-  #define tu_ntohl(u32)  tu_bswap32(u32)
 
-  #define tu_htons(u16)  tu_bswap16(u16)
-  #define tu_ntohs(u16)  tu_bswap16(u16)
+  #define tu_htons(u16)  (TU_BSWAP16(u16))
+  #define tu_ntohs(u16)  (TU_BSWAP16(u16))
 
-  #define tu_htole16(x) (x)
-  #define tu_le16toh(x) (x)
+  #define tu_htonl(u32)  (TU_BSWAP32(u32))
+  #define tu_ntohl(u32)  (TU_BSWAP32(u32))
 
-  #define tu_htole32(x) (x)
-  #define tu_le32toh(x) (x)
+  #define tu_htole16(u16) (u16)
+  #define tu_le16toh(u16) (u16)
+
+  #define tu_htole32(u32) (u32)
+  #define tu_le32toh(u32) (u32)
 
 #elif (TU_BYTE_ORDER == TU_BIG_ENDIAN)
-  #define tu_htonl(u32)  (x)
-  #define tu_ntohl(u32)  (x)
 
-  #define tu_htons(u16)  (x)
-  #define tu_ntohs(u16)  (x)
+  #define tu_htons(u16)  (u16)
+  #define tu_ntohs(u16)  (u16)
 
-  #define tu_htole16(x) tu_bswap16(u32)
-  #define tu_le16toh(x) tu_bswap16(u32)
+  #define tu_htonl(u32)  (u32)
+  #define tu_ntohl(u32)  (u32)
 
-  #define tu_htole32(x) tu_bswap32(u32)
-  #define tu_le32toh(x) tu_bswap32(u32)
+
+  #define tu_htole16(u16) (tu_bswap16(u16))
+  #define tu_le16toh(u16) (tu_bswap16(u16))
+
+  #define tu_htole32(u32) (tu_bswap32(u32))
+  #define tu_le32toh(u32) (tu_bswap32(u32))
 
 #else
   #error Byte order is undefined

--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -53,6 +53,9 @@
 // for declaration of reserved field, make use of _TU_COUNTER_
 #define TU_RESERVED           TU_XSTRCAT(reserved, _TU_COUNTER_)
 
+#define TU_LITTLE_ENDIAN (0x12u)
+#define TU_BIG_ENDIAN (0x21u)
+
 //--------------------------------------------------------------------+
 // Compiler porting with Attribute and Endian
 //--------------------------------------------------------------------+
@@ -67,20 +70,80 @@
 
   // Endian conversion use well-known host to network (big endian) naming
   #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    #define tu_htonl(u32)  __builtin_bswap32(u32)
-    #define tu_ntohl(u32)  __builtin_bswap32(u32)
-
-    #define tu_htons(u16)  __builtin_bswap16(u16)
-    #define tu_ntohs(u16)  __builtin_bswap16(u16)
+    #define TU_BYTE_ORDER TU_LITTLE_ENDIAN
   #else
-    #define tu_htonl(u32)  (u32)
-    #define tu_ntohl(u32)  (u32)
-
-    #define tu_htons(u16)  (u16)
-    #define tu_ntohs(u16)  (u16)
+    #define TU_BYTE_ORDER TU_BIG_ENDIAN
   #endif
+
+  static inline uint16_t tu_bswap16(uint16_t u16)
+  {
+    return __builtin_bswap16(u16);
+  }
+
+  static inline uint16_t tu_bswap32(uint16_t u32)
+  {
+    return __builtin_bswap32(u32);
+  }
+
+  #define TU_BSWAP16
+
+#elif defined(__TI_COMPILER_VERSION__)
+  #define TU_ATTR_ALIGNED(Bytes)        __attribute__ ((aligned(Bytes)))
+  #define TU_ATTR_SECTION(sec_name)     __attribute__ ((section(#sec_name)))
+  #define TU_ATTR_PACKED                __attribute__ ((packed))
+  #define TU_ATTR_PREPACKED
+  #define TU_ATTR_WEAK                  __attribute__ ((weak))
+  #define TU_ATTR_DEPRECATED(mess)      __attribute__ ((deprecated(mess))) // warn if function with this attribute is used
+  #define TU_ATTR_UNUSED                __attribute__ ((unused))           // Function/Variable is meant to be possibly unused
+
+  // __BYTE_ORDER is defined in the TI ARM compiler, but not MSP430 (which is little endian)
+  #if ((__BYTE_ORDER__) == (__ORDER_LITTLE_ENDIAN__)) || defined(__MSP430__)
+    #define TU_BYTE_ORDER TU_LITTLE_ENDIAN
+  #else
+    #define TU_BYTE_ORDER TU_BIG_ENDIAN
+  #endif
+
+  static inline uint16_t tu_bswap16(uint16_t u16)
+  {
+    return __builtin_bswap16(u16);
+  }
+
+  static inline uint16_t tu_bswap32(uint16_t u32)
+  {
+    return __builtin_bswap32(u32);
+  }
 #else
-  #error "Compiler attribute porting are required"
+  #error "Compiler attribute porting is required"
+#endif
+
+#if (TU_BYTE_ORDER == TU_LITTLE_ENDIAN)
+  #define tu_htonl(u32)  tu_bswap32(u32)
+  #define tu_ntohl(u32)  tu_bswap32(u32)
+
+  #define tu_htons(u16)  tu_bswap16(u16)
+  #define tu_ntohs(u16)  tu_bswap16(u16)
+
+  #define tu_htole16(x) (x)
+  #define tu_le16toh(x) (x)
+
+  #define tu_htole32(x) (x)
+  #define tu_le32toh(x) (x)
+
+#elif (TU_BYTE_ORDER == TU_BIG_ENDIAN)
+  #define tu_htonl(u32)  (x)
+  #define tu_ntohl(u32)  (x)
+
+  #define tu_htons(u16)  (x)
+  #define tu_ntohs(u16)  (x)
+
+  #define tu_htole16(x) tu_bswap16(u32)
+  #define tu_le16toh(x) tu_bswap16(u32)
+
+  #define tu_htole32(x) tu_bswap32(u32)
+  #define tu_le32toh(x) tu_bswap32(u32)
+
+#else
+  #error Byte order is undefined
 #endif
 
 #endif /* _TUSB_COMPILER_H_ */


### PR DESCRIPTION
This adds some definitions for the TI optimizing C compilers. I've built the codebase with a TI TM4C123GXL target (using a null DCD driver). I hope that it will also work with the MSP430.

I'm also adding functions to swap byte orders between LE and host orders. This would be necessary if the library is ported to BE MCUs (nobody is itching to do a ColdFire port, are they?). 

In addition it changes the byteswap macro to be an inline function. This enables compiler type checking, perhaps finding bugs in the future.

(feel free to reject some or any of this)