### PR TITLE
Fix receiving of short packet data (Synopsys)

### DIFF
--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -576,6 +576,12 @@ static void handle_rxflvl_ints(USB_OTG_OUTEndpointTypeDef * out_ep) {
 
         // Increment pointer to xfer data
         xfer->buffer += bcnt;
+
+        // Truncate transfer length in case of short packet
+        if(bcnt < xfer->max_size){
+          xfer->total_len -= (out_ep[epnum].DOEPTSIZ & USB_OTG_DOEPTSIZ_XFRSIZ_Msk) >> USB_OTG_DOEPTSIZ_XFRSIZ_Pos;
+          if(epnum == 0) xfer->total_len -= ep0_pending[TUSB_DIR_OUT];
+        }
       }
       break;
     case 0x03: // Out packet done (Interrupt)

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -578,9 +578,12 @@ static void handle_rxflvl_ints(USB_OTG_OUTEndpointTypeDef * out_ep) {
         xfer->buffer += bcnt;
 
         // Truncate transfer length in case of short packet
-        if(bcnt < xfer->max_size){
+        if(bcnt < xfer->max_size) {
           xfer->total_len -= (out_ep[epnum].DOEPTSIZ & USB_OTG_DOEPTSIZ_XFRSIZ_Msk) >> USB_OTG_DOEPTSIZ_XFRSIZ_Pos;
-          if(epnum == 0) xfer->total_len -= ep0_pending[TUSB_DIR_OUT];
+          if(epnum == 0) {
+            xfer->total_len -= ep0_pending[TUSB_DIR_OUT];
+            ep0_pending[TUSB_DIR_OUT] = 0;
+          }
         }
       }
       break;


### PR DESCRIPTION
**Describe the PR**
Described in #448 there was an error that DCD did not inform USBD about the real number of received bytes. This PR will fix the problem and shorten the transfer length when receiving a short packet that indicates end of transfer.

**Additional context**
Only tested with CDC_MSC example yet.
