### PR TITLE
add bus suspend & resume support for esp32s2

### DIFF
--- a/examples/device/hid_composite_freertos/src/main.c
+++ b/examples/device/hid_composite_freertos/src/main.c
@@ -58,7 +58,12 @@ StaticTimer_t blinky_tmdef;
 TimerHandle_t blinky_tm;
 
 // static task for usbd
-#define USBD_STACK_SIZE     (3*configMINIMAL_STACK_SIZE/2)
+#if CFG_TUSB_DEBUG
+  #define USBD_STACK_SIZE     (3*configMINIMAL_STACK_SIZE)
+#else
+  #define USBD_STACK_SIZE     (3*configMINIMAL_STACK_SIZE/2)
+#endif
+
 StackType_t  usb_device_stack[USBD_STACK_SIZE];
 StaticTask_t usb_device_taskdef;
 

--- a/src/portable/espressif/esp32s2/dcd_esp32s2.c
+++ b/src/portable/espressif/esp32s2/dcd_esp32s2.c
@@ -218,6 +218,9 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void)rhport;
+
+  // TODO must manually clear this bit after 1-15 ms
+  // USB0.DCTL |= USB_RMTWKUPSIG_M;
 }
 
 // connect by enabling internal pull-up resistor on D+/D-
@@ -670,6 +673,7 @@ static void handle_epin_ints(void)
 static void _dcd_int_handler(void* arg)
 {
   (void) arg;
+  uint8_t const rhport = 0;
 
   const uint32_t int_status = USB0.gintsts;
   //const uint32_t int_msk = USB0.gintmsk;
@@ -695,7 +699,19 @@ static void _dcd_int_handler(void* arg)
     // the end of reset.
     USB0.gintsts = USB_ENUMDONE_M;
     enum_done_processing();
-    dcd_event_bus_signal(0, DCD_EVENT_BUS_RESET, true);
+    dcd_event_bus_reset(rhport, TUSB_SPEED_FULL, true);
+  }
+
+  if(int_status & USB_USBSUSP_M)
+  {
+    USB0.gintsts = USB_USBSUSP_M;
+    dcd_event_bus_signal(rhport, DCD_EVENT_SUSPEND, true);
+  }
+
+  if(int_status & USB_WKUPINT_M)
+  {
+    USB0.gintsts = USB_WKUPINT_M;
+    dcd_event_bus_signal(rhport, DCD_EVENT_RESUME, true);
   }
 
   if (int_status & USB_OTGINT_M)

--- a/src/portable/espressif/esp32s2/dcd_esp32s2.c
+++ b/src/portable/espressif/esp32s2/dcd_esp32s2.c
@@ -723,7 +723,7 @@ static void _dcd_int_handler(void* arg)
 
     if (otg_int & USB_SESENDDET_M)
     {
-      dcd_event_bus_signal(0, DCD_EVENT_UNPLUGGED, true);
+      dcd_event_bus_signal(rhport, DCD_EVENT_UNPLUGGED, true);
     }
 
     USB0.gotgint = otg_int;
@@ -732,7 +732,7 @@ static void _dcd_int_handler(void* arg)
 #if USE_SOF
   if (int_status & USB_SOF_M) {
     USB0.gintsts = USB_SOF_M;
-    dcd_event_bus_signal(0, DCD_EVENT_SOF, true); // do nothing actually
+    dcd_event_bus_signal(rhport, DCD_EVENT_SOF, true); // do nothing actually
   }
 #endif
 

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -515,12 +515,14 @@ void dcd_remote_wakeup(uint8_t rhport)
 
 void dcd_connect(uint8_t rhport)
 {
+  (void) rhport;
   USB_OTG_DeviceTypeDef * dev = DEVICE_BASE(rhport);
   dev->DCTL &= ~USB_OTG_DCTL_SDIS;
 }
 
 void dcd_disconnect(uint8_t rhport)
 {
+  (void) rhport;
   USB_OTG_DeviceTypeDef * dev = DEVICE_BASE(rhport);
   dev->DCTL |= USB_OTG_DCTL_SDIS;
 }

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -507,21 +507,21 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
 void dcd_remote_wakeup(uint8_t rhport)
 {
   (void) rhport;
+
+  // TODO must manually clear this bit after 1-15 ms
+  // USB_OTG_DeviceTypeDef * dev = DEVICE_BASE(rhport);
+  // dev->DCTL |= USB_OTG_DCTL_RWUSIG;
 }
 
 void dcd_connect(uint8_t rhport)
 {
-  (void) rhport;
   USB_OTG_DeviceTypeDef * dev = DEVICE_BASE(rhport);
-
   dev->DCTL &= ~USB_OTG_DCTL_SDIS;
 }
 
 void dcd_disconnect(uint8_t rhport)
 {
-  (void) rhport;
   USB_OTG_DeviceTypeDef * dev = DEVICE_BASE(rhport);
-
   dev->DCTL |= USB_OTG_DCTL_SDIS;
 }
 


### PR DESCRIPTION
**Describe the PR**
Add bus suspend and resume support for esp32s2

@dhalbert it is just part of the issue, the esp32s2 can detect suspend signal e.g when PC enter sleep mode, but still couldn't detect disconnection. It see disconnection as indefinite series of suspend https://github.com/hathach/tinyusb/issues/564