### PR TITLE
synopsys: Reduce interrupt time for IN ZLP

### DIFF
--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -372,7 +372,10 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
     in_ep[epnum].DIEPTSIZ = (num_packets << USB_OTG_DIEPTSIZ_PKTCNT_Pos) | \
         ((total_bytes & USB_OTG_DIEPTSIZ_XFRSIZ_Msk) << USB_OTG_DIEPTSIZ_XFRSIZ_Pos);
     in_ep[epnum].DIEPCTL |= USB_OTG_DIEPCTL_EPENA | USB_OTG_DIEPCTL_CNAK;
-    dev->DIEPEMPMSK |= (1 << epnum);
+    // Enable fifo empty interrupt only if there are something to put in the fifo.
+    if(total_bytes != 0) {
+      dev->DIEPEMPMSK |= (1 << epnum);
+    }
   } else {
     // Each complete packet for OUT xfers triggers XFRC.
     out_ep[epnum].DOEPTSIZ |= (1 << USB_OTG_DOEPTSIZ_PKTCNT_Pos) | \


### PR DESCRIPTION
For IN endpoints output FIFO is filled in interrupt, therefor before
endpoint is enabled, DIEPTSIZ is set with correct size of packet.
Then endpoint is enabled and FIFO empty interrupt is enabled.

This works fine except for the ZLP. Enabling FIFO empty interrupt
results in interrupt handler being called all the time because
there is nothing to put in the FIFO.
Eventually it ends when IN token is received and empty
packed is transmitted out.

This change does not enable FIFO empty interrupt for ZLP reducing
CPU load.
