### PR TITLE
Misc. tweaks, and fix for USBTMC descriptors without an INT EP

### DIFF
--- a/examples/device/usbtmc/src/usb_descriptors.c
+++ b/examples/device/usbtmc/src/usb_descriptors.c
@@ -109,18 +109,18 @@ uint8_t const * tud_hid_descriptor_report_cb(void)
      TUD_USBTMC_IF_DESCRIPTOR(_itfnum, _bNumEndpoints,  /*_stridx = */ 4u, TUD_USBTMC_PROTOCOL_USB488), \
      TUD_USBTMC_BULK_DESCRIPTORS(/* OUT = */0x01, /* IN = */ 0x81, /* packet size = */USBTMCD_MAX_PACKET_SIZE)
 
-#if defined(CFG_TUD_USBTMC_ENABLE_INT_EP)
+#if CFG_TUD_USBTMC_ENABLE_INT_EP
 // Interrupt endpoint should be 2 bytes on a FS USB link
 #  define TUD_USBTMC_DESC(_itfnum) \
      TUD_USBTMC_DESC_MAIN(_itfnum, /* _epCount = */ 3), \
      TUD_USBTMC_INT_DESCRIPTOR(/* INT ep # */ 0x82, /* epMaxSize = */ 2, /* bInterval = */16u )
-#  define USBTMC_DESC_LEN (TUD_USBTMC_IF_DESCRIPTOR_LEN + TUD_USBTMC_BULK_DESCRIPTORS_LEN + TUD_USBTMC_INT_DESCRIPTOR_LEN)
+#  define TUD_USBTMC_DESC_LEN (TUD_USBTMC_IF_DESCRIPTOR_LEN + TUD_USBTMC_BULK_DESCRIPTORS_LEN + TUD_USBTMC_INT_DESCRIPTOR_LEN)
 
 #else
 
-#  define USBTMC_DESC(_itfnum) \
-     USBTMC_DESC_MAIN(_itfnum, /* _epCount = */ 2u)
-#  define USBTMC_DESC_LEN (USBTMC_IF_DESCRIPTOR_LEN + USBTMC_BULK_DESCRIPTORS_LEN)
+#  define TUD_USBTMC_DESC(_itfnum) \
+     TUD_USBTMC_DESC_MAIN(_itfnum, /* _epCount = */ 2u)
+#  define TUD_USBTMC_DESC_LEN (TUD_USBTMC_IF_DESCRIPTOR_LEN + TUD_USBTMC_BULK_DESCRIPTORS_LEN)
 
 #endif /* CFG_TUD_USBTMC_ENABLE_INT_EP */
 
@@ -150,7 +150,7 @@ enum
 
 
 #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + CFG_TUD_CDC*TUD_CDC_DESC_LEN + CFG_TUD_MSC*TUD_MSC_DESC_LEN +  \
-    CFG_TUD_HID*TUD_HID_DESC_LEN  + (CFG_TUD_USBTMC)*USBTMC_DESC_LEN)
+    CFG_TUD_HID*TUD_HID_DESC_LEN  + (CFG_TUD_USBTMC)*TUD_USBTMC_DESC_LEN)
 
 #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
   // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number

--- a/examples/device/usbtmc/src/usbtmc_app.c
+++ b/examples/device/usbtmc/src/usbtmc_app.c
@@ -303,7 +303,7 @@ bool tud_usbtmc_check_abort_bulk_out_cb(usbtmc_check_abort_bulk_rsp_t *rsp)
 void tud_usbtmc_bulkIn_clearFeature_cb(void)
 {
 }
-void tud_usmtmc_bulkOut_clearFeature_cb(void)
+void tud_usbtmc_bulkOut_clearFeature_cb(void)
 {
   tud_usbtmc_start_bus_read();
 }

--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -590,7 +590,7 @@ bool usbtmcd_control_request_cb(uint8_t rhport, tusb_control_request_t const * r
       criticalEnter();
       usbtmc_state.state = STATE_NAK; // USBD core has placed EP in NAK state for us
       criticalLeave();
-      tud_usmtmc_bulkOut_clearFeature_cb();
+      tud_usbtmc_bulkOut_clearFeature_cb();
     }
     else if (ep_addr == usbtmc_state.ep_bulk_in)
     {

--- a/src/class/usbtmc/usbtmc_device.h
+++ b/src/class/usbtmc/usbtmc_device.h
@@ -69,7 +69,7 @@ void tud_usbtmc_open_cb(uint8_t interface_id);
 bool tud_usbtmc_msgBulkOut_start_cb(usbtmc_msg_request_dev_dep_out const * msgHeader);
 // transfer_complete does not imply that a message is complete.
 bool tud_usbtmc_msg_data_cb( void *data, size_t len, bool transfer_complete);
-void tud_usmtmc_bulkOut_clearFeature_cb(void); // Notice to clear and abort the pending BULK out transfer
+void tud_usbtmc_bulkOut_clearFeature_cb(void); // Notice to clear and abort the pending BULK out transfer
 
 bool tud_usbtmc_msgBulkIn_request_cb(usbtmc_msg_request_dev_dep_in const * request);
 bool tud_usbtmc_msgBulkIn_complete_cb(void);

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -79,8 +79,8 @@
   #define _MESS_ERR(_err)   printf("%s %d: failed, error = %s\r\n", __func__, __LINE__, tusb_strerr[_err])
   #define _MESS_FAILED()    printf("%s %d: assert failed\r\n", __func__, __LINE__)
 #else
-  #define _MESS_ERR(_err)
-  #define _MESS_FAILED()
+  #define _MESS_ERR(_err) do {} while (0)
+  #define _MESS_FAILED() do {} while (0)
 #endif
 
 // Halt CPU (breakpoint) when hitting error, only apply for Cortex M3, M4, M7
@@ -94,7 +94,7 @@
 #if defined(__riscv)
   #define TU_BREAKPOINT() do { __asm("ebreak\n"); } while(0)
 #else
-  #define TU_BREAKPOINT()
+  #define TU_BREAKPOINT() do {} while (0)
 #endif
 #endif
 

--- a/src/osal/osal.h
+++ b/src/osal/osal.h
@@ -40,8 +40,9 @@ enum
 {
   OSAL_TIMEOUT_NOTIMEOUT    = 0,      // return immediately
   OSAL_TIMEOUT_NORMAL       = 10,     // default timeout
-  OSAL_TIMEOUT_WAIT_FOREVER = 0xFFFFFFFFUL
 };
+
+static const uint32_t  OSAL_TIMEOUT_WAIT_FOREVER = 0xFFFFFFFFUL;
 
 #define OSAL_TIMEOUT_CONTROL_XFER  OSAL_TIMEOUT_WAIT_FOREVER
 

--- a/src/osal/osal.h
+++ b/src/osal/osal.h
@@ -36,13 +36,12 @@
 
 #include "common/tusb_common.h"
 
-enum
-{
-  OSAL_TIMEOUT_NOTIMEOUT    = 0,      // return immediately
-  OSAL_TIMEOUT_NORMAL       = 10,     // default timeout
-};
-
-static const uint32_t  OSAL_TIMEOUT_WAIT_FOREVER = 0xFFFFFFFFUL;
+// Return immediately
+#define OSAL_TIMEOUT_NOTIMEOUT (0)
+// Default timeout
+#define OSAL_TIMEOUT_NORMAL       (10)
+// Wait forever
+#define OSAL_TIMEOUT_WAIT_FOREVER  (UINT32_MAX)
 
 #define OSAL_TIMEOUT_CONTROL_XFER  OSAL_TIMEOUT_WAIT_FOREVER
 


### PR DESCRIPTION
This is a set of random fixes (from my old development branch):

* gcc interprets values as signed in enums, and MAX_DELAY was causing a pedantic warning. Might as well get rid of the issue
* USBTMC descriptors were not properly set when the interrupt endpoint was disabled.
* Typo of usmtmc instead of usbtmc.
* Make some `#defines` functions use the `do{}while(0)` syntax, so they are treated more like normal C functions.