### PR TITLE
ESP32-S2: Detect EP IN Xfer Timeout

### DIFF
--- a/src/portable/espressif/esp32s2/dcd_esp32s2.c
+++ b/src/portable/espressif/esp32s2/dcd_esp32s2.c
@@ -637,6 +637,13 @@ static void handle_epin_ints(void)
           USB0.dtknqr4_fifoemptymsk &= ~(1 << n);
         }
       }
+
+      // XFER Timeout
+      if (USB0.in_ep_reg[n].diepint & USB_D_TIMEOUT0_M) {
+        // Clear interrupt or enpoint will hang.
+        USB0.in_ep_reg[n].diepint = USB_D_TIMEOUT0_M;
+        // Maybe retry?
+      }
     }
   }
 }


### PR DESCRIPTION
In some rare ocasions (bad cable, noise, etc.) data transfer might timeout and hang the endpoint, unless the interrupt flag is cleared.
This pull request targets to solve that case.
