### PR TITLE
Fix too strict checks on subclass and protocol entries of iad descriptor.

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -765,9 +765,7 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num)
         {
           // IAD's first interface number and class/subclass/protocol should match with opened interface
           TU_ASSERT(desc_itf_assoc->bFirstInterface   == desc_itf->bInterfaceNumber   &&
-                    desc_itf_assoc->bFunctionClass    == desc_itf->bInterfaceClass    &&
-                    desc_itf_assoc->bFunctionSubClass == desc_itf->bInterfaceSubClass &&
-                    desc_itf_assoc->bFunctionProtocol == desc_itf->bInterfaceProtocol);
+                    desc_itf_assoc->bFunctionClass    == desc_itf->bInterfaceClass);
 
           for(uint8_t i=1; i<desc_itf_assoc->bInterfaceCount; i++)
           {

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -764,7 +764,7 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num)
         if (desc_itf_assoc)
         {
           // IAD's first interface number and class/subclass/protocol should match with opened interface
-          TU_ASSERT(desc_itf_assoc->bFirstInterface == desc_itf->bInterfaceNumber   &&
+          TU_ASSERT(desc_itf_assoc->bFirstInterface == desc_itf->bInterfaceNumber &&
                     desc_itf_assoc->bFunctionClass  == desc_itf->bInterfaceClass);
 
           for(uint8_t i=1; i<desc_itf_assoc->bInterfaceCount; i++)

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -764,8 +764,8 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num)
         if (desc_itf_assoc)
         {
           // IAD's first interface number and class/subclass/protocol should match with opened interface
-          TU_ASSERT(desc_itf_assoc->bFirstInterface   == desc_itf->bInterfaceNumber   &&
-                    desc_itf_assoc->bFunctionClass    == desc_itf->bInterfaceClass);
+          TU_ASSERT(desc_itf_assoc->bFirstInterface == desc_itf->bInterfaceNumber   &&
+                    desc_itf_assoc->bFunctionClass  == desc_itf->bInterfaceClass);
 
           for(uint8_t i=1; i<desc_itf_assoc->bInterfaceCount; i++)
           {

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -763,7 +763,7 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num)
         // If IAD exist, assign all interfaces to the same driver
         if (desc_itf_assoc)
         {
-          // IAD's first interface number and class/subclass/protocol should match with opened interface
+          // IAD's first interface number and class should match with opened interface
           TU_ASSERT(desc_itf_assoc->bFirstInterface == desc_itf->bInterfaceNumber &&
                     desc_itf_assoc->bFunctionClass  == desc_itf->bInterfaceClass);
 


### PR DESCRIPTION
Fixex #429 - the checks conducted in usbd.c on the IAD descriptor are too strict as subclass and protocol entries may be different to the following interface descriptor (as e.g. is the case for audio functions).