### PR TITLE
specify ruby version for unit test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Setup Ruby
       uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
 
     - name: Checkout TinyUSB
       uses: actions/checkout@v2

--- a/test/test/device/usbd/test_usbd.c
+++ b/test/test/device/usbd/test_usbd.c
@@ -209,10 +209,10 @@ void test_usbd_control_in_zlp(void)
 {
   // 128 byte total len, with EP0 size = 64, and request length = 256
   // ZLP must be return
-  uint8_t zlp_desc_configuration[CFG_TUD_ENDOINT0_SIZE*2] =
+  uint8_t zlp_desc_configuration[CFG_TUD_ENDPOINT0_SIZE*2] =
   {
     // Config number, interface count, string index, total length, attribute, power in mA
-    TUD_CONFIG_DESCRIPTOR(1, 0, 0, CFG_TUD_ENDOINT0_SIZE*2, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CONFIG_DESCRIPTOR(1, 0, 0, CFG_TUD_ENDPOINT0_SIZE*2, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
   };
 
   desc_configuration = zlp_desc_configuration;
@@ -222,13 +222,13 @@ void test_usbd_control_in_zlp(void)
 
   // 1st transaction
   dcd_edpt_xfer_ExpectWithArrayAndReturn(rhport, EDPT_CTRL_IN,
-                                         zlp_desc_configuration, CFG_TUD_ENDOINT0_SIZE, CFG_TUD_ENDOINT0_SIZE, true);
-  dcd_event_xfer_complete(rhport, EDPT_CTRL_IN, CFG_TUD_ENDOINT0_SIZE, 0, false);
+                                         zlp_desc_configuration, CFG_TUD_ENDPOINT0_SIZE, CFG_TUD_ENDPOINT0_SIZE, true);
+  dcd_event_xfer_complete(rhport, EDPT_CTRL_IN, CFG_TUD_ENDPOINT0_SIZE, 0, false);
 
   // 2nd transaction
   dcd_edpt_xfer_ExpectWithArrayAndReturn(rhport, EDPT_CTRL_IN,
-                                         zlp_desc_configuration + CFG_TUD_ENDOINT0_SIZE, CFG_TUD_ENDOINT0_SIZE, CFG_TUD_ENDOINT0_SIZE, true);
-  dcd_event_xfer_complete(rhport, EDPT_CTRL_IN, CFG_TUD_ENDOINT0_SIZE, 0, false);
+                                         zlp_desc_configuration + CFG_TUD_ENDPOINT0_SIZE, CFG_TUD_ENDPOINT0_SIZE, CFG_TUD_ENDPOINT0_SIZE, true);
+  dcd_event_xfer_complete(rhport, EDPT_CTRL_IN, CFG_TUD_ENDPOINT0_SIZE, 0, false);
 
   // Expect Zero length Packet
   dcd_edpt_xfer_ExpectAndReturn(rhport, EDPT_CTRL_IN, NULL, 0, true);

--- a/test/test/support/tusb_config.h
+++ b/test/test/support/tusb_config.h
@@ -74,7 +74,7 @@
 //--------------------------------------------------------------------
 
 #define CFG_TUD_TASK_QUEUE_SZ    100
-#define CFG_TUD_ENDOINT0_SIZE    64
+#define CFG_TUD_ENDPOINT0_SIZE    64
 
 //------------- CLASS -------------//
 //#define CFG_TUD_CDC              0


### PR DESCRIPTION
**Describe the PR**
Ruby v3 seems to break the current unit test, specify version 2.7.
Also fix #614 typo
