### PR TITLE
call tud_init() after freeRTOS kernel is started

### DIFF
--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -83,7 +83,6 @@ void cdc_task(void* params);
 int main(void)
 {
   board_init();
-  tusb_init();
 
   // soft timer for blinky
   blinky_tm = xTimerCreateStatic(NULL, pdMS_TO_TICKS(BLINK_NOT_MOUNTED), true, NULL, led_blinky_cb, &blinky_tmdef);
@@ -115,6 +114,10 @@ void app_main(void)
 void usb_device_task(void* param)
 {
   (void) param;
+
+  // This should be called after scheduler/kernel is started.
+  // Otherwise it could cause kernel issue since USB IRQ handler does use RTOS queue API.
+  tusb_init();
 
   // RTOS forever loop
   while (1)

--- a/examples/device/hid_composite_freertos/src/main.c
+++ b/examples/device/hid_composite_freertos/src/main.c
@@ -79,7 +79,6 @@ void hid_task(void* params);
 int main(void)
 {
   board_init();
-  tusb_init();
 
   // soft timer for blinky
   blinky_tm = xTimerCreateStatic(NULL, pdMS_TO_TICKS(BLINK_NOT_MOUNTED), true, NULL, led_blinky_cb, &blinky_tmdef);
@@ -111,6 +110,10 @@ void app_main(void)
 void usb_device_task(void* param)
 {
   (void) param;
+
+  // This should be called after scheduler/kernel is started.
+  // Otherwise it could cause kernel issue since USB IRQ handler does use RTOS queue API.
+  tusb_init();
 
   // RTOS forever loop
   while (1)

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -42,6 +42,8 @@
 //--------------------------------------------------------------------+
 
 // Init device stack
+// Note: when using with RTOS, this should be called after scheduler/kernel is started.
+// Otherwise it could cause kernel issue since USB IRQ handler does use RTOS queue API.
 bool tud_init (void);
 
 // Task function should be called in main/rtos loop

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -91,6 +91,9 @@ TU_ATTR_WEAK void tuh_umount_cb(uint8_t dev_addr);
 //--------------------------------------------------------------------+
 // CLASS-USBH & INTERNAL API
 //--------------------------------------------------------------------+
+
+// Note: when using with RTOS, this should be called after scheduler/kernel is started.
+// Otherwise it could cause kernel issue since USB IRQ handler does use RTOS queue API.
 bool usbh_init(void);
 bool usbh_control_xfer (uint8_t dev_addr, tusb_control_request_t* request, uint8_t* data);
 

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -109,6 +109,8 @@
  *  @{ */
 
 // Initialize device/host stack
+// Note: when using with RTOS, this should be called after scheduler/kernel is started.
+// Otherwise it could cause kernel issue since USB IRQ handler does use RTOS queue API.
 bool tusb_init(void);
 
 // Check if stack is initialized


### PR DESCRIPTION
**Describe the PR**
TinyUSB IRQ handler make use of RTOS queue API. If stack is initialized before kernel/scheudler, the ISR can invoke RTOS API when kernel is in unknown state which could cause hardfault in case of freeRTOS with portYield().
- update example to call tud_init() after freeRTOS kernel is started
- add note to usb init functions

follow up to #468 