### PR TITLE
Fix synopsys fifo flush during stall

### DIFF
--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -667,7 +667,7 @@ void dcd_edpt_stall (uint8_t rhport, uint8_t ep_addr)
     }
 
     // Flush the FIFO, and wait until we have confirmed it cleared.
-    usb_otg->GRSTCTL |= ((epnum - 1) << USB_OTG_GRSTCTL_TXFNUM_Pos);
+    usb_otg->GRSTCTL |= (epnum << USB_OTG_GRSTCTL_TXFNUM_Pos);
     usb_otg->GRSTCTL |= USB_OTG_GRSTCTL_TXFFLSH;
     while((usb_otg->GRSTCTL & USB_OTG_GRSTCTL_TXFFLSH_Msk) != 0);
   } else {


### PR DESCRIPTION
**Describe the PR**
Wrong FIFO was flushed in dcd_edpt_stall().
(epnum - 1) should only be used when accessing DIEPTXF registers.

For DIEPCTL and GRSTCTL epnum is correct index.
