### PR TITLE
mimxrt1010_evk: double stack size to allow net_lwip_webserver to run

### DIFF
--- a/hw/bsp/mimxrt1010_evk/board.mk
+++ b/hw/bsp/mimxrt1010_evk/board.mk
@@ -19,6 +19,9 @@ MCU_DIR = hw/mcu/nxp/sdk/devices/MIMXRT1011
 # All source paths should be relative to the top level.
 LD_FILE = $(MCU_DIR)/gcc/MIMXRT1011xxxxx_flexspi_nor.ld
 
+LDFLAGS += \
+	-Wl,--defsym,__stack_size__=0x800 \
+
 SRC_C += \
 	$(MCU_DIR)/system_MIMXRT1011.c \
 	$(MCU_DIR)/xip/fsl_flexspi_nor_boot.c \


### PR DESCRIPTION
#289 reported an issue with net_lwip_webserver with the 'NXP Transdimension (18 / 43 / iMX RT)' target.

I had access to a MIMXRT1010_EVK, and the issue was nothing more than a too restrictive stack size in NXP's default stack size value in the linker script.  A minor tweak to the BSP board.mk by adding LDFLAGS to override the value remedies this.

I suspect the same change will remedy others (most notably the MIMXRT1015_EVK, which should be nearly identical to the MIMXRT1010_EVK), but I'll defer this to people who have these platforms and can confirm this.
