### PR TITLE
valentyusb: eptri: don't double-advance read buffer

### DIFF
--- a/src/portable/valentyusb/eptri/dcd_eptri.c
+++ b/src/portable/valentyusb/eptri/dcd_eptri.c
@@ -226,7 +226,7 @@ static void process_rx(void) {
     test_buffer[total_read] = c;
 #endif
     total_read++;
-    if ((rx_buffer_offset[rx_ep] + current_offset) < rx_buffer_max[rx_ep]) {
+    if (current_offset < rx_buffer_max[rx_ep]) {
 #if LOG_USB
       usb_log[usb_log_offset].data[usb_log[usb_log_offset].size++] = c;
 #endif


### PR DESCRIPTION
Ran into this one debugging disk access on circuitpython.  I couldn't figure out why the bottom half of my writes were getting ignored.  Turns out the buffer was getting advanced in a way such that only the first half would ever get filled.