### PR TITLE
added swo as logger

### DIFF
--- a/examples/device/cdc_msc_freertos/src/FreeRTOSConfig.h
+++ b/examples/device/cdc_msc_freertos/src/FreeRTOSConfig.h
@@ -42,77 +42,10 @@
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
-// for OPT_MCU_
-#include "tusb_option.h"
-
-#if   CFG_TUSB_MCU == OPT_MCU_LPC11UXX   || CFG_TUSB_MCU == OPT_MCU_LPC13XX    || \
-      CFG_TUSB_MCU == OPT_MCU_LPC15XX    || CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || \
-      CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC18XX    || \
-      CFG_TUSB_MCU == OPT_MCU_LPC40XX    || CFG_TUSB_MCU == OPT_MCU_LPC43XX
-  #include "chip.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_LPC51UXX || CFG_TUSB_MCU == OPT_MCU_LPC54XXX || \
-      CFG_TUSB_MCU == OPT_MCU_LPC55XX
-  #include "fsl_device_registers.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_NRF5X
-  #include "nrf.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_SAMD21 || CFG_TUSB_MCU == OPT_MCU_SAMD51
-  #include "sam.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_SAMG
-  #undef LITTLE_ENDIAN // hack to suppress "LITTLE_ENDIAN" redefined
-  #include "sam.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F0
-  #include "stm32f0xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F1
-  #include "stm32f1xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F2
-  #include "stm32f2xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F3
-  #include "stm32f3xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F4
-  #include "stm32f4xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F7
-  #include "stm32f7xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32H7
-  #include "stm32h7xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32L0
-  #include "stm32l0xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32L1
-  #include "stm32l1xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32L4
-  #include "stm32l4xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX
-  #include "fsl_device_registers.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_NUC120
-  #include "NUC100Series.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_NUC121 || CFG_TUSB_MCU == OPT_MCU_NUC126
-  #include "NuMicro.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_NUC505
-  #include "NUC505Series.h"
-
-#else
-  #error "FreeRTOSConfig.h need to include low level mcu header for configuration"
-#endif
+// Include MCU header
+#include "bsp/board_mcu.h"
 
 extern uint32_t SystemCoreClock;
-
 
 /* Cortex M23/M33 port configuration. */
 #define configENABLE_MPU								        0

--- a/examples/device/hid_composite_freertos/src/FreeRTOSConfig.h
+++ b/examples/device/hid_composite_freertos/src/FreeRTOSConfig.h
@@ -42,77 +42,10 @@
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
-// for OPT_MCU_
-#include "tusb_option.h"
-
-#if   CFG_TUSB_MCU == OPT_MCU_LPC11UXX   || CFG_TUSB_MCU == OPT_MCU_LPC13XX    || \
-      CFG_TUSB_MCU == OPT_MCU_LPC15XX    || CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || \
-      CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC18XX    || \
-      CFG_TUSB_MCU == OPT_MCU_LPC40XX    || CFG_TUSB_MCU == OPT_MCU_LPC43XX
-  #include "chip.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_LPC51UXX || CFG_TUSB_MCU == OPT_MCU_LPC54XXX || \
-      CFG_TUSB_MCU == OPT_MCU_LPC55XX
-  #include "fsl_device_registers.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_NRF5X
-  #include "nrf.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_SAMD21 || CFG_TUSB_MCU == OPT_MCU_SAMD51
-  #include "sam.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_SAMG
-  #undef LITTLE_ENDIAN // hack to suppress "LITTLE_ENDIAN" redefined
-  #include "sam.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F0
-  #include "stm32f0xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F1
-  #include "stm32f1xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F2
-  #include "stm32f2xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F3
-  #include "stm32f3xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F4
-  #include "stm32f4xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32F7
-  #include "stm32f7xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32H7
-  #include "stm32h7xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32L0
-  #include "stm32l0xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32L1
-  #include "stm32l1xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_STM32L4
-  #include "stm32l4xx.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX
-  #include "fsl_device_registers.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_NUC120
-  #include "NUC100Series.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_NUC121 || CFG_TUSB_MCU == OPT_MCU_NUC126
-  #include "NuMicro.h"
-
-#elif CFG_TUSB_MCU == OPT_MCU_NUC505
-  #include "NUC505Series.h"
-
-#else
-  #error "FreeRTOSConfig.h need to include low level mcu header for configuration"
-#endif
+// Include MCU header
+#include "bsp/board_mcu.h"
 
 extern uint32_t SystemCoreClock;
-
 
 /* Cortex M23/M33 port configuration. */
 #define configENABLE_MPU								        0

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -80,7 +80,7 @@ ifneq ($(LOG),)
   CFLAGS += -DCFG_TUSB_DEBUG=$(LOG)
 endif
 
-# Logger: default is UART, can be set to RTT
+# Logger: default is uart, can be set to rtt or swo
 ifeq ($(LOGGER),rtt)
 	RTT_SRC = lib/SEGGER_RTT
 	
@@ -88,4 +88,8 @@ ifeq ($(LOGGER),rtt)
   INC   += $(TOP)/$(RTT_SRC)/RTT
   SRC_C += $(RTT_SRC)/RTT/SEGGER_RTT_printf.c
   SRC_C += $(RTT_SRC)/RTT/SEGGER_RTT.c
+  
+else ifeq ($(LOGGER),swo)
+	CFLAGS += -DLOGGER_SWO
+
 endif

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -44,13 +44,23 @@ $ make LOG=2 BOARD=feather_nrf52840_express all
 
 ### Logger
 
-By default log message is printed via on-board UART which is slow and take lots of CPU time comparing to USB speed. If your board support on-board/external JLink debugger, it would be more efficient to use it with [RTT protocol](https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer/) for logging. To do that add option `LOGGER=rtt` to build command e.g
+By default log message is printed via on-board UART which is slow and take lots of CPU time comparing to USB speed. If your board support on-board/external debugger, it would be more efficient to use it for logging. There are 2 protocols: 
+
+- `LOGGER=rtt`: use [Segger RTT protocol](https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer/)   
+  - Cons: requires jlink as the debugger.
+  - Pros: work with most if not all MCUs
+  - Software viewer is JLink RTT Viewer/Client/Logger which is bundled with JLink driver package.
+- `LOGGER=swo`: Use dedicated SWO pin of ARM Cortex SWD debug header.
+  - Cons: only work with ARM Cortex MCUs minus M0
+  - Pros: even faster than RTT, and should be compatible with hardware and software debugger that support SWO.
+  - Software viewer is JLink SWO Viewer which is also bundled with JLink driver package.
 
 ```
 $ make LOG=2 LOGGER=rtt BOARD=feather_nrf52840_express all
+$ make LOG=2 LOGGER=swo BOARD=feather_nrf52840_express all
 ```
 
-The log can be retrieved by JLink RTT Viewer/Client/Logger software which is bundled with their JLink driver.
+The log can be retrieved by
 
 ## Flash
 

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -60,8 +60,6 @@ $ make LOG=2 LOGGER=rtt BOARD=feather_nrf52840_express all
 $ make LOG=2 LOGGER=swo BOARD=feather_nrf52840_express all
 ```
 
-The log can be retrieved by
-
 ## Flash
 
 `flash` target will use the default on-board debugger (jlink/cmsisdap/stlink/dfu) to flash the binary, please install those support software in advance. Some board use bootloader/DFU via serial which is required to pass to make command

--- a/hw/bsp/board.c
+++ b/hw/bsp/board.c
@@ -37,7 +37,8 @@
 // newlib read()/write() retarget
 //--------------------------------------------------------------------+
 
-#ifdef LOGGER_RTT
+#if defined(LOGGER_RTT)
+// Logging with RTT
 
 #include "SEGGER_RTT.h"
 
@@ -54,9 +55,31 @@ TU_ATTR_USED int sys_read (int fhdl, char *buf, size_t count)
   return SEGGER_RTT_Read(0, buf, count);
 }
 
+#elif defined(LOGGER_SWO)
+// Logging with SWO for ARM Cortex
+
+#include "board_mcu.h"
+
+TU_ATTR_USED int sys_write (int fhdl, const void *buf, size_t count)
+{
+  (void) fhdl;
+  uint8_t const* buf8 = (uint8_t const*) buf;
+  for(size_t i=0; i<count; i++)
+  {
+    ITM_SendChar(buf8[i]);
+  }
+  return count;
+}
+
+TU_ATTR_USED int sys_read (int fhdl, char *buf, size_t count)
+{
+  (void) fhdl;
+  return 0;
+}
+
 #else
 
-// Default logger is on-board UART
+// Default logging with on-board UART
 TU_ATTR_USED int sys_write (int fhdl, const void *buf, size_t count)
 {
   (void) fhdl;

--- a/hw/bsp/board_mcu.h
+++ b/hw/bsp/board_mcu.h
@@ -1,0 +1,121 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020, Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+
+#ifndef BOARD_MCU_H_
+#define BOARD_MCU_H_
+
+#include "tusb_option.h"
+
+//--------------------------------------------------------------------+
+// Low Level MCU header include. TinyUSB stack and example should be
+// platform independent and mostly doens't need to include this file.
+// However there are still certain situation where this file is needed:
+// - FreeRTOSConfig.h to set up correct clock and NVIC interrupts for ARM Cortex
+// - SWO logging for Cortex M with ITM_SendChar() / ITM_ReceiveChar()
+//--------------------------------------------------------------------+
+
+// Include order follows OPT_MCU_ number
+#if   CFG_TUSB_MCU == OPT_MCU_LPC11UXX   || CFG_TUSB_MCU == OPT_MCU_LPC13XX    || \
+      CFG_TUSB_MCU == OPT_MCU_LPC15XX    || CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || \
+      CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC18XX    || \
+      CFG_TUSB_MCU == OPT_MCU_LPC40XX    || CFG_TUSB_MCU == OPT_MCU_LPC43XX
+  #include "chip.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_LPC51UXX || CFG_TUSB_MCU == OPT_MCU_LPC54XXX || \
+      CFG_TUSB_MCU == OPT_MCU_LPC55XX
+  #include "fsl_device_registers.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_NRF5X
+  #include "nrf.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_SAMD21 || CFG_TUSB_MCU == OPT_MCU_SAMD51
+  #include "sam.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_SAMG
+  #undef LITTLE_ENDIAN // hack to suppress "LITTLE_ENDIAN" redefined
+  #include "sam.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32F0
+  #include "stm32f0xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32F1
+  #include "stm32f1xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32F2
+  #include "stm32f2xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32F3
+  #include "stm32f3xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32F4
+  #include "stm32f4xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32F7
+  #include "stm32f7xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32H7
+  #include "stm32h7xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32L0
+  #include "stm32l0xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32L1
+  #include "stm32l1xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32L4
+  #include "stm32l4xx.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_CXD56
+  // no header needed
+
+#elif CFG_TUSB_MCU == OPT_MCU_MSP430x5xx
+  #include "msp430.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_VALENTYUSB_EPTRI
+  // no header needed
+
+#elif CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX
+  #include "fsl_device_registers.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_NUC120
+  #include "NUC100Series.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_NUC121 || CFG_TUSB_MCU == OPT_MCU_NUC126
+  #include "NuMicro.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_NUC505
+  #include "NUC505Series.h"
+
+#elif CFG_TUSB_MCU == OPT_MCU_ESP32S2
+  // no header needed
+
+#else
+  #error "Missing MCU header"
+#endif
+
+
+#endif /* BOARD_MCU_H_ */

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -75,17 +75,21 @@
 #define OPT_MCU_CXD56             400 ///< SONY CXD56
 
 // TI MSP430
-#define OPT_MCU_MSP430x5xx    500 ///< TI MSP430x5xx
+#define OPT_MCU_MSP430x5xx        500 ///< TI MSP430x5xx
 
+// ValentyUSB eptri
 #define OPT_MCU_VALENTYUSB_EPTRI  600 ///< Fomu eptri config
 
+// NXP iMX RT
 #define OPT_MCU_MIMXRT10XX        700 ///< NXP iMX RT10xx
 
+// Nuvoton
 #define OPT_MCU_NUC121            800
 #define OPT_MCU_NUC126            801
 #define OPT_MCU_NUC120            802
 #define OPT_MCU_NUC505            803
 
+// Espressif
 #define OPT_MCU_ESP32S2           900 ///< Espressif ESP32-S2
 
 /** @} */


### PR DESCRIPTION
tested with feather nrf52840 + jlink. Implement swo part of #367 . Text from examples readme

````
By default log message is printed via on-board UART which is slow and take lots of CPU time comparing to USB speed. If your board support on-board/external debugger, it would be more efficient to use it for logging. There are 2 protocols: 

- `LOGGER=rtt`: use [Segger RTT protocol](https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer/)   
  - Cons: requires jlink as the debugger.
  - Pros: work with most if not all MCUs
  - Software viewer is JLink RTT Viewer/Client/Logger which is bundled with JLink driver package.
- `LOGGER=swo`: Use dedicated SWO pin of ARM Cortex SWD debug header.
  - Cons: only work with ARM Cortex MCUs minus M0
  - Pros: even faster than RTT, and should be compatible with hardware and software debugger that support SWO.
  - Software viewer is JLink SWO Viewer which is also bundled with JLink driver package.

$ make LOG=2 LOGGER=rtt BOARD=feather_nrf52840_express all
$ make LOG=2 LOGGER=swo BOARD=feather_nrf52840_express all
````

![image](https://user-images.githubusercontent.com/249515/79978292-e2684a80-84c9-11ea-9bbe-a190e8f2186a.png)
 