### PR TITLE
net_lwip_webserver: add support for lwip timeouts

### DIFF
--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -43,6 +43,7 @@ The MCU appears to the host as IP address 192.168.7.1, and provides a DHCP serve
 #include "dhserver.h"
 #include "dnserver.h"
 #include "lwip/init.h"
+#include "lwip/timeouts.h"
 #include "httpd.h"
 
 /* lwip context */
@@ -167,6 +168,8 @@ static void service_traffic(void)
     received_frame = NULL;
     tud_network_recv_renew();
   }
+
+  sys_check_timeouts();
 }
 
 void tud_network_init_cb(void)


### PR DESCRIPTION
lwip has network timeout routines (for things like packet re-transmission), but these will not fire unless sys_check_timeouts() is periodically called.
