### PR TITLE
Add alternate bitfield padding option

### DIFF
--- a/src/class/cdc/cdc.h
+++ b/src/class/cdc/cdc.h
@@ -277,11 +277,7 @@ typedef struct TU_ATTR_PACKED
   struct {
     uint8_t handle_call    : 1; ///< 0 - Device sends/receives call management information only over the Communications Class interface. 1 - Device can send/receive call management information over a Data Class interface.
     uint8_t send_recv_call : 1; ///< 0 - Device does not handle call management itself. 1 - Device handles call management itself.
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-    uint8_t unused : 6;
-#else
-    uint8_t : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+    uint8_t TU_RESERVED    : 6;
   } bmCapabilities;
 
   uint8_t bDataInterface;
@@ -294,11 +290,7 @@ typedef struct TU_ATTR_PACKED
   uint8_t support_line_request                    : 1; ///< Device supports the request combination of Set_Line_Coding, Set_Control_Line_State, Get_Line_Coding, and the notification Serial_State.
   uint8_t support_send_break                      : 1; ///< Device supports the request Send_Break
   uint8_t support_notification_network_connection : 1; ///< Device supports the notification Network_Connection.
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-  uint8_t unused : 4;
-#else
-  uint8_t : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+  uint8_t TU_RESERVED                             : 4;
 }cdc_acm_capability_t;
 
 TU_VERIFY_STATIC(sizeof(cdc_acm_capability_t) == 1, "mostly problem with compiler");
@@ -324,11 +316,7 @@ typedef struct TU_ATTR_PACKED
     uint8_t require_pulse_setup   : 1; ///< Device requires extra Pulse_Setup request during pulse dialing sequence to disengage holding circuit.
     uint8_t support_aux_request   : 1; ///< Device supports the request combination of Set_Aux_Line_State, Ring_Aux_Jack, and notification Aux_Jack_Hook_State.
     uint8_t support_pulse_request : 1; ///< Device supports the request combination of Pulse_Setup, Send_Pulse, and Set_Pulse_Time.
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-    uint8_t unused : 5;
-#else
-    uint8_t : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+    uint8_t TU_RESERVED           : 5;
   } bmCapabilities;
 }cdc_desc_func_direct_line_management_t;
 
@@ -356,11 +344,7 @@ typedef struct TU_ATTR_PACKED
     uint8_t simple_mode           : 1;
     uint8_t standalone_mode       : 1;
     uint8_t computer_centric_mode : 1;
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-    uint8_t unused : 5;
-#else
-    uint8_t : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+    uint8_t TU_RESERVED           : 5;
   } bmCapabilities;
 }cdc_desc_func_telephone_operational_modes_t;
 
@@ -379,11 +363,7 @@ typedef struct TU_ATTR_PACKED
     uint32_t incoming_distinctive   : 1; ///< 0 : Reports only incoming ringing. 1 : Reports incoming distinctive ringing patterns.
     uint32_t dual_tone_multi_freq   : 1; ///< 0 : Cannot report dual tone multi-frequency (DTMF) digits input remotely over the telephone line. 1 : Can report DTMF digits input remotely over the telephone line.
     uint32_t line_state_change      : 1; ///< 0 : Does not support line state change notification. 1 : Does support line state change notification
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-    uint32_t unused : 26;
-#else
-    uint32_t : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+    uint32_t TU_RESERVED            : 26;
   } bmCapabilities;
 }cdc_desc_func_telephone_call_state_reporting_capabilities_t;
 

--- a/src/class/cdc/cdc.h
+++ b/src/class/cdc/cdc.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -277,7 +277,11 @@ typedef struct TU_ATTR_PACKED
   struct {
     uint8_t handle_call    : 1; ///< 0 - Device sends/receives call management information only over the Communications Class interface. 1 - Device can send/receive call management information over a Data Class interface.
     uint8_t send_recv_call : 1; ///< 0 - Device does not handle call management itself. 1 - Device handles call management itself.
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+    uint8_t unused : 6;
+#else
     uint8_t : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
   } bmCapabilities;
 
   uint8_t bDataInterface;
@@ -290,7 +294,11 @@ typedef struct TU_ATTR_PACKED
   uint8_t support_line_request                    : 1; ///< Device supports the request combination of Set_Line_Coding, Set_Control_Line_State, Get_Line_Coding, and the notification Serial_State.
   uint8_t support_send_break                      : 1; ///< Device supports the request Send_Break
   uint8_t support_notification_network_connection : 1; ///< Device supports the notification Network_Connection.
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+  uint8_t unused : 4;
+#else
   uint8_t : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
 }cdc_acm_capability_t;
 
 TU_VERIFY_STATIC(sizeof(cdc_acm_capability_t) == 1, "mostly problem with compiler");
@@ -316,7 +324,11 @@ typedef struct TU_ATTR_PACKED
     uint8_t require_pulse_setup   : 1; ///< Device requires extra Pulse_Setup request during pulse dialing sequence to disengage holding circuit.
     uint8_t support_aux_request   : 1; ///< Device supports the request combination of Set_Aux_Line_State, Ring_Aux_Jack, and notification Aux_Jack_Hook_State.
     uint8_t support_pulse_request : 1; ///< Device supports the request combination of Pulse_Setup, Send_Pulse, and Set_Pulse_Time.
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+    uint8_t unused : 5;
+#else
     uint8_t : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
   } bmCapabilities;
 }cdc_desc_func_direct_line_management_t;
 
@@ -344,7 +356,11 @@ typedef struct TU_ATTR_PACKED
     uint8_t simple_mode           : 1;
     uint8_t standalone_mode       : 1;
     uint8_t computer_centric_mode : 1;
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+    uint8_t unused : 5;
+#else
     uint8_t : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
   } bmCapabilities;
 }cdc_desc_func_telephone_operational_modes_t;
 
@@ -363,7 +379,11 @@ typedef struct TU_ATTR_PACKED
     uint32_t incoming_distinctive   : 1; ///< 0 : Reports only incoming ringing. 1 : Reports incoming distinctive ringing patterns.
     uint32_t dual_tone_multi_freq   : 1; ///< 0 : Cannot report dual tone multi-frequency (DTMF) digits input remotely over the telephone line. 1 : Can report DTMF digits input remotely over the telephone line.
     uint32_t line_state_change      : 1; ///< 0 : Does not support line state change notification. 1 : Does support line state change notification
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+    uint32_t unused : 26;
+#else
     uint32_t : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
   } bmCapabilities;
 }cdc_desc_func_telephone_call_state_reporting_capabilities_t;
 

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -342,7 +342,11 @@ typedef struct TU_ATTR_PACKED
   struct TU_ATTR_PACKED {
     uint16_t size           : 11; ///< Maximum packet size this endpoint is capable of sending or receiving when this configuration is selected. \n For isochronous endpoints, this value is used to reserve the bus time in the schedule, required for the per-(micro)frame data payloads. The pipe may, on an ongoing basis, actually use less bandwidth than that reserved. The device reports, if necessary, the actual bandwidth used via its normal, non-USB defined mechanisms. \n For all endpoints, bits 10..0 specify the maximum packet size (in bytes). \n For high-speed isochronous and interrupt endpoints: \n Bits 12..11 specify the number of additional transaction opportunities per microframe: \n- 00 = None (1 transaction per microframe) \n- 01 = 1 additional (2 per microframe) \n- 10 = 2 additional (3 per microframe) \n- 11 = Reserved \n Bits 15..13 are reserved and must be set to zero.
     uint16_t hs_period_mult : 2;
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+    uint16_t unused : 3;
+#else
     uint16_t : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
   }wMaxPacketSize;
 
   uint8_t  bInterval        ; ///< Interval for polling endpoint for data transfers. Expressed in frames or microframes depending on the device operating speed (i.e., either 1 millisecond or 125 us units). \n- For full-/high-speed isochronous endpoints, this value must be in the range from 1 to 16. The bInterval value is used as the exponent for a \f$ 2^(bInterval-1) \f$ value; e.g., a bInterval of 4 means a period of 8 (\f$ 2^(4-1) \f$). \n- For full-/low-speed interrupt endpoints, the value of this field may be from 1 to 255. \n- For high-speed interrupt endpoints, the bInterval value is used as the exponent for a \f$ 2^(bInterval-1) \f$ value; e.g., a bInterval of 4 means a period of 8 (\f$ 2^(4-1) \f$) . This value must be from 1 to 16. \n- For high-speed bulk/control OUT endpoints, the bInterval must specify the maximum NAK rate of the endpoint. A value of 0 indicates the endpoint never NAKs. Other values indicate at most 1 NAK each bInterval number of microframes. This value must be in the range from 0 to 255. \n Refer to Chapter 5 of USB 2.0 specification for more information.

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -342,11 +342,7 @@ typedef struct TU_ATTR_PACKED
   struct TU_ATTR_PACKED {
     uint16_t size           : 11; ///< Maximum packet size this endpoint is capable of sending or receiving when this configuration is selected. \n For isochronous endpoints, this value is used to reserve the bus time in the schedule, required for the per-(micro)frame data payloads. The pipe may, on an ongoing basis, actually use less bandwidth than that reserved. The device reports, if necessary, the actual bandwidth used via its normal, non-USB defined mechanisms. \n For all endpoints, bits 10..0 specify the maximum packet size (in bytes). \n For high-speed isochronous and interrupt endpoints: \n Bits 12..11 specify the number of additional transaction opportunities per microframe: \n- 00 = None (1 transaction per microframe) \n- 01 = 1 additional (2 per microframe) \n- 10 = 2 additional (3 per microframe) \n- 11 = Reserved \n Bits 15..13 are reserved and must be set to zero.
     uint16_t hs_period_mult : 2;
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-    uint16_t unused : 3;
-#else
-    uint16_t : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+    uint16_t TU_RESERVED    : 3;
   }wMaxPacketSize;
 
   uint8_t  bInterval        ; ///< Interval for polling endpoint for data transfers. Expressed in frames or microframes depending on the device operating speed (i.e., either 1 millisecond or 125 us units). \n- For full-/high-speed isochronous endpoints, this value must be in the range from 1 to 16. The bInterval value is used as the exponent for a \f$ 2^(bInterval-1) \f$ value; e.g., a bInterval of 4 means a period of 8 (\f$ 2^(4-1) \f$). \n- For full-/low-speed interrupt endpoints, the value of this field may be from 1 to 255. \n- For high-speed interrupt endpoints, the bInterval value is used as the exponent for a \f$ 2^(bInterval-1) \f$ value; e.g., a bInterval of 4 means a period of 8 (\f$ 2^(4-1) \f$) . This value must be from 1 to 16. \n- For high-speed bulk/control OUT endpoints, the bInterval must specify the maximum NAK rate of the endpoint. A value of 0 indicates the endpoint never NAKs. Other values indicate at most 1 NAK each bInterval number of microframes. This value must be in the range from 0 to 255. \n Refer to Chapter 5 of USB 2.0 specification for more information.

--- a/src/host/ehci/ehci.h
+++ b/src/host/ehci/ehci.h
@@ -231,11 +231,6 @@ typedef struct TU_ATTR_ALIGNED(32)
 	uint32_t             : 1; ///< reserved
 	uint32_t port_number : 7; ///< This field is the port number of the recipient transaction translator.
 	uint32_t direction   : 1; ///<  0 = OUT; 1 = IN. This field encodes whether the full-speed transaction should be an IN or OUT.
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-                              ///< All 32 bits are used
-#else
-    uint32_t             : 0; // padding to the end of current storage unit
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
 
 	// Word 2: Micro-frame Schedule Control
 	uint8_t int_smask   ; ///< This field (along with the Activeand SplitX-statefields in the Statusbyte) are used to determine during which micro-frames the host controller should execute complete-split transactions
@@ -427,11 +422,7 @@ typedef volatile struct
       uint32_t nxp_port_force_fullspeed    : 1; ///< NXP customized: Writing this bit to a 1 will force the port to only connect at Full Speed. It disables the chirp sequence that allowsthe port to identify itself as High Speed. This is useful for testing FS configurations with a HS host, hub or device.
       uint32_t                             : 1;
       uint32_t nxp_port_speed              : 2; ///< NXP customized: This register field indicates the speed atwhich the port is operating. For HS mode operation in the host controllerand HS/FS operation in the device controller the port routing steers data to the Protocol engine. For FS and LS mode operation in the host controller, the port routing steers data to the Protocol Engine w/ Embedded Transaction Translator. 0x0: Fullspeed, 0x1: Lowspeed, 0x2: Highspeed
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-      uint32_t unused                      : 4; ///< padding
-#else
-      uint32_t                             : 0; // padding to the boundary of storage unit
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+      uint32_t TU_RESERVED                 : 4;
     }portsc_bm;
   };
 }ehci_registers_t;

--- a/src/host/ehci/ehci.h
+++ b/src/host/ehci/ehci.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -231,7 +231,11 @@ typedef struct TU_ATTR_ALIGNED(32)
 	uint32_t             : 1; ///< reserved
 	uint32_t port_number : 7; ///< This field is the port number of the recipient transaction translator.
 	uint32_t direction   : 1; ///<  0 = OUT; 1 = IN. This field encodes whether the full-speed transaction should be an IN or OUT.
-	uint32_t             : 0; // padding to the end of current storage unit
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+                              ///< All 32 bits are used
+#else
+    uint32_t             : 0; // padding to the end of current storage unit
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
 
 	// Word 2: Micro-frame Schedule Control
 	uint8_t int_smask   ; ///< This field (along with the Activeand SplitX-statefields in the Statusbyte) are used to determine during which micro-frames the host controller should execute complete-split transactions
@@ -423,7 +427,11 @@ typedef volatile struct
       uint32_t nxp_port_force_fullspeed    : 1; ///< NXP customized: Writing this bit to a 1 will force the port to only connect at Full Speed. It disables the chirp sequence that allowsthe port to identify itself as High Speed. This is useful for testing FS configurations with a HS host, hub or device.
       uint32_t                             : 1;
       uint32_t nxp_port_speed              : 2; ///< NXP customized: This register field indicates the speed atwhich the port is operating. For HS mode operation in the host controllerand HS/FS operation in the device controller the port routing steers data to the Protocol engine. For FS and LS mode operation in the host controller, the port routing steers data to the Protocol Engine w/ Embedded Transaction Translator. 0x0: Fullspeed, 0x1: Lowspeed, 0x2: Highspeed
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+      uint32_t unused                      : 4; ///< padding
+#else
       uint32_t                             : 0; // padding to the boundary of storage unit
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
     }portsc_bm;
   };
 }ehci_registers_t;
@@ -461,4 +469,3 @@ typedef struct
 
 /** @} */
 /** @} */
-

--- a/src/host/hub.h
+++ b/src/host/hub.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -163,7 +163,11 @@ typedef struct {
       uint16_t high_speed             : 1;
       uint16_t port_test_mode         : 1;
       uint16_t port_indicator_control : 1;
-      uint16_t : 0;
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+      uint16_t unused                 : 3;
+#else
+      uint16_t                        : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
     };
 
     uint16_t value;

--- a/src/host/hub.h
+++ b/src/host/hub.h
@@ -163,11 +163,7 @@ typedef struct {
       uint16_t high_speed             : 1;
       uint16_t port_test_mode         : 1;
       uint16_t port_indicator_control : 1;
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-      uint16_t unused                 : 3;
-#else
-      uint16_t                        : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+      uint16_t TU_RESERVED            : 3;
     };
 
     uint16_t value;

--- a/src/host/ohci/ohci.h
+++ b/src/host/ohci/ohci.h
@@ -208,11 +208,7 @@ typedef volatile struct
       uint32_t interrupt_routing          : 1;
       uint32_t remote_wakeup_connected    : 1;
       uint32_t remote_wakeup_enale        : 1;
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-      uint32_t unused                     : 21;
-#else
-      uint32_t                            : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+      uint32_t TU_RESERVED                : 21;
     }control_bit;
   };
 
@@ -280,11 +276,7 @@ typedef volatile struct
       uint32_t port_suspend_status_change         : 1;
       uint32_t port_over_current_indicator_change : 1;
       uint32_t port_reset_status_change           : 1;
-#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-      uint32_t unused                             : 11;
-#else
-      uint32_t                                    : 0;
-#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
+      uint32_t TU_RESERVED                        : 11;
     }rhport_status_bit[2];
   };
 }ohci_registers_t;

--- a/src/host/ohci/ohci.h
+++ b/src/host/ohci/ohci.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -208,7 +208,11 @@ typedef volatile struct
       uint32_t interrupt_routing          : 1;
       uint32_t remote_wakeup_connected    : 1;
       uint32_t remote_wakeup_enale        : 1;
-      uint32_t : 0;
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+      uint32_t unused                     : 21;
+#else
+      uint32_t                            : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
     }control_bit;
   };
 
@@ -276,7 +280,11 @@ typedef volatile struct
       uint32_t port_suspend_status_change         : 1;
       uint32_t port_over_current_indicator_change : 1;
       uint32_t port_reset_status_change           : 1;
+#if CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+      uint32_t unused                             : 11;
+#else
       uint32_t                                    : 0;
+#endif /* CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT */
     }rhport_status_bit[2];
   };
 }ohci_registers_t;

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -197,10 +197,6 @@
   #define CFG_TUSB_OS             OPT_OS_NONE
 #endif
 
-#ifndef CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
-  #define CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT 0
-#endif
-
 //--------------------------------------------------------------------
 // DEVICE OPTIONS
 //--------------------------------------------------------------------

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -197,6 +197,10 @@
   #define CFG_TUSB_OS             OPT_OS_NONE
 #endif
 
+#ifndef CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT
+  #define CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT 0
+#endif
+
 //--------------------------------------------------------------------
 // DEVICE OPTIONS
 //--------------------------------------------------------------------


### PR DESCRIPTION
Adds configuration option CFG_TUSB_ALT_BIT_PACKING_ALIGNMENT, which substitutes bitfield variable " : 0" padding syntax with an unused variable of size equal to the remaining number of bits.

This change is intended to resolve aligned access issues for some platforms.

The default behaviour is original if the option is not explicitly enabled.  Consequently, this change should not affect existing applications.