### PR TITLE
ST FSDEV EP0 left in stall

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -444,10 +444,6 @@ static uint16_t dcd_ep_ctr_handler(void)
           }
 
           /* Process Control Data OUT status Packet*/
-          /*if(EPindex == 0u && xfer->total_len == 0u)
-          {
-             pcd_clear_ep_kind(USB,0); // Good, so allow non-zero length packets now.
-          }*/
           dcd_event_xfer_complete(0, EPindex, xfer->total_len, XFER_RESULT_SUCCESS, true);
 
           pcd_set_ep_rx_cnt(USB, EPindex, CFG_TUD_ENDPOINT0_SIZE);
@@ -694,7 +690,6 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
     if (epnum == 0 && buffer == NULL)
     {
         xfer->buffer = (uint8_t*)_setup_packet;
-        //pcd_set_ep_kind(USB,0); // Expect a zero-byte INPUT
     }
     if(total_bytes > xfer->max_packet_size)
     {

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -418,7 +418,7 @@ static uint16_t dcd_ep_ctr_handler(void)
           uint8_t userMemBuf[8];
           /* Get SETUP Packet*/
           count = pcd_get_ep_rx_cnt(USB, EPindex);
-          if(count == 8) // Setup packet should always be 8 bits. If not, ignore it, and try again.
+          if(count == 8) // Setup packet should always be 8 bytes. If not, ignore it, and try again.
           {
             // Must reset EP to NAK (in case it had been stalling) (though, maybe too late here)
             pcd_set_ep_rx_status(USB,0u,USB_EP_RX_NAK);


### PR DESCRIPTION
The ST FSDEV driver has been sometimes not completing USB enumeration (perhaps 10% of the time). I have not looked at it with a USB analyzer, but my feeling is that it is leaving the EP in a still condition after the host requests the device qualifier (which does not exist), and it's never leaving stall.

This patch removes some hardware validation of control status packets being 0-length, and also resets EP0 (both directions) to NAK upon receiving a SETUP packet.

This patch does not seem correct to me, but seems like it's working better than the original code. I'm not sure where the proper place to reset EP0 from stall is, or maybe this is the correct patch for that. I'll have to study the USB spec more, and if the hardware will automatically NAK control in/out after receiving a SETUP (even though the EP was set to stall).

This patch also adds a check to only pass setup packets to the stack if they are exactly 8 bytes long.

The hardware manual suggests setting the opposite direction of the transfer to stall during all but the last packet. It's not immediately clear what to do to the code, so I'm submitting this as an interim patch to improve the driver while thinking about the correct fix (perhaps in days, perhaps in weeks).

If desired, I can create an issue in the tracker to remind us to improve the driver to use EP_KIND and better stall/unstall.