### PR TITLE
gracefully handle multiple SET_CONFIGURATION requests

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -518,9 +518,11 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
           uint8_t const cfg_num = (uint8_t) p_request->wValue;
 
           dcd_set_config(rhport, cfg_num);
+
+          if ( !_usbd_dev.configured && cfg_num ) TU_ASSERT( process_set_config(rhport, cfg_num) );
+
           _usbd_dev.configured = cfg_num ? 1 : 0;
 
-          if ( cfg_num ) TU_ASSERT( process_set_config(rhport, cfg_num) );
           tud_control_status(rhport, p_request);
         }
         break;


### PR DESCRIPTION
Some Linux-based HID library implementations seem to cause multiple SET_CONFIGURATION requests to be generated.

Such an additional SET_CONFIGURATION causes tinyusb to choke in process_set_config() at the TU_ASSERT marked with the comment "Interface number must not be used already".  It seems dangerous to defeat this TU_ASSERT check, as the various class open calls are implemented on the assumption that they are only called once.

I saw two approaches to gracefully handle multiple SET_CONFIGURATION requests:

1) In usbd.c, store the current configuration number (8-bit) value, replacing the packed 1-bit "configured" field in "_usbd_dev".  When an additional SET_CONFIGURATION requests was received, the new configuration value could be compared against the existing one and the newly arrived one.

2) #1 requires allocating an extra byte of RAM, but tinyusb presently only supports one configuration.  So, any non-zero new configuration must be the same as the present one.  (This is the same logic already used in the GET_CONFIGURATION implementation.)  If additional SET_CONFIGURATION requests are received *and* the device is already configured, we can omit the process_set_config() call.
