### PR TITLE
add provision for alternate interfaces

### DIFF
--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -183,6 +183,10 @@
 #define CFG_TUSB_OS               OPT_OS_NONE
 #endif
 
+#ifndef CFG_TUD_SUPPORT_ALTERNATES
+  #define CFG_TUD_SUPPORT_ALTERNATES 0
+#endif
+
 //--------------------------------------------------------------------
 // DEVICE OPTIONS
 //--------------------------------------------------------------------


### PR DESCRIPTION
Another revision to usbnet CDC-ECM is in the pipeline and operational, but it depends on support for alternate interfaces.  Re-reading the CDC-ECM specification, this is mandatory; although OS X ‘Lion’ and Linux wasn't bothered, the CDC-ECM drivers in more modern MacOS insist upon alternate interfaces.

So, this PR provides provision for this.
