### PR TITLE
Use CRLF on UART log messages?

### DIFF
--- a/examples/device/board_test/src/main.c
+++ b/examples/device/board_test/src/main.c
@@ -42,7 +42,7 @@ enum  {
   BLINK_UNPRESSED = 1000
 };
 
-#define HELLO_STR   "Hello from TinyUSB\n"
+#define HELLO_STR   "Hello from TinyUSB\r\n"
 
 int main(void)
 {

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -335,12 +335,12 @@ bool cdcd_control_request(uint8_t rhport, tusb_control_request_t const * request
   switch ( request->bRequest )
   {
     case CDC_REQUEST_SET_LINE_CODING:
-      TU_LOG2("  Set Line Coding\n");
+      TU_LOG2("  Set Line Coding\r\n");
       tud_control_xfer(rhport, request, &p_cdc->line_coding, sizeof(cdc_line_coding_t));
     break;
 
     case CDC_REQUEST_GET_LINE_CODING:
-      TU_LOG2("  Get Line Coding\n");
+      TU_LOG2("  Get Line Coding\r\n");
       tud_control_xfer(rhport, request, &p_cdc->line_coding, sizeof(cdc_line_coding_t));
     break;
 
@@ -356,7 +356,7 @@ bool cdcd_control_request(uint8_t rhport, tusb_control_request_t const * request
 
       p_cdc->line_state = (uint8_t) request->wValue;
 
-      TU_LOG2("  Set Control Line State: DTR = %d, RTS = %d\n", dtr, rts);
+      TU_LOG2("  Set Control Line State: DTR = %d, RTS = %d\r\n", dtr, rts);
 
       tud_control_status(rhport, request);
 

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -407,7 +407,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
       TU_ASSERT( event == XFER_RESULT_SUCCESS &&
                  xferred_bytes == sizeof(msc_cbw_t) && p_cbw->signature == MSC_CBW_SIGNATURE );
 
-      TU_LOG2("  SCSI Command: %s\n", lookup_find(&_msc_scsi_cmd_table, p_cbw->command[0]));
+      TU_LOG2("  SCSI Command: %s\r\n", lookup_find(&_msc_scsi_cmd_table, p_cbw->command[0]));
       // TU_LOG2_MEM(p_cbw, xferred_bytes, 2);
 
       p_csw->signature    = MSC_CSW_SIGNATURE;
@@ -480,7 +480,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
     break;
 
     case MSC_STAGE_DATA:
-      TU_LOG2("  SCSI Data\n");
+      TU_LOG2("  SCSI Data\r\n");
       //TU_LOG2_MEM(_mscd_buf, xferred_bytes, 2);
 
       // OUT transfer, invoke callback if needed
@@ -577,7 +577,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
       // Wait for the Status phase to complete
       if( (ep_addr == p_msc->ep_in) && (xferred_bytes == sizeof(msc_csw_t)) )
       {
-        TU_LOG2("  SCSI Status: %u\n", p_csw->status);
+        TU_LOG2("  SCSI Status: %u\r\n", p_csw->status);
         // TU_LOG2_MEM(p_csw, xferred_bytes, 2);
 
         // Move to default CMD stage

--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -222,7 +222,7 @@ void tu_print_mem(void const *buf, uint16_t count, uint8_t indent);
 // Log with debug level 1
 #define TU_LOG1               tu_printf
 #define TU_LOG1_MEM           tu_print_mem
-#define TU_LOG1_LOCATION()    tu_printf("%s: %d:\n", __PRETTY_FUNCTION__, __LINE__)
+#define TU_LOG1_LOCATION()    tu_printf("%s: %d:\r\n", __PRETTY_FUNCTION__, __LINE__)
 
 // Log with debug level 2
 #if CFG_TUSB_DEBUG > 1

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -76,8 +76,8 @@
 
 #if CFG_TUSB_DEBUG
   #include <stdio.h>
-  #define _MESS_ERR(_err)   printf("%s %d: failed, error = %s\n", __func__, __LINE__, tusb_strerr[_err])
-  #define _MESS_FAILED()    printf("%s %d: assert failed\n", __func__, __LINE__)
+  #define _MESS_ERR(_err)   printf("%s %d: failed, error = %s\r\n", __func__, __LINE__, tusb_strerr[_err])
+  #define _MESS_FAILED()    printf("%s %d: assert failed\r\n", __func__, __LINE__)
 #else
   #define _MESS_ERR(_err)
   #define _MESS_FAILED()

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -63,7 +63,7 @@ static inline bool _status_stage_xact(uint8_t rhport, tusb_control_request_t con
   // Opposite to endpoint in Data Phase
   uint8_t const ep_addr = request->bmRequestType_bit.direction ? EDPT_CTRL_OUT : EDPT_CTRL_IN;
 
-  TU_LOG2("  XFER Endpoint: 0x%02X, Bytes: %d\n", ep_addr, 0);
+  TU_LOG2("  XFER Endpoint: 0x%02X, Bytes: %d\r\n", ep_addr, 0);
 
   // status direction is reversed to one in the setup packet
   // Note: Status must always be DATA1
@@ -96,7 +96,7 @@ static bool _data_stage_xact(uint8_t rhport)
     if ( xact_len ) memcpy(_usbd_ctrl_buf, _ctrl_xfer.buffer, xact_len);
   }
 
-  TU_LOG2("  XACT Control: 0x%02X, Bytes: %d\n", ep_addr, xact_len);
+  TU_LOG2("  XACT Control: 0x%02X, Bytes: %d\r\n", ep_addr, xact_len);
 
   return dcd_edpt_xfer(rhport, ep_addr, xact_len ? _usbd_ctrl_buf : NULL, xact_len);
 }
@@ -112,7 +112,7 @@ bool tud_control_xfer(uint8_t rhport, tusb_control_request_t const * request, vo
   {
     TU_ASSERT(buffer);
 
-    TU_LOG2("  XFER Endpoint: 0x%02X, Bytes: %d\n", request->bmRequestType_bit.direction ? EDPT_CTRL_IN : EDPT_CTRL_OUT, _ctrl_xfer.data_len);
+    TU_LOG2("  XFER Endpoint: 0x%02X, Bytes: %d\r\n", request->bmRequestType_bit.direction ? EDPT_CTRL_IN : EDPT_CTRL_OUT, _ctrl_xfer.data_len);
 
     // Data stage
     TU_ASSERT( _data_stage_xact(rhport) );


### PR DESCRIPTION
Some log messages use CR, others use CRLF.

This patch standardizes them to use CRLF. Let me know if the patch should standardize on LF, instead. I'm not sure which one is preferred. If we want CR only, let me know and I'll revise this patch.