### PR TITLE
stm32l476disco clock configuration

### DIFF
--- a/hw/bsp/stm32l476disco/stm32l476disco.c
+++ b/hw/bsp/stm32l476disco/stm32l476disco.c
@@ -95,6 +95,10 @@ static void SystemClock_Config(void)
   /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
   HAL_RCCEx_DisableLSECSS();
 
+  /* Set tick interrupt priority, default HAL value is intentionally invalid
+     and that prevents PLL initialization in HAL_RCC_OscConfig() */
+  HAL_InitTick((1UL << __NVIC_PRIO_BITS) - 1UL);
+
   /* Enable MSI Oscillator and activate PLL with MSI as source */
   RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI;
   RCC_OscInitStruct.MSIState            = RCC_MSI_ON;

--- a/hw/bsp/stm32l476disco/stm32l476disco.c
+++ b/hw/bsp/stm32l476disco/stm32l476disco.c
@@ -86,9 +86,10 @@ static void SystemClock_Config(void)
   RCC_OscInitTypeDef RCC_OscInitStruct;
   RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
 
-  /* Enable the LSE Oscilator */
+  /* Enable the LSE Oscillator */
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
   RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
   HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
   /* Enable the CSS interrupt in case LSE signal is corrupted or not present */


### PR DESCRIPTION
**Describe the PR**
There were two problems with **STM32L476** System clock setup.
One is that uninitialized variable could lead to reboot loop due to possible accidental assert.

Second problem resulted in System clock being driven by MSI **48MHz** clock and NOT what code
suggested **80MHz**, due to PLL not being initialized.
PLL was not initialized by accident since Tick interrupt priority was never specified and default
ST value was intentionally invalid:
```c
uint32_t uwTickPrio   = (1UL << __NVIC_PRIO_BITS); /* Invalid PRIO */
```


**Additional context**
Code also initializes PC11 pin as VBUS detection pin which is suggested by board documentation while is seems that it's not needed since like other ST chips PA9 is used for this and not PC11.
