### PR TITLE
stm32fsdev: Implement dcd_connect.

### DIFF
--- a/docs/porting.md
+++ b/docs/porting.md
@@ -62,6 +62,8 @@ All of the code for the low-level device API is in `src/portable/<vendor>/<chip 
 ##### dcd_init
 Initializes the USB peripheral for device mode and enables it.
 
+If the MCU has an internal pull-up, this function should leave it disabled.
+
 #### dcd_int_enable / dcd_int_disable
 
 Enables or disables the USB device interrupt(s). May be used to prevent concurrency issues when mutating data structures shared between main code and the interrupt handler.
@@ -76,6 +78,10 @@ Called when the device received SET_CONFIG request, you can leave this empty if 
 
 ##### dcd_remote_wakeup
 Called to remote wake up host when suspended (e.g hid keyboard)
+
+##### dcd_connect / dcd_disconnect
+
+Connect or disconnect the data-line pull-up resistor. Define as a weak function if the MCU has an internal pull-up, otherwise do not define.
 
 #### Special events
 You must let TinyUSB know when certain events occur so that it can continue its work. There are a few methods you can call to queue events for TinyUSB to process.

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -62,7 +62,7 @@ All of the code for the low-level device API is in `src/portable/<vendor>/<chip 
 ##### dcd_init
 Initializes the USB peripheral for device mode and enables it.
 
-If the MCU has an internal pull-up, this function should leave it disabled.
+This function should leave an internal D+/D- pull-up in its default power-on state. `dcd_connect` will be called by the USBD core following `dcd_init`.
 
 #### dcd_int_enable / dcd_int_disable
 
@@ -81,7 +81,7 @@ Called to remote wake up host when suspended (e.g hid keyboard)
 
 ##### dcd_connect / dcd_disconnect
 
-Connect or disconnect the data-line pull-up resistor. Define as a weak function if the MCU has an internal pull-up, otherwise do not define.
+Connect or disconnect the data-line pull-up resistor. Define only if MCU has an internal pull-up. (BSP may define for MCU without internal pull-up.)
 
 #### Special events
 You must let TinyUSB know when certain events occur so that it can continue its work. There are a few methods you can call to queue events for TinyUSB to process.

--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -107,8 +107,8 @@ void dcd_set_config (uint8_t rhport, uint8_t config_num);
 void dcd_remote_wakeup(uint8_t rhport);
 
 // Connect or disconnect D+/D- line pull-up resistor.
-// Defined as weak in dcd source if MCU has internal pull-up.
-// Can be strongly defined in BSP.
+// Defined in dcd source if MCU has internal pull-up.
+// Otherwise, may be defined in BSP.
 void dcd_connect(uint8_t rhport) TU_ATTR_WEAK;
 void dcd_disconnect(uint8_t rhport) TU_ATTR_WEAK;
 

--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -106,11 +106,11 @@ void dcd_set_config (uint8_t rhport, uint8_t config_num);
 // Wake up host
 void dcd_remote_wakeup(uint8_t rhport);
 
-// disconnect by disabling internal pull-up resistor on D+/D-
-void dcd_disconnect(uint8_t rhport) TU_ATTR_WEAK;
-
-// connect by enabling internal pull-up resistor on D+/D-
+// Connect or disconnect D+/D- line pull-up resistor.
+// Defined as weak in dcd source if MCU has internal pull-up.
+// Can be strongly defined in BSP.
 void dcd_connect(uint8_t rhport) TU_ATTR_WEAK;
+void dcd_disconnect(uint8_t rhport) TU_ATTR_WEAK;
 
 //--------------------------------------------------------------------+
 // Endpoint API

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -332,6 +332,7 @@ bool tud_init (void)
 
   // Init device controller driver
   dcd_init(TUD_OPT_RHPORT);
+  tud_connect();
   dcd_int_enable(TUD_OPT_RHPORT);
 
   return true;

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -243,17 +243,17 @@ void dcd_init (uint8_t rhport)
   // Data-line pull-up is left disconnected.
 }
 
-// Define only on MCU with internal pull-up so BSP can override (needed on MCU without internal pull-up)
+// Define only on MCU with internal pull-up. BSP can define on MCU without internal PU.
 #if defined(USB_BCDR_DPPU)
 
-TU_ATTR_WEAK
+// Disable internal D+ PU
 void dcd_disconnect(uint8_t rhport)
 {
   (void) rhport;
   USB->BCDR &= ~(USB_BCDR_DPPU);
 }
 
-TU_ATTR_WEAK
+// Enable internal D+ PU
 void dcd_connect(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -239,16 +239,28 @@ void dcd_init (uint8_t rhport)
   }
   USB->CNTR |= USB_CNTR_RESETM | USB_CNTR_SOFM | USB_CNTR_ESOFM | USB_CNTR_CTRM | USB_CNTR_SUSPM | USB_CNTR_WKUPM;
   dcd_handle_bus_reset();
-
-  // And finally enable pull-up, which may trigger the RESET IRQ if the host is connected.
-  // (if this MCU has an internal pullup)
-#if defined(USB_BCDR_DPPU)
-  USB->BCDR |= USB_BCDR_DPPU;
-#else
-  // FIXME: callback to the user to ask them to twiddle a GPIO to disable/enable D+???
-#endif
-
+  
+  // Data-line pull-up is left disconnected.
 }
+
+// Define only on MCU with internal pull-up so BSP can override (needed on MCU without internal pull-up)
+#if defined(USB_BCDR_DPPU)
+
+TU_ATTR_WEAK
+void dcd_disconnect(uint8_t rhport)
+{
+  (void) rhport;
+  USB->BCDR &= ~(USB_BCDR_DPPU);
+}
+
+TU_ATTR_WEAK
+void dcd_connect(uint8_t rhport)
+{
+  (void) rhport;
+  USB->BCDR |= USB_BCDR_DPPU;
+}
+
+#endif
 
 // Enable device interrupt
 void dcd_int_enable (uint8_t rhport)

--- a/src/portable/template/dcd_template.c
+++ b/src/portable/template/dcd_template.c
@@ -45,6 +45,20 @@ void dcd_init (uint8_t rhport)
   (void) rhport;
 }
 
+#if HAS_INTERNAL_PULLUP
+// Enable internal D+/D- pullup
+void dcd_connect(uint8_t rhport) TU_ATTR_WEAK
+{
+  (void) rhport;
+}
+
+// Disable internal D+/D- pullup
+void dcd_disconnect(uint8_t rhport) TU_ATTR_WEAK
+{
+  (void) rhport;
+}
+#endif
+
 // Enable device interrupt
 void dcd_int_enable (uint8_t rhport)
 {

--- a/test/test/device/msc/test_msc_device.c
+++ b/test/test/device/msc/test_msc_device.c
@@ -199,6 +199,7 @@ void setUp(void)
   if ( !tusb_inited() )
   {
     dcd_init_Expect(rhport);
+    dcd_connect_Expect(rhport);
     tusb_init();
   }
 

--- a/test/test/device/usbd/test_usbd.c
+++ b/test/test/device/usbd/test_usbd.c
@@ -127,6 +127,7 @@ void setUp(void)
   {
     mscd_init_Expect();
     dcd_init_Expect(rhport);
+    dcd_connect_Expect(rhport);
     tusb_init();
   }
 }


### PR DESCRIPTION
This is a followup for #327.

This patch proposes adding dcd_connect/dcd_disconnect as weak functions in the DCD source. Also, changes the intention of dcd_init to NOT enable internal pull-ups by default, so BSP can more easily override behavior.

This allows the BSP to optionally override these functions, so that an internal pull up does not have to be used (in the case, e.g., that external ESD protection already has its own pull-up).

In the case that there is no internal pull-up, by default nothing will change, unless the BSP defines a `dcd_connect` function, at which time this function will be called as part of `dcd_init`.

This patch also adds documentation for the meanings of these functions.

(Hmm, fails the board_test CI. I'll fix it if this patch is viable.)