### PR TITLE
Make the disk disappear on Windows after it was ejected

### DIFF
--- a/examples/device/cdc_msc/src/msc_disk.c
+++ b/examples/device/cdc_msc/src/msc_disk.c
@@ -28,6 +28,8 @@
 
 #if CFG_TUD_MSC
 
+static bool ejected = false;
+
 // Some MCU doesn't have enough 8KB SRAM to store the whole disk
 // We will use Flash as read-only disk with board that has
 // CFG_EXAMPLE_MSC_READONLY defined
@@ -137,7 +139,13 @@ bool tud_msc_test_unit_ready_cb(uint8_t lun)
 {
   (void) lun;
 
-  return true; // RAM disk is always ready
+  // RAM disk is ready until is not ejected
+  if (ejected) {
+    tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3a, 0x00);
+    return false;
+  }
+
+  return true;
 }
 
 // Invoked when received SCSI_CMD_READ_CAPACITY_10 and SCSI_CMD_READ_FORMAT_CAPACITY to determine the disk size
@@ -166,6 +174,7 @@ bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, boo
     }else
     {
       // unload disk storage
+      ejected = true;
     }
   }
 


### PR DESCRIPTION
Make the disk disappear on Windows after it was ejected. The device needs to be re-inserted or reseted to re-appear again.

This doesn't affect Linux where the device can be mounted and unmounted repeatedly.

Note that this should be applied to three more examples.

Closes https://github.com/hathach/tinyusb/issues/549
