### PR TITLE
fixed build issue with i.MXRT1010-EVK, corrected typo in examples/readme

### DIFF
--- a/examples/readme.md
+++ b/examples/readme.md
@@ -12,7 +12,7 @@ $ cd tinyusb
 TinyUSB examples includes external repos aka submodules to provide low-level MCU peripheral's driver to compile with. Therefore we will firstly fetch those mcu driver repo by running this command in the top folder repo
 
 ```
-$ git submodule update --init --rescursive
+$ git submodule update --init --recursive
 ```
 
 It will takes a bit of time due to the number of supported MCUs, luckily we only need to do this once.

--- a/hw/bsp/mimxrt1010_evk/board.mk
+++ b/hw/bsp/mimxrt1010_evk/board.mk
@@ -11,7 +11,8 @@ CFLAGS += \
   -DCFG_TUSB_MCU=OPT_MCU_MIMXRT10XX
 
 # mcu driver cause following warnings
-CFLAGS += -Wno-error=unused-parameter -Wno-error=implicit-fallthrough=
+# CFLAGS += -Wno-error=unused-parameter -Wno-error=implicit-fallthrough=
+CFLAGS += -Wno-error=unused-parameter
 
 MCU_DIR = hw/mcu/nxp/sdk/devices/MIMXRT1011
 


### PR DESCRIPTION
The build for the RT1010EVK was failing so I modified the make file to be more consistent with the RT1060 which did work for me.  I also cleaned up a typo in the examples readme file.