### PR TITLE
Add Spresense board

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "hw/mcu/st/st_driver"]
 	path = hw/mcu/st/st_driver
 	url = https://github.com/hathach/st_driver.git
+[submodule "hw/mcu/sony/cxd56/spresense-exported-sdk"]
+	path = hw/mcu/sony/cxd56/spresense-exported-sdk
+	url = https://github.com/sonydevworld/spresense-exported-sdk.git

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -80,5 +80,9 @@ CFLAGS += \
 ifeq ($(DEBUG), 1)
   CFLAGS += -O0 -ggdb -DCFG_TUSB_DEBUG=1
 else
+ifneq ($(BOARD), spresense)
   CFLAGS += -flto -Os
+else
+  CFLAGS += -Os
+endif
 endif

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -3,7 +3,11 @@
 #
 
 # libc
-LIBS += -lgcc -lc -lm -lnosys
+LIBS += -lgcc -lm -lnosys
+
+ifneq ($(BOARD), spresense)
+LIBS += -lc
+endif
 
 # TinyUSB Stack source
 SRC_C += \

--- a/hw/bsp/spresense/board.mk
+++ b/hw/bsp/spresense/board.mk
@@ -1,0 +1,47 @@
+SPRESENSE_SDK = $(TOP)/hw/mcu/sony/cxd56/spresense-exported-sdk
+
+INC += \
+	$(SPRESENSE_SDK)/nuttx/include \
+	$(SPRESENSE_SDK)/nuttx/arch \
+	$(SPRESENSE_SDK)/nuttx/arch/chip \
+	$(SPRESENSE_SDK)/sdk/bsp/include \
+	$(SPRESENSE_SDK)/sdk/bsp/include/sdk \
+
+CFLAGS += \
+	-DCONFIG_WCHAR_BUILTIN \
+	-DCONFIG_HAVE_DOUBLE \
+	-Dmain=spresense_main \
+	-pipe \
+	-std=gnu11 \
+	-mcpu=cortex-m4 \
+	-mthumb \
+	-mfpu=fpv4-sp-d16 \
+	-mfloat-abi=hard \
+	-mabi=aapcs \
+	-fno-builtin \
+	-fno-strength-reduce \
+	-fomit-frame-pointer \
+	-DCFG_TUSB_MCU=OPT_MCU_CXD56 \
+
+LIBS += \
+	$(SPRESENSE_SDK)/sdk/libs/libapps.a \
+	$(SPRESENSE_SDK)/sdk/libs/libsdk.a \
+
+LD_FILE = hw/mcu/sony/cxd56/spresense-exported-sdk/nuttx/build/ramconfig.ld
+
+LDFLAGS += \
+	-Xlinker --entry=__start \
+	-nostartfiles \
+	-nodefaultlibs \
+	-Wl,--defsym,__stack=_vectors+786432 \
+	-Wl,--gc-sections \
+	-u spresense_main \
+
+# For TinyUSB port source
+VENDOR = sony
+CHIP_FAMILY = cxd56
+
+# flash
+flash: 
+	$(SPRESENSE_SDK)/sdk/tools/linux/mkspk -c 2 $(BUILD)/spresense-firmware.elf nuttx $(BUILD)/spresense-firmware.spk
+	$(SPRESENSE_SDK)/sdk/tools/flash.sh -c /dev/ttyUSB0 $(BUILD)/spresense-firmware.spk

--- a/hw/bsp/spresense/board_spresense.c
+++ b/hw/bsp/spresense/board_spresense.c
@@ -1,0 +1,105 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright 2019 Sony Semiconductor Solutions Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include <sys/boardctl.h>
+#include <nuttx/arch.h>
+#include <arch/board/board.h>
+#include <arch/chip/pin.h>
+
+#include "bsp/board.h"
+
+/*------------------------------------------------------------------*/
+/* MACRO TYPEDEF CONSTANT ENUM
+ *------------------------------------------------------------------*/
+#define LED_PIN         PIN_I2S1_BCK
+
+#define BUTTON_PIN      PIN_HIF_IRQ_OUT
+
+// Initialize on-board peripherals : led, button, uart and USB
+void board_init(void)
+{
+  boardctl(BOARDIOC_INIT, 0);
+
+  board_gpio_write(PIN_I2S1_BCK, -1);
+  board_gpio_config(PIN_I2S1_BCK, 0, false, true, PIN_FLOAT);
+
+  board_gpio_write(PIN_HIF_IRQ_OUT, -1);
+  board_gpio_config(PIN_HIF_IRQ_OUT, 0, true, true, PIN_FLOAT);
+};
+
+//--------------------------------------------------------------------+
+// Board porting API
+//--------------------------------------------------------------------+
+
+// Turn LED on or off
+void board_led_write(bool state)
+{
+  board_gpio_write(LED_PIN, state);
+}
+
+// Get the current state of button
+// a '1' means active (pressed), a '0' means inactive.
+uint32_t board_button_read(void)
+{
+  if (board_gpio_read(BUTTON_PIN)) 
+  {
+    return 0;
+  }
+
+  return 1;
+}
+
+// Get characters from UART
+int board_uart_read(uint8_t *buf, int len)
+{
+  int r = read(0, buf, len);
+
+  return r;
+}
+
+// Send characters to UART
+int board_uart_write(void const *buf, int len)
+{
+  int r = write(1, buf, len);
+
+  return r;
+}
+
+// Get current milliseconds
+uint32_t board_millis(void)
+{
+  struct timespec tp;
+
+    /* Wait until RTC is available */
+    while (g_rtc_enabled == false);
+
+    if (clock_gettime(CLOCK_MONOTONIC, &tp)) 
+    {
+        return 0;
+    }
+
+    return (((uint64_t)tp.tv_sec) * 1000 + tp.tv_nsec / 1000000);
+}

--- a/src/portable/sony/cxd56/dcd_cxd56.c
+++ b/src/portable/sony/cxd56/dcd_cxd56.c
@@ -141,12 +141,16 @@ static void dcd_suspend(FAR struct usbdevclass_driver_s *driver, FAR struct usbd
 {
   (void) driver;
   (void) dev;
+
+  dcd_event_bus_signal(0, DCD_EVENT_SUSPEND, true);
 }
 
 static void dcd_resume(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev)
 {
   (void) driver;
   (void) dev;
+
+  dcd_event_bus_signal(0, DCD_EVENT_RESUME, true);
 }
 
 void dcd_init(uint8_t rhport)

--- a/src/portable/sony/cxd56/dcd_cxd56.c
+++ b/src/portable/sony/cxd56/dcd_cxd56.c
@@ -1,0 +1,321 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright 2019 Sony Semiconductor Solutions Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "tusb_option.h"
+
+#if TUSB_OPT_DEVICE_ENABLED && CFG_TUSB_MCU == OPT_MCU_CXD56
+
+#include <errno.h>
+#include <nuttx/usb/usbdev.h>
+
+#include "device/dcd.h"
+
+#define CXD56_EPNUM (7)
+
+struct usbdcd_driver_s
+{
+  struct usbdevclass_driver_s usbdevclass_driver;
+  FAR struct usbdev_ep_s *ep[CXD56_EPNUM];
+  FAR struct usbdev_req_s *req[CXD56_EPNUM];
+};
+
+static struct usbdcd_driver_s usbdcd_driver;
+static struct usbdev_s *usbdev;
+
+static int dcd_bind(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev);
+static void dcd_unbind(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev);
+static int dcd_setup(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev,
+                     FAR const struct usb_ctrlreq_s *ctrl, FAR uint8_t *dataout, size_t outlen);
+static void dcd_disconnect(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev);
+static void dcd_suspend(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev);
+static void dcd_resume(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev);
+
+static const struct usbdevclass_driverops_s g_driverops =
+{
+  dcd_bind,       /* bind */
+  dcd_unbind,     /* unbind */
+  dcd_setup,      /* setup */
+  dcd_disconnect, /* disconnect */
+  dcd_suspend,    /* suspend */
+  dcd_resume,     /* resume */
+};
+
+static void usbdcd_ep0incomplete(FAR struct usbdev_ep_s *ep, FAR struct usbdev_req_s *req)
+{
+  (void) ep;
+
+  uint8_t ep_addr = (uint32_t)req->priv;
+
+  if (req->result || req->xfrd != req->len)
+  {
+    if (req->len)
+    {
+      dcd_event_xfer_complete(0, ep_addr, req->xfrd, XFER_RESULT_SUCCESS, true);
+    }
+  }
+  else
+  {
+    if (req->xfrd)
+    {
+      dcd_event_xfer_complete(0, ep_addr, req->xfrd, XFER_RESULT_SUCCESS, true);
+    }
+  }
+}
+
+static int dcd_bind(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev)
+{
+  (void) driver;
+
+  usbdev = dev;
+  usbdcd_driver.ep[0] = dev->ep0;
+
+  usbdcd_driver.req[0] = EP_ALLOCREQ(usbdcd_driver.ep[0]);
+  if (usbdcd_driver.req[0] != NULL)
+  {
+    usbdcd_driver.req[0]->len = 64;
+    usbdcd_driver.req[0]->buf = EP_ALLOCBUFFER(usbdcd_driver.ep[0], 64);
+    if (!usbdcd_driver.req[0]->buf)
+    {
+      EP_FREEREQ(usbdcd_driver.ep[0], usbdcd_driver.req[0]);
+      usbdcd_driver.req[0] = NULL;
+    }
+  }
+
+  usbdcd_driver.req[0]->callback = usbdcd_ep0incomplete;
+
+  DEV_CONNECT(dev);
+  return 0;
+}
+
+static void dcd_unbind(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev)
+{
+  (void) driver;
+  (void) dev;
+}
+
+static int dcd_setup(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev,
+                     FAR const struct usb_ctrlreq_s *ctrl, FAR uint8_t *dataout, size_t outlen)
+{
+  (void) driver;
+  (void) dev;
+  (void) dataout;
+  (void) outlen;
+
+  dcd_event_setup_received(0, (uint8_t *)ctrl, true);
+
+  return 0;
+}
+
+static void dcd_disconnect(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev)
+{
+  (void) driver;
+
+  dcd_event_bus_signal(0, DCD_EVENT_BUS_RESET, true);
+  DEV_CONNECT(dev);
+}
+
+static void dcd_suspend(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev)
+{
+  (void) driver;
+  (void) dev;
+}
+
+static void dcd_resume(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_s *dev)
+{
+  (void) driver;
+  (void) dev;
+}
+
+void dcd_init(uint8_t rhport)
+{
+  (void) rhport;
+
+  usbdcd_driver.usbdevclass_driver.speed = USB_SPEED_HIGH;
+  usbdcd_driver.usbdevclass_driver.ops = &g_driverops;
+
+  usbdev_register(&usbdcd_driver.usbdevclass_driver);
+}
+
+// Enable device interrupt
+void dcd_int_enable(uint8_t rhport)
+{
+  (void) rhport;
+}
+
+// Disable device interrupt
+void dcd_int_disable(uint8_t rhport)
+{
+  (void) rhport;
+}
+
+// Receive Set Address request, mcu port must also include status IN response
+void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
+{
+  (void) rhport;
+  (void) dev_addr;
+}
+
+// Receive Set Config request
+void dcd_set_config(uint8_t rhport, uint8_t config_num)
+{
+  (void) rhport;
+  (void) config_num;
+}
+
+void dcd_remote_wakeup(uint8_t rhport)
+{
+  (void) rhport;
+  
+  DEV_WAKEUP(usbdev);
+}
+
+//--------------------------------------------------------------------+
+// Endpoint API
+//--------------------------------------------------------------------+
+
+bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const *p_endpoint_desc)
+{
+  (void) rhport;
+
+  uint8_t epnum = tu_edpt_number(p_endpoint_desc->bEndpointAddress);
+  uint8_t const dir = tu_edpt_dir(p_endpoint_desc->bEndpointAddress);
+  uint8_t xfrtype = 0;
+  struct usb_epdesc_s epdesc;
+
+  if (epnum >= CXD56_EPNUM)
+  {
+    return false;
+  }
+
+  switch (p_endpoint_desc->bmAttributes.xfer)
+  {
+  case 1:
+    xfrtype = USB_EP_ATTR_XFER_ISOC;
+    break;
+  case 2:
+    xfrtype = USB_EP_ATTR_XFER_BULK;
+    break;
+  case 3:
+    xfrtype = USB_EP_ATTR_XFER_INT;
+    break;
+  }
+
+  usbdcd_driver.ep[epnum] = DEV_ALLOCEP(usbdev, epnum, dir == TUSB_DIR_IN, xfrtype);
+  if (usbdcd_driver.ep[epnum] == NULL)
+  {
+    return false;
+  }
+
+  usbdcd_driver.req[epnum] = NULL;
+  usbdcd_driver.req[epnum] = EP_ALLOCREQ(usbdcd_driver.ep[epnum]);
+  if (usbdcd_driver.req[epnum] != NULL)
+  {
+    usbdcd_driver.req[epnum]->len = p_endpoint_desc->wMaxPacketSize.size;
+  }
+  else
+  {
+    return false;
+  }
+
+  usbdcd_driver.req[epnum]->callback = usbdcd_ep0incomplete;
+
+  epdesc.len = p_endpoint_desc->bLength;
+  epdesc.type = p_endpoint_desc->bDescriptorType;
+  epdesc.addr = p_endpoint_desc->bEndpointAddress;
+  epdesc.attr = xfrtype;
+  epdesc.mxpacketsize[0] = LSBYTE(p_endpoint_desc->wMaxPacketSize.size);
+  epdesc.mxpacketsize[1] = MSBYTE(p_endpoint_desc->wMaxPacketSize.size);
+  epdesc.interval = p_endpoint_desc->bInterval;
+
+  if (EP_CONFIGURE(usbdcd_driver.ep[epnum], &epdesc, false) < 0)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t total_bytes)
+{
+  (void) rhport;
+
+  uint8_t epnum = tu_edpt_number(ep_addr);
+
+  if (epnum >= CXD56_EPNUM)
+  {
+    return false;
+  }
+
+  usbdcd_driver.req[epnum]->len = total_bytes;
+  usbdcd_driver.req[epnum]->priv = (void *)((uint32_t)ep_addr);
+  usbdcd_driver.req[epnum]->flags = 0;
+
+  if (total_bytes)
+  {
+    usbdcd_driver.req[epnum]->buf = buffer;
+  }
+  else
+  {
+    return true;
+  }
+
+  if (EP_SUBMIT(usbdcd_driver.ep[epnum], usbdcd_driver.req[epnum]) < 0)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr)
+{
+  (void) rhport;
+
+  uint8_t epnum = tu_edpt_number(ep_addr);
+
+  if (epnum >= CXD56_EPNUM)
+  {
+    return;
+  }
+
+  EP_STALL(usbdcd_driver.ep[epnum]);
+}
+
+void dcd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr)
+{
+  (void) rhport;
+  
+  uint8_t epnum = tu_edpt_number(ep_addr);
+
+  if (epnum >= CXD56_EPNUM)
+  {
+    return;
+  }
+
+  EP_RESUME(usbdcd_driver.ep[epnum]);
+}
+
+#endif

--- a/src/portable/sony/cxd56/dcd_cxd56.c
+++ b/src/portable/sony/cxd56/dcd_cxd56.c
@@ -30,6 +30,7 @@
 
 #include <errno.h>
 #include <nuttx/usb/usbdev.h>
+#include <nuttx/arch.h>
 
 #include "device/dcd.h"
 
@@ -168,7 +169,7 @@ void dcd_int_enable(uint8_t rhport)
 {
   (void) rhport;
 
-  __asm volatile ("cpsie i" : : : "memory");
+  up_enable_irq(CXD56_IRQ_USB_INT);
 }
 
 // Disable device interrupt
@@ -176,7 +177,7 @@ void dcd_int_disable(uint8_t rhport)
 {
   (void) rhport;
 
-  __asm volatile ("cpsid i" : : : "memory");
+  up_disable_irq(CXD56_IRQ_USB_INT);
 }
 
 // Receive Set Address request, mcu port must also include status IN response

--- a/src/portable/sony/cxd56/dcd_cxd56.c
+++ b/src/portable/sony/cxd56/dcd_cxd56.c
@@ -163,12 +163,16 @@ void dcd_init(uint8_t rhport)
 void dcd_int_enable(uint8_t rhport)
 {
   (void) rhport;
+
+  __asm volatile ("cpsie i" : : : "memory");
 }
 
 // Disable device interrupt
 void dcd_int_disable(uint8_t rhport)
 {
   (void) rhport;
+
+  __asm volatile ("cpsid i" : : : "memory");
 }
 
 // Receive Set Address request, mcu port must also include status IN response

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -67,6 +67,8 @@
 #define OPT_MCU_STM32L1       308 ///< ST STM32L1
 #define OPT_MCU_STM32L4       309 ///< ST STM32L4
 
+#define OPT_MCU_CXD56         400 ///< SONY CXD56
+
 /** @} */
 
 /** \defgroup group_supported_os Supported RTOS


### PR DESCRIPTION
I am currently porting CircuitPython to a Spresense board, which requires tinyUSB porting.

Refer to [developer.sony.com/develop/spresense/](https://developer.sony.com/develop/spresense/) for information about this board.