### PR TITLE
STM32FSDEV: Rewrite transfer ISR

### DIFF
--- a/hw/bsp/stm32f070rbnucleo/stm32f070rbnucleo.c
+++ b/hw/bsp/stm32f070rbnucleo/stm32f070rbnucleo.c
@@ -185,10 +185,7 @@ void HardFault_Handler (void)
   */
 void assert_failed(char *file, uint32_t line)
 { 
-  /* USER CODE BEGIN 6 */
-  /* User can add his own implementation to report the file name and line number,
-     tex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
-  /* USER CODE END 6 */
+  TU_LOG1("Assertion failed (%s:%ld)\r\n", file, line);
 }
 #endif /* USE_FULL_ASSERT */
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -310,6 +310,13 @@ static inline void pcd_set_ep_rx_status(USB_TypeDef * USBx,  uint32_t bEpNum, ui
   pcd_set_endpoint(USBx, bEpNum, regVal);
 } /* pcd_set_ep_rx_status */
 
+static inline uint32_t pcd_get_ep_rx_status(USB_TypeDef * USBx,  uint32_t bEpNum)
+{
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
+  return (regVal & USB_EPRX_STAT) >> (12u);
+} /* pcd_get_ep_rx_status */
+
+
 /**
   * @brief  Toggles DTOG_RX / DTOG_TX bit in the endpoint register.
   * @param  USBx USB peripheral instance register address.


### PR DESCRIPTION
This rewrites the transfer ISR code for STM32FSDEV. The TX logic is unchanged, but the RX logic is greatly simplified.

There were multiple issues, particularity with EP0:
* DTOG was set wrongly.
* EP0 must always be ready to receive status packets, when CTR flag low.
* Use same logic for short packets for all transfers (both control and non-control).

While I cannot find any issues with the code in particular, I'm still unable to connect to the RNDIS webserver (I'm using Windows 10).

I've run my USBTMC test routines, and there seems to be no regressions in it, but I'd appreciate additional testing.