### PR TITLE
RP2040:Enable full size isochronous buffers

### DIFF
--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -153,15 +153,7 @@ void _hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t t
     // Fill in info now that we're kicking off the hw
     ep->total_len = total_len;
     ep->len = 0;
-    // FIXME: What if low speed
-    if(ep->transfer_type == TUSB_XFER_ISOCHRONOUS)
-    {
-        ep->transfer_size = tu_min32(total_len, ep->wMaxPacketSize);
-    }
-    else
-    {
-        ep->transfer_size = tu_min32(total_len, 64);
-    }
+    ep->transfer_size = tu_min32(total_len, ep->wMaxPacketSize);
     ep->active = true;
     ep->user_buf = buffer;
     // Recalculate if this is the last buffer
@@ -239,15 +231,7 @@ bool _hw_endpoint_xfer_continue(struct hw_endpoint *ep)
 
     // Now we have synced our state with the hardware. Is there more data to transfer?
     uint remaining_bytes = ep->total_len - ep->len;
-
-    if(ep->transfer_type == TUSB_XFER_ISOCHRONOUS)
-    {
-        ep->transfer_size = tu_min32(remaining_bytes,ep->wMaxPacketSize);
-    }
-    else
-    {
-        ep->transfer_size = tu_min32(remaining_bytes, 64);
-    }
+    ep->transfer_size = tu_min32(remaining_bytes, ep->wMaxPacketSize);
     _hw_endpoint_update_last_buf(ep);
 
     // Can happen because of programmer error so check for it


### PR DESCRIPTION
**Describe the PR**
The RP2040 spec allows full-sized isochronous buffers, this enables it.
**Additional context**
The rp2040 spec limits none ISO buffers to 64 bits.