### PR TITLE
lpc17xx move set configdevice into set address for removing dcd_set_config()

### DIFF
--- a/docs/porting.md
+++ b/docs/porting.md
@@ -78,10 +78,6 @@ Called when the device is given a new bus address.
 
 If your peripheral automatically changes address during enumeration (like the nrf52) you may leave this empty and also no queue an event for the corresponding SETUP packet.
 
-##### dcd_set_config
-
-Called when the device received SET_CONFIG request, you can leave this empty if your peripheral does not require any specific action.
-
 ##### dcd_remote_wakeup
 
 Called to remote wake up host when suspended (e.g hid keyboard)

--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -100,9 +100,6 @@ void dcd_int_disable(uint8_t rhport);
 // Receive Set Address request, mcu port must also include status IN response
 void dcd_set_address(uint8_t rhport, uint8_t dev_addr);
 
-// Receive Set Configure request
-void dcd_set_config (uint8_t rhport, uint8_t config_num);
-
 // Wake up host
 void dcd_remote_wakeup(uint8_t rhport);
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -515,8 +515,6 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
         {
           uint8_t const cfg_num = (uint8_t) p_request->wValue;
 
-          dcd_set_config(rhport, cfg_num);
-
           if ( !_usbd_dev.configured && cfg_num ) TU_ASSERT( process_set_config(rhport, cfg_num) );
 
           _usbd_dev.configured = cfg_num ? 1 : 0;

--- a/src/portable/espressif/esp32s2/dcd_esp32s2.c
+++ b/src/portable/espressif/esp32s2/dcd_esp32s2.c
@@ -201,13 +201,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0);
 }
 
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void)rhport;
-  (void)config_num;
-  // Nothing to do
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void)rhport;

--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -144,13 +144,6 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
   USB->DEVICE.INTENSET.reg = USB_DEVICE_INTENSET_SUSPEND;
 }
 
-void dcd_set_config (uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-  // Nothing to do
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/microchip/samg/dcd_samg.c
+++ b/src/portable/microchip/samg/dcd_samg.c
@@ -167,16 +167,6 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
   // do it at dcd_edpt0_status_complete()
 }
 
-// Receive Set Configure request
-void dcd_set_config (uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-
-  // Configured State
-//  UDP->UDP_GLB_STAT |= UDP_GLB_STAT_CONFG_Msk;
-}
-
 // Wake up host
 void dcd_remote_wakeup (uint8_t rhport)
 {

--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -216,12 +216,6 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
   NRF_USBD->INTENSET = USBD_INTEN_USBEVENT_Msk;
 }
 
-void dcd_set_config (uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/nuvoton/nuc120/dcd_nuc120.c
+++ b/src/portable/nuvoton/nuc120/dcd_nuc120.c
@@ -219,12 +219,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   assigned_address = dev_addr;
 }
 
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/nuvoton/nuc121/dcd_nuc121.c
+++ b/src/portable/nuvoton/nuc121/dcd_nuc121.c
@@ -225,12 +225,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   assigned_address = dev_addr;
 }
 
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/nuvoton/nuc505/dcd_nuc505.c
+++ b/src/portable/nuvoton/nuc505/dcd_nuc505.c
@@ -298,12 +298,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   assigned_address = dev_addr;
 }
 
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/nxp/lpc17_40/dcd_lpc17_40.c
+++ b/src/portable/nxp/lpc17_40/dcd_lpc17_40.c
@@ -203,12 +203,8 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0);
 
   sie_write(SIE_CMDCODE_SET_ADDRESS, 1, 0x80 | dev_addr); // 7th bit is : device_enable
-}
 
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
+  // Also Set Configure Device to enable non-control endpoint response
   sie_write(SIE_CMDCODE_CONFIGURE_DEVICE, 1, 1);
 }
 
@@ -283,6 +279,7 @@ static uint8_t control_ep_read(void * buffer, uint8_t len)
 //--------------------------------------------------------------------+
 // DCD Endpoint Port
 //--------------------------------------------------------------------+
+
 bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc)
 {
   (void) rhport;

--- a/src/portable/nxp/lpc_ip3511/dcd_lpc_ip3511.c
+++ b/src/portable/nxp/lpc_ip3511/dcd_lpc_ip3511.c
@@ -198,12 +198,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   DCD_REGS->DEVCMDSTAT |= dev_addr;
 }
 
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/nxp/transdimension/dcd_transdimension.c
+++ b/src/portable/nxp/transdimension/dcd_transdimension.c
@@ -363,13 +363,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   dcd_reg->DEVICEADDR = (dev_addr << 25) | TU_BIT(24);
 }
 
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-  // nothing to do
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/sony/cxd56/dcd_cxd56.c
+++ b/src/portable/sony/cxd56/dcd_cxd56.c
@@ -187,13 +187,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   (void) dev_addr;
 }
 
-// Receive Set Config request
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -317,14 +317,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   // do it at dcd_edpt0_status_complete()
 }
 
-// Receive Set Config request
-void dcd_set_config (uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-  // Nothing to do? Handled by stack.
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -234,13 +234,6 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
   dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0);
 }
 
-void dcd_set_config (uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-  // Nothing to do
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/template/dcd_template.c
+++ b/src/portable/template/dcd_template.c
@@ -78,13 +78,6 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
   (void) dev_addr;
 }
 
-// Receive Set Configure request
-void dcd_set_config (uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-}
-
 // Wake up host
 void dcd_remote_wakeup (uint8_t rhport)
 {

--- a/src/portable/ti/msp430x5xx/dcd_msp430x5xx.c
+++ b/src/portable/ti/msp430x5xx/dcd_msp430x5xx.c
@@ -192,13 +192,6 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
   dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0);
 }
 
-void dcd_set_config (uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-  // Nothing to do
-}
-
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;

--- a/src/portable/valentyusb/eptri/dcd_eptri.c
+++ b/src/portable/valentyusb/eptri/dcd_eptri.c
@@ -383,14 +383,6 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   usb_address_write(dev_addr);
 }
 
-// Called when the device received SET_CONFIG request, you can leave this
-// empty if your peripheral does not require any specific action.
-void dcd_set_config(uint8_t rhport, uint8_t config_num)
-{
-  (void) rhport;
-  (void) config_num;
-}
-
 // Called to remote wake up host when suspended (e.g hid keyboard)
 void dcd_remote_wakeup(uint8_t rhport)
 {

--- a/test/test/device/msc/test_msc_device.c
+++ b/test/test/device/msc/test_msc_device.c
@@ -241,8 +241,6 @@ void test_msc(void)
 
   dcd_event_setup_received(rhport, (uint8_t*) &request_set_configuration, false);
 
-  dcd_set_config_Expect(rhport, 1);
-
   // open endpoints
   dcd_edpt_open_ExpectAndReturn(rhport, (tusb_desc_endpoint_t const *) desc_ep, true);
   dcd_edpt_open_ExpectAndReturn(rhport, (tusb_desc_endpoint_t const *) tu_desc_next(desc_ep), true);


### PR DESCRIPTION
This is technically not right, but it will have lpc17 behaves the same as other mcu vendor. Tested and works well on lpc4088 qs