### PR TITLE
stm32 fsdev: fix ISTR and CTR_RX/TX race conditions

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -143,13 +143,17 @@ static inline uint32_t pcd_get_eptype(USB_TypeDef * USBx, uint32_t bEpNum)
 static inline void pcd_clear_rx_ep_ctr(USB_TypeDef * USBx, uint32_t bEpNum)
 {
   uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
-  regVal &= 0x7FFFu & USB_EPREG_MASK;
+  regVal &= USB_EPREG_MASK;
+  regVal &= ~USB_EP_CTR_RX;
+  regVal |= USB_EP_CTR_TX; // preserve CTR_TX (clears on writing 0)
   pcd_set_endpoint(USBx, bEpNum, regVal);
 }
 static inline void pcd_clear_tx_ep_ctr(USB_TypeDef * USBx, uint32_t bEpNum)
 {
   uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
-  regVal &= regVal & 0xFF7FU & USB_EPREG_MASK;
+  regVal &= USB_EPREG_MASK;
+  regVal &= ~USB_EP_CTR_TX;
+  regVal |= USB_EP_CTR_RX; // preserve CTR_RX (clears on writing 0)
   pcd_set_endpoint(USBx, bEpNum,regVal);
 }
 /**


### PR DESCRIPTION
This PR fixes two race conditions in the stm32 fsdev driver:
- USB->ISTR is a register where bits are cleared by writing 0. A non-atomic read-modify-write, as is done in reg16_clear_bits(), may inadvertently clear an interrupt flag that gets set between reading ISTR and writing ISTR, causing that interrupt to be dropped.
- Within the EPxR registers, CTR_TX and CTR_RX are also cleared by writing 0. Ensure that pcd_clear_rx_ep_ctr and pcd_clear_tx_ep_ctr write a 1 to the bit they are not clearing.

This bug occasionally occurred during high speed bidirectional data transfer on a pair of bulk endpoints with the same endpoint address.