### PR TITLE
usbnet: OS-agnostic (Windows/Linux/macOS) network driver

### DIFF
--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -26,13 +26,14 @@
  */
 
 /*
-depending on the value of CFG_TUD_NET (tusb_config.h), this can be a CDC-ECM, RNDIS, or CDC-EEM USB virtual network adapter
+depending on the value of CFG_TUD_NET (tusb_config.h), this can be a RNDIS+CDC-ECM or CDC-EEM USB virtual network adapter
 
-CDC-ECM should be valid on Linux and MacOS hosts
-RNDIS   should be valid on Linux and Windows hosts
-CDC-EEM should be valid on Linux hosts
+OPT_NET_RNDIS_ECM : RNDIS should be valid on Linux and Windows hosts, and CDC-ECM should be valid on Linux and MacOS hosts
+OPT_NET_EEM       : CDC-EEM should be valid on Linux hosts
 
-You *must* customize tusb_config.h to set the CFG_TUD_NET definition to the type of these network adapters to emulate.
+OPT_NET_RNDIS_ECM should be the best choice, as it makes for a hopefully universal solution.
+
+You *must* customize tusb_config.h to set the CFG_TUD_NET definition to the type of these network option.
 
 The MCU appears to the host as IP address 192.168.7.1, and provides a DHCP server, DNS server, and web server.
 */

--- a/examples/device/net_lwip_webserver/src/tusb_config.h
+++ b/examples/device/net_lwip_webserver/src/tusb_config.h
@@ -79,8 +79,7 @@
 #define CFG_TUD_HID               0
 #define CFG_TUD_MIDI              0
 #define CFG_TUD_VENDOR            0
-//#define CFG_TUD_NET               OPT_NET_ECM
-#define CFG_TUD_NET               OPT_NET_RNDIS
+#define CFG_TUD_NET               OPT_NET_RNDIS_ECM
 //#define CFG_TUD_NET               OPT_NET_EEM
 
 #ifdef __cplusplus

--- a/examples/device/net_lwip_webserver/src/usb_descriptors.c
+++ b/examples/device/net_lwip_webserver/src/usb_descriptors.c
@@ -63,13 +63,17 @@ tusb_desc_device_t const desc_device =
 
     .idVendor           = 0xCafe,
     .idProduct          = USB_PID,
-    .bcdDevice          = 0x0100,
+    .bcdDevice          = 0x0101,
 
     .iManufacturer      = STRID_MANUFACTURER,
     .iProduct           = STRID_PRODUCT,
     .iSerialNumber      = STRID_SERIAL,
 
+#if CFG_TUD_NET == OPT_NET_EEM
     .bNumConfigurations = 0x01
+#else
+    .bNumConfigurations = 0x02
+#endif
 };
 
 // Invoked when received GET DEVICE DESCRIPTOR
@@ -85,16 +89,23 @@ uint8_t const * tud_descriptor_device_cb(void)
 enum
 {
   ITF_NUM_CDC = 0,
+#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   ITF_NUM_CDC_DATA,
+#endif
   ITF_NUM_TOTAL
 };
 
-#if CFG_TUD_NET == OPT_NET_ECM
-  #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_ECM_DESC_LEN)
-#elif CFG_TUD_NET == OPT_NET_RNDIS
-  #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_RNDIS_DESC_LEN)
-#elif CFG_TUD_NET == OPT_NET_EEM
-  #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_EEM_DESC_LEN)
+enum
+{
+  CONFIG_NUM_DEFAULT = 1,
+  CONFIG_NUM_ALTERNATE = 2,
+};
+
+#if CFG_TUD_NET == OPT_NET_EEM
+  #define MAIN_CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_EEM_DESC_LEN)
+#else
+  #define MAIN_CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_RNDIS_DESC_LEN)
+  #define ALT_CONFIG_TOTAL_LEN     (TUD_CONFIG_DESC_LEN + TUD_CDC_ECM_DESC_LEN)
 #endif
 
 #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
@@ -105,30 +116,42 @@ enum
   #define EPNUM_CDC     2
 #endif
 
-uint8_t const desc_configuration[] =
+static uint8_t const main_configuration[] =
 {
   // Config number, interface count, string index, total length, attribute, power in mA
-  TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0, 100),
+  TUD_CONFIG_DESCRIPTOR(CONFIG_NUM_DEFAULT, ITF_NUM_TOTAL, 0, MAIN_CONFIG_TOTAL_LEN, 0, 100),
 
-#if CFG_TUD_NET == OPT_NET_ECM
-  // Interface number, description string index, MAC address string index, EP notification address and size, EP data address (out, in), and size, max segment size.
-  TUD_CDC_ECM_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, STRID_MAC, 0x81, 64, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE, CFG_TUD_NET_MTU),
-#elif CFG_TUD_NET == OPT_NET_RNDIS
-  // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  TUD_RNDIS_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, 0x81, 8, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE),
-#elif CFG_TUD_NET == OPT_NET_EEM
+#if CFG_TUD_NET == OPT_NET_EEM
   // Interface number, description string index, EP data address (out, in) and size.
   TUD_CDC_EEM_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE),
+#else
+  // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+  TUD_RNDIS_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, 0x81, 8, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE),
 #endif
 };
+
+#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
+static uint8_t const alt_configuration[] =
+{
+  // Config number, interface count, string index, total length, attribute, power in mA
+  TUD_CONFIG_DESCRIPTOR(CONFIG_NUM_ALTERNATE, ITF_NUM_TOTAL, 0, ALT_CONFIG_TOTAL_LEN, 0, 100),
+
+  // Interface number, description string index, MAC address string index, EP notification address and size, EP data address (out, in), and size, max segment size.
+  TUD_CDC_ECM_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, STRID_MAC, 0x81, 64, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE, CFG_TUD_NET_MTU),
+};
+#endif
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
 uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 {
+#if CFG_TUD_NET == OPT_NET_EEM
   (void) index; // for multiple configurations
-  return desc_configuration;
+  return main_configuration;
+#else
+  return (0 == index) ? main_configuration : alt_configuration;
+#endif
 }
 
 //--------------------------------------------------------------------+
@@ -141,8 +164,8 @@ static char const* string_desc_arr [] =
   [STRID_LANGID]       = (const char[]) { 0x09, 0x04 }, // supported language is English (0x0409)
   [STRID_MANUFACTURER] = "TinyUSB",                     // Manufacturer
   [STRID_PRODUCT]      = "TinyUSB Device",              // Product
-  [STRID_SERIAL]       = "123456",                      // Serials
-  [STRID_INTERFACE]    = "TinyUSB Network Interface"    // CDC-ECM Interface
+  [STRID_SERIAL]       = "123456",                      // Serial
+  [STRID_INTERFACE]    = "TinyUSB Network Interface"    // Interface Description
 
   // STRID_MAC index is handled separately
 };

--- a/src/class/net/net_device.c
+++ b/src/class/net/net_device.c
@@ -41,39 +41,57 @@ void rndis_class_set_handler(uint8_t *data, int size); /* found in ./misc/networ
 typedef struct
 {
   uint8_t itf_num;
+#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   uint8_t ep_notif;
+  bool ecm_mode;
+#endif
   uint8_t ep_in;
   uint8_t ep_out;
 } netd_interface_t;
 
-#if CFG_TUD_NET == OPT_NET_ECM
-  #define CFG_TUD_NET_PACKET_PREFIX_LEN 0
-  #define CFG_TUD_NET_PACKET_SUFFIX_LEN 0
-  #define CFG_TUD_NET_INTERFACESUBCLASS CDC_COMM_SUBCLASS_ETHERNET_NETWORKING_CONTROL_MODEL
-#elif CFG_TUD_NET == OPT_NET_RNDIS
-  #define CFG_TUD_NET_PACKET_PREFIX_LEN sizeof(rndis_data_packet_t)
-  #define CFG_TUD_NET_PACKET_SUFFIX_LEN 0
-  #define CFG_TUD_NET_INTERFACESUBCLASS TUD_RNDIS_ITF_SUBCLASS
-#elif CFG_TUD_NET == OPT_NET_EEM
+#if CFG_TUD_NET == OPT_NET_EEM
   #define CFG_TUD_NET_PACKET_PREFIX_LEN 2
   #define CFG_TUD_NET_PACKET_SUFFIX_LEN 4
-  #define CFG_TUD_NET_INTERFACESUBCLASS CDC_COMM_SUBCLASS_ETHERNET_EMULATION_MODEL
+#else
+  #define CFG_TUD_NET_PACKET_PREFIX_LEN sizeof(rndis_data_packet_t)
+  #define CFG_TUD_NET_PACKET_SUFFIX_LEN 0
 #endif
 
 CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t received[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
 CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t transmitted[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
 
-#if CFG_TUD_NET == OPT_NET_ECM
-  CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static tusb_control_request_t notify =
-  {
-    .bmRequestType = 0x21,
-    .bRequest = 0 /* NETWORK_CONNECTION */,
+struct ecm_notify_struct
+{
+  tusb_control_request_t header;
+  uint32_t downlink, uplink;
+};
+
+static const struct ecm_notify_struct ecm_notify_nc =
+{
+  .header = {
+    .bmRequestType = 0xA1,
+    .bRequest = 0 /* NETWORK_CONNECTION aka NetworkConnection */,
     .wValue = 1 /* Connected */,
     .wLength = 0,
-  };
-#elif CFG_TUD_NET == OPT_NET_RNDIS
-  CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t rndis_buf[120];
-#endif
+  },
+};
+
+static const struct ecm_notify_struct ecm_notify_csc =
+{
+  .header = {
+    .bmRequestType = 0xA1,
+    .bRequest = 0x2A /* CONNECTION_SPEED_CHANGE aka ConnectionSpeedChange */,
+    .wLength = 8,
+  },
+  .downlink = 9728000,
+  .uplink = 9728000,
+};
+
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static union
+{
+  uint8_t rndis_buf[120];
+  struct ecm_notify_struct ecm_buf;
+} notify;
 
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
@@ -95,7 +113,9 @@ static void do_in_xfer(uint8_t *buf, uint16_t len)
 
 void netd_report(uint8_t *buf, uint16_t len)
 {
+#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   usbd_edpt_xfer(TUD_OPT_RHPORT, _netd_itf.ep_notif, buf, len);
+#endif
 }
 
 //--------------------------------------------------------------------+
@@ -106,6 +126,10 @@ void netd_init(void)
   tu_memclr(&_netd_itf, sizeof(_netd_itf));
 }
 
+void netd_init_data(void)
+{
+}
+
 void netd_reset(uint8_t rhport)
 {
   (void) rhport;
@@ -113,21 +137,26 @@ void netd_reset(uint8_t rhport)
   netd_init();
 }
 
+#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
 bool netd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t *p_length)
 {
   // sanity check the descriptor
-  TU_ASSERT (CFG_TUD_NET_INTERFACESUBCLASS == itf_desc->bInterfaceSubClass);
+#if CFG_TUD_NET == OPT_NET_EEM
+  TU_VERIFY (CDC_COMM_SUBCLASS_ETHERNET_EMULATION_MODEL == itf_desc->bInterfaceSubClass);
+#else
+  _netd_itf.ecm_mode = (CDC_COMM_SUBCLASS_ETHERNET_NETWORKING_CONTROL_MODEL == itf_desc->bInterfaceSubClass);
+  TU_VERIFY ( (TUD_RNDIS_ITF_SUBCLASS == itf_desc->bInterfaceSubClass) || _netd_itf.ecm_mode );
+#endif
 
   // confirm interface hasn't already been allocated
-  TU_ASSERT(0 == _netd_itf.ep_in);
+  TU_ASSERT(0 == _netd_itf.ep_notif);
 
-  //------------- first Interface -------------//
+  //------------- Management Interface -------------//
   _netd_itf.itf_num = itf_desc->bInterfaceNumber;
 
   uint8_t const * p_desc = tu_desc_next( itf_desc );
   (*p_length) = sizeof(tusb_desc_interface_t);
 
-#if CFG_TUD_NET != OPT_NET_EEM
   // Communication Functional Descriptors
   while ( TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) )
   {
@@ -143,18 +172,28 @@ bool netd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t 
     _netd_itf.ep_notif = ((tusb_desc_endpoint_t const *) p_desc)->bEndpointAddress;
 
     (*p_length) += p_desc[DESC_OFFSET_LEN];
-    p_desc = tu_desc_next(p_desc);
   }
 
-  //------------- second Interface -------------//
-  if ( (TUSB_DESC_INTERFACE == p_desc[DESC_OFFSET_TYPE]) &&
+  return true;
+}
+#endif
+
+bool netd_open_data(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t *p_length)
+{
+  // confirm interface hasn't already been allocated
+  TU_ASSERT(0 == _netd_itf.ep_in);
+
+  uint8_t const * p_desc = tu_desc_next( itf_desc );
+  (*p_length) = sizeof(tusb_desc_interface_t);
+
+  //------------- Data Interface -------------//
+  while ( (TUSB_DESC_INTERFACE == p_desc[DESC_OFFSET_TYPE]) &&
        (TUSB_CLASS_CDC_DATA == ((tusb_desc_interface_t const *) p_desc)->bInterfaceClass) )
   {
     // next to endpoint descriptor
     p_desc = tu_desc_next(p_desc);
     (*p_length) += sizeof(tusb_desc_interface_t);
   }
-#endif
 
   if (TUSB_DESC_ENDPOINT == p_desc[DESC_OFFSET_TYPE])
   {
@@ -184,16 +223,23 @@ bool netd_control_complete(uint8_t rhport, tusb_control_request_t const * reques
   // Handle class request only
   TU_VERIFY (request->bmRequestType_bit.type == TUSB_REQ_TYPE_CLASS);
 
+#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   TU_VERIFY (_netd_itf.itf_num == request->wIndex);
 
-#if CFG_TUD_NET == OPT_NET_RNDIS
-  if (request->bmRequestType_bit.direction == TUSB_DIR_OUT)
+  if ( !_netd_itf.ecm_mode && (request->bmRequestType_bit.direction == TUSB_DIR_OUT) )
   {
-    rndis_class_set_handler(rndis_buf, request->wLength);
+    rndis_class_set_handler(notify.rndis_buf, request->wLength);
   }
 #endif
 
   return true;
+}
+
+static void ecm_report(bool nc)
+{
+  notify.ecm_buf = (nc) ? ecm_notify_nc : ecm_notify_csc;
+  notify.ecm_buf.header.wIndex = _netd_itf.itf_num;
+  netd_report((uint8_t *)&notify.ecm_buf, (nc) ? sizeof(notify.ecm_buf.header) : sizeof(notify.ecm_buf));
 }
 
 // Handle class control request
@@ -205,28 +251,32 @@ bool netd_control_request(uint8_t rhport, tusb_control_request_t const * request
 
   TU_VERIFY (_netd_itf.itf_num == request->wIndex);
 
-#if CFG_TUD_NET == OPT_NET_ECM
-  /* the only required CDC-ECM Management Element Request is SetEthernetPacketFilter */
-  if (0x43 /* SET_ETHERNET_PACKET_FILTER */ == request->bRequest)
+#if CFG_TUD_NET == OPT_NET_EEM
+  (void)rhport;
+#else
+  if (_netd_itf.ecm_mode)
   {
-    tud_control_xfer(rhport, request, NULL, 0);
-    notify.wIndex = request->wIndex;
-    usbd_edpt_xfer(TUD_OPT_RHPORT, _netd_itf.ep_notif, (uint8_t *)&notify, sizeof(notify));
-  }
-#elif CFG_TUD_NET == OPT_NET_RNDIS
-  if (request->bmRequestType_bit.direction == TUSB_DIR_IN)
-  {
-    rndis_generic_msg_t *rndis_msg = (rndis_generic_msg_t *)rndis_buf;
-    uint32_t msglen = tu_le32toh(rndis_msg->MessageLength);
-    TU_ASSERT(msglen <= sizeof(rndis_buf));
-    tud_control_xfer(rhport, request, rndis_buf, msglen);
+    /* the only required CDC-ECM Management Element Request is SetEthernetPacketFilter */
+    if (0x43 /* SET_ETHERNET_PACKET_FILTER */ == request->bRequest)
+    {
+      tud_control_xfer(rhport, request, NULL, 0);
+      ecm_report(true);
+    }
   }
   else
   {
-    tud_control_xfer(rhport, request, rndis_buf, sizeof(rndis_buf));
+    if (request->bmRequestType_bit.direction == TUSB_DIR_IN)
+    {
+      rndis_generic_msg_t *rndis_msg = (rndis_generic_msg_t *)notify.rndis_buf;
+      uint32_t msglen = tu_le32toh(rndis_msg->MessageLength);
+      TU_ASSERT(msglen <= sizeof(notify.rndis_buf));
+      tud_control_xfer(rhport, request, notify.rndis_buf, msglen);
+    }
+    else
+    {
+      tud_control_xfer(rhport, request, notify.rndis_buf, sizeof(notify.rndis_buf));
+    }
   }
-#else
-  (void)rhport;
 #endif
 
   return true;
@@ -244,18 +294,7 @@ static void handle_incoming_packet(uint32_t len)
   uint8_t *pnt = received;
   uint32_t size = 0;
 
-#if CFG_TUD_NET == OPT_NET_ECM
-  size = len;
-#elif CFG_TUD_NET == OPT_NET_RNDIS
-  rndis_data_packet_t *r = (rndis_data_packet_t *)pnt;
-  if (len >= sizeof(rndis_data_packet_t))
-    if ( (r->MessageType == REMOTE_NDIS_PACKET_MSG) && (r->MessageLength <= len))
-      if ( (r->DataOffset + offsetof(rndis_data_packet_t, DataOffset) + r->DataLength) <= len)
-      {
-        pnt = &received[r->DataOffset + offsetof(rndis_data_packet_t, DataOffset)];
-        size = r->DataLength;
-      }
-#elif CFG_TUD_NET == OPT_NET_EEM
+#if CFG_TUD_NET == OPT_NET_EEM
   struct cdc_eem_packet_header *hdr = (struct cdc_eem_packet_header *)pnt;
 
   (void)len;
@@ -271,25 +310,44 @@ static void handle_incoming_packet(uint32_t len)
     pnt += CFG_TUD_NET_PACKET_PREFIX_LEN;
     size = hdr->length - 4; /* discard the unused CRC-32 */
   }
+#else
+  if (_netd_itf.ecm_mode)
+  {
+    size = len;
+  }
+  else
+  {
+    rndis_data_packet_t *r = (rndis_data_packet_t *)pnt;
+    if (len >= sizeof(rndis_data_packet_t))
+      if ( (r->MessageType == REMOTE_NDIS_PACKET_MSG) && (r->MessageLength <= len))
+        if ( (r->DataOffset + offsetof(rndis_data_packet_t, DataOffset) + r->DataLength) <= len)
+        {
+          pnt = &received[r->DataOffset + offsetof(rndis_data_packet_t, DataOffset)];
+          size = r->DataLength;
+        }
+  }
 #endif
+
+  bool accepted = false;
 
   if (size)
   {
     struct pbuf *p = pbuf_alloc(PBUF_RAW, size, PBUF_POOL);
-    bool accepted = true;
 
     if (p)
     {
       memcpy(p->payload, pnt, size);
       p->len = size;
       accepted = tud_network_recv_cb(p);
-    }
 
-    if (!p || !accepted)
-    {
-      /* if a buffer couldn't be allocated or accepted by the callback, we must discard this packet */
-      tud_network_recv_renew();
+      if (!accepted) pbuf_free(p);
     }
+  }
+
+  if (!accepted)
+  {
+    /* if a buffer was never handled by user code, we must renew on the user's behalf */
+    tud_network_recv_renew();
   }
 }
 
@@ -320,6 +378,13 @@ bool netd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
     }
   }
 
+#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
+  if ( _netd_itf.ecm_mode && (ep_addr == _netd_itf.ep_notif) )
+  {
+    if (sizeof(notify.ecm_buf.header) == xferred_bytes) ecm_report(false);
+  }
+#endif
+
   return true;
 }
 
@@ -337,7 +402,11 @@ void tud_network_xmit(struct pbuf *p)
   if (!can_xmit)
     return;
 
+#if CFG_TUD_NET == OPT_NET_EEM
   len = CFG_TUD_NET_PACKET_PREFIX_LEN;
+#else
+  len = (_netd_itf.ecm_mode) ? 0 : CFG_TUD_NET_PACKET_PREFIX_LEN;
+#endif
   data = transmitted + len;
 
   for(q = p; q != NULL; q = q->next)
@@ -347,14 +416,7 @@ void tud_network_xmit(struct pbuf *p)
     len += q->len;
   }
 
-#if CFG_TUD_NET == OPT_NET_RNDIS
-  rndis_data_packet_t *hdr = (rndis_data_packet_t *)transmitted;
-  memset(hdr, 0, sizeof(rndis_data_packet_t));
-  hdr->MessageType = REMOTE_NDIS_PACKET_MSG;
-  hdr->MessageLength = len;
-  hdr->DataOffset = sizeof(rndis_data_packet_t) - offsetof(rndis_data_packet_t, DataOffset);
-  hdr->DataLength = len - sizeof(rndis_data_packet_t);
-#elif CFG_TUD_NET == OPT_NET_EEM
+#if CFG_TUD_NET == OPT_NET_EEM
   struct cdc_eem_packet_header *hdr = (struct cdc_eem_packet_header *)transmitted;
   /* append a fake CRC-32; the standard allows 0xDEADBEEF, which takes less CPU time */
   data[0] = 0xDE; data[1] = 0xAD; data[2] = 0xBE; data[3] = 0xEF;
@@ -363,6 +425,16 @@ void tud_network_xmit(struct pbuf *p)
   hdr->bmType = 0; /* EEM Data Packet */
   hdr->length = len - sizeof(struct cdc_eem_packet_header);
   hdr->bmCRC = 0; /* Ethernet Frame CRC-32 set to 0xDEADBEEF */
+#else
+  if (!_netd_itf.ecm_mode)
+  {
+    rndis_data_packet_t *hdr = (rndis_data_packet_t *)transmitted;
+    memset(hdr, 0, sizeof(rndis_data_packet_t));
+    hdr->MessageType = REMOTE_NDIS_PACKET_MSG;
+    hdr->MessageLength = len;
+    hdr->DataOffset = sizeof(rndis_data_packet_t) - offsetof(rndis_data_packet_t, DataOffset);
+    hdr->DataLength = len - sizeof(rndis_data_packet_t);
+  }
 #endif
 
   do_in_xfer(transmitted, len);

--- a/src/class/net/net_device.h
+++ b/src/class/net/net_device.h
@@ -73,8 +73,10 @@ void tud_network_xmit(struct pbuf *p);
 // INTERNAL USBD-CLASS DRIVER API
 //--------------------------------------------------------------------+
 void netd_init             (void);
+void netd_init_data        (void);
 void netd_reset            (uint8_t rhport);
 bool netd_open             (uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t *p_length);
+bool netd_open_data        (uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t *p_length);
 bool netd_control_request  (uint8_t rhport, tusb_control_request_t const * request);
 bool netd_control_complete (uint8_t rhport, tusb_control_request_t const * request);
 bool netd_xfer_cb          (uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes);

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -184,21 +184,47 @@ static usbd_class_driver_t const _usbd_driver[] =
   #endif
 
   #if CFG_TUD_NET
+#if CFG_TUD_NET != OPT_NET_EEM
+  /* RNDIS management interface */
   {
-      .class_code       = 
-#if CFG_TUD_NET == OPT_NET_RNDIS
-                          TUD_RNDIS_ITF_CLASS,
-#else
-                          TUSB_CLASS_CDC,
-#endif
+      .class_code       = TUD_RNDIS_ITF_CLASS,
       .init             = netd_init,
       .reset            = netd_reset,
       .open             = netd_open,
       .control_request  = netd_control_request,
       .control_complete = netd_control_complete,
       .xfer_cb          = netd_xfer_cb,
-      .sof              = NULL
+      .sof              = NULL,
   },
+#endif
+  /* CDC-ECM management interface; CDC-EEM data interface */
+  {
+      .class_code       = TUSB_CLASS_CDC,
+      .init             = netd_init,
+      .reset            = netd_reset,
+#if CFG_TUD_NET == OPT_NET_EEM
+      .open             = netd_open_data,
+#else
+      .open             = netd_open,
+#endif
+      .control_request  = netd_control_request,
+      .control_complete = netd_control_complete,
+      .xfer_cb          = netd_xfer_cb,
+      .sof              = NULL,
+  },
+  /* RNDIS/CDC-ECM data interface */
+#if CFG_TUD_NET != OPT_NET_EEM
+  {
+      .class_code       = TUSB_CLASS_CDC_DATA,
+      .init             = netd_init_data,
+      .reset            = NULL,
+      .open             = netd_open_data,
+      .control_request  = NULL,
+      .control_complete = NULL,
+      .xfer_cb          = netd_xfer_cb,
+      .sof              = NULL,
+  },
+#endif
   #endif
 };
 

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -342,8 +342,8 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
 
 //------------- CDC-ECM -------------//
 
-// Length of template descriptor: 62 bytes
-#define TUD_CDC_ECM_DESC_LEN  (9+5+5+13+7+9+7+7)
+// Length of template descriptor: 71 bytes
+#define TUD_CDC_ECM_DESC_LEN  (9+5+5+13+7+9+9+7+7)
 
 // CDC-ECM Descriptor Template
 // Interface number, description string index, MAC address string index, EP notification address and size, EP data address (out, in), and size, max segment size.
@@ -358,8 +358,10 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
   13, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_ETHERNET_NETWORKING, _mac_stridx, 0, 0, 0, 0, U16_TO_U8S_LE(_maxsegmentsize), U16_TO_U8S_LE(0), 0,\
   /* Endpoint Notification */\
   7, TUSB_DESC_ENDPOINT, _ep_notif, TUSB_XFER_INTERRUPT, U16_TO_U8S_LE(_ep_notif_size), 1,\
-  /* CDC Data Interface */\
-  9, TUSB_DESC_INTERFACE, (uint8_t)((_itfnum)+1), 0, 2, TUSB_CLASS_CDC_DATA, 0, 0, 0,\
+  /* CDC Data Interface (default inactive) */\
+  9, TUSB_DESC_INTERFACE, (uint8_t)((_itfnum)+1), 0, 0, TUSB_CLASS_CDC_DATA, 0, 0, 0,\
+  /* CDC Data Interface (alternative active) */\
+  9, TUSB_DESC_INTERFACE, (uint8_t)((_itfnum)+1), 1, 2, TUSB_CLASS_CDC_DATA, 0, 0, 0,\
   /* Endpoint In */\
   7, TUSB_DESC_ENDPOINT, _epin, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0,\
   /* Endpoint Out */\
@@ -372,7 +374,7 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
   /* Windows XP */
   #define TUD_RNDIS_ITF_CLASS    TUSB_CLASS_CDC
   #define TUD_RNDIS_ITF_SUBCLASS CDC_COMM_SUBCLASS_ABSTRACT_CONTROL_MODEL
-  #define TUD_RNDIS_ITF_PROTOCOL CDC_COMM_PROTOCOL_MICROSOFT_RNDIS
+  #define TUD_RNDIS_ITF_PROTOCOL 0xFF /* CDC_COMM_PROTOCOL_MICROSOFT_RNDIS */
 #else
   /* Windows 7+ */
   #define TUD_RNDIS_ITF_CLASS    0xE0

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -128,9 +128,8 @@
  *  \ref CFG_TUD_NET must be defined to one of these
  *  @{ */
 #define OPT_NET_NONE      0 ///< No network interface
-#define OPT_NET_ECM       1 ///< CDC-ECM
-#define OPT_NET_RNDIS     2 ///< RNDIS
-#define OPT_NET_EEM       3 ///< CDC-EEM
+#define OPT_NET_RNDIS_ECM 1 ///< RNDIS+CDC-ECM
+#define OPT_NET_EEM       2 ///< CDC-EEM
 /** @} */
 
 #ifndef CFG_TUSB_RHPORT0_MODE


### PR DESCRIPTION
The existing usbnet RNDIS (Windows/Linux) implementation is enhanced to alternately act as CDC-ECM (Linux/macOS).  Windows and Linux users get driver-less RNDIS USB networking; macOS would get driver-less CDC-ECM USB network.

I think this has value because it allows a generic implementation to be agnostic to the user’s OS.

Windows and Linux will default to RNDIS and work the same as they previously did.

In a pinch, macOS users can immediately take advantage of this new code by simply commenting out this line in ./src/device/usb.c:

            TU_ASSERT(alternate == 0);

Otherwise, they must wait until PR #317 or PR #320 or alternative is approved.

@hathach had expressed interest in being able to test different configurations.  Until PR #326 or alternative is approved, a Linux user will not be able to switch from the default RNDIS configuration to the CDC-ECM configuration.  A normal user would not be bothered by the absence of this.
