### PR TITLE
Change mynewt package type to sdk

### DIFF
--- a/pkg.yml
+++ b/pkg.yml
@@ -5,5 +5,10 @@ pkg.homepage: "https://github.com/hathach/tinyusb"
 pkg.keywords:
     - usb
 
+pkg.type: sdk
+
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
+
+pkg.include_dirs:
+    - src


### PR DESCRIPTION
**Describe the PR**

For normal mynewt packages newt tool wants to have specific
folder structure. It wants to have **src** and **include** directories,
and only include (and arch related) directory is added to compiler
include search list.
Since TinyUSB has different folder structure newt tool will not
add anything to **-I** directives and those would need to be
specified as ```pkg.cflags: "-I@tinyusb/src"```

Recent change to newt tool allowed to add specific include directories
for external (sdk) packages so just including package will add
necessary -I to build commands.

This commit changes package type to sdk and specifies src as include
root for TinyUSB.

For older newt tool adding sdk and include_dirs does not break build.

**Additional context**
To fully utilize what it does latest newt tool is needed.

There is outstanding PR https://github.com/apache/mynewt-core/pull/2279 that tries
to make it easier to use TinyUSB with mynewt.