### PR TITLE
allow application to implement its own os

### DIFF
--- a/src/osal/osal.h
+++ b/src/osal/osal.h
@@ -53,6 +53,8 @@ typedef void (*osal_task_func_t)( void * );
   #include "osal_freertos.h"
 #elif CFG_TUSB_OS == OPT_OS_MYNEWT
   #include "osal_mynewt.h"
+#elif CFG_TUSB_OS == OPT_OS_CUSTOM
+  #include "tusb_os_custom.h" // implemented by application
 #else
   #error OS is not supported yet
 #endif

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -93,9 +93,10 @@
 /** \defgroup group_supported_os Supported RTOS
  *  \ref CFG_TUSB_OS must be defined to one of these
  *  @{ */
-#define OPT_OS_NONE       1 ///< No RTOS
-#define OPT_OS_FREERTOS   2 ///< FreeRTOS
-#define OPT_OS_MYNEWT     3 ///< Mynewt OS
+#define OPT_OS_NONE       1  ///< No RTOS
+#define OPT_OS_FREERTOS   2  ///< FreeRTOS
+#define OPT_OS_MYNEWT     3  ///< Mynewt OS
+#define OPT_OS_CUSTOM     4  ///< Custom OS is implemented by application
 /** @} */
 
 


### PR DESCRIPTION
after discussion in #322 , this allow application to provide its own cutom OS implementation if so desired. 

Note: the osal API() is not finalized nor clean yet. Since part of the API is used by host stack, which is way behind device stack for now.   