### PR TITLE
GET/SET_CONFIGURATION for multiple configurations

### DIFF
--- a/src/class/net/net_device.c
+++ b/src/class/net/net_device.c
@@ -273,23 +273,26 @@ static void handle_incoming_packet(uint32_t len)
   }
 #endif
 
+  bool accepted = false;
+
   if (size)
   {
     struct pbuf *p = pbuf_alloc(PBUF_RAW, size, PBUF_POOL);
-    bool accepted = true;
 
     if (p)
     {
       memcpy(p->payload, pnt, size);
       p->len = size;
       accepted = tud_network_recv_cb(p);
-    }
 
-    if (!p || !accepted)
-    {
-      /* if a buffer couldn't be allocated or accepted by the callback, we must discard this packet */
-      tud_network_recv_renew();
+      if (!accepted) pbuf_free(p);
     }
+  }
+
+  if (!accepted)
+  {
+    /* if a buffer was never handled by user code, we must renew on the user's behalf */
+    tud_network_recv_renew();
   }
 }
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -555,8 +555,7 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
           }
           else
           {
-            TU_VERIFY( (0 == _usbd_dev.config_num) || (cfg_num == _usbd_dev.config_num) );
-            if (0 == _usbd_dev.config_num) TU_ASSERT( process_set_config(rhport, cfg_num) );
+            if (!_usbd_dev.config_num) TU_VERIFY( process_set_config(rhport, cfg_num) );
           }
 
           _usbd_dev.config_num = cfg_num;

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -52,7 +52,7 @@ typedef struct {
     uint8_t self_powered          : 1; // configuration descriptor's attribute
   };
 
-  volatile uint8_t selected_config;
+  volatile uint8_t config_num;
 
   uint8_t itf2drv[16];     // map interface number to driver (0xff is invalid)
   uint8_t ep2drv[8][2];    // map endpoint to driver ( 0xff is invalid )
@@ -295,7 +295,7 @@ static char const* const _tusb_std_request_str[] =
 //--------------------------------------------------------------------+
 bool tud_mounted(void)
 {
-  return _usbd_dev.selected_config;
+  return _usbd_dev.config_num;
 }
 
 bool tud_suspended(void)
@@ -537,7 +537,7 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
 
         case TUSB_REQ_GET_CONFIGURATION:
         {
-          uint8_t cfgnum = _usbd_dev.selected_config;
+          uint8_t cfgnum = _usbd_dev.config_num;
           tud_control_xfer(rhport, p_request, &cfgnum, 1);
         }
         break;
@@ -555,11 +555,11 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
           }
           else
           {
-            TU_VERIFY( (0 == _usbd_dev.selected_config) || (cfg_num == _usbd_dev.selected_config) );
-            if (0 == _usbd_dev.selected_config) TU_ASSERT( process_set_config(rhport, cfg_num) );
+            TU_VERIFY( (0 == _usbd_dev.config_num) || (cfg_num == _usbd_dev.config_num) );
+            if (0 == _usbd_dev.config_num) TU_ASSERT( process_set_config(rhport, cfg_num) );
           }
 
-          _usbd_dev.selected_config = cfg_num;
+          _usbd_dev.config_num = cfg_num;
 
           tud_control_status(rhport, p_request);
         }
@@ -891,7 +891,7 @@ void dcd_event_handler(dcd_event_t const * event, bool in_isr)
       _usbd_dev.connected  = 0;
       _usbd_dev.addressed  = 0;
       _usbd_dev.suspended  = 0;
-      _usbd_dev.selected_config = 0;
+      _usbd_dev.config_num = 0;
       osal_queue_send(_usbd_q, event, in_isr);
     break;
 

--- a/src/portable/nuvoton/nuc120/dcd_nuc120.c
+++ b/src/portable/nuvoton/nuc120/dcd_nuc120.c
@@ -223,6 +223,15 @@ void dcd_set_config(uint8_t rhport, uint8_t config_num)
 {
   (void) rhport;
   (void) config_num;
+
+  /* reset context of all non-control endpoints */
+
+  for (enum ep_enum ep_index = PERIPH_EP2; ep_index < PERIPH_MAX_EP; ep_index++)
+  {
+    USBD->EP[ep_index].CFG = 0;
+  }
+
+  bufseg_addr = PERIPH_EP2_BUF_BASE;
 }
 
 void dcd_remote_wakeup(uint8_t rhport)

--- a/src/portable/nuvoton/nuc121/dcd_nuc121.c
+++ b/src/portable/nuvoton/nuc121/dcd_nuc121.c
@@ -229,6 +229,15 @@ void dcd_set_config(uint8_t rhport, uint8_t config_num)
 {
   (void) rhport;
   (void) config_num;
+
+  /* reset context of all non-control endpoints */
+
+  for (enum ep_enum ep_index = PERIPH_EP2; ep_index < PERIPH_MAX_EP; ep_index++)
+  {
+    USBD->EP[ep_index].CFG = 0;
+  }
+
+  bufseg_addr = PERIPH_EP2_BUF_BASE;
 }
 
 void dcd_remote_wakeup(uint8_t rhport)


### PR DESCRIPTION
This PR cherry-picks aspects of #167.  That PR has several objectives; this has just one: allow GET_CONFIGURATION/SET_CONFIGURATION to facilitate multiple configurations.

Behavior should be as the USB spec says.  A zero configuration value is only accepted when in Address or Configured state.  A non-zero configuration value is accepted only when it matches the current configuration or when the device is in Address state.

Testing can be accomplished with [this suggested procedure](https://github.com/hathach/tinyusb/pull/167#issuecomment-609480555).
