### PR TITLE
net_device: re-factor code so as to not be specific to lwIP

### DIFF
--- a/src/class/net/net_device.h
+++ b/src/class/net/net_device.h
@@ -32,15 +32,13 @@
 #include "device/usbd.h"
 #include "class/cdc/cdc.h"
 
-// TODO should not include external files
-#include "lwip/pbuf.h"
-#include "netif/ethernet.h"
-
 /* declared here, NOT in usb_descriptors.c, so that the driver can intelligently ZLP as needed */
 #define CFG_TUD_NET_ENDPOINT_SIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
 
 /* Maximum Tranmission Unit (in bytes) of the network, including Ethernet header */
-#define CFG_TUD_NET_MTU           (1500 + SIZEOF_ETH_HDR)
+#ifndef CFG_TUD_NET_MTU
+#define CFG_TUD_NET_MTU           1514
+#endif
 
 #ifdef __cplusplus
  extern "C" {
@@ -54,7 +52,10 @@
 void tud_network_init_cb(void);
 
 // client must provide this: return false if the packet buffer was not accepted
-bool tud_network_recv_cb(struct pbuf *p);
+bool tud_network_recv_cb(const uint8_t *src, uint16_t size);
+
+// client must provide this: copy from network stack packet pointer to dst
+uint16_t tud_network_xmit_cb(uint8_t *dst, void *ref, uint16_t arg);
 
 // client must provide this: 48-bit MAC address
 // TODO removed later since it is not part of tinyusb stack
@@ -67,7 +68,7 @@ void tud_network_recv_renew(void);
 bool tud_network_can_xmit(void);
 
 // if network_can_xmit() returns true, network_xmit() can be called once
-void tud_network_xmit(struct pbuf *p);
+void tud_network_xmit(void *ref, uint16_t arg);
 
 //--------------------------------------------------------------------+
 // INTERNAL USBD-CLASS DRIVER API


### PR DESCRIPTION
When the net class driver was originally added to tinyusb, @hathach put in a "TODO should not include external files" comment in  ./src/class/net/net_device.h

This PR re-factors the code to remove the dependency on these include files.  It also has the benefit of making the net class driver not specific to lwIP, making it more agnostic as to which network stack is chosen by the user.

It does this by putting the lwIP-dependent portion of the code in ./examples/device/net_lwip_webserver/src/main.c

An added callback tud_network_xmit_cb() takes care of copying the packet into the net class driver's IN endpoint buffer.

P.S.: note that there are now two arguments (void *ref, uint16_t arg) to tud_network_xmit() and tud_network_xmit_cb().  In the present example, "arg" is unused, but providing "arg" enables a user wanting direct access to virtual Ethernet packets without a network stack to implement tud_network_xmit_cb() as simple as { memcpy(dst, ref, arg); return arg; } where ref is a pointer to a buffer to transmit and arg is the length.

