### PR TITLE
Redesign of Synopsys device transmission

### DIFF
--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -550,14 +550,17 @@ static void transmit_fifo_packet(uint8_t fifo_num, uint8_t * src, uint16_t len){
 	}
 
 	// Write the remaining 1-3 bytes into fifo
-	uint32_t tmp_word = 0;
-	switch(len & 0x0003){
-		case 3: tmp_word |= src[2] << 16;
-		case 2: tmp_word |= src[1] << 8;
-		case 1: tmp_word |= src[0];
-			*tx_fifo = tmp_word;
-			break;
-		default: break;
+	uint8_t bytes_rem = len & 0x03;
+	if(bytes_rem){
+		uint32_t tmp_word = 0;
+		tmp_word |= src[0];
+		if(bytes_rem > 1){
+			tmp_word |= src[1] << 8;
+		}
+		if(bytes_rem > 2){
+			tmp_word |= src[2] << 16;
+		}
+		*tx_fifo = tmp_word;
 	}
 }
 

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -195,7 +195,7 @@ void dcd_init (uint8_t rhport)
 
   // Programming model begins in the last section of the chapter on the USB
   // peripheral in each Reference Manual.
-  USB_OTG_FS->GAHBCFG |= USB_OTG_GAHBCFG_TXFELVL | USB_OTG_GAHBCFG_GINT;
+  USB_OTG_FS->GAHBCFG |= USB_OTG_GAHBCFG_GINT;
 
   // No HNP/SRP (no OTG support), program timeout later, turnaround
   // programmed for 32+ MHz.
@@ -374,7 +374,6 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
                             ((total_bytes & USB_OTG_DIEPTSIZ_XFRSIZ_Msk) << USB_OTG_DIEPTSIZ_XFRSIZ_Pos);
 
     in_ep[epnum].DIEPCTL |= USB_OTG_DIEPCTL_EPENA | USB_OTG_DIEPCTL_CNAK;
-
     // Enable fifo empty interrupt only if there are something to put in the fifo.
     if(total_bytes != 0) {
       dev->DIEPEMPMSK |= (1 << epnum);
@@ -539,46 +538,27 @@ static void receive_packet(xfer_ctl_t * xfer, /* USB_OTG_OUTEndpointTypeDef * ou
   xfer->short_packet = (xfer_size < xfer->max_size);
 }
 
-// Write a data packet to EPIN FIFO
-static void transmit_packet(xfer_ctl_t * xfer, USB_OTG_INEndpointTypeDef * in_ep, uint8_t fifo_num) {
-  usb_fifo_t tx_fifo = FIFO_BASE(fifo_num);
+// Write a single data packet to EPIN FIFO
+static void transmit_fifo_packet(uint8_t fifo_num, uint8_t * src, uint16_t len){
+	usb_fifo_t tx_fifo = FIFO_BASE(fifo_num);
 
-  uint16_t remaining = (in_ep->DIEPTSIZ & USB_OTG_DIEPTSIZ_XFRSIZ_Msk) >> USB_OTG_DIEPTSIZ_XFRSIZ_Pos;
-  xfer->queued_len = xfer->total_len - remaining;
+	// Pushing full available 32 bit words to fifo
+	uint16_t full_words = len >> 2;
+	for(uint16_t i = 0; i < full_words; i++){
+		*tx_fifo = (src[3] << 24) | (src[2] << 16) | (src[1] << 8) | src[0];
+		src += 4;
+	}
 
-  uint16_t to_xfer_size = (remaining > xfer->max_size) ? xfer->max_size : remaining;
-  uint8_t to_xfer_rem = to_xfer_size % 4;
-  uint16_t to_xfer_size_aligned = to_xfer_size - to_xfer_rem;
-
-  // Buffer might not be aligned to 32b, so we need to force alignment
-  // by copying to a temp var.
-  uint8_t * base = (xfer->buffer + xfer->queued_len);
-
-  // This for loop always runs at least once- skip if less than 4 bytes
-  // to send off.
-  if(to_xfer_size >= 4) {
-    for(uint16_t i = 0; i < to_xfer_size_aligned; i += 4) {
-      uint32_t tmp = base[i] | (base[i + 1] << 8) | \
-        (base[i + 2] << 16) | (base[i + 3] << 24);
-      (* tx_fifo) = tmp;
-    }
-  }
-
-  // Do not read beyond end of buffer if not divisible by 4.
-  if(to_xfer_rem != 0) {
-    uint32_t tmp = 0;
-    uint8_t * last_32b_bound = base + to_xfer_size_aligned;
-
-    tmp |= last_32b_bound[0];
-    if(to_xfer_rem > 1) {
-      tmp |= (last_32b_bound[1] << 8);
-    }
-    if(to_xfer_rem > 2) {
-      tmp |= (last_32b_bound[2] << 16);
-    }
-
-    (* tx_fifo) = tmp;
-  }
+	// Write the remaining 1-3 bytes into fifo
+	uint32_t tmp_word = 0;
+	switch(len & 0x0003){
+		case 3: tmp_word |= src[2] << 16;
+		case 2: tmp_word |= src[1] << 8;
+		case 1: tmp_word |= src[0];
+			*tx_fifo = tmp_word;
+			break;
+		default: break;
+	}
 }
 
 static void read_rx_fifo(USB_OTG_OUTEndpointTypeDef * out_ep) {
@@ -677,17 +657,37 @@ static void handle_epin_ints(USB_OTG_DeviceTypeDef * dev, USB_OTG_INEndpointType
       }
 
       // XFER FIFO empty
-      if ( in_ep[n].DIEPINT & USB_OTG_DIEPINT_TXFE )
+      if ( (in_ep[n].DIEPINT & USB_OTG_DIEPINT_TXFE) && (dev->DIEPEMPMSK & (1 << n)) )
       {
         // DIEPINT's TXFE bit is read-only, software cannot clear it.
         // It will only be cleared by hardware when written bytes is more than
         // - 64 bytes or
         // - Half of TX FIFO size (configured by DIEPTXF)
 
-        transmit_packet(xfer, &in_ep[n], n);
+      	// Packets to be processed
+      	uint16_t tx_packet_amount = (in_ep[n].DIEPTSIZ & USB_OTG_DIEPTSIZ_PKTCNT_Msk) >> USB_OTG_DIEPTSIZ_PKTCNT_Pos;
+
+      	// Process every single packet (only whole packets can be written to fifo)
+      	for(uint16_t i = 0; i < tx_packet_amount; i++){
+      		// amount of bytes EP still needs to transfer
+      		uint16_t tx_remaining = (in_ep[n].DIEPTSIZ & USB_OTG_DIEPTSIZ_XFRSIZ_Msk) >> USB_OTG_DIEPTSIZ_XFRSIZ_Pos;
+      		// Packet can not be larger than ep max size
+      		uint16_t packet_size = (tx_remaining > xfer->max_size) ? xfer->max_size : tx_remaining;
+
+      		// It's only possible to write full packets into FIFO. Therefore DTXFSTS register of current
+      		// EP has to be checked if the buffer can take another WHOLE packet
+      		if(packet_size > ((in_ep[n].DTXFSTS & USB_OTG_DTXFSTS_INEPTFSAV_Msk) << 2)){
+      			break;
+      		}
+
+      		xfer->queued_len = xfer->total_len - tx_remaining;
+
+      		// Push packet to Tx-FIFO
+					transmit_fifo_packet(n, (xfer->buffer + xfer->queued_len), packet_size);
+      	}
 
         // Turn off TXFE if all bytes are written.
-        if (xfer->queued_len == xfer->total_len)
+        if (((in_ep[n].DIEPTSIZ & USB_OTG_DIEPTSIZ_XFRSIZ_Msk) >> USB_OTG_DIEPTSIZ_XFRSIZ_Pos) == 0)
         {
           dev->DIEPEMPMSK &= ~(1 << n);
         }


### PR DESCRIPTION
**Describe the PR**
Last changes to Synopsys drivers at PR #380 fixed an issue of interrupt calls. But as already discussed there (e.g. in [this comment](https://github.com/hathach/tinyusb/pull/380#issuecomment-620369094)) there are still a lot of improvements we can do to the drivers.

The effect of this PR is that there will be fewer interruptions of the main application, making it more efficient. Also transmission should invoke a little faster without dead time between packets.

Changes:
**checking if tx buffer empty interrupt is masked:** Before this PR we always spent some time executing commands within the _XFER FIFO empty_ part of the interrupt. Even if the tx buffer empty interrupt was masked with DIEPEMPMSK. This is caused by the TXFE flag also being set if the related mask is set. This means that this functions were always executed if IEPINT in GINTSTS was set (which was also done by some other interrupts).
**process more than one packet in isr:** Before this PR every interrupt could only push one packet into the tx FIFO. Now there will be packets pushed until the buffer is full. This leads to fewer calls of TXFE routine.
**mask tx buffer empty just after all bytes were written:** The fix at PR #380 does not mask the interrupt just after the last packet was written to FIFO. The interrupt has to be called another time to get xfer->queued_len to xfer->total_len. This was changed to let the TXFE interrupt be triggered one time less.
**use of transmit_fifo_packet instead of transmit_packet:** Since there have been a lot of changes due to sending more than just one packet during ISR, I pushed the whole packet management part to _handle_epin_ints_ and changed the _transmit_packet_ function to _transmit_fifo_packet_. Because we write a packet to a related fifo and not to the ep itself, I changed the function parameter and changed the naming as well to prevent confusion.
**trigger TXFE if half empty**: Before this PR TXFE was triggered if the fifo is completely empty. If there was a IN EP transaction with multiple packets the next packet would be written to fifo **after** the fifo was empty. This could lead into some µs time wasting.

**Additional context**
I only test this PR with usbnet example yet. It's working fine there. But there should be much more tests to be done to verify. Please let me know what you think about this.