### PR TITLE
fix #558

### DIFF
--- a/examples/device/usbtmc/src/usb_descriptors.c
+++ b/examples/device/usbtmc/src/usb_descriptors.c
@@ -80,8 +80,8 @@ uint8_t const * tud_descriptor_device_cb(void)
      TUD_USBTMC_BULK_DESCRIPTORS(/* OUT = */0x01, /* IN = */ 0x81, /* packet size = */USBTMCD_MAX_PACKET_SIZE)
 
 #if CFG_TUD_USBTMC_ENABLE_INT_EP
-// USBTMC Interrupt xfer always has length of 2, but we use epMaxSize=8 here for compatibility
-// with microcontrollers that only allow 8, 16, 32 or 64 for FS endpoints
+// USBTMC Interrupt xfer always has length of 2, but we use epMaxSize=8 for
+//  compatibility with mcus that only allow 8, 16, 32 or 64 for FS endpoints
 #  define TUD_USBTMC_DESC(_itfnum) \
      TUD_USBTMC_DESC_MAIN(_itfnum, /* _epCount = */ 3), \
      TUD_USBTMC_INT_DESCRIPTOR(/* INT ep # */ 0x82, /* epMaxSize = */ 8, /* bInterval = */16u )

--- a/examples/device/usbtmc/src/usb_descriptors.c
+++ b/examples/device/usbtmc/src/usb_descriptors.c
@@ -80,10 +80,10 @@ uint8_t const * tud_descriptor_device_cb(void)
      TUD_USBTMC_BULK_DESCRIPTORS(/* OUT = */0x01, /* IN = */ 0x81, /* packet size = */USBTMCD_MAX_PACKET_SIZE)
 
 #if CFG_TUD_USBTMC_ENABLE_INT_EP
-// Interrupt endpoint should be 2 bytes on a FS USB link
+// Interrupt endpoint should be 2 bytes on a FS USB link, but some microcontrollers only allow 8, 16, 32 or 64 for FS
 #  define TUD_USBTMC_DESC(_itfnum) \
      TUD_USBTMC_DESC_MAIN(_itfnum, /* _epCount = */ 3), \
-     TUD_USBTMC_INT_DESCRIPTOR(/* INT ep # */ 0x82, /* epMaxSize = */ 2, /* bInterval = */16u )
+     TUD_USBTMC_INT_DESCRIPTOR(/* INT ep # */ 0x82, /* epMaxSize = */ 8, /* bInterval = */16u )
 #  define TUD_USBTMC_DESC_LEN (TUD_USBTMC_IF_DESCRIPTOR_LEN + TUD_USBTMC_BULK_DESCRIPTORS_LEN + TUD_USBTMC_INT_DESCRIPTOR_LEN)
 
 #else

--- a/examples/device/usbtmc/src/usb_descriptors.c
+++ b/examples/device/usbtmc/src/usb_descriptors.c
@@ -80,7 +80,8 @@ uint8_t const * tud_descriptor_device_cb(void)
      TUD_USBTMC_BULK_DESCRIPTORS(/* OUT = */0x01, /* IN = */ 0x81, /* packet size = */USBTMCD_MAX_PACKET_SIZE)
 
 #if CFG_TUD_USBTMC_ENABLE_INT_EP
-// Interrupt endpoint should be 2 bytes on a FS USB link, but some microcontrollers only allow 8, 16, 32 or 64 for FS
+// USBTMC Interrupt xfer always has length of 2, but we use epMaxSize=8 here for compatibility
+// with microcontrollers that only allow 8, 16, 32 or 64 for FS endpoints
 #  define TUD_USBTMC_DESC(_itfnum) \
      TUD_USBTMC_DESC_MAIN(_itfnum, /* _epCount = */ 3), \
      TUD_USBTMC_INT_DESCRIPTOR(/* INT ep # */ 0x82, /* epMaxSize = */ 8, /* bInterval = */16u )


### PR DESCRIPTION
fix #558
This is needed for SAMD21 and SAMD51 as Full-Speed endpoint max bytes is specified as 8, 16, 32 and 64.
This is for the USBTMC device example.

This change was verified on SAMD21 (seeeduino xiao, adafruit trinket m0), SAMD51 (adafruit itsybitsy m4) and STM32F411CE blackpill (weact 2.0).
