### PR TITLE
osal_none: Fix queue definition

### DIFF
--- a/src/osal/osal_none.h
+++ b/src/osal/osal_none.h
@@ -139,6 +139,8 @@ typedef osal_queue_def_t* osal_queue_t;
       .depth        = _depth,                       \
       .item_size    = sizeof(_type),                \
       .overwritable = false,                        \
+      .max_pointer_idx = (2*(_depth))-1,            \
+      .non_used_index_space = 0xFFFF-((2*(_depth))-1),\
     }\
   }
 


### PR DESCRIPTION
**Describe the PR**
OSAL_QUEUE_DEF was not updated while FIFO was changed
to use unmasked pointers.

Two fields that are crucial to new functionality were left
uninitialized resulting in FIFO slowing down in time.

**Additional context**

