### PR TITLE
Update dcd_stm32_fsdev.c with note about F042Fx remapping

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -30,7 +30,7 @@
 
 /**********************************************
  * This driver has been tested with the following MCUs:
- *  - F070, F072, L053
+ *  - F070, F072, L053, F042F6
  *
  * It also should work with minimal changes for any ST MCU with an "USB A"/"PCD"/"HCD" peripheral. This
  *  covers:
@@ -44,6 +44,9 @@
  * L4x2, L4x3                     1024 byte buffer
  *
  * To use this driver, you must:
+ * - If you are using a device with crystal-less USB, set up the clock recovery system (CRS)
+ * - Remap pins to be D+/D- on devices that they are shared (for example: F042Fx)
+ *   - This is different to the normal "alternate function" GPIO interface, needs to go through SYSCFG->CFGRx register
  * - Enable USB clock; Perhaps use __HAL_RCC_USB_CLK_ENABLE();
  * - (Optionally configure GPIO HAL to tell it the USB driver is using the USB pins)
  * - call tusb_init();


### PR DESCRIPTION
On the STM32F042Fx, there is a special pin remapping step required. It is only used in the low pincount packages and uses a register which is not inside the GPIO group. This just adds a note in the comments about it so hopefully someone else does not waste as much time as I did on this ;)