### PR TITLE
Add TX callback to CDC device

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -416,7 +416,12 @@ bool cdcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
   //       Though maybe the baudrate is not really important !!!
   if ( ep_addr == p_cdc->ep_in )
   {
-    if ( 0 == tud_cdc_n_write_flush(itf) )
+    uint32_t flushed = tud_cdc_n_write_flush(itf);
+
+    // invoke transmit callback to possibly refill tx fifo
+    if ( tud_cdc_tx_complete_cb ) tud_cdc_tx_complete_cb(itf);
+
+    if ( 0 == flushed && tu_fifo_empty(&p_cdc->tx_ff) )
     {
       // There is no data left, a ZLP should be sent if
       // xferred_bytes is multiple of EP size and not zero
@@ -425,9 +430,6 @@ bool cdcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
         usbd_edpt_xfer(TUD_OPT_RHPORT, p_cdc->ep_in, NULL, 0);
       }
     }
-
-    // invoke transmit callback to possibly refill tx fifo
-    if ( tud_cdc_tx_cb && !tu_fifo_full(&p_cdc->tx_ff) ) tud_cdc_tx_cb(itf);
   }
 
   // nothing to do with notif endpoint for now

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -416,9 +416,6 @@ bool cdcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
   //       Though maybe the baudrate is not really important !!!
   if ( ep_addr == p_cdc->ep_in )
   {
-    // invoke transmit callback to possibly refill tx fifo
-    if ( tud_cdc_tx_cb && !tu_fifo_full(&p_cdc->tx_ff) ) tud_cdc_tx_cb(itf);
-
     if ( 0 == tud_cdc_n_write_flush(itf) )
     {
       // There is no data left, a ZLP should be sent if
@@ -428,6 +425,9 @@ bool cdcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
         usbd_edpt_xfer(TUD_OPT_RHPORT, p_cdc->ep_in, NULL, 0);
       }
     }
+
+    // invoke transmit callback to possibly refill tx fifo
+    if ( tud_cdc_tx_cb && !tu_fifo_full(&p_cdc->tx_ff) ) tud_cdc_tx_cb(itf);
   }
 
   // nothing to do with notif endpoint for now

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -416,6 +416,9 @@ bool cdcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
   //       Though maybe the baudrate is not really important !!!
   if ( ep_addr == p_cdc->ep_in )
   {
+    // invoke transmit callback to possibly refill tx fifo
+    if ( tud_cdc_tx_cb && !tu_fifo_full(&p_cdc->tx_ff) ) tud_cdc_tx_cb(itf);
+
     if ( 0 == tud_cdc_n_write_flush(itf) )
     {
       // There is no data left, a ZLP should be sent if

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -416,12 +416,10 @@ bool cdcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
   //       Though maybe the baudrate is not really important !!!
   if ( ep_addr == p_cdc->ep_in )
   {
-    uint32_t flushed = tud_cdc_n_write_flush(itf);
-
     // invoke transmit callback to possibly refill tx fifo
     if ( tud_cdc_tx_complete_cb ) tud_cdc_tx_complete_cb(itf);
 
-    if ( 0 == flushed && tu_fifo_empty(&p_cdc->tx_ff) )
+    if ( 0 == tud_cdc_n_write_flush(itf) )
     {
       // There is no data left, a ZLP should be sent if
       // xferred_bytes is multiple of EP size and not zero

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -129,7 +129,7 @@ TU_ATTR_WEAK void tud_cdc_rx_cb(uint8_t itf);
 TU_ATTR_WEAK void tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char);
 
 // Invoked when space becomes available in TX buffer
-TU_ATTR_WEAK void tud_cdc_tx_cb(uint8_t itf);
+TU_ATTR_WEAK void tud_cdc_tx_complete_cb(uint8_t itf);
 
 // Invoked when line state DTR & RTS are changed via SET_CONTROL_LINE_STATE
 TU_ATTR_WEAK void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts);

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -128,6 +128,9 @@ TU_ATTR_WEAK void tud_cdc_rx_cb(uint8_t itf);
 // Invoked when received `wanted_char`
 TU_ATTR_WEAK void tud_cdc_rx_wanted_cb(uint8_t itf, char wanted_char);
 
+// Invoked when space becomes available in TX buffer
+TU_ATTR_WEAK void tud_cdc_tx_cb(uint8_t itf);
+
 // Invoked when line state DTR & RTS are changed via SET_CONTROL_LINE_STATE
 TU_ATTR_WEAK void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts);
 


### PR DESCRIPTION
Useful for continuous transmission of data, which is difficult currently because there is no notification of tx completion.

**Describe the PR**
Transmitting data continuously via CDC is difficult because there is no way to know when the TX FIFO has room for more data. This PR adds a callback to allow the TX FIFO to be refilled by the user.