### PR TITLE
Set -DCMAKE_BUILD_TYPE=Debug when building in debug for rp2040.

### DIFF
--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -45,6 +45,10 @@ $(BUILD)/$(PROJECT).uf2: $(BUILD)/$(PROJECT).bin
 
 else ifeq ($(FAMILY),rp2040)
 
+ifeq ($(DEBUG), 1)
+CMAKE_DEFSYM += -DCMAKE_BUILD_TYPE=Debug
+endif
+
 $(BUILD):
 	cmake -S . -B $(BUILD) -DFAMILY=$(FAMILY) -DBOARD=$(BOARD) -DPICO_BUILD_DOCS=0 $(CMAKE_DEFSYM)
 


### PR DESCRIPTION
This ensures that the Pico SDK, too, is built in debug mode and with nice debugging symbols. (Otherwise, it's built by default in Release mode.)

I guess that `rules.mk` is not the most elegant place to plop this conditional... I'd love any suggestions for a better way to do it. :-)