### PR TITLE
examples: Allow user to override EP0 size.

### DIFF
--- a/examples/device/cdc_msc/src/tusb_config.h
+++ b/examples/device/cdc_msc/src/tusb_config.h
@@ -68,8 +68,9 @@
 //--------------------------------------------------------------------
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
-
+#ifndef CFG_TUD_ENDOINT0_SIZE
 #define CFG_TUD_ENDOINT0_SIZE    64
+#endif
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1

--- a/examples/device/cdc_msc_hid_freertos/src/tusb_config.h
+++ b/examples/device/cdc_msc_hid_freertos/src/tusb_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -69,7 +69,9 @@
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
+#ifndef CFG_TUD_ENDOINT0_SIZE
 #define CFG_TUD_ENDOINT0_SIZE    64
+#endif
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC              1

--- a/examples/device/hid_composite/src/tusb_config.h
+++ b/examples/device/hid_composite/src/tusb_config.h
@@ -69,7 +69,9 @@
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
-#define CFG_TUD_ENDOINT0_SIZE   64
+#ifndef CFG_TUD_ENDOINT0_SIZE
+#define CFG_TUD_ENDOINT0_SIZE    64
+#endif
 
 //------------- CLASS -------------//
 #define CFG_TUD_HID             1

--- a/examples/device/hid_generic_inout/src/tusb_config.h
+++ b/examples/device/hid_generic_inout/src/tusb_config.h
@@ -69,7 +69,9 @@
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
-#define CFG_TUD_ENDOINT0_SIZE   64
+#ifndef CFG_TUD_ENDOINT0_SIZE
+#define CFG_TUD_ENDOINT0_SIZE    64
+#endif
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC             0

--- a/examples/device/midi_test/src/tusb_config.h
+++ b/examples/device/midi_test/src/tusb_config.h
@@ -69,7 +69,9 @@
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
-#define CFG_TUD_ENDOINT0_SIZE     64
+#ifndef CFG_TUD_ENDOINT0_SIZE
+#define CFG_TUD_ENDOINT0_SIZE    64
+#endif
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC               0

--- a/examples/device/msc_dual_lun/src/tusb_config.h
+++ b/examples/device/msc_dual_lun/src/tusb_config.h
@@ -69,7 +69,9 @@
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
-#define CFG_TUD_ENDOINT0_SIZE   64
+#ifndef CFG_TUD_ENDOINT0_SIZE
+#define CFG_TUD_ENDOINT0_SIZE    64
+#endif
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC             0

--- a/examples/device/webusb_serial/src/tusb_config.h
+++ b/examples/device/webusb_serial/src/tusb_config.h
@@ -69,7 +69,9 @@
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
-#define CFG_TUD_ENDOINT0_SIZE     64
+#ifndef CFG_TUD_ENDOINT0_SIZE
+#define CFG_TUD_ENDOINT0_SIZE    64
+#endif
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC               1


### PR DESCRIPTION
MSP430 only allows a packet size of 8 bytes on EP0. I figured I should make a PR for feedback.