### PR TITLE
Fix endpoint busy flag race condition

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -982,8 +982,8 @@ bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
 
   TU_LOG2("  Queue EP %02X with %u bytes ... ", ep_addr, total_bytes);
 
-  TU_VERIFY( dcd_edpt_xfer(rhport, ep_addr, buffer, total_bytes) );
   _usbd_dev.ep_status[epnum][dir].busy = true;
+  TU_VERIFY_HDLR( dcd_edpt_xfer(rhport, ep_addr, buffer, total_bytes), _usbd_dev.ep_status[epnum][dir].busy = false);
 
   TU_LOG2("OK\r\n");
 


### PR DESCRIPTION
Busy flag was set to true after call to dcd_edpt_xfer().
In some cased it was possible that transfer finished before function ended.
In this case busy flag could be set to false before it was set to true.
Then setting it to true after dcd_edpt_xfer() made edpoint busy forever.

This change marks endpoint as busy before transfer is started to
avoid race condition.

For my case PR #380 would hide the issue but I guess other cases could result in
same behavior.