### PR TITLE
add a number for esp32-s2

### DIFF
--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -80,6 +80,8 @@
 #define OPT_MCU_NUC121            800
 #define OPT_MCU_NUC126            801
 
+#define OPT_MCU_ESP32S2           900 ///< Espressif ESP32-S2
+
 /** @} */
 
 /** \defgroup group_supported_os Supported RTOS


### PR DESCRIPTION
Hi! 
I'd like to propose to assign a number for ESP32-s2 chip cause we are going to use the tinyusb in the [Espressif IoT Development Framework.](https://github.com/espressif/esp-idf)
