### PR TITLE
usbnet RNDIS correction (STM32 RNDIS now valid)

### DIFF
--- a/src/class/net/net_device.c
+++ b/src/class/net/net_device.c
@@ -198,7 +198,17 @@ bool netd_control_request(uint8_t rhport, tusb_control_request_t const * request
   TU_VERIFY (_netd_itf.itf_num == request->wIndex);
 
 #if CFG_TUD_NET == OPT_NET_RNDIS
-  tud_control_xfer(rhport, request, rndis_buf, sizeof(rndis_buf));
+  if (request->bmRequestType_bit.direction == TUSB_DIR_IN)
+  {
+    rndis_generic_msg_t *rndis_msg = (rndis_generic_msg_t *)rndis_buf;
+    uint32_t msglen = tu_le32toh(rndis_msg->MessageLength);
+    TU_ASSERT(msglen <= sizeof(rndis_buf));
+    tud_control_xfer(rhport, request, rndis_buf, msglen);
+  }
+  else
+  {
+    tud_control_xfer(rhport, request, rndis_buf, sizeof(rndis_buf));
+  }
 #else
   (void)rhport;
 #endif

--- a/src/class/net/net_device.c
+++ b/src/class/net/net_device.c
@@ -64,7 +64,7 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t received[CFG_TUD_NET_PACK
 CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t transmitted[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
 
 #if CFG_TUD_NET == OPT_NET_RNDIS
-  CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t rndis_buf[128];
+  CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t rndis_buf[120];
 #endif
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
rndis_report[] resized from 128 bytes to 120 bytes  With hindsight, I believe this is a more correct size for the RNDIS protocol.  As a pleasant side-effect, the driver doesn't need to do a ZLP on EP0.

Added testing successes:

STM32F072 RNDIS

Existing platforms verified as still valid:

SAMD21 CDC-ECM
SAMD21 RNDIS
SAMD21 CDC-EEM
NUC126 CDC-EDM
NUC126 RNDIS
NUC126 CDC-EEM
STM32 CDC-EEM
