### PR TITLE
Fix typo midi write24

### DIFF
--- a/examples/device/dynamic_configuration/src/main.c
+++ b/examples/device/dynamic_configuration/src/main.c
@@ -165,6 +165,9 @@ void midi_task(void)
 {
   static uint32_t start_ms = 0;
 
+  uint8_t const cable_num = 0; // MIDI jack associated with USB endpoint
+  uint8_t const channel   = 0; // 0 for channel 1
+
   // The MIDI interface always creates input and output port/jack descriptors
   // regardless of these being used or not. Therefore incoming traffic should be read
   // (possibly just discarded) to avoid the sender blocking in IO
@@ -183,10 +186,10 @@ void midi_task(void)
   if (previous < 0) previous = sizeof(note_sequence) - 1;
 
   // Send Note On for current position at full velocity (127) on channel 1.
-  tudi_midi_write24(0, 0x90, note_sequence[note_pos], 127);
+  tud_midi_write24(cable_num, 0x90 | channel, note_sequence[note_pos], 127);
 
   // Send Note Off for previous note.
-  tudi_midi_write24(0, 0x80, note_sequence[previous], 0);
+  tud_midi_write24(cable_num, 0x80 | channel, note_sequence[previous], 0);
 
   // Increment position
   note_pos++;

--- a/examples/device/midi_test/src/main.c
+++ b/examples/device/midi_test/src/main.c
@@ -125,6 +125,9 @@ void midi_task(void)
 {
   static uint32_t start_ms = 0;
 
+  uint8_t const cable_num = 0; // MIDI jack associated with USB endpoint
+  uint8_t const channel   = 0; // 0 for channel 1
+
   // The MIDI interface always creates input and output port/jack descriptors
   // regardless of these being used or not. Therefore incoming traffic should be read
   // (possibly just discarded) to avoid the sender blocking in IO
@@ -143,10 +146,10 @@ void midi_task(void)
   if (previous < 0) previous = sizeof(note_sequence) - 1;
 
   // Send Note On for current position at full velocity (127) on channel 1.
-  tudi_midi_write24(0, 0x90, note_sequence[note_pos], 127);
+  tud_midi_write24(cable_num, 0x90 | channel, note_sequence[note_pos], 127);
 
   // Send Note Off for previous note.
-  tudi_midi_write24(0, 0x80, note_sequence[previous], 0);
+  tud_midi_write24(cable_num, 0x80 | channel, note_sequence[previous], 0);
 
   // Increment position
   note_pos++;

--- a/hw/bsp/rp2040/boards/adafruit_feather_rp2040/board.h
+++ b/hw/bsp/rp2040/boards/adafruit_feather_rp2040/board.h
@@ -31,8 +31,12 @@
  extern "C" {
 #endif
 
-#define LED_PIN               14
+#define LED_PIN               13
 #define LED_STATE_ON          1
+
+#define NEOPIXEL_PIN          16
+#define NEOPIXEL_POWER_PIN    17
+#define NEOPIXEL_POWER_STATE  1
 
 // Button pin is BOOTSEL which is flash CS pin
 #define BUTTON_BOOTSEL

--- a/hw/bsp/rp2040/boards/adafruit_itsybitsy_rp2040/board.h
+++ b/hw/bsp/rp2040/boards/adafruit_itsybitsy_rp2040/board.h
@@ -34,6 +34,10 @@
 #define LED_PIN               11
 #define LED_STATE_ON          1
 
+#define NEOPIXEL_PIN          17
+#define NEOPIXEL_POWER_PIN    16
+#define NEOPIXEL_POWER_STATE  1
+
 // Button pin is BOOTSEL which is flash CS pin
 #define BUTTON_BOOTSEL
 #define BUTTON_STATE_ACTIVE   0

--- a/hw/bsp/rp2040/boards/adafruit_qt_rp2040/board.h
+++ b/hw/bsp/rp2040/boards/adafruit_qt_rp2040/board.h
@@ -35,6 +35,10 @@
 #define LED_PIN               11
 #define LED_STATE_ON          1
 
+#define NEOPIXEL_PIN          12
+#define NEOPIXEL_POWER_PIN    11
+#define NEOPIXEL_POWER_STATE  1
+
 // Button pin is BOOTSEL which is flash CS pin
 #define BUTTON_BOOTSEL
 #define BUTTON_STATE_ACTIVE   0

--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -114,15 +114,15 @@ static void _prep_out_transaction (midid_interface_t* p_midi)
 //--------------------------------------------------------------------+
 // READ API
 //--------------------------------------------------------------------+
-uint32_t tud_midi_n_available(uint8_t itf, uint8_t jack_id)
+uint32_t tud_midi_n_available(uint8_t itf, uint8_t cable_num)
 {
-  (void) jack_id;
+  (void) cable_num;
   return tu_fifo_count(&_midid_itf[itf].rx_ff);
 }
 
-uint32_t tud_midi_n_read(uint8_t itf, uint8_t jack_id, void* buffer, uint32_t bufsize)
+uint32_t tud_midi_n_read(uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize)
 {
-  (void) jack_id;
+  (void) cable_num;
   midid_interface_t* midi = &_midid_itf[itf];
 
   // Fill empty buffer
@@ -158,9 +158,9 @@ uint32_t tud_midi_n_read(uint8_t itf, uint8_t jack_id, void* buffer, uint32_t bu
   return n;
 }
 
-void tud_midi_n_read_flush (uint8_t itf, uint8_t jack_id)
+void tud_midi_n_read_flush (uint8_t itf, uint8_t cable_num)
 {
-  (void) jack_id;
+  (void) cable_num;
   midid_interface_t* p_midi = &_midid_itf[itf];
   tu_fifo_clear(&p_midi->rx_ff);
   _prep_out_transaction(p_midi);
@@ -205,7 +205,7 @@ static uint32_t write_flush(midid_interface_t* midi)
   }
 }
 
-uint32_t tud_midi_n_write(uint8_t itf, uint8_t jack_id, uint8_t const* buffer, uint32_t bufsize)
+uint32_t tud_midi_n_write(uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
 {
   midid_interface_t* midi = &_midid_itf[itf];
   if (midi->itf_num == 0) {
@@ -228,7 +228,7 @@ uint32_t tud_midi_n_write(uint8_t itf, uint8_t jack_id, uint8_t const* buffer, u
                 midi->write_target_length = 4;
             }
         } else if ((msg >= 0x8 && msg <= 0xB) || msg == 0xE) {
-            midi->write_buffer[0] = jack_id << 4 | msg;
+            midi->write_buffer[0] = cable_num << 4 | msg;
             midi->write_target_length = 4;
         } else if (msg == 0xf) {
             if (data == 0xf0) {
@@ -246,7 +246,7 @@ uint32_t tud_midi_n_write(uint8_t itf, uint8_t jack_id, uint8_t const* buffer, u
             }
         } else {
             // Pack individual bytes if we don't support packing them into words.
-            midi->write_buffer[0] = jack_id << 4 | 0xf;
+            midi->write_buffer[0] = cable_num << 4 | 0xf;
             midi->write_buffer[2] = 0;
             midi->write_buffer[3] = 0;
             midi->write_buffer_length = 2;

--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -60,13 +60,13 @@
 // CFG_TUD_MIDI > 1
 //--------------------------------------------------------------------+
 bool     tud_midi_n_mounted    (uint8_t itf);
-uint32_t tud_midi_n_available  (uint8_t itf, uint8_t jack_id);
-uint32_t tud_midi_n_read       (uint8_t itf, uint8_t jack_id, void* buffer, uint32_t bufsize);
-void     tud_midi_n_read_flush (uint8_t itf, uint8_t jack_id);
-uint32_t tud_midi_n_write      (uint8_t itf, uint8_t jack_id, uint8_t const* buffer, uint32_t bufsize);
+uint32_t tud_midi_n_available  (uint8_t itf, uint8_t cable_num);
+uint32_t tud_midi_n_read       (uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize);
+void     tud_midi_n_read_flush (uint8_t itf, uint8_t cable_num);
+uint32_t tud_midi_n_write      (uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
 
 static inline
-uint32_t tud_midi_n_write24    (uint8_t itf, uint8_t jack_id, uint8_t b1, uint8_t b2, uint8_t b3);
+uint32_t tud_midi_n_write24    (uint8_t itf, uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3);
 
 bool tud_midi_n_receive        (uint8_t itf, uint8_t packet[4]);
 bool tud_midi_n_send           (uint8_t itf, uint8_t const packet[4]);
@@ -78,8 +78,8 @@ static inline bool     tud_midi_mounted    (void);
 static inline uint32_t tud_midi_available  (void);
 static inline uint32_t tud_midi_read       (void* buffer, uint32_t bufsize);
 static inline void     tud_midi_read_flush (void);
-static inline uint32_t tud_midi_write      (uint8_t jack_id, uint8_t const* buffer, uint32_t bufsize);
-static inline uint32_t tudi_midi_write24   (uint8_t jack_id, uint8_t b1, uint8_t b2, uint8_t b3);
+static inline uint32_t tud_midi_write      (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
+static inline uint32_t tud_midi_write24    (uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3);
 static inline bool     tud_midi_receive    (uint8_t packet[4]);
 static inline bool     tud_midi_send       (uint8_t const packet[4]);
 
@@ -92,10 +92,10 @@ TU_ATTR_WEAK void tud_midi_rx_cb(uint8_t itf);
 // Inline Functions
 //--------------------------------------------------------------------+
 
-static inline uint32_t tud_midi_n_write24 (uint8_t itf, uint8_t jack_id, uint8_t b1, uint8_t b2, uint8_t b3)
+static inline uint32_t tud_midi_n_write24 (uint8_t itf, uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3)
 {
   uint8_t msg[3] = { b1, b2, b3 };
-  return tud_midi_n_write(itf, jack_id, msg, 3);
+  return tud_midi_n_write(itf, cable_num, msg, 3);
 }
 
 static inline bool tud_midi_mounted (void)
@@ -118,15 +118,15 @@ static inline void tud_midi_read_flush (void)
   tud_midi_n_read_flush(0, 0);
 }
 
-static inline uint32_t tud_midi_write (uint8_t jack_id, uint8_t const* buffer, uint32_t bufsize)
+static inline uint32_t tud_midi_write (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
 {
-  return tud_midi_n_write(0, jack_id, buffer, bufsize);
+  return tud_midi_n_write(0, cable_num, buffer, bufsize);
 }
 
-static inline uint32_t tudi_midi_write24 (uint8_t jack_id, uint8_t b1, uint8_t b2, uint8_t b3)
+static inline uint32_t tud_midi_write24 (uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3)
 {
   uint8_t msg[3] = { b1, b2, b3 };
-  return tud_midi_write(jack_id, msg, 3);
+  return tud_midi_write(cable_num, msg, 3);
 }
 
 static inline bool tud_midi_receive (uint8_t packet[4])


### PR DESCRIPTION
**Describe the PR**
- Fix midi write24() typo
- rename jack_id to cable_num in midi API
- make example less ambiguous  between cable number and channel
- unrelated rp2040 board definition