### PR TITLE
Add option to ignore DTR bit in CDC connection check

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -93,8 +93,12 @@ static void _prep_out_transaction (uint8_t itf)
 //--------------------------------------------------------------------+
 bool tud_cdc_n_connected(uint8_t itf)
 {
+#if CFG_TUD_CDC_IGNORE_DTR
+  return tud_ready();
+#else
   // DTR (bit 0) active  is considered as connected
   return tud_ready() && tu_bit_test(_cdcd_itf[itf].line_state, 0);
+#endif
 }
 
 uint8_t tud_cdc_n_get_line_state (uint8_t itf)

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -38,6 +38,14 @@
 #define CFG_TUD_CDC_EPSIZE 64
 #endif
 
+/* Some non-standard terminal programs don't set DTR bit while connected, 
+ * which makes TinyUSB believe that no connection is established.
+ * Use this option to ignore DTR bit in connection check.
+ */
+#ifndef CFG_TUD_CDC_IGNORE_DTR
+#define CFG_TUD_CDC_IGNORE_DTR 0
+#endif
+
 #ifdef __cplusplus
  extern "C" {
 #endif


### PR DESCRIPTION
Some non-standard terminal programs don't set DTR bit while connected, which makes TinyUSB believe that no connection is established.
 
Added an option to ignore DTR bit in connection check.
