### PR TITLE
Fix mynewt osal queue definition

### DIFF
--- a/src/osal/osal_mynewt.h
+++ b/src/osal/osal_mynewt.h
@@ -98,7 +98,7 @@ static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
 // role device/host is used by OS NONE for mutex (disable usb isr) only
 #define OSAL_QUEUE_DEF(_role, _name, _depth, _type) \
   static _type _name##_##buf[_depth];\
-  static struct os_event* _name##_##evbuf[_depth];\
+  static struct os_event _name##_##evbuf[_depth];\
   osal_queue_def_t _name = { .depth = _depth, .item_sz = sizeof(_type), .buf = _name##_##buf, .evbuf =  _name##_##evbuf};\
 
 typedef struct


### PR DESCRIPTION
Queue table has pointers instead of data os_event structs.
This resulted in crashes when elements were put to queue and
overwritten variables that were just after mpool desiged
for queue.