### PR TITLE
Fix a bug in writing SysEx messages.

### DIFF
--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -183,7 +183,7 @@ uint32_t tud_midi_n_write(uint8_t itf, uint8_t jack_id, uint8_t const* buffer, u
             if (data == 0xf7) {
                 midi->write_buffer[0] = 0x5;
             } else {
-                midi->write_buffer_length = 4;
+                midi->write_target_length = 4;
             }
         } else if ((msg >= 0x8 && msg <= 0xB) || msg == 0xE) {
             midi->write_buffer[0] = jack_id << 4 | msg;


### PR DESCRIPTION
At the start of a new USB packet (4 bytes), while in the middle of a SysEx, the code mistakenly
set the buffer length to 4, not the target length. As a consequence, the 3rd and 4th bytes from
the last packet were included, after every byte of the SysEx after the first packet of three.

The fix is simple, as it was just a typo, as can bee seen from the other branches in the same
section of if/else statements: At the start of a new packet, the code should set up the target
length... the buffer length should be left at 2 (as set on line 180).

**Describe the PR**
SysEx messages are garbled by the current code. 
See issue #511 for full details.

This fixes #511 