### PR TITLE
Fix IAR error on memcpy and warnings.

### DIFF
--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -30,6 +30,12 @@
 #include "osal/osal.h"
 #include "tusb_fifo.h"
 
+// Supress IAR warning
+// Warning[Pa082]: undefined behavior: the order of volatile accesses is undefined in this statement
+#if defined(__ICCARM__)
+#pragma diag_suppress = Pa082
+#endif
+
 // implement mutex lock and unlock
 #if CFG_FIFO_MUTEX
 
@@ -106,7 +112,7 @@ static void _ff_push_n(tu_fifo_t* f, void const * data, uint16_t n, uint16_t wRe
     memcpy(f->buffer + (wRel * f->item_size), data, nLin*f->item_size);
 
     // Write data wrapped around
-    memcpy(f->buffer, data + nLin*f->item_size, (n - nLin) * f->item_size);
+    memcpy(f->buffer, ((uint8_t const*) data) + nLin*f->item_size, (n - nLin) * f->item_size);
   }
 }
 
@@ -131,7 +137,7 @@ static void _ff_pull_n(tu_fifo_t* f, void * p_buffer, uint16_t n, uint16_t rRel)
     memcpy(p_buffer, f->buffer + (rRel * f->item_size), nLin*f->item_size);
 
     // Read data wrapped part
-    memcpy(p_buffer + nLin*f->item_size, f->buffer, (n - nLin) * f->item_size);
+    memcpy((uint8_t*)p_buffer + nLin*f->item_size, f->buffer, (n - nLin) * f->item_size);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: MasterPhi <admin@hifiphile.com>

**Describe the PR**
IAR complains on "unknown type" on memcpy, and gives warnings on undefined volatile access order
A clear and concise description of what this PR solve.

