### PR TITLE
added NUC120 support (with caveats)

### DIFF
--- a/hw/bsp/nutiny_sdk_nuc120/board.mk
+++ b/hw/bsp/nutiny_sdk_nuc120/board.mk
@@ -3,6 +3,7 @@ CFLAGS += \
   -mthumb \
   -mabi=aapcs-linux \
   -mcpu=cortex-m0 \
+  -DCFG_EXAMPLE_MSC_READONLY \
   -DCFG_TUSB_MCU=OPT_MCU_NUC120
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/nutiny_sdk_nuc120/board.mk
+++ b/hw/bsp/nutiny_sdk_nuc120/board.mk
@@ -1,0 +1,56 @@
+CFLAGS += \
+  -flto \
+  -mthumb \
+  -mabi=aapcs-linux \
+  -mcpu=cortex-m0 \
+  -DCFG_TUSB_MCU=OPT_MCU_NUC120
+
+# All source paths should be relative to the top level.
+LD_FILE = hw/bsp/nutiny_sdk_nuc120/nuc120_flash.ld
+
+SRC_C += \
+  hw/mcu/nuvoton/nuc100_120/Device/Nuvoton/NUC100Series/Source/system_NUC100Series.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/acmp.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/adc.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/clk.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/crc.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/fmc.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/gpio.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/i2c.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/i2s.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/pdma.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/ps2.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/pwm.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/rtc.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/sc.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/spi.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/sys.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/timer.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/uart.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/usbd.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/wdt.c \
+  hw/mcu/nuvoton/nuc100_120/StdDriver/src/wwdt.c
+
+SRC_S += \
+  hw/mcu/nuvoton/nuc100_120/Device/Nuvoton/NUC100Series/Source/GCC/startup_NUC100Series.S
+
+INC += \
+  $(TOP)/hw/mcu/nuvoton/nuc100_120/Device/Nuvoton/NUC100Series/Include \
+  $(TOP)/hw/mcu/nuvoton/nuc100_120/StdDriver/inc \
+  $(TOP)/hw/mcu/nuvoton/nuc100_120/CMSIS/Include
+
+# For TinyUSB port source
+VENDOR = nuvoton
+CHIP_FAMILY = nuc120
+
+# For freeRTOS port source
+FREERTOS_PORT = ARM_CM0
+
+# For flash-jlink target
+JLINK_DEVICE = NUC120LE3
+JLINK_IF = swd
+
+# Flash using Nuvoton's openocd fork at https://github.com/OpenNuvoton/OpenOCD-Nuvoton
+# Please compile and install it from github source
+flash: $(BUILD)/$(BOARD)-firmware.elf
+	openocd -f interface/nulink.cfg -f target/numicroM0.cfg -c "program $< reset exit"

--- a/hw/bsp/nutiny_sdk_nuc120/nuc120_flash.ld
+++ b/hw/bsp/nutiny_sdk_nuc120/nuc120_flash.ld
@@ -1,0 +1,195 @@
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x20000   /* 128k */
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 0x4000    /*  16k */
+}
+
+/* Library configurations */
+GROUP(libgcc.a libc.a libm.a libnosys.a)
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __Vectors_End
+ *   __Vectors_Size
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.vectors))
+		__Vectors_End = .;
+		__Vectors_Size = __Vectors_End - __Vectors;
+		__end__ = .;
+
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+		*crtbegin.o(.ctors)
+		*crtbegin?.o(.ctors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+		*(SORT(.ctors.*))
+		*(.ctors)
+
+		/* .dtors */
+ 		*crtbegin.o(.dtors)
+ 		*crtbegin?.o(.dtors)
+ 		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+ 		*(SORT(.dtors.*))
+ 		*(.dtors)
+
+		*(.rodata*)
+
+		KEEP(*(.eh_frame*))
+	} > FLASH
+
+	.ARM.extab :
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+	} > FLASH
+	__exidx_end = .;
+
+	/* To copy multiple ROM to RAM sections,
+	 * uncomment .copy.table section and,
+	 * define __STARTUP_COPY_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.copy.table :
+	{
+		. = ALIGN(4);
+		__copy_table_start__ = .;
+		LONG (__etext)
+		LONG (__data_start__)
+		LONG (__data_end__ - __data_start__)
+		LONG (__etext2)
+		LONG (__data2_start__)
+		LONG (__data2_end__ - __data2_start__)
+		__copy_table_end__ = .;
+	} > FLASH
+	*/
+
+	/* To clear multiple BSS sections,
+	 * uncomment .zero.table section and,
+	 * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.zero.table :
+	{
+		. = ALIGN(4);
+		__zero_table_start__ = .;
+		LONG (__bss_start__)
+		LONG (__bss_end__ - __bss_start__)
+		LONG (__bss2_start__)
+		LONG (__bss2_end__ - __bss2_start__)
+		__zero_table_end__ = .;
+	} > FLASH
+	*/
+
+	__etext = .;
+
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP(*(SORT(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP(*(SORT(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		KEEP(*(.jcr*))
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+	} > RAM
+
+	.heap (COPY):
+	{
+		__HeapBase = .;
+		__end__ = .;
+		end = __end__;
+		KEEP(*(.heap*))
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		KEEP(*(.stack*))
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/hw/bsp/nutiny_sdk_nuc120/nutiny_sdk_nuc120.c
+++ b/hw/bsp/nutiny_sdk_nuc120/nutiny_sdk_nuc120.c
@@ -1,0 +1,122 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "bsp/board.h"
+#include "NUC100Series.h"
+#include "clk.h"
+#include "sys.h"
+
+#define LED_PORT     PB
+#define LED_PIN      0
+#define LED_PIN_IO   PB0
+#define LED_STATE_ON 0
+
+void board_init(void)
+{
+  SYS_UnlockReg();
+
+  /* Enable Internal RC 22.1184 MHz clock */
+  CLK_EnableXtalRC(CLK_PWRCON_OSC22M_EN_Msk);
+
+  /* Waiting for Internal RC clock ready */
+  CLK_WaitClockReady(CLK_CLKSTATUS_OSC22M_STB_Msk);
+
+  /* Switch HCLK clock source to Internal RC and HCLK source divide 1 */
+  CLK_SetHCLK(CLK_CLKSEL0_HCLK_S_HIRC, CLK_CLKDIV_HCLK(1));
+
+  /* Enable external XTAL 12 MHz clock */
+  CLK_EnableXtalRC(CLK_PWRCON_XTL12M_EN_Msk);
+
+  /* Waiting for external XTAL clock ready */
+  CLK_WaitClockReady(CLK_CLKSTATUS_XTL12M_STB_Msk);
+
+  /* Set core clock */
+  CLK_SetCoreClock(48000000);
+
+  /* Enable module clock */
+  CLK_EnableModuleClock(USBD_MODULE);
+
+  /* Select module clock source */
+  CLK_SetModuleClock(USBD_MODULE, 0, CLK_CLKDIV_USB(1));
+
+  SYS_LockReg();
+
+#if CFG_TUSB_OS  == OPT_OS_NONE
+  // 1ms tick timer
+  SysTick_Config(48000000 / 1000);
+#endif
+
+  GPIO_SetMode(LED_PORT, 1UL << LED_PIN, GPIO_PMD_OUTPUT);
+}
+
+#if CFG_TUSB_OS  == OPT_OS_NONE
+volatile uint32_t system_ticks = 0;
+void SysTick_Handler (void)
+{
+  system_ticks++;
+}
+
+uint32_t board_millis(void)
+{
+  return system_ticks;
+}
+#endif
+
+//--------------------------------------------------------------------+
+// Board porting API
+//--------------------------------------------------------------------+
+
+void board_led_write(bool state)
+{
+#if 0
+  /* this would be the simplest solution... *IF* the part supported the pin data interface */
+  LED_PIN_IO = (state) ? LED_STATE_ON : (1-LED_STATE_ON);
+#else
+  /* if the part's *PDIO pin data registers don't work, a more elaborate approach is needed */
+  uint32_t irq_state = __get_PRIMASK();
+  __disable_irq();
+  uint32_t current = LED_PORT->DOUT & ~(1UL << LED_PIN);
+  LED_PORT->DOUT = current | (((state) ? LED_STATE_ON : (1UL-LED_STATE_ON)) << LED_PIN);
+  __set_PRIMASK(irq_state);
+#endif
+}
+
+uint32_t board_button_read(void)
+{
+  return 0;
+}
+
+int board_uart_read(uint8_t* buf, int len)
+{
+  (void) buf; (void) len;
+  return 0;
+}
+
+int board_uart_write(void const * buf, int len)
+{
+  (void) buf; (void) len;
+  return 0;
+}

--- a/src/portable/nuvoton/nuc120/dcd_nuc120.c
+++ b/src/portable/nuvoton/nuc120/dcd_nuc120.c
@@ -1,0 +1,433 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2020 Peter Lawrence
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+/*
+  Theory of operation:
+
+  The NUC100/NUC120 USBD peripheral has six "EP"s, but each is simplex, 
+  so two collectively (peripheral nomenclature of "EP0" and "EP1") are needed to 
+  implement USB EP0.  PERIPH_EP0 and PERIPH_EP1 are used by this driver for 
+  EP0_IN and EP0_OUT respectively.  This leaves up to four for user usage.
+*/
+
+#include "tusb_option.h"
+
+#if TUSB_OPT_DEVICE_ENABLED && (CFG_TUSB_MCU == OPT_MCU_NUC120)
+
+#include "device/dcd.h"
+#include "NUC100Series.h"
+
+/* allocation of USBD RAM for Setup, EP0_IN, and and EP_OUT */
+#define PERIPH_SETUP_BUF_BASE  0
+#define PERIPH_SETUP_BUF_LEN   8
+#define PERIPH_EP0_BUF_BASE    (PERIPH_SETUP_BUF_BASE + PERIPH_SETUP_BUF_LEN)
+#define PERIPH_EP0_BUF_LEN     CFG_TUD_ENDPOINT0_SIZE
+#define PERIPH_EP1_BUF_BASE    (PERIPH_EP0_BUF_BASE + PERIPH_EP0_BUF_LEN)
+#define PERIPH_EP1_BUF_LEN     CFG_TUD_ENDPOINT0_SIZE
+#define PERIPH_EP2_BUF_BASE    (PERIPH_EP1_BUF_BASE + PERIPH_EP1_BUF_LEN)
+
+/* rather important info unfortunately not provided by device include files: how much there is */
+#define USBD_BUF_SIZE          512
+
+enum ep_enum
+{
+  PERIPH_EP0 = 0,
+  PERIPH_EP1 = 1,
+  PERIPH_EP2 = 2,
+  PERIPH_EP3 = 3,
+  PERIPH_EP4 = 4,
+  PERIPH_EP5 = 5,
+  PERIPH_MAX_EP,
+};
+
+/* set by dcd_set_address() */
+static volatile uint8_t assigned_address;
+
+/* reset by dcd_init(), this is used by dcd_edpt_open() to assign USBD peripheral buffer addresses */
+static uint32_t bufseg_addr;
+
+/* used by dcd_edpt_xfer() and the ISR to reset the data sync (DATA0/DATA1) in an EP0_IN transfer */
+static bool active_ep0_xfer;
+
+/* RAM table needed to track ongoing transfers performed by dcd_edpt_xfer(), dcd_in_xfer(), and the ISR */
+static struct xfer_ctl_t
+{
+  uint8_t *data_ptr;         /* data_ptr tracks where to next copy data to (for OUT) or from (for IN) */
+  union {
+    uint16_t in_remaining_bytes; /* for IN endpoints, we track how many bytes are left to transfer */
+    uint16_t out_bytes_so_far;   /* but for OUT endpoints, we track how many bytes we've transferred so far */
+  };
+  uint16_t max_packet_size;  /* needed since device driver only finds out this at runtime */
+  uint16_t total_bytes;      /* quantity needed to pass as argument to dcd_event_xfer_complete() (for IN endpoints) */
+} xfer_table[PERIPH_MAX_EP];
+
+/*
+  local helper functions
+*/
+
+static void usb_attach(void)
+{
+  USBD->DRVSE0 &= ~USBD_DRVSE0_DRVSE0_Msk;
+}
+
+static void usb_detach(void)
+{
+  USBD->DRVSE0 |= USBD_DRVSE0_DRVSE0_Msk;
+}
+
+static void usb_control_send_zlp(void)
+{
+  USBD->EP[PERIPH_EP0].CFG |= USBD_CFG_DSQ_SYNC_Msk;
+  USBD->EP[PERIPH_EP0].MXPLD = 0;
+}
+
+/* reconstruct ep_addr from particular USB Configuration Register */
+static uint8_t decode_ep_addr(USBD_EP_T *ep)
+{
+  uint8_t ep_addr = ep->CFG & USBD_CFG_EP_NUM_Msk;
+  if ( USBD_CFG_EPMODE_IN == (ep->CFG & USBD_CFG_STATE_Msk) )
+    ep_addr |= TUSB_DIR_IN_MASK;
+  return ep_addr;
+}
+
+/* map 8-bit ep_addr into peripheral endpoint index (PERIPH_EP0...) */
+static USBD_EP_T *ep_entry(uint8_t ep_addr, bool add)
+{
+  USBD_EP_T *ep;
+  enum ep_enum ep_index;
+
+  for (ep_index = PERIPH_EP0, ep = USBD->EP; ep_index < PERIPH_MAX_EP; ep_index++, ep++)
+  {
+    if (add)
+    {
+      /* take first peripheral endpoint that is unused */
+      if (0 == (ep->CFG & USBD_CFG_STATE_Msk)) return ep;
+    }
+    else
+    {
+      /* find a peripheral endpoint that matches ep_addr */
+      uint8_t candidate_ep_addr = decode_ep_addr(ep);
+      if (candidate_ep_addr == ep_addr) return ep;
+    }
+  }
+
+  return NULL;
+}
+
+/* perform an IN endpoint transfer; this is called by dcd_edpt_xfer() and the ISR  */
+static void dcd_in_xfer(struct xfer_ctl_t *xfer, USBD_EP_T *ep)
+{
+  uint16_t bytes_now = tu_min16(xfer->in_remaining_bytes, xfer->max_packet_size);
+
+  memcpy((uint8_t *)(USBD_BUF_BASE + ep->BUFSEG), xfer->data_ptr, bytes_now);
+  ep->MXPLD = bytes_now;
+}
+
+/* called by dcd_init() as well as by the ISR during a USB bus reset */
+static void bus_reset(void)
+{
+  USBD->STBUFSEG = PERIPH_SETUP_BUF_BASE;
+
+  for (enum ep_enum ep_index = PERIPH_EP0; ep_index < PERIPH_MAX_EP; ep_index++)
+  {
+    USBD->EP[ep_index].CFG = 0;
+    USBD->EP[ep_index].CFGP = 0;
+  }
+
+  /* allocate the default EP0 endpoints */
+
+  USBD->EP[PERIPH_EP0].CFG = USBD_CFG_CSTALL_Msk | USBD_CFG_EPMODE_IN;
+  USBD->EP[PERIPH_EP0].BUFSEG = PERIPH_EP0_BUF_BASE;
+  xfer_table[PERIPH_EP0].max_packet_size = PERIPH_EP0_BUF_LEN;
+
+  USBD->EP[PERIPH_EP1].CFG = USBD_CFG_CSTALL_Msk | USBD_CFG_EPMODE_OUT;
+  USBD->EP[PERIPH_EP1].BUFSEG = PERIPH_EP1_BUF_BASE;
+  xfer_table[PERIPH_EP1].max_packet_size = PERIPH_EP1_BUF_LEN;
+
+  /* USB RAM beyond what we've allocated above is available to the user */
+  bufseg_addr = PERIPH_EP2_BUF_BASE;
+
+  /* Reset USB device address */
+  USBD->FADDR = 0;
+
+  /* reset EP0_IN flag */
+  active_ep0_xfer = false;
+}
+
+/* centralized location for USBD interrupt enable bit mask */
+static const uint32_t enabled_irqs = USBD_INTSTS_FLDET_STS_Msk | USBD_INTSTS_BUS_STS_Msk | USBD_INTSTS_SETUP_Msk | USBD_INTSTS_USB_STS_Msk;
+
+/*
+  NUC100/NUC120 TinyUSB API driver implementation
+*/
+
+void dcd_init(uint8_t rhport)
+{
+  (void) rhport;
+
+  USBD->ATTR = 0x7D0;
+
+  usb_detach();
+
+  bus_reset();
+
+  usb_attach();
+
+  USBD->INTSTS = enabled_irqs;
+  USBD->INTEN  = enabled_irqs;
+}
+
+void dcd_int_enable(uint8_t rhport)
+{
+  (void) rhport;
+  NVIC_EnableIRQ(USBD_IRQn);
+}
+
+void dcd_int_disable(uint8_t rhport)
+{
+  (void) rhport;
+  NVIC_DisableIRQ(USBD_IRQn);
+}
+
+void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
+{
+  (void) rhport;
+  usb_control_send_zlp(); /* SET_ADDRESS is the one exception where TinyUSB doesn't use dcd_edpt_xfer() to generate a ZLP */
+  assigned_address = dev_addr;
+}
+
+void dcd_set_config(uint8_t rhport, uint8_t config_num)
+{
+  (void) rhport;
+  (void) config_num;
+}
+
+void dcd_remote_wakeup(uint8_t rhport)
+{
+  (void) rhport;
+  USBD->ATTR = USBD_ATTR_RWAKEUP_Msk;
+}
+
+bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc)
+{
+  (void) rhport;
+
+  USBD_EP_T *ep = ep_entry(p_endpoint_desc->bEndpointAddress, true);
+  TU_ASSERT(ep);
+
+  /* mine the data for the information we need */
+  int const dir = tu_edpt_dir(p_endpoint_desc->bEndpointAddress);
+  int const size = p_endpoint_desc->wMaxPacketSize.size;
+  tusb_xfer_type_t const type = p_endpoint_desc->bmAttributes.xfer;
+  struct xfer_ctl_t *xfer = &xfer_table[ep - USBD->EP];
+
+  /* allocate buffer from USB RAM */
+  ep->BUFSEG = bufseg_addr;
+  bufseg_addr += size;
+  TU_ASSERT(bufseg_addr <= USBD_BUF_SIZE);
+
+  /* construct USB Configuration Register value and then write it */
+  uint32_t cfg = tu_edpt_number(p_endpoint_desc->bEndpointAddress);
+  cfg |= (TUSB_DIR_IN == dir) ? USBD_CFG_EPMODE_IN : USBD_CFG_EPMODE_OUT;
+  if (TUSB_XFER_ISOCHRONOUS == type)
+    cfg |= USBD_CFG_TYPE_ISO;
+  ep->CFG = cfg;
+
+  /* make a note of the endpoint size */
+  xfer->max_packet_size = size;
+
+  return true;
+}
+
+bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t total_bytes)
+{
+  (void) rhport;
+
+  /* mine the data for the information we need */
+  tusb_dir_t dir = tu_edpt_dir(ep_addr);
+  USBD_EP_T *ep = ep_entry(ep_addr, false);
+  struct xfer_ctl_t *xfer = &xfer_table[ep - USBD->EP];
+
+  /* store away the information we'll needing now and later */
+  xfer->data_ptr = buffer;
+  xfer->in_remaining_bytes = total_bytes;
+  xfer->total_bytes = total_bytes;
+
+  /* for the first of one or more EP0_IN packets in a message, the first must be DATA1 */
+  if ( (0x80 == ep_addr) && !active_ep0_xfer ) ep->CFG |= USBD_CFG_DSQ_SYNC_Msk;
+
+  if (TUSB_DIR_IN == dir)
+  {
+    dcd_in_xfer(xfer, ep);
+  }
+  else
+  {
+    xfer->out_bytes_so_far = 0;
+    ep->MXPLD = xfer->max_packet_size;
+  }
+
+  return true;
+}
+
+void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr)
+{
+  (void) rhport;
+  USBD_EP_T *ep = ep_entry(ep_addr, false);
+  ep->CFGP |= USBD_CFGP_SSTALL_Msk;
+}
+
+void dcd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr)
+{
+  (void) rhport;
+  USBD_EP_T *ep = ep_entry(ep_addr, false);
+  ep->CFG |= USBD_CFG_CSTALL_Msk;
+}
+
+void USBD_IRQHandler(void)
+{
+  uint32_t status = USBD->INTSTS;
+  uint32_t state = USBD->ATTR & 0xf;
+
+  if(status & USBD_INTSTS_FLDET_STS_Msk)
+  {
+    if(USBD->FLDET & USBD_FLDET_FLDET_Msk)
+    {
+      /* USB connect */
+      USBD->ATTR |= USBD_ATTR_USB_EN_Msk | USBD_ATTR_PHY_EN_Msk;
+    }
+    else
+    {
+      /* USB disconnect */
+      USBD->ATTR &= ~USBD_ATTR_USB_EN_Msk;
+    }
+  }
+
+  if(status & USBD_INTSTS_BUS_STS_Msk)
+  {
+    if(state & USBD_STATE_USBRST)
+    {
+      /* USB bus reset */
+      USBD->ATTR |= USBD_ATTR_USB_EN_Msk | USBD_ATTR_PHY_EN_Msk;
+
+      bus_reset();
+
+      dcd_event_bus_signal(0, DCD_EVENT_BUS_RESET, true);
+    }
+
+    if(state & USBD_STATE_SUSPEND)
+    {
+      /* Enable USB but disable PHY */
+      USBD->ATTR &= ~USBD_ATTR_PHY_EN_Msk;
+      dcd_event_bus_signal(0, DCD_EVENT_SUSPEND, true);
+    }
+
+    if(state & USBD_STATE_RESUME)
+    {
+      /* Enable USB and enable PHY */
+      USBD->ATTR |= USBD_ATTR_USB_EN_Msk | USBD_ATTR_PHY_EN_Msk;
+      dcd_event_bus_signal(0, DCD_EVENT_RESUME, true);
+    }
+  }
+
+  if(status & USBD_INTSTS_SETUP_Msk)
+  {
+    /* clear the data ready flag of control endpoints */
+    USBD->EP[PERIPH_EP0].CFGP |= USBD_CFGP_CLRRDY_Msk;
+    USBD->EP[PERIPH_EP1].CFGP |= USBD_CFGP_CLRRDY_Msk;
+
+    /* get SETUP packet from USB buffer */
+    dcd_event_setup_received(0, (uint8_t *)USBD_BUF_BASE, true);
+  }
+
+  if(status & USBD_INTSTS_USB_STS_Msk)
+  {
+    if (status & (1UL << USBD_INTSTS_EPEVT_Pos)) /* PERIPH_EP0 (EP0_IN) event: this is treated separately from the rest */
+    {
+      /* given ACK from host has happened, we can now set the address (if not already done) */
+      if((USBD->FADDR != assigned_address) && (USBD->FADDR == 0)) USBD->FADDR = assigned_address;
+
+      uint16_t const available_bytes = USBD->EP[PERIPH_EP0].MXPLD;
+
+      active_ep0_xfer = (available_bytes == xfer_table[PERIPH_EP0].max_packet_size);
+
+      dcd_event_xfer_complete(0, 0x80, available_bytes, XFER_RESULT_SUCCESS, true);
+    }
+
+    /* service PERIPH_EP1 through PERIPH_EP7 */
+    enum ep_enum ep_index;
+    uint32_t mask;
+    struct xfer_ctl_t *xfer;
+    USBD_EP_T *ep;
+    for (ep_index = PERIPH_EP1, mask = (2UL << USBD_INTSTS_EPEVT_Pos), xfer = &xfer_table[PERIPH_EP1], ep = &USBD->EP[PERIPH_EP1]; ep_index < PERIPH_MAX_EP; ep_index++, mask <<= 1, xfer++, ep++)
+    {
+      if(status & mask)
+      {
+        USBD->INTSTS = mask;
+
+        uint16_t const available_bytes = ep->MXPLD;
+        uint8_t const ep_addr = decode_ep_addr(ep);
+        bool const out_ep = !(ep_addr & TUSB_DIR_IN_MASK);
+
+        if (out_ep)
+        {
+          /* copy the data from the PC to the previously provided buffer */
+          memcpy(xfer->data_ptr, (uint8_t *)(USBD_BUF_BASE + ep->BUFSEG), available_bytes);
+          xfer->out_bytes_so_far += available_bytes;
+          xfer->data_ptr += available_bytes;
+
+          /* when the transfer is finished, alert TinyUSB; otherwise, accept more data */
+          if ( (xfer->total_bytes == xfer->out_bytes_so_far) || (available_bytes < xfer->max_packet_size) )
+            dcd_event_xfer_complete(0, ep_addr, xfer->out_bytes_so_far, XFER_RESULT_SUCCESS, true);
+          else
+            ep->MXPLD = xfer->max_packet_size;
+        }
+        else
+        {
+          /* update the bookkeeping to reflect the data that has now been sent to the PC */
+          xfer->in_remaining_bytes -= available_bytes;
+          xfer->data_ptr += available_bytes;
+
+          /* if more data to send, send it; otherwise, alert TinyUSB that we've finished */
+          if (xfer->in_remaining_bytes)
+            dcd_in_xfer(xfer, ep);
+          else
+            dcd_event_xfer_complete(0, ep_addr, xfer->total_bytes, XFER_RESULT_SUCCESS, true);
+        }
+      }
+    }
+  }
+
+  /* acknowledge all interrupts */
+  USBD->INTSTS = status & enabled_irqs;
+}
+
+void dcd_isr(uint8_t rhport)
+{
+  (void) rhport;
+  USBD_IRQHandler();
+}
+
+#endif

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -79,6 +79,7 @@
 
 #define OPT_MCU_NUC121            800
 #define OPT_MCU_NUC126            801
+#define OPT_MCU_NUC120            802
 
 /** @} */
 


### PR DESCRIPTION
I thought this was going to be a quick and easy addition, but it proved to be much more of a pain.

IMPORTANT: the NUC120 only has six endpoints in total, two of which get used for the control endpoints.  Given that a CDC port, for example, takes three of those, and many of the TinyUSB examples won't even run.

At least with the particular NUC120LE3 on the NuTiny-SDK-NUC120 that I bought, certain registers didn't work.  The Nuvoton errata sheet for the part shows a glowing situation of only one minor erratum, and this was not my experience.  (Pre-production part?)  CLK->CLKSTATUS always reads zero, forcing me to diagnose the problem and re-write portions of their clk.c driver.  The GPIO peripheral has registers to individually address particular pins, and that didn't work either (forcing an alternate solution in the ./hw/bsp/ board driver).

Given that Nuvoton's FAQ makes mention of one of these, perhaps the errata sheet is not kept current:

https://www.nuvoton.com/support/technical-support/faq/d5f1bbab-04f1-11ea-b113-05daf7eedf03/

So, given the choice of designing in a part, I would choose the newer NUC121/NUC125/NUC126 over the older NUC120 in a heartbeat.  The newer parts support crystal-less USB operation to boot.

There is also allegedly a NuTiny-NUC120V board, but this is not stocked by the US distributor that I ordered from.

P.S.: msc_dual_lun fails the build, but this is only because that example requires more RAM than the part has.
