### PR TITLE
walkround for samd21 setup_packet overflow

### DIFF
--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -39,11 +39,14 @@
 static TU_ATTR_ALIGNED(4) UsbDeviceDescBank sram_registers[8][2];
 
 // Setup packet is only 8 bytes in length. However under certain scenario,
-// SAMD21 USB DMA controller is "suspected" to overwrite/overflow the setup_packet with 2 extra bytes.
-// Which corrupt other variable and cause issue such as
-//    https://github.com/adafruit/circuitpython/issues/3912 (on macOS)
-// Therefore we increase it to 12 bytes as walk-around until figuring out the root cause
-static TU_ATTR_ALIGNED(4) uint8_t _setup_packet[8+4];
+// USB DMA controller may decide to overwrite/overflow the buffer  with
+// 2 extra bytes of CRC. From datasheet's "Management of SETUP Transactions" section
+//    If the number of received data bytes is the maximum data payload specified by
+//    PCKSIZE.SIZE minus one, only the first CRC data is written to the data buffer.
+//    If the number of received data is equal or less than the data payload specified
+//    by PCKSIZE.SIZE minus two, both CRC data bytes are written to the data buffer.
+// Therefore we will increase it to 10 bytes just to be safe
+static TU_ATTR_ALIGNED(4) uint8_t _setup_packet[8+2];
 
 // ready for receiving SETUP packet
 static inline void prepare_setup(void)

--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -45,7 +45,7 @@ static TU_ATTR_ALIGNED(4) UsbDeviceDescBank sram_registers[8][2];
 //    PCKSIZE.SIZE minus one, only the first CRC data is written to the data buffer.
 //    If the number of received data is equal or less than the data payload specified
 //    by PCKSIZE.SIZE minus two, both CRC data bytes are written to the data buffer.
-// Therefore we will increase it to 10 bytes just to be safe
+// Therefore we will need to increase it to 10 bytes here.
 static TU_ATTR_ALIGNED(4) uint8_t _setup_packet[8+2];
 
 // ready for receiving SETUP packet


### PR DESCRIPTION
**Describe the PR**
increase setup packet size from 8 to ~~12~~ 10, since USB DMA controller is suspected to overflow the buffer with 2 extra bytes for CRC (somehow I decide there is enough space for CRC). Issue is discovered while troubleshooting  https://github.com/adafruit/circuitpython/issues/3912 . This is considered a ~~walkaround/hack rather than~~ actual fix. ~~It may probably overflow more than 4 bytes in the future~~, currently ~~4~~ 2 bytes is too cheap for a fix considering the amount of work to trace it down so far. We may take a look at it later on if needed (like figuring out why USB DMA decide to do so).

@dhalbert 