### PR TITLE
Fix for TinyUSB and FreeRTOS on STM32F1

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -280,6 +280,9 @@ void dcd_int_enable (uint8_t rhport)
   NVIC_EnableIRQ(USB_LP_CAN_RX0_IRQn);
   NVIC_EnableIRQ(USBWakeUp_IRQn);
 #elif CFG_TUSB_MCU == OPT_MCU_STM32F1
+  NVIC_SetPriority(USB_HP_CAN1_TX_IRQn, 15);
+  NVIC_SetPriority(USB_LP_CAN1_RX0_IRQn, 15);
+  NVIC_SetPriority(USBWakeUp_IRQn, 15);
   NVIC_EnableIRQ(USB_HP_CAN1_TX_IRQn);
   NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
   NVIC_EnableIRQ(USBWakeUp_IRQn);


### PR DESCRIPTION
When testing the cdc_msc_freertos example on a stm32f1 board, it doesn't work properly. This is because the IRQ for the USB is higher than the freertos one.

This fix basically sets the USB IRQ priority to a lower value which enables it to function as it should.