### PR TITLE
dcd_samd: Provide implementation for OPT_MCU_SAME5X

### DIFF
--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -91,7 +91,7 @@ void dcd_init (uint8_t rhport)
   USB->DEVICE.INTENSET.reg = /* USB_DEVICE_INTENSET_SOF | */ USB_DEVICE_INTENSET_EORST;
 }
 
-#if CFG_TUSB_MCU == OPT_MCU_SAMD51
+#if CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAME5X
 
 void dcd_int_enable(uint8_t rhport)
 {
@@ -124,6 +124,11 @@ void dcd_int_disable(uint8_t rhport)
   (void) rhport;
   NVIC_DisableIRQ(USB_IRQn);
 }
+
+#else
+
+#error "No implementation available for dcd_int_enable / dcd_int_disable"
+
 #endif
 
 void dcd_set_address (uint8_t rhport, uint8_t dev_addr)


### PR DESCRIPTION
This PR fixes the build of tinyusb with CFG_TUSB_MCU == OPT_MCU_SAME5X, encountered when using this option to build CircuitPython for the SAM E54 Xplained board.  It also adds a "#error" so that the reported location of a problem is close to where it needs to be fixed.

Without this change, errors such as the following occurred (slightly abbreviated for clarity):
```
in function `osal_queue_send':
…/lib/tinyusb/src/osal/osal_none.h:151: undefined reference to `dcd_int_disable'
```

This problem occurred in https://github.com/adafruit/circuitpython/tree/bc4c74517a261e2eb80a1829877d4ad3b29763d2 when updating the lib/tinyusb submodule to the tip of its main development branch, d489581debc9a9e63e242f4ab1528592c86c0b1b.  The following change in ports/atmel-samd/Makefile was also applied:
```
diff --git a/ports/atmel-samd/Makefile b/ports/atmel-samd/Makefile
index 5f901a199..82388df5e 100644
--- a/ports/atmel-samd/Makefile
+++ b/ports/atmel-samd/Makefile
@@ -103,7 +103,7 @@ ifeq ($(CHIP_FAMILY), same54)
 PERIPHERALS_CHIP_FAMILY=sam_d5x_e5x
 CFLAGS += -Os -DNDEBUG
 # TinyUSB defines
-CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_SAMD51 -DCFG_TUD_MIDI_RX_BUFSIZE=128 -DCFG_TUD_CDC_RX_BUFSIZE=256 -DCFG_TUD_MIDI_TX_BUFSIZE=128 -DCFG_TUD_CDC_TX_BUFSIZE=256 -DCFG_TUD_MSC_BUFSIZE=1024
+CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_SAME5X -DCFG_TUD_MIDI_RX_BUFSIZE=128 -DCFG_TUD_CDC_RX_BUFSIZE=256 -DCFG_TUD_MIDI_TX_BUFSIZE=128 -DCFG_TUD_CDC_TX_BUFSIZE=256 -DCFG_TUD_MSC_BUFSIZE=1024
 endif
 
 $(echo PERIPHERALS_CHIP_FAMILY=$(PERIPHERALS_CHIP_FAMILY))
```
then the build command `build BOARD=same54_xplained` was executed in the `ports/atmel-samd` directory.

I have not tested this change on hardware, however it does build now.