### PR TITLE
Add support for Windows10 Command Prompt as a shell on GNU make.

### DIFF
--- a/examples/make.mk
+++ b/examples/make.mk
@@ -34,9 +34,14 @@ CXX = $(CROSS_COMPILE)g++
 OBJCOPY = $(CROSS_COMPILE)objcopy
 SIZE = $(CROSS_COMPILE)size
 MKDIR = mkdir
+ifeq ($(UNAME),Windows)
+CP = copy
+RM = del
+else
 SED = sed
 CP = cp
 RM = rm
+endif
 
 #-------------- Source files and compiler flags --------------
 

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -34,7 +34,7 @@ CXX = $(CROSS_COMPILE)g++
 OBJCOPY = $(CROSS_COMPILE)objcopy
 SIZE = $(CROSS_COMPILE)size
 MKDIR = mkdir
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 CP = copy
 RM = del
 else

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -81,7 +81,11 @@ uf2: $(BUILD)/$(BOARD)-firmware.uf2
 OBJ_DIRS = $(sort $(dir $(OBJ)))
 $(OBJ): | $(OBJ_DIRS)
 $(OBJ_DIRS):
+ifeq ($(UNAME),Windows)
+	@$(MKDIR) $(subst /,\,$@)
+else
 	@$(MKDIR) -p $@
+endif
 
 $(BUILD)/$(BOARD)-firmware.elf: $(OBJ)
 	@echo LINK $@
@@ -107,6 +111,7 @@ vpath %.c . $(TOP)
 $(BUILD)/obj/%.o: %.c
 	@echo CC $(notdir $@)
 	@$(CC) $(CFLAGS) -c -MD -o $@ $<
+ifneq ($(UNAME),Windows)
 	@# The following fixes the dependency file.
 	@# See http://make.paulandlesley.org/autodep.html for details.
 	@# Regex adjusted from the above to play better with Windows paths, etc.
@@ -114,6 +119,7 @@ $(BUILD)/obj/%.o: %.c
 	  $(SED) -e 's/#.*//' -e 's/^.*:  *//' -e 's/ *\\$$//' \
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:.o=.d) >> $(@:.o=.P); \
 	  $(RM) $(@:.o=.d)
+endif
 
 # ASM sources lower case .s
 vpath %.s . $(TOP)
@@ -134,7 +140,11 @@ size: $(BUILD)/$(BOARD)-firmware.elf
 
 .PHONY: clean
 clean:
+ifeq ($(UNAME),Windows)
+	rd /S /Q $(subst /,\,$(BUILD))
+else
 	$(RM) -rf $(BUILD)
+endif
 
 # Print out the value of a make variable.
 # https://stackoverflow.com/questions/16467718/how-to-print-out-a-variable-in-makefile

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -81,7 +81,7 @@ uf2: $(BUILD)/$(BOARD)-firmware.uf2
 OBJ_DIRS = $(sort $(dir $(OBJ)))
 $(OBJ): | $(OBJ_DIRS)
 $(OBJ_DIRS):
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 	@$(MKDIR) $(subst /,\,$@)
 else
 	@$(MKDIR) -p $@
@@ -111,15 +111,6 @@ vpath %.c . $(TOP)
 $(BUILD)/obj/%.o: %.c
 	@echo CC $(notdir $@)
 	@$(CC) $(CFLAGS) -c -MD -o $@ $<
-ifneq ($(UNAME),Windows)
-	@# The following fixes the dependency file.
-	@# See http://make.paulandlesley.org/autodep.html for details.
-	@# Regex adjusted from the above to play better with Windows paths, etc.
-	@$(CP) $(@:.o=.d) $(@:.o=.P); \
-	  $(SED) -e 's/#.*//' -e 's/^.*:  *//' -e 's/ *\\$$//' \
-	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:.o=.d) >> $(@:.o=.P); \
-	  $(RM) $(@:.o=.d)
-endif
 
 # ASM sources lower case .s
 vpath %.s . $(TOP)
@@ -140,7 +131,7 @@ size: $(BUILD)/$(BOARD)-firmware.elf
 
 .PHONY: clean
 clean:
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 	rd /S /Q $(subst /,\,$(BUILD))
 else
 	$(RM) -rf $(BUILD)

--- a/hw/bsp/adafruit_clue/board.mk
+++ b/hw/bsp/adafruit_clue/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/adafruit_clue/board.mk
+++ b/hw/bsp/adafruit_clue/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/arduino_nano33_ble/board.mk
+++ b/hw/bsp/arduino_nano33_ble/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/arduino_nano33_ble/board.mk
+++ b/hw/bsp/arduino_nano33_ble/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/circuitplayground_bluefruit/board.mk
+++ b/hw/bsp/circuitplayground_bluefruit/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/circuitplayground_bluefruit/board.mk
+++ b/hw/bsp/circuitplayground_bluefruit/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/da14695_dk_usb/board.mk
+++ b/hw/bsp/da14695_dk_usb/board.mk
@@ -21,7 +21,7 @@ SRC_C += \
 	$(MCU_FAMILY_DIR)/src/da1469x_clock.c \
 	$(MCU_FAMILY_DIR)/src/hal_gpio.c \
 
-SRC_S += $(TOP)/hw/bsp/$(BOARD)/gcc_startup_da1469x.S
+SRC_S += hw/bsp/$(BOARD)/gcc_startup_da1469x.S
 
 INC += \
 	$(TOP)/hw/bsp/$(BOARD) \

--- a/hw/bsp/da1469x_dk_pro/board.mk
+++ b/hw/bsp/da1469x_dk_pro/board.mk
@@ -21,7 +21,7 @@ SRC_C += \
 	$(MCU_FAMILY_DIR)/src/da1469x_clock.c \
 	$(MCU_FAMILY_DIR)/src/hal_gpio.c \
 
-SRC_S += $(TOP)/hw/bsp/$(BOARD)/gcc_startup_da1469x.S
+SRC_S += hw/bsp/$(BOARD)/gcc_startup_da1469x.S
 
 INC += \
 	$(TOP)/hw/bsp/$(BOARD) \

--- a/hw/bsp/double_m33_express/board.mk
+++ b/hw/bsp/double_m33_express/board.mk
@@ -26,7 +26,7 @@ SRC_C += \
 	$(MCU_DIR)/drivers/fsl_reset.c \
 	$(MCU_DIR)/drivers/fsl_usart.c \
 	$(MCU_DIR)/drivers/fsl_flexcomm.c \
-	$(TOP)/lib/sct_neopixel/sct_neopixel.c 
+	lib/sct_neopixel/sct_neopixel.c 
 
 INC += \
     $(TOP)/hw/bsp/ \

--- a/hw/bsp/feather_nrf52840_express/board.mk
+++ b/hw/bsp/feather_nrf52840_express/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/feather_nrf52840_express/board.mk
+++ b/hw/bsp/feather_nrf52840_express/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/feather_nrf52840_sense/board.mk
+++ b/hw/bsp/feather_nrf52840_sense/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/feather_nrf52840_sense/board.mk
+++ b/hw/bsp/feather_nrf52840_sense/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/itsybitsy_nrf52840/board.mk
+++ b/hw/bsp/itsybitsy_nrf52840/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/itsybitsy_nrf52840/board.mk
+++ b/hw/bsp/itsybitsy_nrf52840/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/nrf52840_mdk_dongle/board.mk
+++ b/hw/bsp/nrf52840_mdk_dongle/board.mk
@@ -13,8 +13,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/nrf52840_mdk_dongle/board.mk
+++ b/hw/bsp/nrf52840_mdk_dongle/board.mk
@@ -13,7 +13,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/pca10056/board.mk
+++ b/hw/bsp/pca10056/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/pca10056/board.mk
+++ b/hw/bsp/pca10056/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/pca10059/board.mk
+++ b/hw/bsp/pca10059/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/pca10059/board.mk
+++ b/hw/bsp/pca10059/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/pca10100/board.mk
+++ b/hw/bsp/pca10100/board.mk
@@ -14,7 +14,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/hw/bsp/pca10100/board.mk
+++ b/hw/bsp/pca10100/board.mk
@@ -14,8 +14,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/raytac_mdbt50q_rx/board.mk
+++ b/hw/bsp/raytac_mdbt50q_rx/board.mk
@@ -13,8 +13,14 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
+ifeq ($(UNAME),Windows)
+ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
+CFLAGS += -Wno-error=cast-function-type
+endif
+else
 ifeq ($(shell expr $(GCCVERSION) \>= 8), 1)
 CFLAGS += -Wno-error=cast-function-type
+endif
 endif
 
 # All source paths should be relative to the top level.

--- a/hw/bsp/raytac_mdbt50q_rx/board.mk
+++ b/hw/bsp/raytac_mdbt50q_rx/board.mk
@@ -13,7 +13,7 @@ CFLAGS += -Wno-error=undef -Wno-error=unused-parameter -Wno-error=cast-align
 
 # due to tusb_hal_nrf_power_event
 GCCVERSION = $(firstword $(subst ., ,$(shell arm-none-eabi-gcc -dumpversion)))
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 ifeq ($(shell if $(GCCVERSION) geq 8 echo 1), 1)
 CFLAGS += -Wno-error=cast-function-type
 endif

--- a/tools/top.mk
+++ b/tools/top.mk
@@ -2,10 +2,10 @@ ifneq ($(lastword a b),b)
 $(error This Makefile require make 3.81 or newer)
 endif
 
-# Detect windows or not
+# Detect whether shell style is windows or not
 # https://stackoverflow.com/questions/714100/os-detecting-makefile/52062069#52062069
 ifeq '$(findstring ;,$(PATH))' ';'
-UNAME := Windows
+CMDEXE := 1
 endif
 
 # Set TOP to be the path to get from the current directory (where make was
@@ -15,14 +15,14 @@ endif
 THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 TOP := $(patsubst %/tools/top.mk,%,$(THIS_MAKEFILE))
 
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 TOP := $(subst \,/,$(shell for %%i in ( $(TOP) ) do echo %%~fi))
 else
 TOP := $(shell realpath $(TOP))
 endif
 #$(info Top directory is $(TOP))
 
-ifeq ($(UNAME),Windows)
+ifeq ($(CMDEXE),1)
 CURRENT_PATH := $(subst $(TOP)/,,$(subst \,/,$(shell echo %CD%)))
 else
 CURRENT_PATH := $(shell realpath --relative-to=$(TOP) `pwd`)

--- a/tools/top.mk
+++ b/tools/top.mk
@@ -2,6 +2,12 @@ ifneq ($(lastword a b),b)
 $(error This Makefile require make 3.81 or newer)
 endif
 
+# Detect windows or not
+# https://stackoverflow.com/questions/714100/os-detecting-makefile/52062069#52062069
+ifeq '$(findstring ;,$(PATH))' ';'
+UNAME := Windows
+endif
+
 # Set TOP to be the path to get from the current directory (where make was
 # invoked) to the top of the tree. $(lastword $(MAKEFILE_LIST)) returns
 # the name of this makefile relative to where make was invoked.
@@ -9,9 +15,16 @@ endif
 THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 TOP := $(patsubst %/tools/top.mk,%,$(THIS_MAKEFILE))
 
+ifeq ($(UNAME),Windows)
+TOP := $(subst \,/,$(shell for %%i in ( $(TOP) ) do echo %%~fi))
+else
 TOP := $(shell realpath $(TOP))
-
+endif
 #$(info Top directory is $(TOP))
 
+ifeq ($(UNAME),Windows)
+CURRENT_PATH := $(subst $(TOP)/,,$(subst \,/,$(shell echo %CD%)))
+else
 CURRENT_PATH := $(shell realpath --relative-to=$(TOP) `pwd`)
+endif
 #$(info Path from top is $(CURRENT_PATH))


### PR DESCRIPTION
**Describe the PR**
Add support for `Windows10 Command Prompt` as a shell on GNU make.

**Additional context**
This patch has been checked for build with the following tools. I'm sorry, but I haven't checked for esp32s2.
- [GNU make of chocolatey](https://chocolatey.org/packages/make)
- [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) for windows
- [MSP430-GCC-OPENSOURCE](https://www.ti.com/tool/download/MSP430-GCC-OPENSOURCE)
- [GNU RISC-V Embedded GCC](https://xpack.github.io/riscv-none-embed-gcc/install/)

I skipped the rule that `.d` files are converted to `.P` files when run at the Windows Command Prompt. Because `.P` files are not included any makefiles, I think this rule could be skip.
