### PR TITLE
dcd_eptri: Fix rx_buffer/tx_buffer volatile annotation

### DIFF
--- a/src/portable/valentyusb/eptri/dcd_eptri.c
+++ b/src/portable/valentyusb/eptri/dcd_eptri.c
@@ -75,13 +75,13 @@ uint8_t queue_log_offset;
 #define EP_SIZE 64
 
 uint16_t volatile rx_buffer_offset[16];
-uint8_t volatile * rx_buffer[16];
+uint8_t* volatile rx_buffer[16];
 uint16_t volatile rx_buffer_max[16];
 
 volatile uint8_t tx_ep;
 volatile bool tx_active;
 volatile uint16_t tx_buffer_offset[16];
-uint8_t volatile * tx_buffer[16];
+uint8_t* volatile tx_buffer[16];
 volatile uint16_t tx_buffer_max[16];
 volatile uint8_t reset_count;
 


### PR DESCRIPTION
This makes `rx_buffer` and `tx_buffer` *pointers*
volatile in order to avoid caching them in a register.

The original notation meant "a pointer to a volatile value"
(equivalent of `volatile uint8_t *`). This resulted in
`while(rx_buffer[ep_num] != NULL) ;` loop to get stuck
forever, even though the IRQ handler set the `rx_buffer[ep_num] = NULL`.