### PR TITLE
correct the TUD_HID_REPORT_DESC_GAMEPAD

### DIFF
--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -264,7 +264,7 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
     HID_LOGICAL_MAX  ( 1                                      ) ,\
     HID_REPORT_COUNT ( 16                                     ) ,\
     HID_REPORT_SIZE  ( 1                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_ARRAY | HID_ABSOLUTE    ) ,\
+    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
     /* X, Y, Z, Rz (min -127, max 127 ) */ \
     HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
     HID_LOGICAL_MIN  ( 0x81                                   ) ,\


### PR DESCRIPTION
**Describe the PR**
Fix incorrect gamepad input type in the teamplte
Spotted and fixed in Arduino port by https://github.com/adafruit/Adafruit_TinyUSB_ArduinoCore/pull/14/files 