### PR TITLE
automatically patch bConfigurationValue

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -806,6 +806,8 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
       uint16_t total_len;
       memcpy(&total_len, &desc_config->wTotalLength, 2); // possibly mis-aligned memory
 
+      tud_control_config(desc_index + 1);
+
       return tud_control_xfer(rhport, p_request, (void*) desc_config, total_len);
     }
     break;

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -87,6 +87,9 @@ bool tud_control_xfer(uint8_t rhport, tusb_control_request_t const * request, vo
 // Send STATUS (zero length) packet
 bool tud_control_status(uint8_t rhport, tusb_control_request_t const * request);
 
+// Pass configuration number for configuration descriptor
+void tud_control_config(uint8_t cfg_num);
+
 //--------------------------------------------------------------------+
 // Application Callbacks (WEAK is optional)
 //--------------------------------------------------------------------+


### PR DESCRIPTION
This may raise some eyebrows, but I’ll try proposing it anyway…

The notion of this PR is to have TinyUSB automatically set the “bConfigurationValue” correctly in the Configuration Descriptor sent to the host.  It can do this because all EP0 IN transfers happen to already be stored in an intermediate RAM buffer before the transfer takes place.

TinyUSB has a macro “TUD_CONFIG_DESCRIPTOR”.  Presently, the user must correctly set arguments to this in the one or more configuration descriptors in usb_descriptors.c.  Nothing automatically ensures consistency between what the host requests and what the user has entered.

Furthermore, if the app needs the same descriptor to appear in multiple configurations, the present system forces the user to store redundant instances in flash, each absolutely identical except for the bConfigurationValue.

So, why on earth would there be such redundant instances?  Well, I’ve encountered such a possible scenario in my pursuit of having net_lwip_webserver work automatically with as many hosts as possible.  It turns out that Android smartphones that I’ve tried have their Linux kernel configured with only CDC-ECM drivers, and Linux is one of those OSes that can’t be bothered to choose the correct configuration by itself.  So, the device has to soft disconnect and re-appear to the host with the default configuration already chosen correctly on the host’s behalf.)

If this draft PR were deemed acceptable, I would go back and do an additional commit to update all instances of TUD_CONFIG_DESCRIPTOR to always use a bConfigurationValue of zero (and remove the config_num as an argument); the value sent to the host would always get patched on-the-fly after the call to tud_descriptor_configuration_cb().

As you can see, the bConfigurationValue patch happens in _data_stage_xact() of usbd_control.c, and would work even in the pathological worst case of CFG_TUD_ENDPOINT0_SIZE being only 8 bytes.
