### PR TITLE
Feature dbl m33

### DIFF
--- a/docs/boards.md
+++ b/docs/boards.md
@@ -86,6 +86,7 @@ This code base already had supported for a handful of following boards (sorted a
 - [LPCXpresso 54114](https://www.nxp.com/design/microcontrollers-developer-resources/lpcxpresso-boards/lpcxpresso54114-board:OM13089)
 - [LPCXpresso 55s69 EVK](https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/lpc5500-cortex-m33/lpcxpresso55s69-development-board:LPC55S69-EVK)
 - [NGX LPC4330-Xplorer](https://www.nxp.com/design/designs/lpc4330-xplorer-board:OM13027)
+- [Double M33 Express](https://www.crowdsupply.com/steiert-solutions/double-m33-express)
 
 ### Sony
 

--- a/hw/bsp/double_m33_express/LPC55S69_cm33_core0_uf2.ld
+++ b/hw/bsp/double_m33_express/LPC55S69_cm33_core0_uf2.ld
@@ -1,0 +1,234 @@
+/*
+** ###################################################################
+**     Processors:          LPC55S69JBD100_cm33_core0
+**                          LPC55S69JBD64_cm33_core0
+**                          LPC55S69JEV98_cm33_core0
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    LPC55S6x/LPC55S2x/LPC552x User manual(UM11126) Rev.1.3  16 May 2019
+**     Version:             rev. 1.1, 2019-05-16
+**     Build:               b191008
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2019 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+** ###################################################################
+*/
+
+
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0800;
+RPMSG_SHMEM_SIZE = DEFINED(__use_shmem__) ? 0x1800 : 0;
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x00010000, LENGTH = 0x00000200
+  m_text                (RX)  : ORIGIN = 0x00010200, LENGTH = 0x0007FE00
+  m_core1_image         (RX)  : ORIGIN = 0x00090000, LENGTH = 0x00008000
+  m_data                (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00033000 - RPMSG_SHMEM_SIZE
+  rpmsg_sh_mem          (RW)  : ORIGIN = 0x20033000 - RPMSG_SHMEM_SIZE, LENGTH = RPMSG_SHMEM_SIZE
+  m_usb_sram            (RW)  : ORIGIN = 0x40100000, LENGTH = 0x00004000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* section for storing the secondary core image */
+  .m0code :
+  {
+     . = ALIGN(4) ;
+    KEEP (*(.m0code))
+     *(.m0code*)
+     . = ALIGN(4) ;
+  } > m_core1_image
+
+  /* NOINIT section for rpmsg_sh_mem */
+  .noinit_rpmsg_sh_mem (NOLOAD) : ALIGN(4)
+  {
+     __RPMSG_SH_MEM_START__ = .;
+     *(.noinit.$rpmsg_sh_mem*)
+     . = ALIGN(4) ;
+     __RPMSG_SH_MEM_END__ = .;
+  } > rpmsg_sh_mem
+
+  /* The startup code goes first into internal flash */
+  .interrupts :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  /* The program code and other data goes into internal flash */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .data : AT(__DATA_ROM)
+  {
+    . = ALIGN(4);
+    __DATA_RAM = .;
+    __data_start__ = .;      /* create a global symbol at data start */
+    *(.ramfunc*)             /* for functions in ram */
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data
+
+  m_usb_bdt (NOLOAD) :
+  {
+    . = ALIGN(512);
+    *(m_usb_bdt)
+  } > m_usb_sram
+
+  m_usb_global (NOLOAD) :
+  {
+    *(m_usb_global)
+  } > m_usb_sram
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data) + LENGTH(m_data);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data overflowed with stack and heap")
+}
+

--- a/hw/bsp/double_m33_express/board.mk
+++ b/hw/bsp/double_m33_express/board.mk
@@ -1,0 +1,49 @@
+CFLAGS += \
+  -flto \
+  -mthumb \
+  -mabi=aapcs \
+  -mcpu=cortex-m33 \
+  -mfloat-abi=hard \
+  -mfpu=fpv5-sp-d16 \
+  -DCPU_LPC55S69JBD100_cm33_core0 \
+  -DCFG_TUSB_MCU=OPT_MCU_LPC55XX \
+  -DCFG_TUSB_MEM_SECTION='__attribute__((section(".data")))' \
+  -DCFG_TUSB_MEM_ALIGN='__attribute__((aligned(64)))'
+
+# mcu driver cause following warnings
+CFLAGS += -Wno-error=unused-parameter -Wno-error=float-equal
+
+MCU_DIR = hw/mcu/nxp/sdk/devices/LPC55S69
+
+# All source paths should be relative to the top level.
+LD_FILE = hw/bsp/$(BOARD)/LPC55S69_cm33_core0_uf2.ld
+
+SRC_C += \
+	$(MCU_DIR)/system_LPC55S69_cm33_core0.c \
+	$(MCU_DIR)/drivers/fsl_clock.c \
+	$(MCU_DIR)/drivers/fsl_gpio.c \
+	$(MCU_DIR)/drivers/fsl_power.c \
+	$(MCU_DIR)/drivers/fsl_reset.c
+
+INC += \
+	$(TOP)/$(MCU_DIR)/../../CMSIS/Include \
+	$(TOP)/$(MCU_DIR) \
+	$(TOP)/$(MCU_DIR)/drivers
+
+SRC_S += $(MCU_DIR)/gcc/startup_LPC55S69_cm33_core0.S
+
+LIBS += $(TOP)/$(MCU_DIR)/gcc/libpower_hardabi.a
+
+# For TinyUSB port source
+VENDOR = nxp
+CHIP_FAMILY = lpc_ip3511
+
+# For freeRTOS port source
+FREERTOS_PORT = ARM_CM33_NTZ/non_secure
+
+# For flash-jlink target
+JLINK_DEVICE = LPC55S69
+
+# flash using pyocd
+flash: $(BUILD)/$(BOARD)-firmware.hex
+	pyocd flash -t LPC55S69 $<

--- a/hw/bsp/double_m33_express/board.mk
+++ b/hw/bsp/double_m33_express/board.mk
@@ -23,7 +23,9 @@ SRC_C += \
 	$(MCU_DIR)/drivers/fsl_clock.c \
 	$(MCU_DIR)/drivers/fsl_gpio.c \
 	$(MCU_DIR)/drivers/fsl_power.c \
-	$(MCU_DIR)/drivers/fsl_reset.c
+	$(MCU_DIR)/drivers/fsl_reset.c \
+	$(MCU_DIR)/drivers/fsl_usart.c \
+	$(MCU_DIR)/drivers/fsl_flexcomm.c 
 
 INC += \
 	$(TOP)/$(MCU_DIR)/../../CMSIS/Include \

--- a/hw/bsp/double_m33_express/double_m33_express.c
+++ b/hw/bsp/double_m33_express/double_m33_express.c
@@ -1,0 +1,227 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018, hathach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "../board.h"
+#include "fsl_device_registers.h"
+#include "fsl_gpio.h"
+#include "fsl_power.h"
+#include "fsl_iocon.h"
+
+//--------------------------------------------------------------------+
+// Forward USB interrupt events to TinyUSB IRQ Handler
+//--------------------------------------------------------------------+
+void USB0_IRQHandler(void)
+{
+  tud_int_handler(0);
+}
+
+void USB1_IRQHandler(void)
+{
+  tud_int_handler(1);
+}
+
+//--------------------------------------------------------------------+
+// MACRO TYPEDEF CONSTANT ENUM
+//--------------------------------------------------------------------+
+#define LED_PORT              0
+#define LED_PIN               1
+#define LED_STATE_ON          1
+
+// WAKE button
+#define BUTTON_PORT           0
+#define BUTTON_PIN            5
+#define BUTTON_STATE_ACTIVE   0
+
+// IOCON pin mux
+#define IOCON_PIO_DIGITAL_EN 0x0100u  /*!<@brief Enables digital function */
+#define IOCON_PIO_FUNC0 0x00u         /*!<@brief Selects pin function 0 */
+#define IOCON_PIO_FUNC1 0x01u         /*!<@brief Selects pin function 1 */
+#define IOCON_PIO_FUNC7 0x07u         /*!<@brief Selects pin function 7 */
+#define IOCON_PIO_INV_DI 0x00u        /*!<@brief Input function is not inverted */
+#define IOCON_PIO_MODE_INACT 0x00u    /*!<@brief No addition pin function */
+#define IOCON_PIO_OPENDRAIN_DI 0x00u  /*!<@brief Open drain is disabled */
+#define IOCON_PIO_SLEW_STANDARD 0x00u /*!<@brief Standard mode, output slew rate control is enabled */
+
+/****************************************************************
+name: BOARD_BootClockFROHF96M
+outputs:
+- {id: SYSTICK_clock.outFreq, value: 96 MHz}
+- {id: System_clock.outFreq, value: 96 MHz}
+settings:
+- {id: SYSCON.MAINCLKSELA.sel, value: SYSCON.fro_hf}
+sources:
+- {id: SYSCON.fro_hf.outFreq, value: 96 MHz}
+******************************************************************/
+void BootClockFROHF96M(void)
+{
+  /*!< Set up the clock sources */
+  /*!< Set up FRO */
+  POWER_DisablePD(kPDRUNCFG_PD_FRO192M); /*!< Ensure FRO is on  */
+  CLOCK_SetupFROClocking(12000000U);     /*!< Set up FRO to the 12 MHz, just for sure */
+  CLOCK_AttachClk(kFRO12M_to_MAIN_CLK); /*!< Switch to FRO 12MHz first to ensure we can change voltage without
+                                             accidentally being below the voltage for current speed */
+
+  CLOCK_SetupFROClocking(96000000U); /*!< Set up high frequency FRO output to selected frequency */
+
+  POWER_SetVoltageForFreq(96000000U); /*!< Set voltage for the one of the fastest clock outputs: System clock output */
+  CLOCK_SetFLASHAccessCyclesForFreq(96000000U); /*!< Set FLASH wait states for core */
+
+  /*!< Set up dividers */
+  CLOCK_SetClkDiv(kCLOCK_DivAhbClk, 1U, false);     /*!< Set AHBCLKDIV divider to value 1 */
+
+  /*!< Set up clock selectors - Attach clocks to the peripheries */
+  CLOCK_AttachClk(kFRO_HF_to_MAIN_CLK); /*!< Switch MAIN_CLK to FRO_HF */
+
+  /*!< Set SystemCoreClock variable. */
+  SystemCoreClock = 96000000U;
+}
+
+void board_init(void)
+{
+  // Enable IOCON clock
+  CLOCK_EnableClock(kCLOCK_Iocon);
+
+  // Init 96 MHz clock
+  BootClockFROHF96M();
+
+#if CFG_TUSB_OS == OPT_OS_NONE
+  // 1ms tick timer
+  SysTick_Config(SystemCoreClock / 1000);
+#elif CFG_TUSB_OS == OPT_OS_FREERTOS
+  // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
+  NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
+#endif
+
+  GPIO_PortInit(GPIO, LED_PORT);
+  GPIO_PortInit(GPIO, BUTTON_PORT);
+
+  // LED
+  gpio_pin_config_t const led_config = { kGPIO_DigitalOutput, 0};
+  GPIO_PinInit(GPIO, LED_PORT, LED_PIN, &led_config);
+  board_led_write(true);
+
+  // Button
+  const uint32_t port1_pin18_config = (
+      IOCON_PIO_FUNC0         | /* Pin is configured as PIO1_18 */
+      IOCON_PIO_MODE_INACT    | /* No addition pin function */
+      IOCON_PIO_SLEW_STANDARD | /* Standard mode, output slew rate control is enabled */
+      IOCON_PIO_INV_DI        | /* Input function is not inverted */
+      IOCON_PIO_DIGITAL_EN    | /* Enables digital function */
+      IOCON_PIO_OPENDRAIN_DI    /* Open drain is disabled */
+  );
+  /* PORT1 PIN18 (coords: 64) is configured as PIO1_18 */
+  IOCON_PinMuxSet(IOCON, 1U, 18U, port1_pin18_config);
+
+  gpio_pin_config_t const button_config = { kGPIO_DigitalInput, 0};
+  GPIO_PinInit(GPIO, BUTTON_PORT, BUTTON_PIN, &button_config);
+
+  // USB VBUS
+  const uint32_t port0_pin22_config = (
+      IOCON_PIO_FUNC7         | /* Pin is configured as USB0_VBUS */
+      IOCON_PIO_MODE_INACT    | /* No addition pin function */
+      IOCON_PIO_SLEW_STANDARD | /* Standard mode, output slew rate control is enabled */
+      IOCON_PIO_INV_DI        | /* Input function is not inverted */
+      IOCON_PIO_DIGITAL_EN    | /* Enables digital function */
+      IOCON_PIO_OPENDRAIN_DI    /* Open drain is disabled */
+  );
+  /* PORT0 PIN22 (coords: 78) is configured as USB0_VBUS */
+  IOCON_PinMuxSet(IOCON, 0U, 22U, port0_pin22_config);
+
+  // USB Controller
+  POWER_DisablePD(kPDRUNCFG_PD_USB0_PHY); /*Turn on USB0 Phy */
+  POWER_DisablePD(kPDRUNCFG_PD_USB1_PHY); /*< Turn on USB1 Phy */
+
+  /* reset the IP to make sure it's in reset state. */
+  RESET_PeripheralReset(kUSB0D_RST_SHIFT_RSTn);
+  RESET_PeripheralReset(kUSB0HSL_RST_SHIFT_RSTn);
+  RESET_PeripheralReset(kUSB0HMR_RST_SHIFT_RSTn);
+  RESET_PeripheralReset(kUSB1H_RST_SHIFT_RSTn);
+  RESET_PeripheralReset(kUSB1D_RST_SHIFT_RSTn);
+  RESET_PeripheralReset(kUSB1_RST_SHIFT_RSTn);
+  RESET_PeripheralReset(kUSB1RAM_RST_SHIFT_RSTn);
+
+#if (defined USB_DEVICE_CONFIG_LPCIP3511HS) && (USB_DEVICE_CONFIG_LPCIP3511HS)
+  CLOCK_EnableClock(kCLOCK_Usbh1);
+  /* Put PHY powerdown under software control */
+  *((uint32_t *)(USBHSH_BASE + 0x50)) = USBHSH_PORTMODE_SW_PDCOM_MASK;
+  /* According to reference mannual, device mode setting has to be set by access usb host register */
+  *((uint32_t *)(USBHSH_BASE + 0x50)) |= USBHSH_PORTMODE_DEV_ENABLE_MASK;
+  /* enable usb1 host clock */
+  CLOCK_DisableClock(kCLOCK_Usbh1);
+#endif
+
+#if 1 || (defined USB_DEVICE_CONFIG_LPCIP3511FS) && (USB_DEVICE_CONFIG_LPCIP3511FS)
+  CLOCK_SetClkDiv(kCLOCK_DivUsb0Clk, 1, false);
+  CLOCK_AttachClk(kFRO_HF_to_USB0_CLK);
+  /* enable usb0 host clock */
+  CLOCK_EnableClock(kCLOCK_Usbhsl0);
+  /*According to reference mannual, device mode setting has to be set by access usb host register */
+  *((uint32_t *)(USBFSH_BASE + 0x5C)) |= USBFSH_PORTMODE_DEV_ENABLE_MASK;
+  /* disable usb0 host clock */
+  CLOCK_DisableClock(kCLOCK_Usbhsl0);
+  CLOCK_EnableUsbfs0DeviceClock(kCLOCK_UsbfsSrcFro, CLOCK_GetFreq(kCLOCK_FroHf)); /* enable USB Device clock */
+#endif
+}
+
+//--------------------------------------------------------------------+
+// Board porting API
+//--------------------------------------------------------------------+
+
+void board_led_write(bool state)
+{
+  GPIO_PinWrite(GPIO, LED_PORT, LED_PIN, state ? LED_STATE_ON : (1-LED_STATE_ON));
+}
+
+uint32_t board_button_read(void)
+{
+  // active low
+  return BUTTON_STATE_ACTIVE == GPIO_PinRead(GPIO, BUTTON_PORT, BUTTON_PIN);
+}
+
+int board_uart_read(uint8_t* buf, int len)
+{
+  (void) buf; (void) len;
+  return 0;
+}
+
+int board_uart_write(void const * buf, int len)
+{
+  (void) buf; (void) len;
+  return 0;
+}
+
+#if CFG_TUSB_OS == OPT_OS_NONE
+volatile uint32_t system_ticks = 0;
+void SysTick_Handler(void)
+{
+  system_ticks++;
+}
+
+uint32_t board_millis(void)
+{
+  return system_ticks;
+}
+#endif


### PR DESCRIPTION
Adding Double M33 Express board to TinyUSB.
This includes a simple driver for the neopixels.
The linker script is offset for use with TinyUF2.