### PR TITLE
remove cmsis 5 from submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "lib/FreeRTOS"]
 	path = lib/FreeRTOS
 	url = https://github.com/FreeRTOS/FreeRTOS.git
-[submodule "lib/CMSIS_5"]
-	path = lib/CMSIS_5
-	url = https://github.com/ARM-software/CMSIS_5.git
 [submodule "lib/CMSIS_4"]
 	path = lib/CMSIS_4
 	url = https://github.com/ARM-software/CMSIS.git


### PR DESCRIPTION
cmsis 5 use git lfs causing issue with submodule cloning and isn't used
yet. Could re-add later if needed.