### PR TITLE
use same51 driver to adafruit asf4 submodule

### DIFF
--- a/hw/bsp/d5035_01/board.mk
+++ b/hw/bsp/d5035_01/board.mk
@@ -1,3 +1,5 @@
+HWREV ?= 1
+
 CFLAGS += \
   -mthumb \
   -mabi=aapcs \
@@ -12,41 +14,37 @@ CFLAGS += \
   -DCFG_TUSB_MCU=OPT_MCU_SAME5X \
   -DD5035_01=1 \
   -DBOARD_NAME="\"D5035-01\"" \
-  -DSVC_Handler=SVCall_Handler
-
-HWREV ?= 1
-
-CFLAGS += -DHWREV=$(HWREV)
-
+  -DSVC_Handler=SVCall_Handler \
+  -DHWREV=$(HWREV)
 
 # All source paths should be relative to the top level.
 LD_FILE = hw/bsp/$(BOARD)/same51j19a_flash.ld
 
 SRC_C += \
-	hw/mcu/microchip/same51/gcc/gcc/startup_same51.c \
-  hw/mcu/microchip/same51/gcc/system_same51.c \
+	hw/mcu/microchip/samd/asf4/same51/gcc/gcc/startup_same51.c \
+  hw/mcu/microchip/samd/asf4/same51/gcc/system_same51.c \
 
 ifdef SYSCALLS
 ifneq ($(SYSCALLS),0)
-  SRC_C += hw/mcu/microchip/same51/hal/utils/src/utils_syscalls.c
+  SRC_C += hw/mcu/microchip/samd/asf4/same51/hal/utils/src/utils_syscalls.c
 endif
 endif
 
 ifdef LOG
 ifneq ($(LOG),0)
-  SRC_C += hw/mcu/microchip/same51/hal/utils/src/utils_syscalls.c
+  SRC_C += hw/mcu/microchip/samd/asf4/same51/hal/utils/src/utils_syscalls.c
 endif
 endif
 
 INC += \
-	$(TOP)/hw/mcu/microchip/same51/ \
-	$(TOP)/hw/mcu/microchip/same51/config \
-	$(TOP)/hw/mcu/microchip/same51/include \
-	$(TOP)/hw/mcu/microchip/same51/hal/include \
-	$(TOP)/hw/mcu/microchip/same51/hal/utils/include \
-	$(TOP)/hw/mcu/microchip/same51/hpl/port \
-	$(TOP)/hw/mcu/microchip/same51/hri \
-	$(TOP)/hw/mcu/microchip/same51/CMSIS/Core/Include
+	$(TOP)/hw/mcu/microchip/samd/asf4/same51/ \
+	$(TOP)/hw/mcu/microchip/samd/asf4/same51/config \
+	$(TOP)/hw/mcu/microchip/samd/asf4/same51/include \
+	$(TOP)/hw/mcu/microchip/samd/asf4/same51/hal/include \
+	$(TOP)/hw/mcu/microchip/samd/asf4/same51/hal/utils/include \
+	$(TOP)/hw/mcu/microchip/samd/asf4/same51/hpl/port \
+	$(TOP)/hw/mcu/microchip/samd/asf4/same51/hri \
+	$(TOP)/hw/mcu/microchip/samd/asf4/same51/CMSIS/Include
 
 # For TinyUSB port source
 VENDOR = microchip


### PR DESCRIPTION
**Describe the PR**
same5x is added recently to asf4, it is better to re-use it than maintaining its driver ourself.

@jgressmann  may want to review this.