### PR TITLE
Rp2040 followup2

### DIFF
--- a/examples/device/board_test/src/main.c
+++ b/examples/device/board_test/src/main.c
@@ -55,10 +55,6 @@ int main(void)
   {
     uint32_t interval_ms = board_button_read() ? BLINK_PRESSED : BLINK_UNPRESSED;
 
-    // uart echo
-//    uint8_t ch;
-//    if ( board_uart_read(&ch, 1) ) board_uart_write(&ch, 1);
-
     // Blink every interval ms
     if ( !(board_millis() - start_ms < interval_ms) )
     {

--- a/hw/bsp/rp2040/boards/adafruit_feather_rp2040/board.h
+++ b/hw/bsp/rp2040/boards/adafruit_feather_rp2040/board.h
@@ -35,9 +35,12 @@
 #define LED_STATE_ON          1
 
 // Button pin is BOOTSEL which is flash CS pin
-
 #define BUTTON_BOOTSEL
 #define BUTTON_STATE_ACTIVE   0
+
+#define UART_DEV              uart0
+#define UART_TX_PIN           0
+#define UART_RX_PIN           1
 
 #ifdef __cplusplus
  }

--- a/hw/bsp/rp2040/boards/adafruit_itsybitsy_rp2040/board.h
+++ b/hw/bsp/rp2040/boards/adafruit_itsybitsy_rp2040/board.h
@@ -35,9 +35,12 @@
 #define LED_STATE_ON          1
 
 // Button pin is BOOTSEL which is flash CS pin
-
 #define BUTTON_BOOTSEL
 #define BUTTON_STATE_ACTIVE   0
+
+#define UART_DEV              uart0
+#define UART_TX_PIN           0
+#define UART_RX_PIN           1
 
 #ifdef __cplusplus
  }

--- a/hw/bsp/rp2040/boards/adafruit_qt_rp2040/board.h
+++ b/hw/bsp/rp2040/boards/adafruit_qt_rp2040/board.h
@@ -36,9 +36,13 @@
 #define LED_STATE_ON          1
 
 // Button pin is BOOTSEL which is flash CS pin
-
 #define BUTTON_BOOTSEL
 #define BUTTON_STATE_ACTIVE   0
+
+
+#define UART_DEV              uart0
+#define UART_TX_PIN           0
+#define UART_RX_PIN           1
 
 #ifdef __cplusplus
  }

--- a/hw/bsp/rp2040/boards/raspberry_pi_pico/board.h
+++ b/hw/bsp/rp2040/boards/raspberry_pi_pico/board.h
@@ -35,9 +35,12 @@
 #define LED_STATE_ON          1
 
 // Button pin is BOOTSEL which is flash CS pin
-
 #define BUTTON_BOOTSEL
 #define BUTTON_STATE_ACTIVE   0
+
+#define UART_DEV              uart0
+#define UART_TX_PIN           0
+#define UART_RX_PIN           1
 
 #ifdef __cplusplus
  }

--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -78,12 +78,17 @@ bool __no_inline_not_in_flash_func(get_bootsel_button)() {
 
 void board_init(void)
 {
-  setup_default_uart();
   gpio_init(LED_PIN);
   gpio_set_dir(LED_PIN, GPIO_OUT);
 
   // Button
 #ifndef BUTTON_BOOTSEL
+#endif
+
+#ifdef UART_DEV
+  uart_init(UART_DEV, CFG_BOARD_UART_BAUDRATE);
+  gpio_set_function(UART_TX_PIN, GPIO_FUNC_UART);
+  gpio_set_function(UART_RX_PIN, GPIO_FUNC_UART);
 #endif
 
   // todo probably set up device mode?
@@ -116,18 +121,27 @@ uint32_t board_button_read(void)
 
 int board_uart_read(uint8_t* buf, int len)
 {
+#ifdef UART_DEV
   for(int i=0;i<len;i++) {
-    buf[i] = uart_getc(uart_default);
+    buf[i] = uart_getc(UART_DEV);
   }
+  return len;
+#else
   return 0;
+#endif
 }
 
 int board_uart_write(void const * buf, int len)
 {
+#ifdef UART_DEV
+  char const* bufch = (uint8_t const*) buf;
   for(int i=0;i<len;i++) {
-    uart_putc(uart_default, ((char *)buf)[i]);
+    uart_putc(UART_DEV, bufch[i]);
   }
+  return len;
+#else
   return 0;
+#endif
 }
 
 //--------------------------------------------------------------------+

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -48,7 +48,6 @@
 #define usb_hw_clear hw_clear_alias(usb_hw)
 
 // Init these in dcd_init
-static uint8_t assigned_address;
 static uint8_t *next_buffer_ptr;
 
 // Endpoints 0-15, direction 0 for out and 1 for in.
@@ -319,8 +318,7 @@ static void dcd_rp2040_irq(void)
     if (status & USB_INTS_BUS_RESET_BITS)
     {
         pico_trace("BUS RESET (addr %d -> %d)\n", assigned_address, 0);
-        assigned_address = 0;
-        usb_hw->dev_addr_ctrl = assigned_address;
+        usb_hw->dev_addr_ctrl = 0;
         handled |= USB_INTS_BUS_RESET_BITS;
         dcd_event_bus_signal(0, DCD_EVENT_BUS_RESET, true);
         usb_hw_clear->sie_status = USB_SIE_STATUS_BUS_RESET_BITS;
@@ -355,7 +353,6 @@ void dcd_init (uint8_t rhport)
 
     irq_set_exclusive_handler(USBCTRL_IRQ, dcd_rp2040_irq);
     memset(hw_endpoints, 0, sizeof(hw_endpoints));
-    assigned_address = 0;
     next_buffer_ptr = &usb_dpram->epx_data[0];
 
     // EP0 always exists so init it now
@@ -394,14 +391,12 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
     assert(rhport == 0);
 
     // Can't set device address in hardware until status xfer has complete
-    assigned_address = dev_addr;
-
     ep0_0len_status();
 }
 
 void dcd_remote_wakeup(uint8_t rhport)
 {
-    panic("dcd_remote_wakeup %d\n", rhport);
+    pico_info("dcd_remote_wakeup %d is not supported yet\n", rhport);
     assert(rhport == 0);
 }
 
@@ -435,7 +430,7 @@ void dcd_edpt0_status_complete(uint8_t rhport, tusb_control_request_t const * re
         request->bRequest == TUSB_REQ_SET_ADDRESS)
     {
         pico_trace("Set HW address %d\n", assigned_address);
-        usb_hw->dev_addr_ctrl = assigned_address;
+        usb_hw->dev_addr_ctrl = (uint8_t) request->wValue;
     }
 
     reset_ep0();

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -24,10 +24,13 @@
  * This file is part of the TinyUSB stack.
  */
 
+#include "tusb_option.h"
+
+#if CFG_TUSB_MCU == OPT_MCU_RP2040
+
 #include <stdlib.h>
 #include "rp2040_usb.h"
 #include "hardware/clocks.h"
-#include "tusb_option.h"
 
 // Direction strings for debug
 const char *ep_dir_string[] = {
@@ -277,3 +280,4 @@ void _hw_endpoint_xfer(struct hw_endpoint *ep, uint8_t *buffer, uint16_t total_l
     }
 }
 
+#endif

--- a/tools/build_family.py
+++ b/tools/build_family.py
@@ -49,6 +49,7 @@ def build_family(example, family):
     for entry in os.scandir("hw/bsp/{}/boards".format(family)):
         if entry.is_dir():
             all_boards.append(entry.name)
+    filter_with_input(all_boards)
     all_boards.sort()
     
     for board in all_boards:
@@ -83,7 +84,7 @@ def build_board(example, board):
         print(build_format.format(example, board, success, "{:.2f}s".format(build_duration), flash_size, sram_size))
 
         if build_result.returncode != 0:
-            print(build_result.stdout.decode("utf-8"))            
+            print(build_result.stdout.decode("utf-8"))
 
 def build_size(example, board):
     #elf_file = 'examples/device/{}/_build/{}/{}-firmware.elf'.format(example, board, board)


### PR DESCRIPTION
**Describe the PR**
Follow up to update the dcd port of rp2040 as mentioned in the feedback issue
- removed the `assigned_address` in dcd, which can be extracted from request
- change panic in dcd_remote_wakeup to pico_info() with not supported yet message.
- wrap **rp2040_usb.c** around `CFG_TUSB_MCU == OPT_MCU_RP2040` since some auto build system such as arduino will include all the C file which cause compile error on other port (due to lack of pico-sdk etc ..) 
- dcd_int_handler() wrapper is already done as part of PR #601, please check it out as well.

Note: There is also BSP modification piggy-packed as well, you could just ignore it and pay attention to `dcd_rp2040.c` and `rp2040_usb.c`. You could also test out the uploaded artifacts in ci build without the need to compile the example namely `rp2040-tinyusb-examples`.  https://github.com/hathach/tinyusb/actions/runs/515064202