### PR TITLE
usbnet: remove CDC-EEM

### DIFF
--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -26,14 +26,9 @@
  */
 
 /*
-depending on the value of CFG_TUD_NET (tusb_config.h), this can be a RNDIS+CDC-ECM or CDC-EEM USB virtual network adapter
+this appears as either a RNDIS or CDC-ECM USB virtual network adapter; the OS picks its preference
 
-OPT_NET_RNDIS_ECM : RNDIS should be valid on Linux and Windows hosts, and CDC-ECM should be valid on Linux and MacOS hosts
-OPT_NET_EEM       : CDC-EEM should be valid on Linux hosts
-
-OPT_NET_RNDIS_ECM should be the best choice, as it makes for a hopefully universal solution.
-
-You *must* customize tusb_config.h to set the CFG_TUD_NET definition to the type of these network option.
+RNDIS should be valid on Linux and Windows hosts, and CDC-ECM should be valid on Linux and macOS hosts
 
 The MCU appears to the host as IP address 192.168.7.1, and provides a DHCP server, DNS server, and web server.
 */

--- a/examples/device/net_lwip_webserver/src/tusb_config.h
+++ b/examples/device/net_lwip_webserver/src/tusb_config.h
@@ -79,8 +79,7 @@
 #define CFG_TUD_HID               0
 #define CFG_TUD_MIDI              0
 #define CFG_TUD_VENDOR            0
-#define CFG_TUD_NET               OPT_NET_RNDIS_ECM
-//#define CFG_TUD_NET               OPT_NET_EEM
+#define CFG_TUD_NET               1
 
 #ifdef __cplusplus
  }

--- a/examples/device/net_lwip_webserver/src/usb_descriptors.c
+++ b/examples/device/net_lwip_webserver/src/usb_descriptors.c
@@ -30,7 +30,7 @@
  * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
  *
  * Auto ProductID layout's Bitmap:
- *   [MSB]       NET1:NET0 | VENDOR | MIDI | HID | MSC | CDC          [LSB]
+ *   [MSB]       NET | VENDOR | MIDI | HID | MSC | CDC          [LSB]
  */
 #define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
 #define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
@@ -69,11 +69,7 @@ tusb_desc_device_t const desc_device =
     .iProduct           = STRID_PRODUCT,
     .iSerialNumber      = STRID_SERIAL,
 
-#if CFG_TUD_NET == OPT_NET_EEM
-    .bNumConfigurations = 0x01
-#else
     .bNumConfigurations = 0x02
-#endif
 };
 
 // Invoked when received GET DEVICE DESCRIPTOR
@@ -89,9 +85,7 @@ uint8_t const * tud_descriptor_device_cb(void)
 enum
 {
   ITF_NUM_CDC = 0,
-#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   ITF_NUM_CDC_DATA,
-#endif
   ITF_NUM_TOTAL
 };
 
@@ -101,12 +95,8 @@ enum
   CONFIG_NUM_ALTERNATE = 2,
 };
 
-#if CFG_TUD_NET == OPT_NET_EEM
-  #define MAIN_CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_EEM_DESC_LEN)
-#else
-  #define MAIN_CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_RNDIS_DESC_LEN)
-  #define ALT_CONFIG_TOTAL_LEN     (TUD_CONFIG_DESC_LEN + TUD_CDC_ECM_DESC_LEN)
-#endif
+#define MAIN_CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_RNDIS_DESC_LEN)
+#define ALT_CONFIG_TOTAL_LEN     (TUD_CONFIG_DESC_LEN + TUD_CDC_ECM_DESC_LEN)
 
 #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
   // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
@@ -121,16 +111,10 @@ static uint8_t const main_configuration[] =
   // Config number, interface count, string index, total length, attribute, power in mA
   TUD_CONFIG_DESCRIPTOR(CONFIG_NUM_DEFAULT, ITF_NUM_TOTAL, 0, MAIN_CONFIG_TOTAL_LEN, 0, 100),
 
-#if CFG_TUD_NET == OPT_NET_EEM
-  // Interface number, description string index, EP data address (out, in) and size.
-  TUD_CDC_EEM_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE),
-#else
   // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_RNDIS_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, 0x81, 8, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE),
-#endif
 };
 
-#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
 static uint8_t const alt_configuration[] =
 {
   // Config number, interface count, string index, total length, attribute, power in mA
@@ -139,19 +123,13 @@ static uint8_t const alt_configuration[] =
   // Interface number, description string index, MAC address string index, EP notification address and size, EP data address (out, in), and size, max segment size.
   TUD_CDC_ECM_DESCRIPTOR(ITF_NUM_CDC, STRID_INTERFACE, STRID_MAC, 0x81, 64, EPNUM_CDC, 0x80 | EPNUM_CDC, CFG_TUD_NET_ENDPOINT_SIZE, CFG_TUD_NET_MTU),
 };
-#endif
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
 uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 {
-#if CFG_TUD_NET == OPT_NET_EEM
-  (void) index; // for multiple configurations
-  return main_configuration;
-#else
   return (0 == index) ? main_configuration : alt_configuration;
-#endif
 }
 
 //--------------------------------------------------------------------+

--- a/src/class/net/net_device.c
+++ b/src/class/net/net_device.c
@@ -27,7 +27,7 @@
 
 #include "tusb_option.h"
 
-#if ( TUSB_OPT_DEVICE_ENABLED && (CFG_TUD_NET != OPT_NET_NONE) )
+#if ( TUSB_OPT_DEVICE_ENABLED && CFG_TUD_NET )
 
 #include "net_device.h"
 #include "device/usbd_pvt.h"
@@ -41,21 +41,14 @@ void rndis_class_set_handler(uint8_t *data, int size); /* found in ./misc/networ
 typedef struct
 {
   uint8_t itf_num;
-#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   uint8_t ep_notif;
   bool ecm_mode;
-#endif
   uint8_t ep_in;
   uint8_t ep_out;
 } netd_interface_t;
 
-#if CFG_TUD_NET == OPT_NET_EEM
-  #define CFG_TUD_NET_PACKET_PREFIX_LEN 2
-  #define CFG_TUD_NET_PACKET_SUFFIX_LEN 4
-#else
-  #define CFG_TUD_NET_PACKET_PREFIX_LEN sizeof(rndis_data_packet_t)
-  #define CFG_TUD_NET_PACKET_SUFFIX_LEN 0
-#endif
+#define CFG_TUD_NET_PACKET_PREFIX_LEN sizeof(rndis_data_packet_t)
+#define CFG_TUD_NET_PACKET_SUFFIX_LEN 0
 
 CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t received[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
 CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t transmitted[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
@@ -113,9 +106,7 @@ static void do_in_xfer(uint8_t *buf, uint16_t len)
 
 void netd_report(uint8_t *buf, uint16_t len)
 {
-#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   usbd_edpt_xfer(TUD_OPT_RHPORT, _netd_itf.ep_notif, buf, len);
-#endif
 }
 
 //--------------------------------------------------------------------+
@@ -137,16 +128,11 @@ void netd_reset(uint8_t rhport)
   netd_init();
 }
 
-#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
 bool netd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t *p_length)
 {
   // sanity check the descriptor
-#if CFG_TUD_NET == OPT_NET_EEM
-  TU_VERIFY (CDC_COMM_SUBCLASS_ETHERNET_EMULATION_MODEL == itf_desc->bInterfaceSubClass);
-#else
   _netd_itf.ecm_mode = (CDC_COMM_SUBCLASS_ETHERNET_NETWORKING_CONTROL_MODEL == itf_desc->bInterfaceSubClass);
   TU_VERIFY ( (TUD_RNDIS_ITF_SUBCLASS == itf_desc->bInterfaceSubClass) || _netd_itf.ecm_mode );
-#endif
 
   // confirm interface hasn't already been allocated
   TU_ASSERT(0 == _netd_itf.ep_notif);
@@ -176,7 +162,6 @@ bool netd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t 
 
   return true;
 }
-#endif
 
 bool netd_open_data(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t *p_length)
 {
@@ -223,14 +208,12 @@ bool netd_control_complete(uint8_t rhport, tusb_control_request_t const * reques
   // Handle class request only
   TU_VERIFY (request->bmRequestType_bit.type == TUSB_REQ_TYPE_CLASS);
 
-#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   TU_VERIFY (_netd_itf.itf_num == request->wIndex);
 
   if ( !_netd_itf.ecm_mode && (request->bmRequestType_bit.direction == TUSB_DIR_OUT) )
   {
     rndis_class_set_handler(notify.rndis_buf, request->wLength);
   }
-#endif
 
   return true;
 }
@@ -251,9 +234,6 @@ bool netd_control_request(uint8_t rhport, tusb_control_request_t const * request
 
   TU_VERIFY (_netd_itf.itf_num == request->wIndex);
 
-#if CFG_TUD_NET == OPT_NET_EEM
-  (void)rhport;
-#else
   if (_netd_itf.ecm_mode)
   {
     /* the only required CDC-ECM Management Element Request is SetEthernetPacketFilter */
@@ -277,40 +257,15 @@ bool netd_control_request(uint8_t rhport, tusb_control_request_t const * request
       tud_control_xfer(rhport, request, notify.rndis_buf, sizeof(notify.rndis_buf));
     }
   }
-#endif
 
   return true;
 }
-
-struct cdc_eem_packet_header
-{
-  uint16_t length:14;
-  uint16_t bmCRC:1;
-  uint16_t bmType:1;
-};
 
 static void handle_incoming_packet(uint32_t len)
 {
   uint8_t *pnt = received;
   uint32_t size = 0;
 
-#if CFG_TUD_NET == OPT_NET_EEM
-  struct cdc_eem_packet_header *hdr = (struct cdc_eem_packet_header *)pnt;
-
-  (void)len;
-
-  if (hdr->bmType)
-  {
-    /* EEM Control Packet: discard it */
-    tud_network_recv_renew();
-  }
-  else
-  {
-    /* EEM Data Packet */
-    pnt += CFG_TUD_NET_PACKET_PREFIX_LEN;
-    size = hdr->length - 4; /* discard the unused CRC-32 */
-  }
-#else
   if (_netd_itf.ecm_mode)
   {
     size = len;
@@ -326,7 +281,6 @@ static void handle_incoming_packet(uint32_t len)
           size = r->DataLength;
         }
   }
-#endif
 
   bool accepted = false;
 
@@ -378,12 +332,10 @@ bool netd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
     }
   }
 
-#if CFG_TUD_NET == OPT_NET_RNDIS_ECM
   if ( _netd_itf.ecm_mode && (ep_addr == _netd_itf.ep_notif) )
   {
     if (sizeof(notify.ecm_buf.header) == xferred_bytes) ecm_report(false);
   }
-#endif
 
   return true;
 }
@@ -402,11 +354,7 @@ void tud_network_xmit(struct pbuf *p)
   if (!can_xmit)
     return;
 
-#if CFG_TUD_NET == OPT_NET_EEM
-  len = CFG_TUD_NET_PACKET_PREFIX_LEN;
-#else
   len = (_netd_itf.ecm_mode) ? 0 : CFG_TUD_NET_PACKET_PREFIX_LEN;
-#endif
   data = transmitted + len;
 
   for(q = p; q != NULL; q = q->next)
@@ -416,16 +364,6 @@ void tud_network_xmit(struct pbuf *p)
     len += q->len;
   }
 
-#if CFG_TUD_NET == OPT_NET_EEM
-  struct cdc_eem_packet_header *hdr = (struct cdc_eem_packet_header *)transmitted;
-  /* append a fake CRC-32; the standard allows 0xDEADBEEF, which takes less CPU time */
-  data[0] = 0xDE; data[1] = 0xAD; data[2] = 0xBE; data[3] = 0xEF;
-  /* adjust length to reflect added fake CRC-32 */
-  len += 4;
-  hdr->bmType = 0; /* EEM Data Packet */
-  hdr->length = len - sizeof(struct cdc_eem_packet_header);
-  hdr->bmCRC = 0; /* Ethernet Frame CRC-32 set to 0xDEADBEEF */
-#else
   if (!_netd_itf.ecm_mode)
   {
     rndis_data_packet_t *hdr = (rndis_data_packet_t *)transmitted;
@@ -435,7 +373,6 @@ void tud_network_xmit(struct pbuf *p)
     hdr->DataOffset = sizeof(rndis_data_packet_t) - offsetof(rndis_data_packet_t, DataOffset);
     hdr->DataLength = len - sizeof(rndis_data_packet_t);
   }
-#endif
 
   do_in_xfer(transmitted, len);
 }

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -184,7 +184,6 @@ static usbd_class_driver_t const _usbd_driver[] =
   #endif
 
   #if CFG_TUD_NET
-#if CFG_TUD_NET != OPT_NET_EEM
   /* RNDIS management interface */
   {
       .class_code       = TUD_RNDIS_ITF_CLASS,
@@ -196,24 +195,18 @@ static usbd_class_driver_t const _usbd_driver[] =
       .xfer_cb          = netd_xfer_cb,
       .sof              = NULL,
   },
-#endif
-  /* CDC-ECM management interface; CDC-EEM data interface */
+  /* CDC-ECM management interface */
   {
       .class_code       = TUSB_CLASS_CDC,
       .init             = netd_init,
       .reset            = netd_reset,
-#if CFG_TUD_NET == OPT_NET_EEM
-      .open             = netd_open_data,
-#else
       .open             = netd_open,
-#endif
       .control_request  = netd_control_request,
       .control_complete = netd_control_complete,
       .xfer_cb          = netd_xfer_cb,
       .sof              = NULL,
   },
   /* RNDIS/CDC-ECM data interface */
-#if CFG_TUD_NET != OPT_NET_EEM
   {
       .class_code       = TUSB_CLASS_CDC_DATA,
       .init             = netd_init_data,
@@ -224,7 +217,6 @@ static usbd_class_driver_t const _usbd_driver[] =
       .xfer_cb          = netd_xfer_cb,
       .sof              = NULL,
   },
-#endif
   #endif
 };
 

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -124,14 +124,6 @@
 #define OPT_MODE_HIGH_SPEED   0x10 ///< High speed
 /** @} */
 
-/** \defgroup group_supported_netif Supported Network Interface
- *  \ref CFG_TUD_NET must be defined to one of these
- *  @{ */
-#define OPT_NET_NONE      0 ///< No network interface
-#define OPT_NET_RNDIS_ECM 1 ///< RNDIS+CDC-ECM
-#define OPT_NET_EEM       2 ///< CDC-EEM
-/** @} */
-
 #ifndef CFG_TUSB_RHPORT0_MODE
   #define CFG_TUSB_RHPORT0_MODE OPT_MODE_NONE
 #endif


### PR DESCRIPTION
CDC-EEM is too obscure a protocol to justify [the request to include it as a run-time option](https://github.com/hathach/tinyusb/pull/334#pullrequestreview-392807281).

It seems a more prudent choice is to just cull the source code associated with CDC-EEM.
