### PR TITLE
correct apparent Adafruit typo in SAMD21 board.mk

### DIFF
--- a/hw/bsp/feather_m0_express/board.mk
+++ b/hw/bsp/feather_m0_express/board.mk
@@ -25,7 +25,7 @@ INC += \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/include \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hal/include \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hal/utils/include \
-	$(TOP)/hw/mcu/microchip/samd/asf4/samd51/hpl/pm/ \
+	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hpl/pm/ \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hpl/port \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hri \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/CMSIS/Include

--- a/hw/bsp/metro_m0_express/board.mk
+++ b/hw/bsp/metro_m0_express/board.mk
@@ -25,7 +25,7 @@ INC += \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/include \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hal/include \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hal/utils/include \
-	$(TOP)/hw/mcu/microchip/samd/asf4/samd51/hpl/pm/ \
+	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hpl/pm/ \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hpl/port \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/hri \
 	$(TOP)/hw/mcu/microchip/samd/asf4/samd21/CMSIS/Include


### PR DESCRIPTION
For one line only in their respective board.mk, feather_m0_express and metro_m0_express are including the SAMD51 path instead of the applicable SAMD21 one. 