### PR TITLE
added tud_task_event_ready() 

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -339,6 +339,14 @@ static void usbd_reset(uint8_t rhport)
   }
 }
 
+bool tud_task_event_ready(void)
+{
+  // Skip if stack is not initialized
+  if ( !tusb_inited() ) return false;
+
+  return !osal_queue_empty(_usbd_q);
+}
+
 /* USB Device Driver task
  * This top level thread manages all device controller event and delegates events to class-specific drivers.
  * This should be called periodically within the mainloop or rtos thread.

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -47,6 +47,9 @@ bool tud_init (void);
 // Task function should be called in main/rtos loop
 void tud_task (void);
 
+// Check if there is pending events need proccessing by tud_task()
+bool tud_task_event_ready(void);
+
 // Interrupt handler, name alias to DCD
 #define tud_int_handler   dcd_int_handler
 

--- a/src/osal/osal.h
+++ b/src/osal/osal.h
@@ -80,6 +80,7 @@ static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl);
 static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef);
 static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data);
 static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, bool in_isr);
+static inline bool osal_queue_empty(osal_queue_t const qhdl);
 
 #if 0  // TODO remove subtask related macros later
 // Sub Task

--- a/src/osal/osal.h
+++ b/src/osal/osal.h
@@ -78,9 +78,9 @@ static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl);
 
 //------------- Queue -------------//
 static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef);
-static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data);
-static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, bool in_isr);
-static inline bool osal_queue_empty(osal_queue_t const qhdl);
+static inline bool osal_queue_receive(osal_queue_t qhdl, void* data);
+static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr);
+static inline bool osal_queue_empty(osal_queue_t qhdl);
 
 #if 0  // TODO remove subtask related macros later
 // Sub Task

--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -118,14 +118,19 @@ static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
   return xQueueCreateStatic(qdef->depth, qdef->item_sz, (uint8_t*) qdef->buf, &qdef->sq);
 }
 
-static inline bool osal_queue_receive(osal_queue_t const queue_hdl, void* data)
+static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data)
 {
-  return xQueueReceive(queue_hdl, data, portMAX_DELAY);
+  return xQueueReceive(qhdl, data, portMAX_DELAY);
 }
 
-static inline bool osal_queue_send(osal_queue_t const queue_hdl, void const * data, bool in_isr)
+static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, bool in_isr)
 {
-  return in_isr ? xQueueSendToBackFromISR(queue_hdl, data, NULL) : xQueueSendToBack(queue_hdl, data, OSAL_TIMEOUT_WAIT_FOREVER);
+  return in_isr ? xQueueSendToBackFromISR(qhdl, data, NULL) : xQueueSendToBack(qhdl, data, OSAL_TIMEOUT_WAIT_FOREVER);
+}
+
+static inline bool osal_queue_empty(osal_queue_t const qhdl)
+{
+  return uxQueueMessagesWaiting(qhdl) > 0;
 }
 
 #ifdef __cplusplus

--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -118,17 +118,17 @@ static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
   return xQueueCreateStatic(qdef->depth, qdef->item_sz, (uint8_t*) qdef->buf, &qdef->sq);
 }
 
-static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data)
+static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
 {
   return xQueueReceive(qhdl, data, portMAX_DELAY);
 }
 
-static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, bool in_isr)
+static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
   return in_isr ? xQueueSendToBackFromISR(qhdl, data, NULL) : xQueueSendToBack(qhdl, data, OSAL_TIMEOUT_WAIT_FOREVER);
 }
 
-static inline bool osal_queue_empty(osal_queue_t const qhdl)
+static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
   return uxQueueMessagesWaiting(qhdl) > 0;
 }

--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -130,7 +130,7 @@ static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in
 
 static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
-  return uxQueueMessagesWaiting(qhdl) > 0;
+  return uxQueueMessagesWaiting(qhdl) == 0;
 }
 
 #ifdef __cplusplus

--- a/src/osal/osal_mynewt.h
+++ b/src/osal/osal_mynewt.h
@@ -161,6 +161,12 @@ static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, b
   return true;
 }
 
+static inline bool osal_queue_empty(osal_queue_t const qhdl)
+{
+  return STAILQ_EMPTY(&qhdl->evq.evq_list);
+}
+
+
 #ifdef __cplusplus
  }
 #endif

--- a/src/osal/osal_mynewt.h
+++ b/src/osal/osal_mynewt.h
@@ -125,7 +125,7 @@ static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
   return (osal_queue_t) qdef;
 }
 
-static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data)
+static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
 {
   struct os_event* ev;
   ev = os_eventq_get(&qhdl->evq);
@@ -137,7 +137,7 @@ static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data)
   return true;
 }
 
-static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, bool in_isr)
+static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
   (void) in_isr;
 
@@ -161,7 +161,7 @@ static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, b
   return true;
 }
 
-static inline bool osal_queue_empty(osal_queue_t const qhdl)
+static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
   return STAILQ_EMPTY(&qhdl->evq.evq_list);
 }

--- a/src/osal/osal_none.h
+++ b/src/osal/osal_none.h
@@ -142,7 +142,7 @@ typedef osal_queue_def_t* osal_queue_t;
     }\
   }
 
-// lock queue by disable usb isr
+// lock queue by disable USB interrupt
 static inline void _osal_q_lock(osal_queue_t qhdl)
 {
   (void) qhdl;
@@ -176,7 +176,6 @@ static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
   return (osal_queue_t) qdef;
 }
 
-// non blocking
 static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data)
 {
   _osal_q_lock(qhdl);
@@ -201,6 +200,15 @@ static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, b
   TU_ASSERT(success);
 
   return success;
+}
+
+static inline bool osal_queue_empty(osal_queue_t const qhdl)
+{
+  _osal_q_lock(qhdl);
+  bool is_empty = tu_fifo_empty(&qhdl->ff);
+  _osal_q_unlock(qhdl);
+
+  return is_empty;
 }
 
 #ifdef __cplusplus

--- a/src/osal/osal_none.h
+++ b/src/osal/osal_none.h
@@ -204,11 +204,9 @@ static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in
 
 static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
-  _osal_q_lock(qhdl);
-  bool is_empty = tu_fifo_empty(&qhdl->ff);
-  _osal_q_unlock(qhdl);
-
-  return is_empty;
+  // Skip queue lock/unlock since this function is primarily called
+  // with interrupt disabled before going into low power mode
+  return tu_fifo_empty(&qhdl->ff);
 }
 
 #ifdef __cplusplus

--- a/src/osal/osal_none.h
+++ b/src/osal/osal_none.h
@@ -176,7 +176,7 @@ static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
   return (osal_queue_t) qdef;
 }
 
-static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data)
+static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
 {
   _osal_q_lock(qhdl);
   bool success = tu_fifo_read(&qhdl->ff, data);
@@ -185,7 +185,7 @@ static inline bool osal_queue_receive(osal_queue_t const qhdl, void* data)
   return success;
 }
 
-static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, bool in_isr)
+static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
   if (!in_isr) {
     _osal_q_lock(qhdl);
@@ -202,7 +202,7 @@ static inline bool osal_queue_send(osal_queue_t const qhdl, void const * data, b
   return success;
 }
 
-static inline bool osal_queue_empty(osal_queue_t const qhdl)
+static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
   _osal_q_lock(qhdl);
   bool is_empty = tu_fifo_empty(&qhdl->ff);


### PR DESCRIPTION
**Describe the PR**
added tud_task_event_ready() to check if there is pending events in the tud task without executing
it. Useful to check before entering low power mode with WFI/WFE. This helps to resovle https://github.com/adafruit/circuitpython/pull/2868 

This requires an additional `osal_queue_empty()` to be implemented.

**Additional context**

TockOS, like a lot of other operating systems divides interrupt processing in two halves. The top-half runs in interrupt context, which is mapped to ARMv7-M's handler mode. The bottom-half processing happens in kernel context, which is mapped to ARMv7-M's privileged thread mode. 

The main USB interrupt processing happens in the bottom half, and within the bottom half we add to TinyUSB task queue. Therefore we can call `wfi`, _only when_ both TinyUSB task queue is empty **and** no more bottom half interrupt processing is left to do. 

Hence the need for `tud_task_is_queue_empty()` function.

_Originally posted by @rajivr in https://github.com/hathach/tinyusb/issues/279#issuecomment-583957143_