### PR TITLE
Fixes RP2040 buffer reallocation overrun problem

### DIFF
--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -166,9 +166,10 @@ static void _hw_endpoint_init(struct hw_endpoint *ep, uint8_t ep_addr, uint wMax
 
         // Now if it hasn't already been done
         //alloc a buffer and fill in endpoint control register
-        if( !(ep->configured)){
-        _hw_endpoint_alloc(ep);
-    }
+        if( !(ep->configured))
+        {
+            _hw_endpoint_alloc(ep);
+        }
     }
 
     ep->configured = true;

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -166,7 +166,7 @@ static void _hw_endpoint_init(struct hw_endpoint *ep, uint8_t ep_addr, uint wMax
 
         // Now if it hasn't already been done
         //alloc a buffer and fill in endpoint control register
-        if( !(ep->configured))
+        if(!(ep->configured))
         {
             _hw_endpoint_alloc(ep);
         }

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -164,8 +164,11 @@ static void _hw_endpoint_init(struct hw_endpoint *ep, uint8_t ep_addr, uint wMax
             ep->endpoint_control = &usb_dpram->ep_ctrl[num-1].out;
         }
 
-        // Now alloc a buffer and fill in endpoint control register
+        // Now if it hasn't already been done
+        //alloc a buffer and fill in endpoint control register
+        if( !(ep->configured)){
         _hw_endpoint_alloc(ep);
+    }
     }
 
     ep->configured = true;


### PR DESCRIPTION
**Describe the PR**
This is a simple fix for the rp2040 device that prevents drives that open and close an ep (ie. audio device) from reallocating the buffer in the DPRAM and running out of space and failing the assert.

This should close:
#628 
raspberrypi/pico-sdk/issues/85

**Additional context**
If applicable, add any other context about the PR and/or screenshots here.
