### PR TITLE
start the assimilation of Pi Pico into TU  

### DIFF
--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -444,6 +444,7 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * 
     
     // Get appropriate ep. Either EPX or interrupt endpoint
     struct hw_endpoint *ep = get_dev_ep(dev_addr, ep_addr);
+    assert(ep);
 
     if (ep_addr != ep->ep_addr)
     {

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -86,7 +86,7 @@ static void set_dev_ep(uint8_t dev_addr, uint8_t ep_addr, struct hw_endpoint *ep
     uint8_t num = tu_edpt_number(ep_addr);
     uint8_t in = (ep_addr & TUSB_DIR_IN_MASK) ? 1 : 0;
     uint32_t index = ep - eps;
-    hard_assert(index < count_of(eps));
+    hard_assert(index < TU_ARRAY_SIZE(eps));
     // todo revisit why dev_addr can be 0 here
     if (dev_addr) {
         dev_ep_map[dev_addr-1][num][in] = 128u | index;
@@ -245,7 +245,7 @@ static void hcd_rp2040_irq(void)
 static struct hw_endpoint *_next_free_interrupt_ep(void)
 {
     struct hw_endpoint *ep = NULL;
-    for (uint i = 1; i < count_of(eps); i++)
+    for (uint i = 1; i < TU_ARRAY_SIZE(eps); i++)
     {
         ep = &eps[i];
         if (!ep->configured)


### PR DESCRIPTION
hcd_edpt_xfer() calls get_dev_ep(), which may return NULL, and then unconditionally uses the return pointer.  "assert" is used elsewhere in the rp2040 driver code and its use seems warranted here too.

Including "pico/stdlib.h" seems superfluous; there appear to be no issues with its removal.

By convention, TU drivers should implement the dcd_int_handler() API.  Ensuring its presence allows users to let a fixed interrupt handler call the driver code.

Interloper macros were substituted with native TU macros like TU_MIN and TU_ARRAY_SIZE.
