### PR TITLE
STM32F3 IRQ remap option and some minor improvements

### DIFF
--- a/hw/bsp/stm32f303disco/stm32f303disco.c
+++ b/hw/bsp/stm32f303disco/stm32f303disco.c
@@ -31,27 +31,29 @@
 // Forward USB interrupt events to TinyUSB IRQ Handler
 //--------------------------------------------------------------------+
 
-// USB defaults to using interrupts 19, 20, and 42 (based on SYSCFG_CFGR1.USB_IT_RMP)
+// USB defaults to using interrupts 19, 20 and 42, however, this BSP sets the
+// SYSCFG_CFGR1.USB_IT_RMP bit remapping interrupts to 74, 75 and 76.
+
 // FIXME: Do all three need to be handled, or just the LP one?
-// USB high-priority interrupt (Channel 19): Triggered only by a correct
+// USB high-priority interrupt (Channel 74): Triggered only by a correct
 // transfer event for isochronous and double-buffer bulk transfer to reach
 // the highest possible transfer rate.
-void USB_HP_CAN_TX_IRQHandler(void)
+void USB_HP_IRQHandler(void)
 {
   tud_int_handler(0);
 }
 
-// USB low-priority interrupt (Channel 20): Triggered by all USB events
+// USB low-priority interrupt (Channel 75): Triggered by all USB events
 // (Correct transfer, USB reset, etc.). The firmware has to check the
 // interrupt source before serving the interrupt.
-void USB_LP_CAN_RX0_IRQHandler(void)
+void USB_LP_IRQHandler(void)
 {
   tud_int_handler(0);
 }
 
-// USB wakeup interrupt (Channel 42): Triggered by the wakeup event from the USB
+// USB wakeup interrupt (Channel 76): Triggered by the wakeup event from the USB
 // Suspend mode.
-void USBWakeUp_IRQHandler(void)
+void USBWakeUp_RMP_IRQHandler(void)
 {
   tud_int_handler(0);
 }
@@ -126,6 +128,10 @@ void board_init(void)
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
   #endif
+
+  // Remap the USB interrupts
+  __HAL_RCC_SYSCFG_CLK_ENABLE();
+  __HAL_REMAPINTERRUPT_USB_ENABLE();
 
   // LED
   __HAL_RCC_GPIOE_CLK_ENABLE();

--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -44,8 +44,10 @@
 #endif
 
 // Compile-time Assert
-#if __STDC_VERSION__ >= 201112L
+#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
   #define TU_VERIFY_STATIC   _Static_assert
+#elif defined (__cplusplus) && __cplusplus >= 201103L
+  #define TU_VERIFY_STATIC   static_assert
 #else
   #define TU_VERIFY_STATIC(const_expr, _mess) enum { TU_XSTRCAT(_verify_static_, _TU_COUNTER_) = 1/(!!(const_expr)) }
 #endif

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -142,7 +142,9 @@
 #define ASSERT_1ARGS(_cond)            TU_VERIFY_DEFINE(_cond, _MESS_FAILED(); TU_BREAKPOINT(), false)
 #define ASSERT_2ARGS(_cond, _ret)      TU_VERIFY_DEFINE(_cond, _MESS_FAILED(); TU_BREAKPOINT(), _ret)
 
+#ifndef TU_ASSERT
 #define TU_ASSERT(...)             GET_3RD_ARG(__VA_ARGS__, ASSERT_2ARGS, ASSERT_1ARGS,UNUSED)(__VA_ARGS__)
+#endif
 
 // TODO remove TU_ASSERT_ERR() later
 
@@ -163,10 +165,12 @@
 /* ASSERT Error
  * basically TU_VERIFY Error with TU_BREAKPOINT() as handler
  *------------------------------------------------------------------*/
-#define ASERT_ERR_1ARGS(_error)         TU_VERIFY_ERR_DEF2(_error, TU_BREAKPOINT())
-#define ASERT_ERR_2ARGS(_error, _ret)   TU_VERIFY_ERR_DEF3(_error, TU_BREAKPOINT(), _ret)
+#define ASSERT_ERR_1ARGS(_error)         TU_VERIFY_ERR_DEF2(_error, TU_BREAKPOINT())
+#define ASSERT_ERR_2ARGS(_error, _ret)   TU_VERIFY_ERR_DEF3(_error, TU_BREAKPOINT(), _ret)
 
-#define TU_ASSERT_ERR(...)         GET_3RD_ARG(__VA_ARGS__, ASERT_ERR_2ARGS, ASERT_ERR_1ARGS,UNUSED)(__VA_ARGS__)
+#ifndef TU_ASSERT_ERR
+#define TU_ASSERT_ERR(...)         GET_3RD_ARG(__VA_ARGS__, ASSERT_ERR_2ARGS, ASSERT_ERR_1ARGS,UNUSED)(__VA_ARGS__)
+#endif
 
 /*------------------------------------------------------------------*/
 /* ASSERT HDLR

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -76,8 +76,8 @@
 
 #if CFG_TUSB_DEBUG
   #include <stdio.h>
-  #define _MESS_ERR(_err)   printf("%s %d: failed, error = %s\r\n", __func__, __LINE__, tusb_strerr[_err])
-  #define _MESS_FAILED()    printf("%s %d: assert failed\r\n", __func__, __LINE__)
+  #define _MESS_ERR(_err)   tu_printf("%s %d: failed, error = %s\r\n", __func__, __LINE__, tusb_strerr[_err])
+  #define _MESS_FAILED()    tu_printf("%s %d: assert failed\r\n", __func__, __LINE__)
 #else
   #define _MESS_ERR(_err) do {} while (0)
   #define _MESS_FAILED() do {} while (0)

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -276,9 +276,23 @@ void dcd_int_enable (uint8_t rhport)
 #if CFG_TUSB_MCU == OPT_MCU_STM32F0 || CFG_TUSB_MCU == OPT_MCU_STM32L0
   NVIC_EnableIRQ(USB_IRQn);
 #elif CFG_TUSB_MCU == OPT_MCU_STM32F3
-  NVIC_EnableIRQ(USB_HP_CAN_TX_IRQn);
-  NVIC_EnableIRQ(USB_LP_CAN_RX0_IRQn);
-  NVIC_EnableIRQ(USBWakeUp_IRQn);
+  // Some STM32F302/F303 devices allow to remap the USB interrupt vectors from
+  // shared USB/CAN IRQs to separate CAN and USB IRQs.
+  // This dynamically checks if this remap is active to enable the right IRQs.
+  #ifdef SYSCFG_CFGR1_USB_IT_RMP
+  if (SYSCFG->CFGR1 & SYSCFG_CFGR1_USB_IT_RMP)
+  {
+    NVIC_EnableIRQ(USB_HP_IRQn);
+    NVIC_EnableIRQ(USB_LP_IRQn);
+    NVIC_EnableIRQ(USBWakeUp_RMP_IRQn);
+  }
+  else
+  #endif
+  {
+    NVIC_EnableIRQ(USB_HP_CAN_TX_IRQn);
+    NVIC_EnableIRQ(USB_LP_CAN_RX0_IRQn);
+    NVIC_EnableIRQ(USBWakeUp_IRQn);
+  }
 #elif CFG_TUSB_MCU == OPT_MCU_STM32F1
   NVIC_EnableIRQ(USB_HP_CAN1_TX_IRQn);
   NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
@@ -296,9 +310,23 @@ void dcd_int_disable(uint8_t rhport)
 #if CFG_TUSB_MCU == OPT_MCU_STM32F0 || CFG_TUSB_MCU == OPT_MCU_STM32L0
   NVIC_DisableIRQ(USB_IRQn);
 #elif CFG_TUSB_MCU == OPT_MCU_STM32F3
-  NVIC_DisableIRQ(USB_HP_CAN_TX_IRQn);
-  NVIC_DisableIRQ(USB_LP_CAN_RX0_IRQn);
-  NVIC_DisableIRQ(USBWakeUp_IRQn);
+  // Some STM32F302/F303 devices allow to remap the USB interrupt vectors from
+  // shared USB/CAN IRQs to separate CAN and USB IRQs.
+  // This dynamically checks if this remap is active to disable the right IRQs.
+  #ifdef SYSCFG_CFGR1_USB_IT_RMP
+  if (SYSCFG->CFGR1 & SYSCFG_CFGR1_USB_IT_RMP)
+  {
+    NVIC_DisableIRQ(USB_HP_IRQn);
+    NVIC_DisableIRQ(USB_LP_IRQn);
+    NVIC_DisableIRQ(USBWakeUp_RMP_IRQn);
+  }
+  else
+  #endif
+  {
+    NVIC_DisableIRQ(USB_HP_CAN_TX_IRQn);
+    NVIC_DisableIRQ(USB_LP_CAN_RX0_IRQn);
+    NVIC_DisableIRQ(USBWakeUp_IRQn);
+  }
 #elif CFG_TUSB_MCU == OPT_MCU_STM32F1
   NVIC_DisableIRQ(USB_HP_CAN1_TX_IRQn);
   NVIC_DisableIRQ(USB_LP_CAN1_RX0_IRQn);

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -110,11 +110,13 @@
 
 
 // Allow to use command line to change the config name/location
-#ifndef CFG_TUSB_CONFIG_FILE
-  #define CFG_TUSB_CONFIG_FILE "tusb_config.h"
+#ifdef CFG_TUSB_CONFIG_FILE
+  #include CFG_TUSB_CONFIG_FILE
+#else
+  #include "tusb_config.h"
 #endif
 
-#include CFG_TUSB_CONFIG_FILE
+
 
 /** \addtogroup group_configuration
  *  @{ */


### PR DESCRIPTION
Hi, thanks for this awesome library! I'm currently integrating TinyUSB into modm (https://github.com/modm-io/modm/pull/478) and I found some minor things to improve:

1. I added a simple `STM32F3_IRQ_REMAP`, which can be defined in the config to remap the IRQs. The user must remap the IRQs in their hardware setup (it's just `SYSCFG->CFGR1 |= SYSCFG_CFGR1_USB_IT_RMP;`).
2. We're using TinyUSB in C++, which doesn't define the `__STDC_VERSION__` macro, thus throwing a warning. Just a simple fix.
3. The `_MESS_ERR()` and `_MESS_FAILED()` macros use `printf` instead of `tu_printf`, which is unfortunate for debugging and also links the newlib version of printf which requires heap, thus pulling a whole lot of unrelated code.
4. To improve debugability I'm overwriting the `TU_ASSERT` macros with our own fault reporting implementation, and to allow this I just wrapped them in `#ifndef`. Unfortunately OpenOCD does not by default reset the debugger connected flag on disconnect, thus `TU_BREAKPOINT()` causes a HardFault, which isn't great to debug.
5. We're using SCons to compile, which has issues resolving `#include CFG_TUSB_CONFIG_FILE`, thus not recompiling TinyUSB sources when the config changes. So I changed the mechanism to "fallback" to a plain `#include "tusb_config.h"`, which solves this issue.