### PR TITLE
nrf5x: poll isr for dma status if irqs are disabled

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -101,7 +101,11 @@ static void edpt_dma_start(volatile uint32_t* reg_startep)
     else
     {
       // Otherwise simply block wait
-      while ( _dcd.dma_running )  { }
+      while ( _dcd.dma_running )  {
+        // Manually poll the handler if interrupts are disabled
+        if ( __get_PRIMASK() )
+          dcd_int_handler(0);
+      }
     }
   }
 


### PR DESCRIPTION
The `tud_poll()` function is used to clear the tinyusb buffers and
respond to various events in the main thread.

This is important in order to properly utilise the `wfi` instruction.

When an interrupt appears, the appropriate handler is called and
tinyusb polls it in a "top half" function.  It then adds events to
a queue which will be handled in a "bottom half" function in the
main thread.

If an interrupt comes in between running the "bottom half" function
and issuing a "wfi", then there will be stale data in the queue
and the host will be left with potentially unanswered data.

In order to avoid this scenario, the following sequence of events
needs to happen:

1. Disable interrupts
2. Flush the queue by calling `tud_task()`
3. Issue WFI
4. Enable interrupts

If an interrupt comes in between (2) and (3), the WFI will return
immediately even though interrupts are disabled.

Because of this, `tud_task()` needs to be able to run without
interrupts.

Modify the nrf52 code so that it polls the ISR if interrupts are not
enabled.  This prevents a deadlock waiting for DMA to finish, ensuring
this can be run with interrupts disabled.