### PR TITLE
fix incorrect setup packet

### DIFF
--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -56,7 +56,13 @@ StaticTimer_t blinky_tmdef;
 TimerHandle_t blinky_tm;
 
 // static task for usbd
-#define USBD_STACK_SIZE     (3*configMINIMAL_STACK_SIZE/2)
+// Increase stack size when debug log is enabled
+#if CFG_TUSB_DEBUG
+  #define USBD_STACK_SIZE     (3*configMINIMAL_STACK_SIZE)
+#else
+  #define USBD_STACK_SIZE     (3*configMINIMAL_STACK_SIZE/2)
+#endif
+
 StackType_t  usb_device_stack[USBD_STACK_SIZE];
 StaticTask_t usb_device_taskdef;
 

--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -200,7 +200,7 @@ void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
   if ( dtr && rts )
   {
     // print initial message when connected
-    tud_cdc_write_str("\r\nTinyUSB CDC MSC HID device with FreeRTOS example\r\n");
+    tud_cdc_write_str("\r\nTinyUSB CDC MSC device with FreeRTOS example\r\n");
   }
 }
 

--- a/src/portable/espressif/esp32s2/dcd_esp32s2.c
+++ b/src/portable/espressif/esp32s2/dcd_esp32s2.c
@@ -331,9 +331,8 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t to
     USB0.dtknqr4_fifoemptymsk |= (1 << epnum);
   } else {
     // Each complete packet for OUT xfers triggers XFRC.
-    USB0.out_ep_reg[epnum].doeptsiz = USB_PKTCNT0_M |
-        ((xfer->max_size & USB_XFERSIZE0_V) << USB_XFERSIZE0_S);
-    USB0.out_ep_reg[epnum].doepctl |= USB_EPENA0_M | USB_CNAK0_M;
+    USB0.out_ep_reg[epnum].doeptsiz |= USB_PKTCNT0_M | ((xfer->max_size & USB_XFERSIZE0_V) << USB_XFERSIZE0_S);
+    USB0.out_ep_reg[epnum].doepctl  |= USB_EPENA0_M | USB_CNAK0_M;
   }
   return true;
 }
@@ -603,8 +602,7 @@ static void handle_epout_ints(void)
           dcd_event_xfer_complete(0, n, xfer->queued_len, XFER_RESULT_SUCCESS, true);
         } else {
           // Schedule another packet to be received.
-          USB0.out_ep_reg[n].doeptsiz = USB_PKTCNT0_M |
-              ((xfer->max_size & USB_XFERSIZE0_V) << USB_XFERSIZE0_S);
+          USB0.out_ep_reg[n].doeptsiz |= USB_PKTCNT0_M | ((xfer->max_size & USB_XFERSIZE0_V) << USB_XFERSIZE0_S);
           USB0.out_ep_reg[n].doepctl |= USB_EPENA0_M | USB_CNAK0_M;
         }
       }


### PR DESCRIPTION
also increase usbd stack in example when debug is enabled. We should really merge esp32s2 and stm32 together later on maybe once it is more accessible for everyone and the esp32 usb specs is out. So that problems like this doesn't happen again.

@hathach Change [line 334](https://github.com/hathach/tinyusb/pull/319/files#diff-371e8160b188a80c1a3821c75d194adfR334) from:

```
USB0.out_ep_reg[epnum].doeptsiz = USB_PKTCNT0_M |
        ((xfer->max_size & USB_XFERSIZE0_V) << USB_XFERSIZE0_S);
```

to

```
USB0.out_ep_reg[epnum].doeptsiz |= USB_PKTCNT0_M |
        ((xfer->max_size & USB_XFERSIZE0_V) << USB_XFERSIZE0_S);
```

Do the same for [line 606](https://github.com/hathach/tinyusb/commit/d4302dacc584c4488cf1905caa822f96bd64930d).

Note the ORing. See if the bug goes away and you can save all 3 setup packets again. This seems quite similar to a [bug](https://github.com/hathach/tinyusb/commit/d4302dacc584c4488cf1905caa822f96bd64930d) I fixed from my original STM32 port.

SETUPCNT would become `3` again after receiving a new SETUP packet because it's a 2-bit counter that wraps around.

_Originally posted by @cr1901 in https://github.com/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDQwNjg0NDE2OQ==/comments/review_comment_