### PR TITLE
Rp2040 logger and enum fix

### DIFF
--- a/examples/device/audio_test/CMakeLists.txt
+++ b/examples/device/audio_test/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/board_test/CMakeLists.txt
+++ b/examples/device/board_test/CMakeLists.txt
@@ -37,7 +37,7 @@ elseif(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/cdc_dual_ports/CMakeLists.txt
+++ b/examples/device/cdc_dual_ports/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/cdc_msc/CMakeLists.txt
+++ b/examples/device/cdc_msc/CMakeLists.txt
@@ -39,7 +39,7 @@ elseif(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/dfu_rt/CMakeLists.txt
+++ b/examples/device/dfu_rt/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/dynamic_configuration/CMakeLists.txt
+++ b/examples/device/dynamic_configuration/CMakeLists.txt
@@ -34,7 +34,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/hid_composite/CMakeLists.txt
+++ b/examples/device/hid_composite/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/hid_generic_inout/CMakeLists.txt
+++ b/examples/device/hid_generic_inout/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/hid_multiple_interface/CMakeLists.txt
+++ b/examples/device/hid_multiple_interface/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/midi_test/CMakeLists.txt
+++ b/examples/device/midi_test/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/msc_dual_lun/CMakeLists.txt
+++ b/examples/device/msc_dual_lun/CMakeLists.txt
@@ -34,7 +34,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/net_lwip_webserver/CMakeLists.txt
+++ b/examples/device/net_lwip_webserver/CMakeLists.txt
@@ -80,7 +80,7 @@ if(FAMILY STREQUAL "rp2040")
     HTTPD_USE_CUSTOM_FSDATA=0
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/uac2_headset/CMakeLists.txt
+++ b/examples/device/uac2_headset/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/usbtmc/CMakeLists.txt
+++ b/examples/device/usbtmc/CMakeLists.txt
@@ -34,7 +34,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/device/webusb_serial/CMakeLists.txt
+++ b/examples/device/webusb_serial/CMakeLists.txt
@@ -33,7 +33,7 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib)
+  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
   pico_add_extra_outputs(${PROJECT})
 
 else()

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -112,13 +112,18 @@ endif
 
 # Log level is mapped to TUSB DEBUG option
 ifneq ($(LOG),)
+  CMAKE_DEFSYM +=	-DLOG=$(LOG)
   CFLAGS += -DCFG_TUSB_DEBUG=$(LOG)
 endif
 
 # Logger: default is uart, can be set to rtt or swo
+ifneq ($(LOGGER),)
+	CMAKE_DEFSYM +=	-DLOGGER=$(LOGGER)
+endif
+
 ifeq ($(LOGGER),rtt)
-  RTT_SRC = lib/SEGGER_RTT
   CFLAGS += -DLOGGER_RTT -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+  RTT_SRC = lib/SEGGER_RTT
   INC   += $(TOP)/$(RTT_SRC)/RTT
   SRC_C += $(RTT_SRC)/RTT/SEGGER_RTT.c
 else ifeq ($(LOGGER),swo)

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -11,30 +11,30 @@ ifeq ($(FAMILY),esp32s2)
 .PHONY: all clean flash
 
 all:
-	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) build
+	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) $(CMAKE_DEFSYM) build
 
 build: all
 
 clean:
-	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) clean
+	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) $(CMAKE_DEFSYM) clean
 
 fullclean:
-	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) fullclean
+	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) $(CMAKE_DEFSYM) fullclean
 
 flash:
-	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) flash
+	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) $(CMAKE_DEFSYM) flash
 
 bootloader-flash:
-	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) bootloader-flash
+	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) $(CMAKE_DEFSYM) bootloader-flash
 
 app-flash:
-	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) app-flash
+	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) $(CMAKE_DEFSYM) app-flash
 
 erase:
-	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) erase_flash
+	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) $(CMAKE_DEFSYM) erase_flash
 
 monitor:
-	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) monitor
+	idf.py -B$(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) $(CMAKE_DEFSYM) monitor
 
 UF2_FAMILY_ID = 0xbfdd4eee
 $(BUILD)/$(PROJECT).uf2: $(BUILD)/$(PROJECT).hex
@@ -43,12 +43,17 @@ $(BUILD)/$(PROJECT).uf2: $(BUILD)/$(PROJECT).hex
 
 else ifeq ($(FAMILY),rp2040)
 
-all:
-	[ -d $(BUILD) ] || cmake -S . -B $(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) -DPICO_BUILD_DOCS=0
+$(BUILD):
+	cmake -S . -B $(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) -DPICO_BUILD_DOCS=0 $(CMAKE_DEFSYM)
+
+all: $(BUILD)
 	$(MAKE) -C $(BUILD)
 
 clean:
 	$(RM) -rf $(BUILD)
+
+flash:
+	@$(CP) $(BUILD)/$(PROJECT).uf2 /media/$(USER)/RPI-RP2
 
 else
 # GNU Make build system

--- a/hw/bsp/rp2040/family.cmake
+++ b/hw/bsp/rp2040/family.cmake
@@ -30,6 +30,7 @@ target_include_directories(${PROJECT} PUBLIC
 
 target_compile_definitions(${PROJECT} PUBLIC
   CFG_TUSB_MCU=OPT_MCU_RP2040
+  PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1
 )
 
 if(DEFINED LOG)

--- a/hw/bsp/rp2040/family.cmake
+++ b/hw/bsp/rp2040/family.cmake
@@ -31,3 +31,26 @@ target_include_directories(${PROJECT} PUBLIC
 target_compile_definitions(${PROJECT} PUBLIC
   CFG_TUSB_MCU=OPT_MCU_RP2040
 )
+
+if(DEFINED LOG)
+  target_compile_definitions(${PROJECT} PUBLIC CFG_TUSB_DEBUG=${LOG} )
+  pico_enable_stdio_uart(${PROJECT} 1)
+endif()
+
+if(LOGGER STREQUAL "rtt")
+  pico_enable_stdio_uart(${PROJECT} 0)
+
+  target_compile_definitions(${PROJECT} PUBLIC
+    LOGGER_RTT
+    SEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+  )
+
+  target_sources(${PROJECT} PUBLIC
+    ${TOP}/lib/SEGGER_RTT/RTT/SEGGER_RTT.c
+  )
+
+  target_include_directories(${PROJECT} PUBLIC
+    ${TOP}/lib/SEGGER_RTT/RTT
+  )
+endif()
+


### PR DESCRIPTION
**Describe the PR**
- Add `LOG=` forward from make to cmake
- also pre-add support for segger rtt (not tested since jlink rp2040 not supported yet)
- Add PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1 and target linke pico_fix_rp2040_usb_device_enumeration for all examples
