### PR TITLE
added OPT_MCU_SAME5X option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Special thanks to all the people who spent their precious time and effort to hel
 The stack supports the following MCUs:
 
 - **Espressif:** ESP32-S2
-- **MicroChip:** SAMD21, SAMD51 (device only)
+- **MicroChip:** SAMD21, SAMD51, SAME5x (device only)
 - **NordicSemi:** nRF52833, nRF52840
 - **Nuvoton:** NUC120, NUC121/NUC125, NUC126, NUC505
 - **NXP:** 

--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -26,7 +26,8 @@
 
 #include "tusb_option.h"
 
-#if TUSB_OPT_DEVICE_ENABLED && (CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAMD21)
+#if TUSB_OPT_DEVICE_ENABLED && \
+    (CFG_TUSB_MCU == OPT_MCU_SAMD21 || CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAME5X)
 
 #include "sam.h"
 #include "device/dcd.h"

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -58,6 +58,7 @@
 #define OPT_MCU_SAMD21            200 ///< MicroChip SAMD21
 #define OPT_MCU_SAMD51            201 ///< MicroChip SAMD51
 #define OPT_MCU_SAMG              202 ///< MicroChip SAMDG series
+#define OPT_MCU_SAME5X            203 ///< MicroChip SAM E5x
 
 // STM32
 #define OPT_MCU_STM32F0           300 ///< ST STM32F0


### PR DESCRIPTION
**Describe the PR**
Try to fix #440 

@jepler for discussion, please let me know if this PR makes sense to you ? Let's me know if you have any other suggestion. 

PS: The `samd/dcd_samd.c`  should be renamed to `sam_de/dcd_sam_de.c` as well, though It will probably get renamed again when new series with same IP is added. So we could leave it as it is now, and will do a bit of google to see if we could figure out the microchip IP name (like dcd_synopsys of stm). 