### PR TITLE
Allow use of internal FS PHY on OTG_HS interface

### DIFF
--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -416,9 +416,7 @@ void dcd_init (uint8_t rhport)
   if ( rhport == 1 )
   {
     // On selected MCUs HS port1 can be used with external PHY via ULPI interface
-#if defined(TUD_OPT_SYNOPSYS_FS_PHY)
-      usb_otg->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
-#else
+#if CFG_TUSB_RHPORT1_MODE & OPT_MODE_HIGH_SPEED
     // deactivate internal PHY
     usb_otg->GCCFG &= ~USB_OTG_GCCFG_PWRDWN;
 
@@ -427,6 +425,8 @@ void dcd_init (uint8_t rhport)
 
     // Select default internal VBUS Indicator and Drive for ULPI
     usb_otg->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD | USB_OTG_GUSBCFG_ULPIEVBUSI);
+#else
+    usb_otg->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
 #endif
 
 #if defined(USB_HS_PHYC)
@@ -470,11 +470,11 @@ void dcd_init (uint8_t rhport)
 
   set_speed(rhport, TUD_OPT_HIGH_SPEED ? TUSB_SPEED_HIGH : TUSB_SPEED_FULL);
 
-  // Enable internal USB transceiver. Unconditional if using FS PHY on HS core.
-#if defined(TUD_OPT_SYNOPSYS_FS_PHY)
-  usb_otg->GCCFG |= USB_OTG_GCCFG_PWRDWN;
-#else
+  // Enable internal USB transceiver, unless using HS core (port 1) with external PHY.
+#if CFG_TUSB_RHPORT1_MODE & OPT_MODE_HIGH_SPEED
   if ( rhport == 0 ) usb_otg->GCCFG |= USB_OTG_GCCFG_PWRDWN;
+#else
+  usb_otg->GCCFG |= USB_OTG_GCCFG_PWRDWN;
 #endif
 
 

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -416,7 +416,9 @@ void dcd_init (uint8_t rhport)
   if ( rhport == 1 )
   {
     // On selected MCUs HS port1 can be used with external PHY via ULPI interface
-
+#if defined(TUD_OPT_SYNOPSYS_FS_PHY)
+      usb_otg->GUSBCFG |= USB_OTG_GUSBCFG_PHYSEL;
+#else
     // deactivate internal PHY
     usb_otg->GCCFG &= ~USB_OTG_GCCFG_PWRDWN;
 
@@ -425,6 +427,7 @@ void dcd_init (uint8_t rhport)
 
     // Select default internal VBUS Indicator and Drive for ULPI
     usb_otg->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD | USB_OTG_GUSBCFG_ULPIEVBUSI);
+#endif
 
 #if defined(USB_HS_PHYC)
     // Highspeed with embedded UTMI PHYC
@@ -467,8 +470,13 @@ void dcd_init (uint8_t rhport)
 
   set_speed(rhport, TUD_OPT_HIGH_SPEED ? TUSB_SPEED_HIGH : TUSB_SPEED_FULL);
 
-  // Enable internal USB transceiver.
+  // Enable internal USB transceiver. Unconditional if using FS PHY on HS core.
+#if defined(TUD_OPT_SYNOPSYS_FS_PHY)
+  usb_otg->GCCFG |= USB_OTG_GCCFG_PWRDWN;
+#else
   if ( rhport == 0 ) usb_otg->GCCFG |= USB_OTG_GCCFG_PWRDWN;
+#endif
+
 
   usb_otg->GINTMSK |= USB_OTG_GINTMSK_USBRST   | USB_OTG_GINTMSK_ENUMDNEM |
       USB_OTG_GINTMSK_USBSUSPM | USB_OTG_GINTMSK_WUIM     |

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -471,12 +471,7 @@ void dcd_init (uint8_t rhport)
   set_speed(rhport, TUD_OPT_HIGH_SPEED ? TUSB_SPEED_HIGH : TUSB_SPEED_FULL);
 
   // Enable internal USB transceiver, unless using HS core (port 1) with external PHY.
-#if CFG_TUSB_RHPORT1_MODE & OPT_MODE_HIGH_SPEED
-  if ( rhport == 0 ) usb_otg->GCCFG |= USB_OTG_GCCFG_PWRDWN;
-#else
-  usb_otg->GCCFG |= USB_OTG_GCCFG_PWRDWN;
-#endif
-
+  if (!(rhport == 1 && (CFG_TUSB_RHPORT1_MODE & OPT_MODE_HIGH_SPEED))) usb_otg->GCCFG |= USB_OTG_GCCFG_PWRDWN;
 
   usb_otg->GINTMSK |= USB_OTG_GINTMSK_USBRST   | USB_OTG_GINTMSK_ENUMDNEM |
       USB_OTG_GINTMSK_USBSUSPM | USB_OTG_GINTMSK_WUIM     |


### PR DESCRIPTION
**Describe the PR**
Allow use of internal FS PHY on OTG_HS interface

**Additional context**
Some ST parts (like STM32F74xxx / STM32F75xxx, maybe others) allow the USB_OTG_FS core to be used with either an external ULPI PHY or an internal full-speed-only (12mbps) PHY. Currently the code assumes than an ULPI PHY is used unless the chip has an internal high-speed PHY (`#if defined(USB_HS_PHYC)`), with no provision to use the internal FS PHY.

I'm not sure an #ifdef is the right way to do this, or if so, that the option name I'm using is good (`TUD_OPT_SYNOPSYS_FS_PHY`) - suggestions appreciated.