### PR TITLE
device: fix build warning when CFG_TUSB_DEBUG >= 2

### DIFF
--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -32,6 +32,10 @@
 #include "device/usbd_pvt.h"
 #include "dcd.h"
 
+#if CFG_TUSB_DEBUG >= 2
+extern void usbd_driver_print_control_complete_name(bool (*control_complete) (uint8_t, tusb_control_request_t const *));
+#endif
+
 enum
 {
   EDPT_CTRL_OUT = 0x00,
@@ -192,7 +196,6 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t result
     if ( _ctrl_xfer.complete_cb )
     {
       #if CFG_TUSB_DEBUG >= 2
-      extern void usbd_driver_print_control_complete_name(bool (*control_complete) (uint8_t, tusb_control_request_t const *));
       usbd_driver_print_control_complete_name(_ctrl_xfer.complete_cb);
       #endif
 


### PR DESCRIPTION
The function is defined inside of a function body which generates a
warning.  Circuit Python treats these warnings as errors, and so
refuses to build with debugging enabled:

```
    ../../lib/tinyusb/src/device/usbd_control.c: In function 'usbd_control_xfer_cb':
    ../../lib/tinyusb/src/device/usbd_control.c:195:19: error: nested extern declaration of 'usbd_driver_print_control_complete_name' [-Werror=nested-externs]
      195 |       extern void usbd_driver_print_control_complete_name(bool (*control_complete) (uint8_t, tusb_control_request_t const *));
          |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    cc1: all warnings being treated as errors
    make: *** [../../py/mkrules.mk:55:
    build-simmel/lib/tinyusb/src/device/usbd_control.o] Error 1
```

Move the declaration to the top of the function to silence this warning.