### PR TITLE
dcd_synopsys: Fix off-by-one error in FIFO allocation.

### DIFF
--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -268,10 +268,10 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
 
   uint8_t const epnum = tu_edpt_number(desc_edpt->bEndpointAddress);
   uint8_t const dir   = tu_edpt_dir(desc_edpt->bEndpointAddress);
-  
+
   TU_ASSERT(desc_edpt->wMaxPacketSize.size <= 64);
   TU_ASSERT(epnum < EP_MAX);
-  
+
   xfer_ctl_t * xfer = XFER_CTL_BASE(epnum, dir);
   xfer->max_size = desc_edpt->wMaxPacketSize.size;
 
@@ -305,18 +305,22 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
     // Since OUT FIFO = GRXFSIZ, FIFO 0 = 16, for simplicity, we equally allocated for the rest of endpoints
     // - Size  : (FIFO_SIZE/4 - GRXFSIZ - 16) / (EP_MAX-1)
     // - Offset: GRXFSIZ + 16 + Size*(epnum-1)
+    // - IN EP 1 gets FIFO 1, IN EP "n" gets FIFO "n".
 
     in_ep[epnum].DIEPCTL |= (1 << USB_OTG_DIEPCTL_USBAEP_Pos) | \
-      (epnum - 1) << USB_OTG_DIEPCTL_TXFNUM_Pos | \
+      epnum << USB_OTG_DIEPCTL_TXFNUM_Pos | \
       desc_edpt->bmAttributes.xfer << USB_OTG_DIEPCTL_EPTYP_Pos | \
       (desc_edpt->bmAttributes.xfer != TUSB_XFER_ISOCHRONOUS ? USB_OTG_DOEPCTL_SD0PID_SEVNFRM : 0) | \
       desc_edpt->wMaxPacketSize.size << USB_OTG_DIEPCTL_MPSIZ_Pos;
     dev->DAINTMSK |= (1 << (USB_OTG_DAINTMSK_IEPM_Pos + epnum));
 
-    // Both TXFD and TXSA are in unit of 32-bit words
+    // Both TXFD and TXSA are in unit of 32-bit words.
+    // IN FIFO 0 was configured during enumeration, hence the "+ 16".
     uint16_t const allocated_size = (USB_OTG_FS->GRXFSIZ & 0x0000ffff) + 16;
     uint16_t const fifo_size = (EP_FIFO_SIZE/4 - allocated_size) / (EP_MAX-1);
     uint32_t const fifo_offset = allocated_size + fifo_size*(epnum-1);
+
+    // DIEPTXF starts at FIFO #1.
     USB_OTG_FS->DIEPTXF[epnum - 1] = (fifo_size << USB_OTG_DIEPTXF_INEPTXFD_Pos) | fifo_offset;
   }
 


### PR DESCRIPTION
In a [comment](https://github.com/hathach/tinyusb/issues/139#issuecomment-531095383) in #139, I said the following about the `hid_composite` demo:

>In addition, if the keyboard and mouse fail to initialize, I am able to crash the demo eventually by repeatedly pressing the user button on my Nucleo 743. According to gdb, this is because one of the IN endpoints triggers a TimeOut Condition (USB_OTG_DIEPINT_TOC) interrupt, which I have enabled, but don't actually handle in code right now :P. I'll open a separate issue re: this soon.

While the crash disappeared when #139 was fixed, I suspected it was hiding another bug, so I started some [digging](https://github.com/hathach/tinyusb/issues/171#issuecomment-533410701).

>According to my USB captures, an HID IN xfer gets sent down the control pipe as the Data Phase to a "Get Device Descriptor" SETUP xfer. Not a typo. Meaning somehow I managed to get tinyusb into a state where it's sending data meant for EP 1 down EP 0. I'll look into it more after I sleep.

Turns out I had a nasty off-by-one error that was never triggered _except_ as a side effect of the `hid_composite` demo being broken. Before this PR, IN EP 0 and IN EP 1 were sharing the same TX FIFO. This means it was possible to the core to send data meant for EP 1 down EP 0 and vice versa.

I'll write up a more detailed analysis later, but this patch "fixes" the crash I described from when `hid_composite` was broken. Of course, the demo remains broken if using a commit before #151, like I am ;)...

EDIT: What makes this interesting to me is that the docs say:

>Bits 25:22 TXFNUM: TxFIFO number
These bits specify the FIFO number associated with this endpoint. Each active IN endpoint
must be programmed to a separate FIFO number.

However, you already _have_ to use different addresses for different endpoints to write data into the FIFOs; EP IN/OUT 0 is at peripheral offset 0x1000, IN/OUT 1 at 0x2000, etc. Without seeing the HDL (fat chance!), I don't know why Synopsys wants you to assign both a FIFO number and use a specific address to write data for each IN endpoint. But clearly it makes a difference...