### PR TITLE
bsp: fomu: fix rom address for example programs

### DIFF
--- a/hw/bsp/fomu/fomu.ld
+++ b/hw/bsp/fomu/fomu.ld
@@ -7,7 +7,7 @@ MEMORY {
 	csr : ORIGIN = 0x60000000, LENGTH = 0x01000000
 	vexriscv_debug : ORIGIN = 0xf00f0000, LENGTH = 0x00000100
 	ram : ORIGIN = 0x10000000, LENGTH = 0x00020000
-	rom : ORIGIN = 0x2001a000, LENGTH = 0x00200000 - 0x1a000
+	rom : ORIGIN = 0x20040000, LENGTH = 0x00200000 - 0x40000
 }
 
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */


### PR DESCRIPTION
When developing tinyusb and the usb HDL code, I appended the program directly to the bitstream.  The bitstream is 0x1a000 bytes long, so that's where the `example` offset is.

Now that Foboot-2 is almost ready to be released (!), I've discovered that this address doesn't match what customers see.  When you load a program using Foboot, it goes to offset 0x40000 from the flash (offset 0x20040000 in RAM).

With this patch, you can now run the tinyusb examples on a Fomu running Foboot 2!  My next goal is to actually come up with a release of Foboot 2 so that users can actually run it on their boards.