### PR TITLE
implment dcd_edpt_close_all() API

### DIFF
--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -132,6 +132,9 @@ void dcd_edpt_stall       (uint8_t rhport, uint8_t ep_addr);
 // clear stall, data toggle is also reset to DATA0
 void dcd_edpt_clear_stall (uint8_t rhport, uint8_t ep_addr);
 
+// Close/Disable all non-control endpoints
+void dcd_edpt_close_all(uint8_t rhport);
+
 //--------------------------------------------------------------------+
 // Event API (Implemented by device stack)
 //--------------------------------------------------------------------+


### PR DESCRIPTION
Although the API will only be used (for now) when switching the configuration. But it is trivial enough for DCD to implement, mostly is a loop to disable all non-control endpoints enabled bit or so. It should be mandatory instead of optional.

Port checklikst
- [ ] Espressif ESP32-S2
- [ ] Microchip SAMD
- [ ] Microchip SAMG 
- [ ] Nordic nRF5x 
- [ ] Nuvoton NUC120
- [ ] Nuvoton NUC121/125/126
- [ ] Nuvoton NUC505
- [ ] NXP LPC3511
- [ ] NXP LPC17/40
- [ ] NXP Transdimension (18/ iMX RT)
- [ ] Sony CXD56
- [ ] STM32 FSDev
- [ ] STM32 Synopsys
- [ ] TI MSP430
- [ ] ValentyUSB eptri (fomu)