### PR TITLE
synopsys turn off TX FIFO Empty for EPIN if all bytes are written

### DIFF
--- a/src/class/net/net_device.c
+++ b/src/class/net/net_device.c
@@ -89,7 +89,8 @@ static const struct ecm_notify_struct ecm_notify_csc =
   .uplink = 9728000,
 };
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static union
+// TODO remove CFG_TUSB_MEM_SECTION, control internal buffer is already in this special section
+CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4) static union
 {
   uint8_t rndis_buf[120];
   struct ecm_notify_struct ecm_buf;
@@ -98,6 +99,7 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static union
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
+// TODO remove CFG_TUSB_MEM_SECTION
 CFG_TUSB_MEM_SECTION static netd_interface_t _netd_itf;
 
 static bool can_xmit;

--- a/src/class/net/net_device.c
+++ b/src/class/net/net_device.c
@@ -90,7 +90,7 @@ static const struct ecm_notify_struct ecm_notify_csc =
 };
 
 // TODO remove CFG_TUSB_MEM_SECTION, control internal buffer is already in this special section
-CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4) static union
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static union
 {
   uint8_t rndis_buf[120];
   struct ecm_notify_struct ecm_buf;

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -232,15 +232,15 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t event,
 #if CFG_TUSB_DEBUG >= 2
 static char const* const _usbd_event_str[DCD_EVENT_COUNT] =
 {
-  "INVALID"        ,
-  "BUS_RESET"      ,
-  "UNPLUGGED"      ,
+  "Invalid"        ,
+  "Bus Reset"      ,
+  "Unplugged"      ,
   "SOF"            ,
-  "SUSPEND"        ,
-  "RESUME"         ,
-  "SETUP_RECEIVED" ,
-  "XFER_COMPLETE"  ,
-  "FUNC_CALL"
+  "Suspend"        ,
+  "Resume"         ,
+  "Setup Received" ,
+  "Xfer Complete"  ,
+  "Func Call"
 };
 
 static char const* const _tusb_std_request_str[] =
@@ -259,6 +259,19 @@ static char const* const _tusb_std_request_str[] =
   "Set Interface"     ,
   "Synch Frame"
 };
+
+// for usbd_control to print the name of control complete driver
+void usbd_driver_print_control_complete_name(bool (*control_complete) (uint8_t, tusb_control_request_t const * ))
+{
+  for (uint8_t i = 0; i < USBD_CLASS_DRIVER_COUNT; i++)
+  {
+    if (_usbd_driver[i].control_complete == control_complete )
+    {
+      TU_LOG2("  %s control complete\r\n", _usbd_driver[i].name);
+      return;
+    }
+  }
+}
 
 #endif
 
@@ -356,7 +369,7 @@ void tud_task (void)
 
     if ( !osal_queue_receive(_usbd_q, &event) ) return;
 
-    TU_LOG2("USBD: %s", event.event_id < DCD_EVENT_COUNT ? _usbd_event_str[event.event_id] : "CORRUPTED");
+    TU_LOG2("USBD %s", event.event_id < DCD_EVENT_COUNT ? _usbd_event_str[event.event_id] : "CORRUPTED");
     TU_LOG2("%s", (event.event_id != DCD_EVENT_XFER_COMPLETE && event.event_id != DCD_EVENT_SETUP_RECEIVED) ? "\r\n" : " ");
 
     switch ( event.event_id )

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -82,7 +82,7 @@ bool tud_control_status(uint8_t rhport, tusb_control_request_t const * request)
   return _status_stage_xact(rhport, request);
 }
 
-// Queue an transaction in Data Stage
+// Queue a transaction in Data Stage
 // Each transaction has up to Endpoint0's max packet size.
 // This function can also transfer an zero-length packet
 static bool _data_stage_xact(uint8_t rhport)

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -58,6 +58,7 @@ static uint8_t _usbd_ctrl_buf[CFG_TUD_ENDPOINT0_SIZE];
 // Application API
 //--------------------------------------------------------------------+
 
+// Queue ZLP status transaction
 static inline bool _status_stage_xact(uint8_t rhport, tusb_control_request_t const * request)
 {
   // Opposite to endpoint in Data Phase
@@ -81,7 +82,7 @@ bool tud_control_status(uint8_t rhport, tusb_control_request_t const * request)
   return _status_stage_xact(rhport, request);
 }
 
-// Transfer an transaction in Data Stage
+// Queue an transaction in Data Stage
 // Each transaction has up to Endpoint0's max packet size.
 // This function can also transfer an zero-length packet
 static bool _data_stage_xact(uint8_t rhport)
@@ -102,7 +103,6 @@ static bool _data_stage_xact(uint8_t rhport)
 }
 
 // Transmit data to/from the control endpoint.
-// 
 // If the request's wLength is zero, a status packet is sent instead.
 bool tud_control_xfer(uint8_t rhport, tusb_control_request_t const * request, void* buffer, uint16_t len)
 {
@@ -182,7 +182,7 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t result
 
   // Data Stage is complete when all request's length are transferred or
   // a short packet is sent including zero-length packet.
-  if ( (_ctrl_xfer.request.wLength == _ctrl_xfer.total_xferred) || xferred_bytes < CFG_TUD_ENDPOINT0_SIZE )
+  if ( (_ctrl_xfer.request.wLength == _ctrl_xfer.total_xferred) || (xferred_bytes < CFG_TUD_ENDPOINT0_SIZE) )
   {
     // DATA stage is complete
     bool is_ok = true;
@@ -191,6 +191,11 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t result
     // callback can still stall control in status phase e.g out data does not make sense
     if ( _ctrl_xfer.complete_cb )
     {
+      #if CFG_TUSB_DEBUG >= 2
+      extern void usbd_driver_print_control_complete_name(bool (*control_complete) (uint8_t, tusb_control_request_t const *));
+      usbd_driver_print_control_complete_name(_ctrl_xfer.complete_cb);
+      #endif
+
       is_ok = _ctrl_xfer.complete_cb(rhport, &_ctrl_xfer.request);
     }
 

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -679,7 +679,8 @@ static void handle_epin_ints(USB_OTG_DeviceTypeDef * dev, USB_OTG_INEndpointType
       // XFER FIFO empty
       if ( in_ep[n].DIEPINT & USB_OTG_DIEPINT_TXFE )
       {
-        in_ep[n].DIEPINT = USB_OTG_DIEPINT_TXFE;
+        // DIEPINT's TXFE bit is read-only -> no need to clear
+
         transmit_packet(xfer, &in_ep[n], n);
 
         // Turn off TXFE if all bytes are written.

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -291,9 +291,10 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
 
   if(dir == TUSB_DIR_OUT)
   {
-    out_ep[epnum].DOEPCTL |= (1 << USB_OTG_DOEPCTL_USBAEP_Pos) | \
-      desc_edpt->bmAttributes.xfer << USB_OTG_DOEPCTL_EPTYP_Pos | \
-      desc_edpt->wMaxPacketSize.size << USB_OTG_DOEPCTL_MPSIZ_Pos;
+    out_ep[epnum].DOEPCTL |= (1 << USB_OTG_DOEPCTL_USBAEP_Pos) |
+                             (desc_edpt->bmAttributes.xfer << USB_OTG_DOEPCTL_EPTYP_Pos) |
+                             (desc_edpt->wMaxPacketSize.size << USB_OTG_DOEPCTL_MPSIZ_Pos);
+
     dev->DAINTMSK |= (1 << (USB_OTG_DAINTMSK_OEPM_Pos + epnum));
   }
   else
@@ -321,11 +322,12 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
     // - Offset: GRXFSIZ + 16 + Size*(epnum-1)
     // - IN EP 1 gets FIFO 1, IN EP "n" gets FIFO "n".
 
-    in_ep[epnum].DIEPCTL |= (1 << USB_OTG_DIEPCTL_USBAEP_Pos) | \
-      epnum << USB_OTG_DIEPCTL_TXFNUM_Pos | \
-      desc_edpt->bmAttributes.xfer << USB_OTG_DIEPCTL_EPTYP_Pos | \
-      (desc_edpt->bmAttributes.xfer != TUSB_XFER_ISOCHRONOUS ? USB_OTG_DOEPCTL_SD0PID_SEVNFRM : 0) | \
-      desc_edpt->wMaxPacketSize.size << USB_OTG_DIEPCTL_MPSIZ_Pos;
+    in_ep[epnum].DIEPCTL |= (1 << USB_OTG_DIEPCTL_USBAEP_Pos) |
+                            (epnum << USB_OTG_DIEPCTL_TXFNUM_Pos) |
+                            (desc_edpt->bmAttributes.xfer << USB_OTG_DIEPCTL_EPTYP_Pos) |
+                            (desc_edpt->bmAttributes.xfer != TUSB_XFER_ISOCHRONOUS ? USB_OTG_DOEPCTL_SD0PID_SEVNFRM : 0) |
+                            (desc_edpt->wMaxPacketSize.size << USB_OTG_DIEPCTL_MPSIZ_Pos);
+
     dev->DAINTMSK |= (1 << (USB_OTG_DAINTMSK_IEPM_Pos + epnum));
 
     // Both TXFD and TXSA are in unit of 32-bit words.
@@ -352,9 +354,9 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
   uint8_t const dir   = tu_edpt_dir(ep_addr);
 
   xfer_ctl_t * xfer = XFER_CTL_BASE(epnum, dir);
-  xfer->buffer = buffer;
-  xfer->total_len = total_bytes;
-  xfer->queued_len = 0;
+  xfer->buffer       = buffer;
+  xfer->total_len    = total_bytes;
+  xfer->queued_len   = 0;
   xfer->short_packet = false;
 
   uint16_t num_packets = (total_bytes / xfer->max_size);
@@ -365,21 +367,23 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
     num_packets++;
   }
 
-  // IN and OUT endpoint xfers are interrupt-driven, we just schedule them
-  // here.
+  // IN and OUT endpoint xfers are interrupt-driven, we just schedule them here.
   if(dir == TUSB_DIR_IN) {
     // A full IN transfer (multiple packets, possibly) triggers XFRC.
-    in_ep[epnum].DIEPTSIZ = (num_packets << USB_OTG_DIEPTSIZ_PKTCNT_Pos) | \
-        ((total_bytes & USB_OTG_DIEPTSIZ_XFRSIZ_Msk) << USB_OTG_DIEPTSIZ_XFRSIZ_Pos);
+    in_ep[epnum].DIEPTSIZ = (num_packets << USB_OTG_DIEPTSIZ_PKTCNT_Pos) |
+                            ((total_bytes & USB_OTG_DIEPTSIZ_XFRSIZ_Msk) << USB_OTG_DIEPTSIZ_XFRSIZ_Pos);
+
     in_ep[epnum].DIEPCTL |= USB_OTG_DIEPCTL_EPENA | USB_OTG_DIEPCTL_CNAK;
+
     // Enable fifo empty interrupt only if there are something to put in the fifo.
     if(total_bytes != 0) {
       dev->DIEPEMPMSK |= (1 << epnum);
     }
   } else {
     // Each complete packet for OUT xfers triggers XFRC.
-    out_ep[epnum].DOEPTSIZ |= (1 << USB_OTG_DOEPTSIZ_PKTCNT_Pos) | \
-        ((xfer->max_size & USB_OTG_DOEPTSIZ_XFRSIZ_Msk) << USB_OTG_DOEPTSIZ_XFRSIZ_Pos);
+    out_ep[epnum].DOEPTSIZ |= (1 << USB_OTG_DOEPTSIZ_PKTCNT_Pos) |
+                              ((xfer->max_size & USB_OTG_DOEPTSIZ_XFRSIZ_Msk) << USB_OTG_DOEPTSIZ_XFRSIZ_Pos);
+
     out_ep[epnum].DOEPCTL |= USB_OTG_DOEPCTL_EPENA | USB_OTG_DOEPCTL_CNAK;
   }
 
@@ -535,6 +539,7 @@ static void receive_packet(xfer_ctl_t * xfer, /* USB_OTG_OUTEndpointTypeDef * ou
   xfer->short_packet = (xfer_size < xfer->max_size);
 }
 
+// Write a data packet to EPIN FIFO
 static void transmit_packet(xfer_ctl_t * xfer, USB_OTG_INEndpointTypeDef * in_ep, uint8_t fifo_num) {
   usb_fifo_t tx_fifo = FIFO_BASE(fifo_num);
 
@@ -658,21 +663,30 @@ static void handle_epout_ints(USB_OTG_DeviceTypeDef * dev, USB_OTG_OUTEndpointTy
 static void handle_epin_ints(USB_OTG_DeviceTypeDef * dev, USB_OTG_INEndpointTypeDef * in_ep) {
   // DAINT for a given EP clears when DIEPINTx is cleared.
   // IEPINT will be cleared when DAINT's out bits are cleared.
-  for(uint8_t n = 0; n < EP_MAX; n++) {
-    xfer_ctl_t * xfer = XFER_CTL_BASE(n, TUSB_DIR_IN);
+  for ( uint8_t n = 0; n < EP_MAX; n++ )
+  {
+    xfer_ctl_t *xfer = XFER_CTL_BASE(n, TUSB_DIR_IN);
 
-    if(dev->DAINT & (1 << (USB_OTG_DAINT_IEPINT_Pos + n))) {
+    if ( dev->DAINT & (1 << (USB_OTG_DAINT_IEPINT_Pos + n)) )
+    {
       // IN XFER complete (entire xfer).
-      if(in_ep[n].DIEPINT & USB_OTG_DIEPINT_XFRC) {
+      if ( in_ep[n].DIEPINT & USB_OTG_DIEPINT_XFRC )
+      {
         in_ep[n].DIEPINT = USB_OTG_DIEPINT_XFRC;
-        dev->DIEPEMPMSK &= ~(1 << n); // Turn off TXFE b/c xfer inactive.
         dcd_event_xfer_complete(0, n | TUSB_DIR_IN_MASK, xfer->total_len, XFER_RESULT_SUCCESS, true);
       }
 
       // XFER FIFO empty
-      if(in_ep[n].DIEPINT & USB_OTG_DIEPINT_TXFE) {
+      if ( in_ep[n].DIEPINT & USB_OTG_DIEPINT_TXFE )
+      {
         in_ep[n].DIEPINT = USB_OTG_DIEPINT_TXFE;
         transmit_packet(xfer, &in_ep[n], n);
+
+        // Turn off TXFE if all bytes are written.
+        if (xfer->queued_len == xfer->total_len)
+        {
+          dev->DIEPEMPMSK &= ~(1 << n);
+        }
       }
     }
   }

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -679,7 +679,10 @@ static void handle_epin_ints(USB_OTG_DeviceTypeDef * dev, USB_OTG_INEndpointType
       // XFER FIFO empty
       if ( in_ep[n].DIEPINT & USB_OTG_DIEPINT_TXFE )
       {
-        // DIEPINT's TXFE bit is read-only -> no need to clear
+        // DIEPINT's TXFE bit is read-only, software cannot clear it.
+        // It will only be cleared by hardware when written bytes is more than
+        // - 64 bytes or
+        // - Half of TX FIFO size (configured by DIEPTXF)
 
         transmit_packet(xfer, &in_ep[n], n);
 


### PR DESCRIPTION
**Describe the PR**
TXFE is currently cleared after all data is transferred to host. However host can be blocking wait for another EP (e.g control)  and doesn't issue IN token to receive/complete the transfer. This cause the TXFE constantly fired repeatedly and block/reduce processing other tasks. 

Fixed by turning of TXFE when the last data is written to FIFO (nothing else to write). Related to  #378 

This also fix the issue with usbnet mentioned in #289 

**Additional context**
![image](https://user-images.githubusercontent.com/249515/80311731-87a55a80-880b-11ea-82b9-51dea62f6f71.png)
screenshot when running lwip_webserver example with stm32f4 
- Host send RNDIS control message trigger Control DATA OUT 24 bytes (status phase not complete yet) 
- usbd forward data to the usbnet driver 
- usbnet parse rndis message and queue an 8 bytes transfer on notification endpoint 0x81
- TXFE occurred internally, stm32 write 8 bytes to FIFO of 0x81
- However since the control status is not yet complete, Host continue to send IN token to EP0, and **never** attempt to send IN token to 0x81
- the above TXFE keeps firing and block stm32 mcu to response to the control status response

Host waits for Control Status before sending IN to 0x81, but it is blocked by constatnt TXFE on 0x81 internally prevent stm32 to response to Control which is resulted to deadblock.

Update: also update esp32s2 as well, we should really merge esp32 and stm32 synopsys sometime in the future.