### PR TITLE
Fix unintended control transfers in webserial example.

### DIFF
--- a/examples/device/webusb_serial/src/main.c
+++ b/examples/device/webusb_serial/src/main.c
@@ -151,52 +151,47 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
   // nothing to with DATA & ACK stage
   if (stage != CONTROL_STAGE_SETUP ) return true;
 
-  switch (request->bRequest)
-  {
-    case VENDOR_REQUEST_WEBUSB:
-      // match vendor request in BOS descriptor
-      // Get landing page url
-      return tud_control_xfer(rhport, request, (void*) &desc_url, desc_url.bLength);
+  if (request->bmRequestType_bit.type == TUSB_REQ_TYPE_VENDOR) {
+    switch (request->bRequest) {
+      case VENDOR_REQUEST_WEBUSB:
+        // match vendor request in BOS descriptor
+        // Get landing page url
+        return tud_control_xfer(rhport, request, (void*) &desc_url, desc_url.bLength);
 
-    case VENDOR_REQUEST_MICROSOFT:
-      if ( request->wIndex == 7 )
-      {
-        // Get Microsoft OS 2.0 compatible descriptor
-        uint16_t total_len;
-        memcpy(&total_len, desc_ms_os_20+8, 2);
+      case VENDOR_REQUEST_MICROSOFT:
+        if ( request->wIndex == 7 ) {
+          // Get Microsoft OS 2.0 compatible descriptor
+          uint16_t total_len;
+          memcpy(&total_len, desc_ms_os_20+8, 2);
 
-        return tud_control_xfer(rhport, request, (void*) desc_ms_os_20, total_len);
-      }else
-      {
-        return false;
-      }
+          return tud_control_xfer(rhport, request, (void*) desc_ms_os_20, total_len);
+        } else {
+          return false;
+        }
+    }
+  } else if (
+        request->bmRequestType_bit.type == TUSB_REQ_TYPE_CLASS &&
+        request->bRequest == 0x22) {
+    // Webserial simulate the CDC_REQUEST_SET_CONTROL_LINE_STATE (0x22) to
+    // connect and disconnect.
+    web_serial_connected = (request->wValue != 0);
 
-    case 0x22:
-      // Webserial simulate the CDC_REQUEST_SET_CONTROL_LINE_STATE (0x22) to
-      // connect and disconnect.
-      web_serial_connected = (request->wValue != 0);
+    // Always lit LED if connected
+    if ( web_serial_connected ) {
+      board_led_write(true);
+      blink_interval_ms = BLINK_ALWAYS_ON;
 
-      // Always lit LED if connected
-      if ( web_serial_connected )
-      {
-        board_led_write(true);
-        blink_interval_ms = BLINK_ALWAYS_ON;
+      tud_vendor_write_str("\r\nTinyUSB WebUSB device example\r\n");
+    } else {
+      blink_interval_ms = BLINK_MOUNTED;
+    }
 
-        tud_vendor_write_str("\r\nTinyUSB WebUSB device example\r\n");
-      }else
-      {
-        blink_interval_ms = BLINK_MOUNTED;
-      }
-
-      // response with status OK
-      return tud_control_status(rhport, request);
-
-    default:
-      // stall unknown request
-      return false;
+    // response with status OK
+    return tud_control_status(rhport, request);
   }
 
-  return true;
+  // stall unknown request
+  return false;
 }
 
 void webserial_task(void)

--- a/examples/device/webusb_serial/src/main.c
+++ b/examples/device/webusb_serial/src/main.c
@@ -152,22 +152,28 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
   if (stage != CONTROL_STAGE_SETUP ) return true;
 
   if (request->bmRequestType_bit.type == TUSB_REQ_TYPE_VENDOR) {
-    switch (request->bRequest) {
+    switch (request->bRequest)
+    {
       case VENDOR_REQUEST_WEBUSB:
         // match vendor request in BOS descriptor
         // Get landing page url
         return tud_control_xfer(rhport, request, (void*) &desc_url, desc_url.bLength);
 
       case VENDOR_REQUEST_MICROSOFT:
-        if ( request->wIndex == 7 ) {
+        if ( request->wIndex == 7 )
+        {
           // Get Microsoft OS 2.0 compatible descriptor
           uint16_t total_len;
           memcpy(&total_len, desc_ms_os_20+8, 2);
 
           return tud_control_xfer(rhport, request, (void*) desc_ms_os_20, total_len);
-        } else {
+        }else
+        {
           return false;
         }
+
+      default:
+        return false;
     }
   } else if (
         request->bmRequestType_bit.type == TUSB_REQ_TYPE_CLASS &&
@@ -182,7 +188,8 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
       blink_interval_ms = BLINK_ALWAYS_ON;
 
       tud_vendor_write_str("\r\nTinyUSB WebUSB device example\r\n");
-    } else {
+    }else
+    {
       blink_interval_ms = BLINK_MOUNTED;
     }
 


### PR DESCRIPTION
As discussed in https://github.com/hathach/tinyusb/issues/609,

The problem is that when receiving a "standard" CLEAR_FEATURE request, usbd.c calls into the _class_ driver:
https://github.com/hathach/tinyusb/blob/a96ee8f1d850bbd645040e0f5d133e6c1c93a3a4/src/device/usbd.c#L757. (The comment there says that the class *must not* call tud_control_status.)

Unfortunately the "class driver", i.e. the webusb example's main function, intereprets this as a "class" request with bRequest==1 (i.e. VENDOR_REQUEST_WEBUSB), rather than as a "endpoint" request with bRequest==CLEAR_FEATURE,
https://github.com/hathach/tinyusb/blob/a96ee8f1d850bbd645040e0f5d133e6c1c93a3a4/examples/device/webusb_serial/src/main.c#L156, and sends back a report.

To fix this, the class driver should ignore requests that are not clearly meant for it.