### PR TITLE
Add tud_cdc_flushed function

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -179,6 +179,10 @@ uint32_t tud_cdc_n_write_available (uint8_t itf)
   return tu_fifo_remaining(&_cdcd_itf[itf].tx_ff);
 }
 
+bool tud_cdc_n_flushed (uint8_t itf)
+{
+  return tu_fifo_empty(&_cdcd_itf[itf].tx_ff);
+}
 
 //--------------------------------------------------------------------+
 // USBD Driver API

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -98,6 +98,9 @@ uint32_t tud_cdc_n_write_flush     (uint8_t itf);
 // Return number of characters available for writing
 uint32_t tud_cdc_n_write_available (uint8_t itf);
 
+// Check whether output fifo is flushed
+bool     tud_cdc_n_flushed         (uint8_t itf);
+
 //--------------------------------------------------------------------+
 // Application API (Single Port)
 //--------------------------------------------------------------------+
@@ -117,6 +120,7 @@ static inline uint32_t tud_cdc_write           (void const* buffer, uint32_t buf
 static inline uint32_t tud_cdc_write_str       (char const* str);
 static inline uint32_t tud_cdc_write_flush     (void);
 static inline uint32_t tud_cdc_write_available (void);
+static inline bool     tud_cdc_flushed         (void);
 
 //--------------------------------------------------------------------+
 // Application Callback API (weak is optional)
@@ -221,6 +225,11 @@ static inline uint32_t tud_cdc_write_flush (void)
 static inline uint32_t tud_cdc_write_available(void)
 {
   return tud_cdc_n_write_available(0);
+}
+
+static inline bool tud_cdc_flushed(void)
+{
+  return tud_cdc_n_flushed(0);
 }
 
 /** @} */


### PR DESCRIPTION
**Describe the PR**

tud_cdc_write_flush() returns 0 when ednpoint is busy (function was called
to soon) or endpoint fifo is empty.
To make it easier to decide if flush should be called later, new function
tud_cdc_flushed() returns true if output fifo is empty.

Without this it is possible it accomplish same task with following
condition

tud_cdc_write_available() < USBD_CDC_DATA_EP_SIZE

...but code is more awkward.


**Additional context**
Naming of the function could be change if it does not match TinyUSB conventions (like fifo_empty, is_fifo_empty or such)
