### PR TITLE
change default CFG_TUD_HID_EP_BUFSIZE from 16 to 64

### DIFF
--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef CFG_TUD_HID_EP_BUFSIZE
-  #define CFG_TUD_HID_EP_BUFSIZE     16
+  #define CFG_TUD_HID_EP_BUFSIZE     64
 #endif
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
report size is often 64 bytes, and user often overlook this macros. Change default to 64 to avoid buffer overflow. Application with smaller need (e.g keyboard/mouse) can change it to smaller value.

@dhalbert