### PR TITLE
Fix midi sysex sending bug

### DIFF
--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -192,6 +192,7 @@ uint32_t tud_midi_n_write(uint8_t itf, uint8_t jack_id, uint8_t const* buffer, u
         if (midi->write_buffer[0] == 0x4) {
             if (data == 0xf7) {
                 midi->write_buffer[0] = 0x5;
+                midi->write_target_length = 2;
             } else {
                 midi->write_target_length = 4;
             }


### PR DESCRIPTION
Fixes write buffer corruption when sending certain lengths of sysex.

All the paths in this section should set write_target_length, but this one did not.