### PR TITLE
Modify include of HAL, remove CMSIS clock configuration code, STM32F407 UART

### DIFF
--- a/hw/bsp/stm32f070rbnucleo/stm32f070rbnucleo.c
+++ b/hw/bsp/stm32f070rbnucleo/stm32f070rbnucleo.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32f0xx.h"
-#include "stm32f0xx_hal_conf.h"
+#include "stm32f0xx_hal.h"
 
 #define LED_PORT              GPIOA
 #define LED_PIN               GPIO_PIN_5
@@ -57,10 +56,7 @@ static void all_rcc_clk_enable(void)
 
 void board_init(void)
 {
-  #if CFG_TUSB_OS  == OPT_OS_NONE
-  // 1ms tick timer
-  SysTick_Config(SystemCoreClock / 1000);
-  #endif
+
 
   /* Configure the system clock to 48 MHz */
   RCC_ClkInitTypeDef RCC_ClkInitStruct;
@@ -90,9 +86,12 @@ void board_init(void)
   (void)HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) ;
   
   // Notify runtime of frequency change.
-  SystemCoreClockUpdate();
-
   all_rcc_clk_enable();
+
+  #if CFG_TUSB_OS  == OPT_OS_NONE
+  // 1ms tick timer
+  SysTick_Config(SystemCoreClock / 1000);
+  #endif
 
   // LED
   GPIO_InitTypeDef  GPIO_InitStruct;

--- a/hw/bsp/stm32f072disco/stm32f072disco.c
+++ b/hw/bsp/stm32f072disco/stm32f072disco.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32f0xx.h"
-#include "stm32f0xx_hal_conf.h"
+#include "stm32f0xx_hal.h"
 
 #define LED_PORT              GPIOC
 #define LED_PIN               GPIO_PIN_6
@@ -95,15 +94,13 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+  all_rcc_clk_enable();
+
   #if CFG_TUSB_OS  == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
   #endif
-
-  SystemClock_Config();
-  SystemCoreClockUpdate();
-  
-  all_rcc_clk_enable();
 
   // LED
   GPIO_InitTypeDef  GPIO_InitStruct;

--- a/hw/bsp/stm32f103bluepill/stm32f103bluepill.c
+++ b/hw/bsp/stm32f103bluepill/stm32f103bluepill.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32f1xx.h"
-#include "stm32f1xx_hal_conf.h"
+#include "stm32f1xx_hal.h"
 
 #define LED_PORT              GPIOC
 #define LED_PIN               GPIO_PIN_13
@@ -85,16 +84,14 @@ void SystemClock_Config(void)
 
 void board_init(void)
 {
+
+  SystemClock_Config();
+  
   #if CFG_TUSB_OS  == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
   #endif
-
-  SystemClock_Config();
   
-  // Notify runtime of frequency change.
-  SystemCoreClockUpdate();
-
   // LED
   __HAL_RCC_GPIOC_CLK_ENABLE();
   GPIO_InitTypeDef  GPIO_InitStruct;

--- a/hw/bsp/stm32f207nucleo/stm32f207nucleo.c
+++ b/hw/bsp/stm32f207nucleo/stm32f207nucleo.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32f2xx.h"
-#include "stm32f2xx_hal_conf.h"
+#include "stm32f2xx_hal.h"
 
 #define LED_PORT              GPIOB
 #define LED_PIN               GPIO_PIN_14
@@ -93,13 +92,13 @@ void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+  
   #if CFG_TUSB_OS  == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
   #endif
 
-  SystemClock_Config();
-  SystemCoreClockUpdate();
 
   all_rcc_clk_enable();
 

--- a/hw/bsp/stm32f303disco/stm32f303disco.c
+++ b/hw/bsp/stm32f303disco/stm32f303disco.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32f3xx.h"
-#include "stm32f3xx_hal_conf.h"
+#include "stm32f3xx_hal.h"
 
 #define LED_PORT              GPIOE
 #define LED_PIN               GPIO_PIN_9
@@ -89,15 +88,12 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+
   #if CFG_TUSB_OS  == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
   #endif
-
-  SystemClock_Config();
-
-  // Notify runtime of frequency change.
-  SystemCoreClockUpdate();
 
   // LED
   __HAL_RCC_GPIOE_CLK_ENABLE();

--- a/hw/bsp/stm32f401blackpill/stm32f401blackpill.c
+++ b/hw/bsp/stm32f401blackpill/stm32f401blackpill.c
@@ -100,6 +100,9 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+  all_rcc_clk_enable();
+
 #if CFG_TUSB_OS == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
@@ -107,11 +110,7 @@ void board_init(void)
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
   //NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
 #endif
-
-  SystemClock_Config();
-  SystemCoreClockUpdate();
-  all_rcc_clk_enable();
-
+  
   GPIO_InitTypeDef  GPIO_InitStruct;
 
   // LED

--- a/hw/bsp/stm32f407disco/board.mk
+++ b/hw/bsp/stm32f407disco/board.mk
@@ -19,6 +19,7 @@ SRC_C += \
 	$(ST_CMSIS)/Source/Templates/system_stm32f4xx.c \
 	$(ST_HAL_DRIVER)/Src/stm32f4xx_hal.c \
 	$(ST_HAL_DRIVER)/Src/stm32f4xx_hal_cortex.c \
+	$(ST_HAL_DRIVER)/Src/stm32f4xx_hal_uart.c \
 	$(ST_HAL_DRIVER)/Src/stm32f4xx_hal_rcc.c \
 	$(ST_HAL_DRIVER)/Src/stm32f4xx_hal_gpio.c
 

--- a/hw/bsp/stm32f407disco/stm32f407disco.c
+++ b/hw/bsp/stm32f407disco/stm32f407disco.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
+#include "stm32f4xx_hal.h"
 
 #define LED_PORT              GPIOD
 #define LED_PIN               GPIO_PIN_14
@@ -38,11 +37,22 @@
 #define BUTTON_STATE_ACTIVE   1
 
 
+// Enable PA2 as the debug log UART
+// It is not routed to the ST/Link on the Discovery board.
+#define UARTx                 USART2
+#define UART_GPIO_PORT        GPIOA
+#define UART_GPIO_AF          GPIO_AF7_USART2
+#define UART_TX_PIN           GPIO_PIN_2
+#define UART_RX_PIN           GPIO_PIN_3
+
+UART_HandleTypeDef UartHandle;
+
 // enable all LED, Button, Uart, USB clock
 static void all_rcc_clk_enable(void)
 {
   __HAL_RCC_GPIOA_CLK_ENABLE();  // USB D+, D-, Button
   __HAL_RCC_GPIOD_CLK_ENABLE();  // LED
+  __HAL_RCC_USART2_CLK_ENABLE(); // Uart module
 }
 
 /**
@@ -101,6 +111,9 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+  all_rcc_clk_enable();
+
 #if CFG_TUSB_OS  == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
@@ -108,10 +121,6 @@ void board_init(void)
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
   //NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
 #endif
-
-  SystemClock_Config();
-  SystemCoreClockUpdate();
-  all_rcc_clk_enable();
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 
@@ -155,6 +164,25 @@ void board_init(void)
   GPIO_InitStruct.Alternate = GPIO_AF10_OTG_FS;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
+  GPIO_InitStruct.Pin       = UART_TX_PIN | UART_RX_PIN;
+  GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+  GPIO_InitStruct.Pull      = GPIO_PULLUP;
+  GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_HIGH;
+  GPIO_InitStruct.Alternate = UART_GPIO_AF;
+  HAL_GPIO_Init(UART_GPIO_PORT, &GPIO_InitStruct);
+
+  UartHandle = (UART_HandleTypeDef){
+    .Instance        = UARTx,
+    .Init.BaudRate   = CFG_BOARD_UART_BAUDRATE,
+    .Init.WordLength = UART_WORDLENGTH_8B,
+    .Init.StopBits   = UART_STOPBITS_1,
+    .Init.Parity     = UART_PARITY_NONE,
+    .Init.HwFlowCtl  = UART_HWCONTROL_NONE,
+    .Init.Mode       = UART_MODE_TX_RX,
+    .Init.OverSampling = UART_OVERSAMPLING_16
+  };
+  HAL_UART_Init(&UartHandle);
+
   // Enable USB OTG clock
   __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
 
@@ -185,8 +213,8 @@ int board_uart_read(uint8_t* buf, int len)
 
 int board_uart_write(void const * buf, int len)
 {
-  (void) buf; (void) len;
-  return 0;
+  HAL_UART_Transmit(&UartHandle, (uint8_t*) buf, len, 0xffff);
+  return len;
 }
 
 #if CFG_TUSB_OS  == OPT_OS_NONE

--- a/hw/bsp/stm32f407disco/stm32f4xx_hal_conf.h
+++ b/hw/bsp/stm32f407disco/stm32f4xx_hal_conf.h
@@ -79,7 +79,7 @@
 /* #define HAL_SD_MODULE_ENABLED         */
 // #define HAL_SPI_MODULE_ENABLED
 /* #define HAL_TIM_MODULE_ENABLED       */
-/* #define HAL_UART_MODULE_ENABLED      */
+#define HAL_UART_MODULE_ENABLED
 /* #define HAL_USART_MODULE_ENABLED     */ 
 /* #define HAL_IRDA_MODULE_ENABLED      */
 /* #define HAL_SMARTCARD_MODULE_ENABLED */

--- a/hw/bsp/stm32f411blackpill/stm32f411blackpill.c
+++ b/hw/bsp/stm32f411blackpill/stm32f411blackpill.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
+#include "stm32f4xx_hal.h"
 
 #define LED_PORT              GPIOC
 #define LED_PIN               GPIO_PIN_13
@@ -100,6 +99,9 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+  all_rcc_clk_enable();
+
 #if CFG_TUSB_OS == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
@@ -107,10 +109,6 @@ void board_init(void)
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
   //NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
 #endif
-
-  SystemClock_Config();
-  SystemCoreClockUpdate();
-  all_rcc_clk_enable();
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 

--- a/hw/bsp/stm32f411disco/stm32f411disco.c
+++ b/hw/bsp/stm32f411disco/stm32f411disco.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32f4xx.h"
-#include "stm32f4xx_hal_conf.h"
+#include "stm32f4xx_hal.h"
 
 #define LED_PORT              GPIOD
 #define LED_PIN               GPIO_PIN_13
@@ -100,6 +99,9 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+  all_rcc_clk_enable();
+
 #if CFG_TUSB_OS == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
@@ -107,10 +109,6 @@ void board_init(void)
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
   //NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
 #endif
-
-  SystemClock_Config();
-  SystemCoreClockUpdate();
-  all_rcc_clk_enable();
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 

--- a/hw/bsp/stm32f412disco/stm32f412disco.c
+++ b/hw/bsp/stm32f412disco/stm32f412disco.c
@@ -122,7 +122,6 @@ static void SystemClock_Config(void)
 void board_init(void)
 {
   SystemClock_Config();
-  SystemCoreClockUpdate();
   all_rcc_clk_enable();
 
 #if CFG_TUSB_OS == OPT_OS_NONE

--- a/hw/bsp/stm32f767nucleo/stm32f767nucleo.c
+++ b/hw/bsp/stm32f767nucleo/stm32f767nucleo.c
@@ -27,8 +27,7 @@
 
 #include "../board.h"
 
-#include "stm32f7xx.h"
-#include "stm32f7xx_hal_conf.h"
+#include "stm32f7xx_hal.h"
 
 #define LED_PORT              GPIOB
 #define LED_PIN               GPIO_PIN_14
@@ -121,15 +120,15 @@ void SystemClock_Config(void)
 
 void board_init(void)
 {
-  #if CFG_TUSB_OS  == OPT_OS_NONE
-    // 1ms tick timer
-    SysTick_Config(SystemCoreClock / 1000);
-  #endif
+
 
   SystemClock_Config();
-  SystemCoreClockUpdate();
-
   all_rcc_clk_enable();
+
+#if CFG_TUSB_OS  == OPT_OS_NONE
+  // 1ms tick timer
+  SysTick_Config(SystemCoreClock / 1000);
+#endif
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 

--- a/hw/bsp/stm32h743nucleo/stm32h743nucleo.c
+++ b/hw/bsp/stm32h743nucleo/stm32h743nucleo.c
@@ -27,8 +27,7 @@
 
 #include "../board.h"
 
-#include "stm32h7xx.h"
-#include "stm32h7xx_hal_conf.h"
+#include "stm32h7xx_hal.h"
 
 #define LED_PORT              GPIOB
 #define LED_PIN               GPIO_PIN_0
@@ -98,6 +97,7 @@ static void SystemClock_Config(void)
   RCC_OscInitStruct.PLL.PLLN = 336;
   RCC_OscInitStruct.PLL.PLLP = 2;
   RCC_OscInitStruct.PLL.PLLQ = 7;
+  RCC_OscInitStruct.PLL.PLLR = 2; /* Unused */
   RCC_OscInitStruct.PLL.PLLRGE = RCC_PLL1VCIRANGE_0;
   RCC_OscInitStruct.PLL.PLLVCOSEL = RCC_PLL1VCOMEDIUM;
   RCC_OscInitStruct.PLL.PLLFRACN = 0;
@@ -134,15 +134,14 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+  all_rcc_clk_enable();
+
   #if CFG_TUSB_OS  == OPT_OS_NONE
     // 1ms tick timer
     SysTick_Config(SystemCoreClock / 1000);
   #endif
-
-  SystemClock_Config();
-  SystemCoreClockUpdate();
-  all_rcc_clk_enable();
-
+  
   GPIO_InitTypeDef  GPIO_InitStruct;
 
   // LED

--- a/hw/bsp/stm32l0538disco/stm32l0538disco.c
+++ b/hw/bsp/stm32l0538disco/stm32l0538disco.c
@@ -26,8 +26,7 @@
 
 #include "../board.h"
 
-#include "stm32l0xx.h"
-#include "stm32l0xx_hal_conf.h"
+#include "stm32l0xx_hal.h"
 
 #define LED_PORT              GPIOA
 #define LED_PIN               GPIO_PIN_5
@@ -101,6 +100,8 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+
 #if CFG_TUSB_OS  == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
@@ -108,11 +109,6 @@ void board_init(void)
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
   //NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
 #endif
-
-  SystemClock_Config();
-
-  // Notify runtime of frequency change.
-  SystemCoreClockUpdate();
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 

--- a/hw/bsp/stm32l476disco/stm32l476disco.c
+++ b/hw/bsp/stm32l476disco/stm32l476disco.c
@@ -26,8 +26,6 @@
 
 #include "../board.h"
 
-#include "stm32l4xx.h"
-#include "stm32l4xx_hal_conf.h"
 #include "stm32l4xx_hal.h"
 
 #define LED_PORT              GPIOB
@@ -118,6 +116,9 @@ static void SystemClock_Config(void)
 
 void board_init(void)
 {
+  SystemClock_Config();
+  all_rcc_clk_enable();
+
 #if CFG_TUSB_OS  == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
@@ -125,10 +126,6 @@ void board_init(void)
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
   //NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
 #endif
-
-  SystemClock_Config();
-  SystemCoreClockUpdate();
-  all_rcc_clk_enable();
 
   /* Enable Power Clock*/
   __HAL_RCC_PWR_CLK_ENABLE();


### PR DESCRIPTION
Fixes #204 

(It has only been tested on the F407, lets hope it passes CI.)

There is still a little bit of non-uniformity to the BSP. This patch leaves some of the individuality.