### PR TITLE
eptri: clear proper endpoint when opening IN port

### DIFF
--- a/src/portable/valentyusb/eptri/dcd_eptri.c
+++ b/src/portable/valentyusb/eptri/dcd_eptri.c
@@ -415,7 +415,7 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc)
     rx_buffer[ep_num] = NULL;
   }
 
-  else if (ep_dir == TUSB_DIR_OUT) {
+  else if (ep_dir == TUSB_DIR_IN) {
     tx_buffer_offset[ep_num] = 0;
     tx_buffer_max[ep_num] = 0;
     tx_buffer[ep_num] = NULL;


### PR DESCRIPTION
When opening a USB port, we ensure the buffer is NULL and has
a length of 0.

Due to a mistake in specifying the endpoint type, we never actually
cleared the value when opening an IN endpoint.  This patch fixes
the comparison when opening an IN endpoint.

This fixes issue #218.

Signed-off-by: Sean Cross <sean@xobs.io>