### PR TITLE
Fix IAR compiler warnings.

### DIFF
--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -194,7 +194,9 @@ uint16_t hidd_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, uint1
 
   p_hid->boot_mode = false; // default mode is REPORT
   p_hid->itf_num   = desc_itf->bInterfaceNumber;
-  memcpy(&p_hid->report_desc_len, &(p_hid->hid_descriptor->wReportLength), 2);
+  
+  // Use offsetof to avoid pointer to the odd/misaligned address
+  memcpy(&p_hid->report_desc_len, (uint8_t*) p_hid->hid_descriptor + offsetof(tusb_hid_descriptor_hid_t, wReportLength), 2);
 
   // Prepare for output endpoint
   if (p_hid->ep_out)

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -80,7 +80,8 @@ static inline uint32_t rdwr10_get_lba(uint8_t const command[])
 
   // copy first to prevent mis-aligned access
   uint32_t lba;
-  memcpy(&lba, &p_rdwr10->lba, 4);
+  // use offsetof to avoid pointer to the odd/misaligned address
+  memcpy(&lba, (uint8_t*) p_rdwr10 + offsetof(scsi_write10_t, lba), 4);
 
   // lba is in Big Endian format
   return tu_ntohl(lba);
@@ -93,7 +94,8 @@ static inline uint16_t rdwr10_get_blockcount(uint8_t const command[])
 
   // copy first to prevent mis-aligned access
   uint16_t block_count;
-  memcpy(&block_count, &p_rdwr10->block_count, 2);
+  // use offsetof to avoid pointer to the odd/misaligned address
+  memcpy(&block_count, (uint8_t*) p_rdwr10 + offsetof(scsi_write10_t, block_count), 2);
 
   return tu_ntohs(block_count);
 }

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -437,7 +437,7 @@ void tud_task (void)
 
         if ( 0 == epnum )
         {
-          usbd_control_xfer_cb(event.rhport, ep_addr, event.xfer_complete.result, event.xfer_complete.len);
+          usbd_control_xfer_cb(event.rhport, ep_addr, (xfer_result_t)event.xfer_complete.result, event.xfer_complete.len);
         }
         else
         {
@@ -445,7 +445,7 @@ void tud_task (void)
           TU_ASSERT(drv_id < USBD_CLASS_DRIVER_COUNT,);
 
           TU_LOG2("  %s xfer callback\r\n", _usbd_driver[drv_id].name);
-          _usbd_driver[drv_id].xfer_cb(event.rhport, ep_addr, event.xfer_complete.result, event.xfer_complete.len);
+          _usbd_driver[drv_id].xfer_cb(event.rhport, ep_addr, (xfer_result_t)event.xfer_complete.result, event.xfer_complete.len);
         }
       }
       break;
@@ -846,8 +846,10 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
       if (!tud_descriptor_bos_cb) return false;
 
       tusb_desc_bos_t const* desc_bos = (tusb_desc_bos_t const*) tud_descriptor_bos_cb();
+
       uint16_t total_len;
-      memcpy(&total_len, &desc_bos->wTotalLength, 2); // possibly mis-aligned memory
+      // Use offsetof to avoid pointer to the odd/misaligned address
+      memcpy(&total_len, (uint8_t*) desc_bos + offsetof(tusb_desc_bos_t, wTotalLength), 2);
 
       return tud_control_xfer(rhport, p_request, (void*) desc_bos, total_len);
     }
@@ -861,7 +863,8 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
       TU_ASSERT(desc_config);
 
       uint16_t total_len;
-      memcpy(&total_len, &desc_config->wTotalLength, 2); // possibly mis-aligned memory
+      // Use offsetof to avoid pointer to the odd/misaligned address
+      memcpy(&total_len, (uint8_t*) desc_config + offsetof(tusb_desc_configuration_t, wTotalLength), 2);
 
       return tud_control_xfer(rhport, p_request, (void*) desc_config, total_len);
     }
@@ -915,8 +918,6 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
 
     default: return false;
   }
-
-  return true;
 }
 
 //--------------------------------------------------------------------+

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -698,7 +698,6 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc
 
   default:
     TU_ASSERT(false);
-    return false;
   }
 
   pcd_set_eptype(USB, epnum, wType);


### PR DESCRIPTION
**Describe the PR**
Some workarounds are used to prevent unaligned memory access of struct member, but they are not needed since both GCC and IAR generate correct instructions for packed struct.

For example`usbd.c` line 784, instead of
```
uint16_t total_len;
memcpy(&total_len, &desc_bos->wTotalLength, 2); // possibly mis-aligned memory

return tud_control_xfer(rhport, p_request, (void*) desc_bos, total_len);
```
We can simplely do:
```
return tud_control_xfer(rhport, p_request, (void*) desc_bos, desc_bos->wTotalLength);
```
Generated code:
```
return tud_control_xfer(rhport, p_request, (void*) desc_bos, desc_bos->wTotalLength);
    80027fa:   7881        ldrb    r1, [r0, #2]
    80027fc:   78c3        ldrb    r3, [r0, #3]
    80027fe:   021b        lsls    r3, r3, #8
    8002800:   430b        orrs    r3, r1
    8002802:   0021        movs    r1, r4
    8002804:   0028        movs    r0, r5
    8002806:   f7ff fb1d   bl  8001e44 <tud_control_xfer>
```

In this way we can  make a little optimization and prevent  a IAR warning `Pa039 : use of address of unaligned structure member`