### PR TITLE
net_lwip_webserver: efficiency tweaks

### DIFF
--- a/examples/device/net_lwip_webserver/src/lwipopts.h
+++ b/examples/device/net_lwip_webserver/src/lwipopts.h
@@ -35,7 +35,7 @@
 /* Prevent having to link sys_arch.c (we don't test the API layers in unit tests) */
 #define NO_SYS                          1
 #define MEM_ALIGNMENT                   4
-#define LWIP_RAW                        1
+#define LWIP_RAW                        0
 #define LWIP_NETCONN                    0
 #define LWIP_SOCKET                     0
 #define LWIP_DHCP                       0
@@ -53,5 +53,7 @@
 #define LWIP_HTTPD_CGI                  0
 #define LWIP_HTTPD_SSI                  0
 #define LWIP_HTTPD_SSI_INCLUDE_TAG      0
+
+#define LWIP_SINGLE_NETIF               1
 
 #endif /* __LWIPOPTS_H__ */

--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -71,22 +71,21 @@ static const ip_addr_t gateway = IPADDR4_INIT_BYTES(0, 0, 0, 0);
 /* database IP addresses that can be offered to the host; this must be in RAM to store assigned MAC addresses */
 static dhcp_entry_t entries[] =
 {
-  /* mac    ip address        subnet mask        lease time */
-  { {0}, {192, 168, 7, 2}, {255, 255, 255, 0}, 24 * 60 * 60 },
-  { {0}, {192, 168, 7, 3}, {255, 255, 255, 0}, 24 * 60 * 60 },
-  { {0}, {192, 168, 7, 4}, {255, 255, 255, 0}, 24 * 60 * 60 }
+    /* mac ip address                          lease time */
+    { {0}, IPADDR4_INIT_BYTES(192, 168, 7, 2), 24 * 60 * 60 },
+    { {0}, IPADDR4_INIT_BYTES(192, 168, 7, 3), 24 * 60 * 60 },
+    { {0}, IPADDR4_INIT_BYTES(192, 168, 7, 4), 24 * 60 * 60 },
 };
 
-/* DHCP configuration parameters, leveraging "entries" above */
 static const dhcp_config_t dhcp_config =
 {
-  {192, 168, 7, 1}, 67,    /* server address (self), port */
-  {192, 168, 7, 1},        /* dns server (self) */
-  "usb",                   /* dns suffix */
-  TU_ARRAY_SIZE(entries),  /* number of entries */
-  entries                  /* pointer to entries */
+    .router = IPADDR4_INIT_BYTES(0, 0, 0, 0),  /* router address (if any) */
+    .port = 67,                                /* listen port */
+    .dns = IPADDR4_INIT_BYTES(192, 168, 7, 1), /* dns server (if any) */
+    "usb",                                     /* dns suffix */
+    TU_ARRAY_SIZE(entries),                    /* num entry */
+    entries                                    /* entries */
 };
-
 static err_t linkoutput_fn(struct netif *netif, struct pbuf *p)
 {
   (void)netif;

--- a/lib/networking/dhserver.h
+++ b/lib/networking/dhserver.h
@@ -42,16 +42,15 @@
 typedef struct dhcp_entry
 {
 	uint8_t  mac[6];
-	uint8_t  addr[4];
-	uint8_t  subnet[4];
+	ip_addr_t addr;
 	uint32_t lease;
 } dhcp_entry_t;
 
 typedef struct dhcp_config
 {
-	uint8_t       addr[4];
+	ip_addr_t     router;
 	uint16_t      port;
-	uint8_t       dns[4];
+	ip_addr_t     dns;
 	const char   *domain;
 	int           num_entry;
 	dhcp_entry_t *entries;


### PR DESCRIPTION
small code and data reduction by:
a) tweaking lwip compile-time options in examples/device/net_lwip_webserver/src/lwipopts.h
b) changing the DHCP server to not store duplicate values of what the stack already knows
