### PR TITLE
ESP32S2 USB Persistence and Stability

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1033,6 +1033,19 @@ void usbd_defer_func(osal_task_func_t func, void* param, bool in_isr)
   dcd_event_handler(&event, in_isr);
 }
 
+// Can be called by the dcd driver when rebooting wirh persistent USB
+bool usbd_force_reconfig(uint8_t rhport, uint8_t cfg_num)
+{
+    usbd_reset(rhport);
+    if ( !_usbd_dev.configured && cfg_num )
+    {
+        TU_ASSERT( process_set_config(rhport, cfg_num) );
+    }
+
+    _usbd_dev.configured = cfg_num ? 1 : 0;
+    return 1;
+}
+
 //--------------------------------------------------------------------+
 // USBD Endpoint API
 //--------------------------------------------------------------------+


### PR DESCRIPTION
This change implements proper handling of the USB peripheral, when the ESP32S2 is booting with USB Persistence enabled.
Also add some small fixes here and there to contribute to more stable USB.

There is one new function added to usbd. I did not find a better way to do what it does otherwice. Ideas are welcome
