### PR TITLE
Cache MSP430 toolchain and NPM modules.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,15 +31,6 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
     
-    - name: Cache xPacks
-      uses: actions/cache@v1
-      env:
-        cache-name: cache-xpacks-modules
-      with:
-        path: ~/opt/xPacks # xpm cache files are installed in `~/opt/xPacks` on Linux.
-        # Update key with new serial number when packages are updated
-        key: xpm-${{ runner.os }}-build-${{ env.cache-name }}-0
-    
     - name: Cache MSP430 Toolchain
       id: cache-msp430
       uses: actions/cache@v1
@@ -50,13 +41,12 @@ jobs:
     
     - name: Setup Node.js
       uses: actions/setup-node@v1.1.0
-
+      
     - name: Install Toolchains
       run: |
         npm install --global xpm
-        # If updating version, update cache key above
-        xpm install --global @xpack-dev-tools/arm-none-eabi-gcc@9.2.1-1.1.1
-        xpm install --global @xpack-dev-tools/riscv-none-embed-gcc@8.3.0-1.1.1
+        xpm install --global @xpack-dev-tools/arm-none-eabi-gcc@latest
+        xpm install --global @xpack-dev-tools/riscv-none-embed-gcc@latest
         mkdir -p /tmp/dl/
         [ -f "/tmp/dl/msp430-gcc.tar.bz2" ] || wget --progress=dot:mega http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/8_3_0_0/exports/msp430-gcc-8.3.0.16_linux64.tar.bz2 -O /tmp/dl/msp430-gcc.tar.bz2
         tar -C $HOME -xaf /tmp/dl/msp430-gcc.tar.bz2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,29 +30,53 @@ jobs:
     steps:
     - name: Setup Python
       uses: actions/setup-python@v1
-
+    
+    - name: Cache xPacks
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-xpacks-modules
+      with:
+        path: ~/opt/xPacks # xpm cache files are installed in `~/opt/xPacks` on Linux.
+        # Update key with new serial number when packages are updated
+        key: xpm-${{ runner.os }}-build-${{ env.cache-name }}-0
+    
+    - name: Cache MSP430 Toolchain
+      id: cache-msp430
+      uses: actions/cache@v1
+      with:
+        path: /tmp/dl/
+        # Increment serial number at end when updating downloads
+        key: msp430-${{ runner.os }}-0
+    
     - name: Setup Node.js
       uses: actions/setup-node@v1.1.0
-      
+
     - name: Install Toolchains
       run: |
         npm install --global xpm
-        xpm install --global @xpack-dev-tools/arm-none-eabi-gcc@latest
-        xpm install --global @xpack-dev-tools/riscv-none-embed-gcc@latest
-        wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/8_3_0_0/exports/msp430-gcc-8.3.0.16_linux64.tar.bz2 -O /tmp/msp430-gcc.tar.bz2
-        tar -C $HOME -xaf /tmp/msp430-gcc.tar.bz2
+        # If updating version, update cache key above
+        xpm install --global @xpack-dev-tools/arm-none-eabi-gcc@9.2.1-1.1.1
+        xpm install --global @xpack-dev-tools/riscv-none-embed-gcc@8.3.0-1.1.1
+        mkdir -p /tmp/dl/
+        [ -f "/tmp/dl/msp430-gcc.tar.bz2" ] || wget --progress=dot:mega http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/8_3_0_0/exports/msp430-gcc-8.3.0.16_linux64.tar.bz2 -O /tmp/dl/msp430-gcc.tar.bz2
+        tar -C $HOME -xaf /tmp/dl/msp430-gcc.tar.bz2
         echo "::add-path::`echo $HOME/opt/xPacks/@xpack-dev-tools/arm-none-eabi-gcc/*/.content/bin`"
         echo "::add-path::`echo $HOME/opt/xPacks/@xpack-dev-tools/riscv-none-embed-gcc/*/.content/bin`"
         echo "::add-path::`echo $HOME/msp430-gcc-*_linux64/bin`"
       
     - name: Checkout TinyUSB
       uses: actions/checkout@v2
-    
+      with:
+        # Cannot do submodule checkout here since LWIP's git server cannot checkout unadventised commits (it must use tags)
+        submodules: 'false'
+        
     - name: Checkout Submodules
       run: |
         git submodule sync --recursive
-        git submodule update --init --recursive
-    
+        # Special case LWIP since GNU's Savannah can't do shallow checkout of non-tagged commits
+        git submodule update --init --recursive lib/lwip
+        git submodule update --init --recursive --depth 1
+
     - name: Build
       run: python3 tools/build_all.py ${{ matrix.example }}
 


### PR DESCRIPTION
This uses github actions to cache xPack and MSP430 downloads.

It looks like there's no great way to derive a cache hash key from the downloads, so I'm manually setting the hash keys with a `-0` serial number. When package revisions are updated, the serial number should be incremented. I explicitly mark the xPack revisions to use so that multiple versions of an xPack package won't be installed simultaneously (the cached and the latest). 

This PR also limits the depth of git submodule checkouts to `1`. The LWIP repository can't handle checking out arbitrary commits with a depth of `1`, so it has to be special-cased.  Referencing a tagged commit (a release commit), would work, but the latest release is 16 months ago. Except for this special case, the `checkout` action could automatically also checkout submodules, by setting `submodules` to true.

Overall, this reduces the CI runtime by somewhat more than 1 minute (if the the toolchains are already in the cache). I don't know if it's worth the extra complexity or not.

This PR conflicts with the ESP32 changes, so I'm marking this as draft. I'll update this commit once ESP32 changes are merged.