### PR TITLE
Improvements to Synopsys EP OUT

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,6 +56,9 @@
   * Synopsys DesignWare device driver port for STM32 L4, F2, F4, F7, H7 etc ...
   * TI MSP430 device driver port
   * Board support for STM32F407 Discovery, STM32H743 Nucleo, pyboard v1.1, msp_exp430f5529lp etc ...
+  
+* **[Jan Dümpelmann](https://github.com/duempel)**
+  * Improvements to Synopsys device controller driver (DCD) for STM32 MCUs
 
 
 **[Full contributors list](https://github.com/hathach/tinyusb/contributors).**

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2018 Scott Shawcroft, 2019 William D. Jones for Adafruit Industries
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ * Copyright (c) 2020 Jan Duempelmann
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -101,9 +101,7 @@ static uint8_t _setup_offs; // We store up to 3 setup packets.
 typedef struct {
   uint8_t * buffer;
   uint16_t total_len;
-  uint16_t queued_len;
   uint16_t max_size;
-  bool short_packet;
 } xfer_ctl_t;
 
 typedef volatile uint32_t * usb_fifo_t;
@@ -356,8 +354,6 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
   xfer_ctl_t * xfer = XFER_CTL_BASE(epnum, dir);
   xfer->buffer       = buffer;
   xfer->total_len    = total_bytes;
-  xfer->queued_len   = 0;
-  xfer->short_packet = false;
 
   uint16_t num_packets = (total_bytes / xfer->max_size);
   uint8_t short_packet_size = total_bytes % xfer->max_size;
@@ -379,9 +375,10 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
       dev->DIEPEMPMSK |= (1 << epnum);
     }
   } else {
-    // Each complete packet for OUT xfers triggers XFRC.
-    out_ep[epnum].DOEPTSIZ |= (1 << USB_OTG_DOEPTSIZ_PKTCNT_Pos) |
-                              ((xfer->max_size & USB_OTG_DOEPTSIZ_XFRSIZ_Msk) << USB_OTG_DOEPTSIZ_XFRSIZ_Pos);
+    // A full OUT transfer (multiple packets, possibly) triggers XFRC.
+    out_ep[epnum].DOEPTSIZ &= ~(USB_OTG_DOEPTSIZ_PKTCNT_Msk | USB_OTG_DOEPTSIZ_XFRSIZ);
+    out_ep[epnum].DOEPTSIZ |= (num_packets << USB_OTG_DOEPTSIZ_PKTCNT_Pos) |
+                              ((total_bytes << USB_OTG_DOEPTSIZ_XFRSIZ_Pos) & USB_OTG_DOEPTSIZ_XFRSIZ_Msk);
 
     out_ep[epnum].DOEPCTL |= USB_OTG_DOEPCTL_EPENA | USB_OTG_DOEPCTL_CNAK;
   }
@@ -477,65 +474,33 @@ void dcd_edpt_clear_stall (uint8_t rhport, uint8_t ep_addr)
 
 /*------------------------------------------------------------------*/
 
-// TODO: Split into "receive on endpoint 0" and "receive generic"; endpoint 0's
-// DOEPTSIZ register is smaller than the others, and so is insufficient for
-// determining how much of an OUT transfer is actually remaining.
-static void receive_packet(xfer_ctl_t * xfer, /* USB_OTG_OUTEndpointTypeDef * out_ep, */ uint16_t xfer_size) {
+// Read a single data packet from receive FIFO
+static void read_fifo_packet(uint8_t * dst, uint16_t len){
   usb_fifo_t rx_fifo = FIFO_BASE(0);
 
-  // See above TODO
-  // uint16_t remaining = (out_ep->DOEPTSIZ & USB_OTG_DOEPTSIZ_XFRSIZ_Msk) >> USB_OTG_DOEPTSIZ_XFRSIZ_Pos;
-  // xfer->queued_len = xfer->total_len - remaining;
-
-  uint16_t remaining = xfer->total_len - xfer->queued_len;
-  uint16_t to_recv_size;
-
-  if(remaining <= xfer->max_size) {
-    // Avoid buffer overflow.
-    to_recv_size = (xfer_size > remaining) ? remaining : xfer_size;
-  } else {
-    // Room for full packet, choose recv_size based on what the microcontroller
-    // claims.
-    to_recv_size = (xfer_size > xfer->max_size) ? xfer->max_size : xfer_size;
+  // Reading full available 32 bit words from fifo
+  uint16_t full_words = len >> 2;
+  for(uint16_t i = 0; i < full_words; i++) {
+    uint32_t tmp = *rx_fifo;
+    dst[0] = tmp & 0x000000FF;
+    dst[1] = (tmp & 0x0000FF00) >> 8;
+    dst[2] = (tmp & 0x00FF0000) >> 16;
+    dst[3] = (tmp & 0xFF000000) >> 24;
+    dst += 4;
   }
 
-  uint8_t to_recv_rem = to_recv_size % 4;
-  uint16_t to_recv_size_aligned = to_recv_size - to_recv_rem;
-
-  // Do not assume xfer buffer is aligned.
-  uint8_t * base = (xfer->buffer + xfer->queued_len);
-
-  // This for loop always runs at least once- skip if less than 4 bytes
-  // to collect.
-  if(to_recv_size >= 4) {
-    for(uint16_t i = 0; i < to_recv_size_aligned; i += 4) {
-      uint32_t tmp = (* rx_fifo);
-      base[i] = tmp & 0x000000FF;
-      base[i + 1] = (tmp & 0x0000FF00) >> 8;
-      base[i + 2] = (tmp & 0x00FF0000) >> 16;
-      base[i + 3] = (tmp & 0xFF000000) >> 24;
+  // Read the remaining 1-3 bytes from fifo
+  uint8_t bytes_rem = len & 0x03;
+  if(bytes_rem != 0) {
+    uint32_t tmp = *rx_fifo;
+    dst[0] = tmp & 0x000000FF;
+    if(bytes_rem > 1) {
+      dst[1] = (tmp & 0x0000FF00) >> 8;
+    }
+    if(bytes_rem > 2) {
+      dst[2] = (tmp & 0x00FF0000) >> 16;
     }
   }
-
-  // Do not read invalid bytes from RX FIFO.
-  if(to_recv_rem != 0) {
-    uint32_t tmp = (* rx_fifo);
-    uint8_t * last_32b_bound = base + to_recv_size_aligned;
-
-    last_32b_bound[0] = tmp & 0x000000FF;
-    if(to_recv_rem > 1) {
-      last_32b_bound[1] = (tmp & 0x0000FF00) >> 8;
-    }
-    if(to_recv_rem > 2) {
-      last_32b_bound[2] = (tmp & 0x00FF0000) >> 16;
-    }
-  }
-
-  xfer->queued_len += xfer_size;
-
-  // Per USB spec, a short OUT packet (including length 0) is always
-  // indicative of the end of a transfer (at least for ctl, bulk, int).
-  xfer->short_packet = (xfer_size < xfer->max_size);
 }
 
 // Write a single data packet to EPIN FIFO
@@ -564,11 +529,10 @@ static void write_fifo_packet(uint8_t fifo_num, uint8_t * src, uint16_t len){
   }
 }
 
-static void read_rx_fifo(USB_OTG_OUTEndpointTypeDef * out_ep) {
+static void handle_rxflvl_ints(USB_OTG_OUTEndpointTypeDef * out_ep) {
   usb_fifo_t rx_fifo = FIFO_BASE(0);
 
-  // Pop control word off FIFO (completed xfers will have 2 control words,
-  // we only pop one ctl word each interrupt).
+  // Pop control word off FIFO
   uint32_t ctl_word = USB_OTG_FS->GRXSTSP;
   uint8_t pktsts = (ctl_word & USB_OTG_GRXSTSP_PKTSTS_Msk) >> USB_OTG_GRXSTSP_PKTSTS_Pos;
   uint8_t epnum = (ctl_word &  USB_OTG_GRXSTSP_EPNUM_Msk) >>  USB_OTG_GRXSTSP_EPNUM_Pos;
@@ -580,7 +544,13 @@ static void read_rx_fifo(USB_OTG_OUTEndpointTypeDef * out_ep) {
     case 0x02: // Out packet recvd
       {
         xfer_ctl_t * xfer = XFER_CTL_BASE(epnum, TUSB_DIR_OUT);
-        receive_packet(xfer, bcnt);
+
+        // Use BCNT to calculate correct bytes before data entry popped out from RxFIFO
+        uint16_t remaining_bytes = ((out_ep[epnum].DOEPTSIZ & USB_OTG_DOEPTSIZ_XFRSIZ_Msk) \
+                                    >> USB_OTG_DOEPTSIZ_XFRSIZ_Pos) + bcnt;
+
+        // Read packet off RxFIFO
+        read_fifo_packet((xfer->buffer + xfer->total_len - remaining_bytes), bcnt);
       }
       break;
     case 0x03: // Out packet done (Interrupt)
@@ -619,25 +589,10 @@ static void handle_epout_ints(USB_OTG_DeviceTypeDef * dev, USB_OTG_OUTEndpointTy
         _setup_offs = 0;
       }
 
-      // OUT XFER complete (single packet).
+      // OUT XFER complete
       if(out_ep[n].DOEPINT & USB_OTG_DOEPINT_XFRC) {
         out_ep[n].DOEPINT = USB_OTG_DOEPINT_XFRC;
-
-        // TODO: Because of endpoint 0's constrained size, we handle XFRC
-        // on a packet-basis. The core can internally handle multiple OUT
-        // packets; it would be more efficient to only trigger XFRC on a
-        // completed transfer for non-0 endpoints.
-
-        // Transfer complete if short packet or total len is transferred
-        if(xfer->short_packet || (xfer->queued_len == xfer->total_len)) {
-          xfer->short_packet = false;
-          dcd_event_xfer_complete(0, n, xfer->queued_len, XFER_RESULT_SUCCESS, true);
-        } else {
-          // Schedule another packet to be received.
-          out_ep[n].DOEPTSIZ |= (1 << USB_OTG_DOEPTSIZ_PKTCNT_Pos) | \
-              ((xfer->max_size & USB_OTG_DOEPTSIZ_XFRSIZ_Msk) << USB_OTG_DOEPTSIZ_XFRSIZ_Pos);
-          out_ep[n].DOEPCTL |= USB_OTG_DOEPCTL_EPENA | USB_OTG_DOEPCTL_CNAK;
-        }
+        dcd_event_xfer_complete(0, n, xfer->total_len, XFER_RESULT_SUCCESS, true);
       }
     }
   }
@@ -682,11 +637,8 @@ static void handle_epin_ints(USB_OTG_DeviceTypeDef * dev, USB_OTG_INEndpointType
             break;
           }
 
-          // TODO: queued_len can be removed later
-          xfer->queued_len = xfer->total_len - remaining_bytes;
-
           // Push packet to Tx-FIFO
-          write_fifo_packet(n, (xfer->buffer + xfer->queued_len), packet_size);
+          write_fifo_packet(n, (xfer->buffer + xfer->total_len - remaining_bytes), packet_size);
         }
 
         // Turn off TXFE if all bytes are written.
@@ -756,12 +708,14 @@ void dcd_int_handler(uint8_t rhport) {
   }
 #endif
 
-  if(int_status & USB_OTG_GINTSTS_RXFLVL) {
+  // Use while loop to handle more than one fifo data entry
+  // within a single interrupt call
+  while(USB_OTG_FS->GINTSTS & USB_OTG_GINTSTS_RXFLVL) {
     // RXFLVL bit is read-only
 
     // Mask out RXFLVL while reading data from FIFO
     USB_OTG_FS->GINTMSK &= ~USB_OTG_GINTMSK_RXFLVLM;
-    read_rx_fifo(out_ep);
+    handle_rxflvl_ints(out_ep);
     USB_OTG_FS->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }
 


### PR DESCRIPTION
**Describe the PR**
After PR #387 I wanted to make some changes to the receiving process. I'm not 100% satisfied with my changes yet. Hope to get some good advise here, so we can finish this PR together.

The main benefits are:
- Use register based XFRSIZ to determine transfer complete
  (xfer->queued_len and xfer->short_packet were deleted)
- Pop out as many RxFIFO data entries as available within a IRQ call
- less application interruption due to XFRC calls

**Additional context**
I will introduce the changes here:
1. Rename of `receive_packet()` to `read_fifo_packet()` which provides equal functionality to the `write_fifo_packet()` used by IN EP
2. Rename of `read_rx_fifo()` to `handle_rxflvl_ints()`, because we are not always reading the fifo there (e.g. setup packet done). Now it's naming scheme is like epout and epin interrupt handlers
3. RXFLVL flag checking was changed to a loop. Even if this flag is triggered already after the first packet was received, it is possible that there is already more than just one packet to pop off fifo.
4. Added _num_packets_ and _total_bytes_ to `dcd_edpt_xfer()`. It was necessary to reset the counters in DOEPTSIZ before.
5. Deleted `xfer->queued_len` and `xfer->short_packet` and used the counters in DOEPTSIZ to set buffer positions and recognize transfer complete.
6. OUT XFRC interrupt only forwards event to tusb, since this interrupt is only fired if reception was complete.

This PR seems to work fine, but as I said in the beginning, I'm not 100% happy yet. There are a few open question:

You might wonder, why I did not handle EP0 different to the others, since this one has a very limited XFRSIZ and PKTCNT. I just did not see a use case for this. Maybe I'm wrong. I do not know a lot about USB but could not see any EP0 OUT transaction which would have to send more than 64 byte. I guess if there was a special case for this, it would also be implemented in the peripheral. Right now the software does not check if there is a invalid xfer size for EP0. I did not use a check for this within dcd because I think if there would be a invalid xfer caused by the tu stack, there's nothing dcd could fix.

Reading a RxFIFO packet is always using exactly BCNT len. The length is not saturated to _xfer->max_size_ anymore. The BCNT field in GRXSTSP can not become larger than max_size. If it would there probably is a fault within USB OTG core and we couldn't assume that USB works at all. 

I had to reset the XFRSIZ and PKTCNT counters of the out endpoint within `dcd_edpt_xfer()`. Honesty I am not sure, why these fields did not contain NULL values when starting a new xfer. Without the reset the new values would be random after using |= operator.

Of course I have already done some testing. Equal to what I did at PR #387 I used counters to indicate how often the interrupts are called. The counters are
- `usb_int_cnt` which is incremented every time `dcd_int_handler` is called
- `xfrc_int_cnt` which is incremented only at OUT XFRC interrupts

1st test was 10 seconds of usbnet example (USB was plugged in before execution). The first figure shows the raise of those counters if using the current drivers. The second figure shows same example with this PR.

![old_10s_usbnet_example](https://user-images.githubusercontent.com/64088163/81445910-1b671700-917a-11ea-8216-191329bffe77.jpeg)

![new_10s_usbnet_example](https://user-images.githubusercontent.com/64088163/81445893-11ddaf00-917a-11ea-97ae-be6820387e54.jpeg)

To get the difference more obvious I've run this example 30s and requested the webpage 5 times. The result is:
- `usb_int_cnt`: 2950 (before) -> 1636 (now)
- `xfrc_int_cnt`: 830 (before) -> 312 (now)

**Receiving large data results in much fewer interrupt calls.**

But the cdc_msc example did not make any obvious changes to this. Since the class driver only supports packet by packet. In the first seconds while usb setup was done and msc file system was requested there have been less interrupts. After sending a lot of data (2,586,897 bytes) and echo it back via CDC interface, there was no big difference at all:
- `usb_int_cnt`: 275172 (before) -> 246955 (now)
- `xfrc_int_cnt`: 52026 (before) -> 51953 (now)
- Average speed: 143.7 kB/s (before) -> 126.2 kB/s (now)

Even the average speed was going down a bit. This could also be caused by my Windows application. I need to think about a better way for CDC testing. We could use #189 to discuss about this.