### PR TITLE
usbnet: tweak CDC-ECM after MacOS testing

### DIFF
--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -53,7 +53,8 @@ static struct pbuf *received_frame;
 
 /* this is used by this code, ./class/net/net_driver.c, and usb_descriptors.c */
 /* ideally speaking, this should be generated from the hardware's unique ID (if available) */
-const uint8_t tud_network_mac_address[6] = {0x20,0x89,0x84,0x6A,0x96,0x00};
+/* it is suggested that the first two bytes are 0x02,0x02 to indicate a link-local address */
+const uint8_t tud_network_mac_address[6] = {0x02,0x02,0x84,0x6A,0x96,0x00};
 
 /* network parameters of this MCU */
 static const ip_addr_t ipaddr  = IPADDR4_INIT_BYTES(192, 168, 7, 1);
@@ -124,8 +125,11 @@ static void init_lwip(void)
   struct netif *netif = &netif_data;
 
   lwip_init();
+
+  /* the lwip virtual MAC address must be different from the host's; to ensure this, we toggle the LSbit */
   netif->hwaddr_len = sizeof(tud_network_mac_address);
   memcpy(netif->hwaddr, tud_network_mac_address, sizeof(tud_network_mac_address));
+  netif->hwaddr[5] ^= 0x01;
 
   netif = netif_add(netif, &ipaddr, &netmask, &gateway, NULL, netif_init_cb, ip_input);
   netif_set_default(netif);

--- a/examples/device/net_lwip_webserver/src/usb_descriptors.c
+++ b/examples/device/net_lwip_webserver/src/usb_descriptors.c
@@ -112,7 +112,7 @@ uint8_t const desc_configuration[] =
 
 #if CFG_TUD_NET == OPT_NET_ECM
   // Interface number, description string index, MAC address string index, EP notification address and size, EP data address (out, in), and size, max segment size.
-  TUD_CDC_ECM_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, STRID_MAC, 0x81, 8, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE, CFG_TUD_NET_MTU),
+  TUD_CDC_ECM_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, STRID_MAC, 0x81, 64, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE, CFG_TUD_NET_MTU),
 #elif CFG_TUD_NET == OPT_NET_RNDIS
   // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_RNDIS_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, 0x81, 8, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE),


### PR DESCRIPTION
I was able to borrow an older MacOS X Lion (2012-era) host and use it to test the net class CDC-ECM implementation.  MacOS is more picky than Linux, and it forced me to improve the implementation.

I had test success with all the targets I tried (SAMD21, STM32F0, NUC505, and NUC126).

Code changes were:

1) The ECM descriptor had to use a 64 byte, not 8 byte, max packet size for the ECM notification endpoint (despite the largest message used being only 8 bytes).
2) The CDC-ECM standard requires support for one particular class request (aka "Management Element Request") named SET_ETHERNET_PACKET_FILTER, and the previous implementation had omitted this.
3) Apparently, MacOS defaults to the assumption that a CDC-ECM network interface is unconnected unless it receives a "Management Element Notification" with a NETWORK_CONNECTION message indicating Connected.
4) I had mistakenly assigned the same MAC address to both the PC host (ECM provides a MAC address as a USB string) and the virtual lwip Ethernet interface.  Linux didn’t care, but MacOS got very confused.

A longer-term stretch goal would be to change the implementation to support both PC/Linux and MacOS hosts without re-compiling by dynamically switching between RNDIS and CDC-ECM configurations.  However, I promise nothing.
