### PR TITLE
fix missing source file for cdc_msc to compile

### DIFF
--- a/examples/device/cdc_msc/ses/nrf5x/nrf5x.emProject
+++ b/examples/device/cdc_msc/ses/nrf5x/nrf5x.emProject
@@ -60,6 +60,7 @@
               <folder Name="src">
                 <file file_name="../../../../../hw/mcu/nordic/nrfx/drivers/src/nrfx_power.c" />
                 <file file_name="../../../../../hw/mcu/nordic/nrfx/drivers/src/nrfx_qspi.c" />
+                <file file_name="../../../../../hw/mcu/nordic/nrfx/drivers/src/nrfx_uarte.c" />
               </folder>
             </folder>
             <folder Name="hal">


### PR DESCRIPTION
Segger Embedded Studio project file is missing the uart driver in order for the cdc_msc example to compile.