### PR TITLE
rp2040/family.c: allow LED_PIN to be undefined

### DIFF
--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -110,8 +110,10 @@ void stdio_rtt_init(void)
 
 void board_init(void)
 {
+#ifdef LED_PIN
   gpio_init(LED_PIN);
   gpio_set_dir(LED_PIN, GPIO_OUT);
+#endif
 
   // Button
 #ifndef BUTTON_BOOTSEL
@@ -141,7 +143,9 @@ void board_init(void)
 
 void board_led_write(bool state)
 {
+#ifdef LED_PIN
   gpio_put(LED_PIN, state ? LED_STATE_ON : (1-LED_STATE_ON));
+#endif
 }
 
 uint32_t board_button_read(void)


### PR DESCRIPTION
Similar to the usage of `#ifdef UART_DEV` and `#ifdef BUTTON_BOOTSEL` in the same file.