### PR TITLE
introducing usbd_interface_t

### DIFF
--- a/src/device/usbd_pvt.h
+++ b/src/device/usbd_pvt.h
@@ -33,6 +33,22 @@
  extern "C" {
 #endif
 
+//typedef struct TU_ATTR_PACKED
+//{
+//  uint8_t itf_num; // Interface number
+//  uint8_t itf_alt; // Interface Alternate in use
+//  uint8_t ep_num;  // Number of endpoints used by current Alt Interface
+//  uint8_t ep_arr[1];   // Array of endpoints
+//} usbd_interface_t;
+
+#define usbd_interface_t(_epnum)                         \
+  struct TU_ATTR_PACKED { \
+    uint8_t itf_num;    /* Interface number */           \
+    uint8_t itf_alt;    /* Interface Alternate in use */ \
+    uint8_t ep_num;     /* Number of endpoints in use */ \
+    uint8_t ep_arr[_epnum]; /* endpoint array */         \
+ }\
+
 //--------------------------------------------------------------------+
 // USBD Endpoint API
 //--------------------------------------------------------------------+


### PR DESCRIPTION
it is an enhancement, there will be an additional class_get_interface() which return the pointer to currently active (alt) interface from class driver. 

Note: currently there is not much benefit to use this, we may not use this at all. I am sorting my thought on how to implement alt interface.