### PR TITLE
Move pull-up enabling to dcd_init() instead of usbd

### DIFF
--- a/docs/porting.md
+++ b/docs/porting.md
@@ -62,7 +62,7 @@ All of the code for the low-level device API is in `src/portable/<vendor>/<chip 
 ##### dcd_init
 
 Initializes the USB peripheral for device mode and enables it.
-This function should leave an internal D+/D- pull-up in its default power-on state. `dcd_connect` will be called by the USBD core following `dcd_init`.
+This function should enable internal D+/D- pull-up for enumeration.
 
 ##### dcd_int_enable / dcd_int_disable
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -339,7 +339,6 @@ bool tud_init (void)
 
   // Init device controller driver
   dcd_init(TUD_OPT_RHPORT);
-  tud_connect();
   dcd_int_enable(TUD_OPT_RHPORT);
 
   return true;

--- a/src/portable/dialog/da146xx/dcd_da146xx.c
+++ b/src/portable/dialog/da146xx/dcd_da146xx.c
@@ -555,10 +555,10 @@ static void handle_ep0_nak(void)
  *------------------------------------------------------------------*/
 void dcd_init(uint8_t rhport)
 {
-  (void)rhport;
-
   USB->USB_MCTRL_REG = USB_USB_MCTRL_REG_USBEN_Msk;
   tusb_vbus_changed((CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_VBUS_AVAILABLE_Msk) != 0);
+
+  dcd_connect(rhport);
 }
 
 void dcd_int_enable(uint8_t rhport)

--- a/src/portable/espressif/esp32s2/dcd_esp32s2.c
+++ b/src/portable/espressif/esp32s2/dcd_esp32s2.c
@@ -165,8 +165,6 @@ static void enum_done_processing(void)
  *------------------------------------------------------------------*/
 void dcd_init(uint8_t rhport)
 {
-  (void)rhport;
-
   ESP_LOGV(TAG, "DCD init - Start");
 
   // A. Disconnect
@@ -204,6 +202,8 @@ void dcd_init(uint8_t rhport)
                  USB_ENUMDONEMSK_M |
                  USB_RESETDETMSK_M |
                  USB_DISCONNINTMSK_M; // host most only
+
+  dcd_connect(rhport);
 }
 
 void dcd_set_address(uint8_t rhport, uint8_t dev_addr)

--- a/src/portable/microchip/samg/dcd_samg.c
+++ b/src/portable/microchip/samg/dcd_samg.c
@@ -154,9 +154,8 @@ static void bus_reset(void)
 // Initialize controller to device mode
 void dcd_init (uint8_t rhport)
 {
-  (void) rhport;
-
   tu_memclr(_dcd_xfer, sizeof(_dcd_xfer));
+  dcd_connect(rhport);
 }
 
 // Enable device interrupt

--- a/src/portable/nxp/lpc17_40/dcd_lpc17_40.c
+++ b/src/portable/nxp/lpc17_40/dcd_lpc17_40.c
@@ -181,6 +181,8 @@ void dcd_init(uint8_t rhport)
   LPC_USB->UDCAH = (uint32_t) _dcd.udca;
   LPC_USB->DMAIntEn = (DMA_INT_END_OF_XFER_MASK /*| DMA_INT_NEW_DD_REQUEST_MASK*/ | DMA_INT_ERROR_MASK);
 
+  dcd_connect(rhport);
+
   // Clear pending IRQ
   NVIC_ClearPendingIRQ(USB_IRQn);
 }

--- a/src/portable/nxp/transdimension/dcd_transdimension.c
+++ b/src/portable/nxp/transdimension/dcd_transdimension.c
@@ -345,7 +345,8 @@ void dcd_init(uint8_t rhport)
   dcd_reg->USBSTS  = dcd_reg->USBSTS;
   dcd_reg->USBINTR = INTR_USB | INTR_ERROR | INTR_PORT_CHANGE | INTR_RESET | INTR_SUSPEND /*| INTR_SOF*/;
 
-  dcd_reg->USBCMD &= ~0x00FF0000; // Interrupt Threshold Interval = 0
+  dcd_reg->USBCMD &= ~0x00FF0000;     // Interrupt Threshold Interval = 0
+  dcd_reg->USBCMD |= USBCMD_RUN_STOP; // Connect
 }
 
 void dcd_int_enable(uint8_t rhport)

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -205,7 +205,6 @@ static inline void reg16_clear_bits(__IO uint16_t *reg, uint16_t mask) {
 
 void dcd_init (uint8_t rhport)
 {
-  (void)rhport;
   /* Clocks should already be enabled */
   /* Use __HAL_RCC_USB_CLK_ENABLE(); to enable the clocks before calling this function */
 
@@ -244,7 +243,8 @@ void dcd_init (uint8_t rhport)
   USB->CNTR |= USB_CNTR_RESETM | (USE_SOF ? USB_CNTR_SOFM : 0) | USB_CNTR_ESOFM | USB_CNTR_CTRM | USB_CNTR_SUSPM | USB_CNTR_WKUPM;
   dcd_handle_bus_reset();
   
-  // Data-line pull-up is left disconnected.
+  // Enable pull-up if supported
+  if ( dcd_connect ) dcd_connect(rhport);
 }
 
 // Define only on MCU with internal pull-up. BSP can define on MCU without internal PU.

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -453,6 +453,8 @@ void dcd_init (uint8_t rhport)
 
   // Enable global interrupt
   usb_otg->GAHBCFG |= USB_OTG_GAHBCFG_GINT;
+
+  dcd_connect(rhport);
 }
 
 void dcd_int_enable (uint8_t rhport)

--- a/src/portable/ti/msp430x5xx/dcd_msp430x5xx.c
+++ b/src/portable/ti/msp430x5xx/dcd_msp430x5xx.c
@@ -134,6 +134,9 @@ void dcd_init (uint8_t rhport)
   // Enable reset and wait for it before continuing.
   USBIE |= RSTRIE;
 
+  // Enable pullup.
+  USBCNF |= PUR_EN;
+
   USBKEYPID = 0;
 }
 

--- a/test/test/device/msc/test_msc_device.c
+++ b/test/test/device/msc/test_msc_device.c
@@ -199,7 +199,6 @@ void setUp(void)
   if ( !tusb_inited() )
   {
     dcd_init_Expect(rhport);
-    dcd_connect_Expect(rhport);
     tusb_init();
   }
 

--- a/test/test/device/usbd/test_usbd.c
+++ b/test/test/device/usbd/test_usbd.c
@@ -127,7 +127,6 @@ void setUp(void)
   {
     mscd_init_Expect();
     dcd_init_Expect(rhport);
-    dcd_connect_Expect(rhport);
     tusb_init();
   }
 }


### PR DESCRIPTION
**Describe the PR**
Some MCU like nRF5x doesn't want to enable Pull-up when init. Pullup is preferably enabled within VBUS power detection, this help nrf5x to save (a little) more power than needed. Since nRF5x mostly run by itself on battery with bluetooth, this can help a bit (if any). In general, I think it may be just better to leave the `dcd_init()` to decide rather than usbd to force pull-up. 

https://github.com/hathach/tinyusb/blob/master/src/portable/nordic/nrf5x/dcd_nrf5x.c#L808

This PR revert some changes previously and move the pull-up enabled from usbd to dcd_init() (if needed). 