### PR TITLE
Rename CDC_COMM_SUBCLASS_ETHERNET_NETWORKING_CONTROL_MODEL

### DIFF
--- a/src/class/cdc/cdc.h
+++ b/src/class/cdc/cdc.h
@@ -63,7 +63,7 @@ typedef enum
   CDC_COMM_SUBCLASS_TELEPHONE_CONTROL_MODEL           , ///< Telephone Control Model  [USBPSTN1.2]
   CDC_COMM_SUBCLASS_MULTICHANNEL_CONTROL_MODEL        , ///< Multi-Channel Control Model  [USBISDN1.2]
   CDC_COMM_SUBCLASS_CAPI_CONTROL_MODEL                , ///< CAPI Control Model  [USBISDN1.2]
-  CDC_COMM_SUBCLASS_ETHERNET_NETWORKING_CONTROL_MODEL , ///< Ethernet Networking Control Model  [USBECM1.2]
+  CDC_COMM_SUBCLASS_ETHERNET_CONTROL_MODEL            , ///< Ethernet Networking Control Model  [USBECM1.2]
   CDC_COMM_SUBCLASS_ATM_NETWORKING_CONTROL_MODEL      , ///< ATM Networking Control Model  [USBATM1.2]
   CDC_COMM_SUBCLASS_WIRELESS_HANDSET_CONTROL_MODEL    , ///< Wireless Handset Control Model  [USBWMC1.1]
   CDC_COMM_SUBCLASS_DEVICE_MANAGEMENT                 , ///< Device Management  [USBWMC1.1]

--- a/src/class/net/net_device.c
+++ b/src/class/net/net_device.c
@@ -141,9 +141,9 @@ uint16_t netd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint1
                          TUD_RNDIS_ITF_SUBCLASS == itf_desc->bInterfaceSubClass &&
                          TUD_RNDIS_ITF_PROTOCOL == itf_desc->bInterfaceProtocol);
 
-  bool const is_ecm = (TUSB_CLASS_CDC                                      == itf_desc->bInterfaceClass &&
-                       CDC_COMM_SUBCLASS_ETHERNET_NETWORKING_CONTROL_MODEL == itf_desc->bInterfaceSubClass &&
-                       0x00                                                == itf_desc->bInterfaceProtocol);
+  bool const is_ecm = (TUSB_CLASS_CDC                           == itf_desc->bInterfaceClass &&
+                       CDC_COMM_SUBCLASS_ETHERNET_CONTROL_MODEL == itf_desc->bInterfaceSubClass &&
+                       0x00                                     == itf_desc->bInterfaceProtocol);
 
   TU_VERIFY(is_rndis || is_ecm, 0);
 

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -554,9 +554,9 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
 // Interface number, description string index, MAC address string index, EP notification address and size, EP data address (out, in), and size, max segment size.
 #define TUD_CDC_ECM_DESCRIPTOR(_itfnum, _desc_stridx, _mac_stridx, _ep_notif, _ep_notif_size, _epout, _epin, _epsize, _maxsegmentsize) \
   /* Interface Association */\
-  8, TUSB_DESC_INTERFACE_ASSOCIATION, _itfnum, 2, TUSB_CLASS_CDC, CDC_COMM_SUBCLASS_ETHERNET_NETWORKING_CONTROL_MODEL, 0, 0,\
+  8, TUSB_DESC_INTERFACE_ASSOCIATION, _itfnum, 2, TUSB_CLASS_CDC, CDC_COMM_SUBCLASS_ETHERNET_CONTROL_MODEL, 0, 0,\
   /* CDC Control Interface */\
-  9, TUSB_DESC_INTERFACE, _itfnum, 0, 1, TUSB_CLASS_CDC, CDC_COMM_SUBCLASS_ETHERNET_NETWORKING_CONTROL_MODEL, 0, _desc_stridx,\
+  9, TUSB_DESC_INTERFACE, _itfnum, 0, 1, TUSB_CLASS_CDC, CDC_COMM_SUBCLASS_ETHERNET_CONTROL_MODEL, 0, _desc_stridx,\
   /* CDC-ECM Header */\
   5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_HEADER, U16_TO_U8S_LE(0x0120),\
   /* CDC-ECM Union */\


### PR DESCRIPTION
**Describe the PR**
This was a confusing name; "Ethernet control model" (CDC ECM)
and "network control model" (CDC NCM) are two separate USB subclasses.

**Additional context**
I'm working on a PR to add CDC NCM support to tinyUSB, and this is an initial cleanup step.