### PR TITLE
nrf52: Fix edpt_dma_start() wrong condition check

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -122,7 +122,7 @@ static void edpt_dma_start(volatile uint32_t* reg_startep)
         // for the DMA complete by comparing current pending DMA with number of ENDED Events
         uint32_t ended = 0;
 
-        while ( _dcd.dma_pending < ((uint8_t) ended) )
+        while ( _dcd.dma_pending > ((uint8_t) ended) )
         {
           ended = NRF_USBD->EVENTS_ENDISOIN + NRF_USBD->EVENTS_ENDISOOUT;
 


### PR DESCRIPTION
**Describe the PR**
Operator < used in while condition was obviously incorrect.
Loop starts with checking if unsigned variable is less then 0.
This condition is always false.

This reverses condition to follow intention of of the code.

**Additional context**

