### PR TITLE
move VBUS sense out of dcd_synosys to bsp

### DIFF
--- a/hw/bsp/feather_stm32f405/feather_stm32f405.c
+++ b/hw/bsp/feather_stm32f405/feather_stm32f405.c
@@ -152,9 +152,6 @@ void board_init(void)
   GPIO_InitStruct.Alternate = UART_GPIO_AF;
   HAL_GPIO_Init(UART_GPIO_PORT, &GPIO_InitStruct);
 
-  // Enable USB OTG clock
-  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
-
   // USB Pin Init
   // PA9- VUSB, PA10- ID, PA11- DM, PA12- DP
 
@@ -179,6 +176,13 @@ void board_init(void)
   GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
   GPIO_InitStruct.Alternate = GPIO_AF10_OTG_FS;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  // Enable USB OTG clock
+  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/pyboardv11/pyboardv11.c
+++ b/hw/bsp/pyboardv11/pyboardv11.c
@@ -38,6 +38,14 @@
 #define BUTTON_PIN            GPIO_PIN_3
 #define BUTTON_STATE_ACTIVE   1
 
+
+// enable all LED, Button, Uart, USB clock
+static void all_rcc_clk_enable(void)
+{
+  __HAL_RCC_GPIOA_CLK_ENABLE();  // USB D+, D-
+  __HAL_RCC_GPIOB_CLK_ENABLE();  // LED, Button
+}
+
 /**
   * @brief  System Clock Configuration
   *         The system Clock is configured as follow :
@@ -107,14 +115,11 @@ void board_init(void)
   // Notify runtime of frequency change.
   SystemCoreClockUpdate();
 
-  __HAL_RCC_GPIOA_CLK_ENABLE(); // USB D+/D-
-  __HAL_RCC_GPIOB_CLK_ENABLE(); // button, LED
+  all_rcc_clk_enable();
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 
   // LED
-  __HAL_RCC_GPIOD_CLK_ENABLE();
-
   GPIO_InitStruct.Pin = LED_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_PULLUP;
@@ -130,12 +135,8 @@ void board_init(void)
   GPIO_InitStruct.Speed = GPIO_SPEED_FAST;
   HAL_GPIO_Init(BUTTON_PORT, &GPIO_InitStruct);
 
-  // Enable USB OTG clock
-  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
-
   // USB Pin Init
   // PA9- VUSB, PA10- ID, PA11- DM, PA12- DP
-  __HAL_RCC_GPIOA_CLK_ENABLE();
 
   /* Configure DM DP Pins */
   GPIO_InitStruct.Pin = GPIO_PIN_11 | GPIO_PIN_12;
@@ -158,6 +159,13 @@ void board_init(void)
   GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
   GPIO_InitStruct.Alternate = GPIO_AF10_OTG_FS;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  // Enable USB OTG clock
+  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/stm32f207nucleo/stm32f207nucleo.c
+++ b/hw/bsp/stm32f207nucleo/stm32f207nucleo.c
@@ -38,6 +38,14 @@
 #define BUTTON_STATE_ACTIVE   1
 
 
+// enable all LED, Button, Uart, USB clock
+static void all_rcc_clk_enable(void)
+{
+  __HAL_RCC_GPIOA_CLK_ENABLE();  // USB D+, D-
+  __HAL_RCC_GPIOB_CLK_ENABLE();  // LED
+  __HAL_RCC_GPIOC_CLK_ENABLE();  // Button
+}
+
 /**
   * @brief  System Clock Configuration
   *         The system Clock is configured as follow :
@@ -91,21 +99,22 @@ void board_init(void)
   #endif
 
   SystemClock_Config();
-
-  // Notify runtime of frequency change.
   SystemCoreClockUpdate();
 
-  // LED
-  __HAL_RCC_GPIOB_CLK_ENABLE();
+  all_rcc_clk_enable();
+
   GPIO_InitTypeDef  GPIO_InitStruct;
+
+  // LED
   GPIO_InitStruct.Pin = LED_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_PULLUP;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
   HAL_GPIO_Init(LED_PORT, &GPIO_InitStruct);
 
+  board_led_write(false);
+
   // Button
-  __HAL_RCC_GPIOC_CLK_ENABLE();
   GPIO_InitStruct.Pin = BUTTON_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_PULLDOWN;
@@ -113,7 +122,6 @@ void board_init(void)
   HAL_GPIO_Init(BUTTON_PORT, &GPIO_InitStruct);
 
   /* Configure DM DP Pins */
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = (GPIO_PIN_11 | GPIO_PIN_12);
   GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
@@ -136,6 +144,10 @@ void board_init(void)
 
   /* Enable USB FS Clocks */
   __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/stm32f407disco/stm32f407disco.c
+++ b/hw/bsp/stm32f407disco/stm32f407disco.c
@@ -37,6 +37,14 @@
 #define BUTTON_PIN            GPIO_PIN_0
 #define BUTTON_STATE_ACTIVE   1
 
+
+// enable all LED, Button, Uart, USB clock
+static void all_rcc_clk_enable(void)
+{
+  __HAL_RCC_GPIOA_CLK_ENABLE();  // USB D+, D-, Button
+  __HAL_RCC_GPIOD_CLK_ENABLE();  // LED
+}
+
 /**
   * @brief  System Clock Configuration
   *         The system Clock is configured as follow :
@@ -102,14 +110,12 @@ void board_init(void)
 #endif
 
   SystemClock_Config();
-
-  // Notify runtime of frequency change.
   SystemCoreClockUpdate();
+  all_rcc_clk_enable();
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 
   // LED
-  __HAL_RCC_GPIOD_CLK_ENABLE();
   GPIO_InitStruct.Pin = LED_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_PULLUP;
@@ -119,7 +125,6 @@ void board_init(void)
   board_led_write(false);
 
   // Button
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = BUTTON_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_PULLDOWN;
@@ -129,7 +134,6 @@ void board_init(void)
   // USB Pin Init
   // PA9- VUSB, PA10- ID, PA11- DM, PA12- DP
   /* Configure DM DP Pins */
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = GPIO_PIN_11 | GPIO_PIN_12;
   GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
   GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -153,6 +157,10 @@ void board_init(void)
 
   // Enable USB OTG clock
   __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/stm32f411disco/stm32f411disco.c
+++ b/hw/bsp/stm32f411disco/stm32f411disco.c
@@ -37,6 +37,13 @@
 #define BUTTON_PIN            GPIO_PIN_0
 #define BUTTON_STATE_ACTIVE   1
 
+// enable all LED, Button, Uart, USB clock
+static void all_rcc_clk_enable(void)
+{
+  __HAL_RCC_GPIOA_CLK_ENABLE();  // USB D+, D-, Button
+  __HAL_RCC_GPIOD_CLK_ENABLE();  // LED
+}
+
 /**
   * @brief  System Clock Configuration
   *         The system Clock is configured as follow :
@@ -102,14 +109,12 @@ void board_init(void)
 #endif
 
   SystemClock_Config();
-
-  // Notify runtime of frequency change.
   SystemCoreClockUpdate();
+  all_rcc_clk_enable();
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 
   // LED
-  __HAL_RCC_GPIOD_CLK_ENABLE();
   GPIO_InitStruct.Pin = LED_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_PULLUP;
@@ -119,19 +124,14 @@ void board_init(void)
   board_led_write(false);
 
   // Button
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = BUTTON_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_PULLDOWN;
   GPIO_InitStruct.Speed = GPIO_SPEED_FAST;
   HAL_GPIO_Init(BUTTON_PORT, &GPIO_InitStruct);
 
-  // Enable USB OTG clock
-  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
-
   /* Configure USB FS GPIOs */
   /* Configure USB D+ D- Pins */
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = GPIO_PIN_11 | GPIO_PIN_12;
   GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
   GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -152,6 +152,13 @@ void board_init(void)
   GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
   GPIO_InitStruct.Alternate = GPIO_AF10_OTG_FS;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  // Enable USB OTG clock
+  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/stm32f412disco/stm32f412disco.c
+++ b/hw/bsp/stm32f412disco/stm32f412disco.c
@@ -38,6 +38,14 @@
 #define BUTTON_PIN            GPIO_PIN_0
 #define BUTTON_STATE_ACTIVE   1
 
+
+// enable all LED, Button, Uart, USB clock
+static void all_rcc_clk_enable(void)
+{
+  __HAL_RCC_GPIOA_CLK_ENABLE();  // USB D+, D-, Button
+  __HAL_RCC_GPIOE_CLK_ENABLE();  // LED
+}
+
 /**
   * @brief  System Clock Configuration
   *         The system Clock is configured as follow :
@@ -114,9 +122,8 @@ static void SystemClock_Config(void)
 void board_init(void)
 {
   SystemClock_Config();
-
-  // Notify runtime of frequency change.
   SystemCoreClockUpdate();
+  all_rcc_clk_enable();
 
 #if CFG_TUSB_OS == OPT_OS_NONE
   // 1ms tick timer
@@ -129,7 +136,6 @@ void board_init(void)
   GPIO_InitTypeDef  GPIO_InitStruct;
 
   // LED
-  __HAL_RCC_GPIOE_CLK_ENABLE();
   GPIO_InitStruct.Pin = LED_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_PULLUP;
@@ -139,7 +145,6 @@ void board_init(void)
   board_led_write(false);
 
   // Button
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = BUTTON_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_PULLDOWN;
@@ -148,7 +153,6 @@ void board_init(void)
 
   /* Configure USB FS GPIOs */
   /* Configure USB D+ D- Pins */
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = GPIO_PIN_11 | GPIO_PIN_12;
   GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
   GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
@@ -179,6 +183,9 @@ void board_init(void)
 
   // Enable USB OTG clock
   __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/stm32f767nucleo/stm32f767nucleo.c
+++ b/hw/bsp/stm32f767nucleo/stm32f767nucleo.c
@@ -189,6 +189,9 @@ void board_init(void)
 
   /* Enable USB FS Clocks */
   __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/stm32h743nucleo/stm32h743nucleo.c
+++ b/hw/bsp/stm32h743nucleo/stm32h743nucleo.c
@@ -30,10 +30,23 @@
 #include "stm32h7xx.h"
 #include "stm32h7xx_hal_conf.h"
 
-#define LED_PORT  GPIOB
-#define LED_PIN   GPIO_PIN_0
-#define BUTTON_PORT GPIOC
-#define BUTTON_PIN  GPIO_PIN_13
+#define LED_PORT              GPIOB
+#define LED_PIN               GPIO_PIN_0
+#define LED_STATE_ON          1
+
+#define BUTTON_PORT           GPIOC
+#define BUTTON_PIN            GPIO_PIN_13
+#define BUTTON_STATE_ACTIVE   1
+
+// enable all LED, Button, Uart, USB clock
+static void all_rcc_clk_enable(void)
+{
+  __HAL_RCC_GPIOA_CLK_ENABLE();  // USB D+, D-
+  __HAL_RCC_GPIOB_CLK_ENABLE();  // LED
+  __HAL_RCC_GPIOC_CLK_ENABLE();  // Button
+//  __HAL_RCC_GPIOD_CLK_ENABLE();  // Uart tx, rx
+//  __HAL_RCC_USART3_CLK_ENABLE(); // Uart module
+}
 
 /* PWR, RCC, GPIO (All): AHB4 (D3 domain)
    USB{1,2} OTG_{H,F}S: AHB1 (D2 domain)
@@ -127,14 +140,27 @@ void board_init(void)
   #endif
 
   SystemClock_Config();
-
   SystemCoreClockUpdate();
+  all_rcc_clk_enable();
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 
+  // LED
+  GPIO_InitStruct.Pin = LED_PIN;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+  HAL_GPIO_Init(LED_PORT, &GPIO_InitStruct);
+
+  // Button
+  GPIO_InitStruct.Pin = BUTTON_PIN;
+  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+  HAL_GPIO_Init(BUTTON_PORT, &GPIO_InitStruct);
+
   // USB Pin Init
   // PA9- VUSB, PA10- ID, PA11- DM, PA12- DP
-  __HAL_RCC_GPIOA_CLK_ENABLE();
 
   /* Configure DM DP Pins */
   GPIO_InitStruct.Pin = GPIO_PIN_11 | GPIO_PIN_12;
@@ -158,27 +184,13 @@ void board_init(void)
   GPIO_InitStruct.Alternate = GPIO_AF10_OTG2_HS;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-  // LED
-  __HAL_RCC_GPIOB_CLK_ENABLE();
-
-  GPIO_InitStruct.Pin = LED_PIN;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_PULLUP;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-  HAL_GPIO_Init(LED_PORT, &GPIO_InitStruct);
-
-  // Button
-  __HAL_RCC_GPIOC_CLK_ENABLE();
-  GPIO_InitStruct.Pin = BUTTON_PIN;
-  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-  HAL_GPIO_Init(BUTTON_PORT, &GPIO_InitStruct);
-
   // https://community.st.com/s/question/0D50X00009XkYZLSA3/stm32h7-nucleo-usb-fs-cdc
   // TODO: Board init actually works fine without this line.
   HAL_PWREx_EnableUSBVoltageDetector();
   __HAL_RCC_USB2_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/stm32l476disco/stm32l476disco.c
+++ b/hw/bsp/stm32l476disco/stm32l476disco.c
@@ -38,6 +38,16 @@
 #define BUTTON_PIN            GPIO_PIN_0
 #define BUTTON_STATE_ACTIVE   1
 
+
+// enable all LED, Button, Uart, USB clock
+static void all_rcc_clk_enable(void)
+{
+  __HAL_RCC_GPIOA_CLK_ENABLE(); // USB D+, D-, Button
+  __HAL_RCC_GPIOB_CLK_ENABLE(); // LED
+  __HAL_RCC_GPIOC_CLK_ENABLE(); // VBUS pin
+}
+
+
 /**
   * @brief  System Clock Configuration
   *         The system Clock is configured as follow :
@@ -117,6 +127,8 @@ void board_init(void)
 #endif
 
   SystemClock_Config();
+  SystemCoreClockUpdate();
+  all_rcc_clk_enable();
 
   /* Enable Power Clock*/
   __HAL_RCC_PWR_CLK_ENABLE();
@@ -124,13 +136,9 @@ void board_init(void)
   /* Enable USB power on Pwrctrl CR2 register */
   HAL_PWREx_EnableVddUSB();
 
-  // Notify runtime of frequency change.
-  SystemCoreClockUpdate();
-
   GPIO_InitTypeDef  GPIO_InitStruct;
 
   // LED
-  __HAL_RCC_GPIOB_CLK_ENABLE();
   GPIO_InitStruct.Pin = LED_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_PULLUP;
@@ -140,7 +148,6 @@ void board_init(void)
   board_led_write(false);
 
   // Button
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = BUTTON_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_PULLDOWN;
@@ -149,7 +156,6 @@ void board_init(void)
 
   // USB
   /* Configure DM DP Pins */
-  __HAL_RCC_GPIOA_CLK_ENABLE();
   GPIO_InitStruct.Pin = (GPIO_PIN_11 | GPIO_PIN_12);
   GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
@@ -158,7 +164,6 @@ void board_init(void)
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
   /* Configure VBUS Pin */
-  __HAL_RCC_GPIOC_CLK_ENABLE();
   GPIO_InitStruct.Pin = GPIO_PIN_11;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
@@ -166,6 +171,9 @@ void board_init(void)
 
   /* Enable USB FS Clock */
   __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+  // Enable VBUS sense (B device) via pin PA9
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
 
 //--------------------------------------------------------------------+

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -207,12 +207,8 @@ void dcd_init (uint8_t rhport)
     USB_OTG_GINTMSK_SOFM | USB_OTG_GINTMSK_RXFLVLM /* SB_OTG_GINTMSK_ESUSPM | \
     USB_OTG_GINTMSK_USBSUSPM */;
 
-  // Enable VBUS hardware sensing, enable pullup, enable peripheral.
-#ifdef USB_OTG_GCCFG_VBDEN
-  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN | USB_OTG_GCCFG_PWRDWN;
-#else
-  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN | USB_OTG_GCCFG_PWRDWN;
-#endif
+  // Enable USB transceiver.
+  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_PWRDWN;
 
   // Soft Connect -> Enable pullup on D+/D-.
   // This step does not appear to be specified in the programmer's model.


### PR DESCRIPTION
Hardware VBUS sensing with PA9 is optional in case application want to force either Host or Device most (no OTG). Since this is a valid use case,which is the case of low-cost stm32f411 **blackpill** https://github.com/adafruit/circuitpython/pull/2361 .  `dcd_synosys` should not enforce VBUS sensing and should leave this to board initialization. 

@cr1901 @tannewt  @hierophect for review

![image](https://user-images.githubusercontent.com/249515/70599375-981fb480-1c1f-11ea-9bb4-5252556e539e.png)

![image](https://user-images.githubusercontent.com/249515/70498661-aef3d780-1b49-11ea-8c18-a43e81e3c4c5.png)

- Also add VBUS sense enable for all current boards.