### PR TITLE
Fix to fifo pointer overflow mathmatics

### DIFF
--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -74,7 +74,7 @@ bool tu_fifo_config(tu_fifo_t *f, void* buffer, uint16_t depth, uint16_t item_si
   f->overwritable = overwritable;
 
   f->max_pointer_idx = 2*depth - 1;               // Limit index space to 2*depth - this allows for a fast "modulo" calculation but limits the maximum depth to 2^16/2 = 2^15 and buffer overflows are detectable only if overflow happens once (important for unsupervised DMA applications)
-  f->non_used_index_space = 0xFFFF - f->max_pointer_idx;
+  f->non_used_index_space = UINT16_MAX - f->max_pointer_idx;
 
   f->rd_idx = f->wr_idx = 0;
 

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -86,7 +86,7 @@ typedef struct
         .item_size              = sizeof(_type),                        \
         .overwritable           = _overwritable,                        \
         .max_pointer_idx        = 2*_depth-1,                           \
-        .non_used_index_space   = 0xFFFF - 2*_depth-1,                  \
+        .non_used_index_space   = UINT16_MAX - (2*_depth-1),                  \
     }
 
 bool tu_fifo_set_overwritable(tu_fifo_t *f, bool overwritable);

--- a/src/osal/osal_pico.h
+++ b/src/osal/osal_pico.h
@@ -123,6 +123,8 @@ typedef osal_queue_def_t* osal_queue_t;
       .depth        = _depth,                       \
       .item_size    = sizeof(_type),                \
       .overwritable = false,                        \
+       .max_pointer_idx        = 2*_depth-1,                           \
+      .non_used_index_space   = UINT16_MAX - (2*_depth-1),                  \
     }\
   }
 


### PR DESCRIPTION
**Describe the PR**
The basics are as follows: (non_used_index_space + max_pointer_idx)  should equal UINT16_MAX so that when you add anything to those values it rolls over.


**Additional context**
This will likely fix a bunch of difficult problems which have been itermitent.
