### PR TITLE
add itf argument to hid API to support multiple instances

### DIFF
--- a/examples/device/hid_composite/src/main.c
+++ b/examples/device/hid_composite/src/main.c
@@ -239,9 +239,10 @@ void tud_hid_report_complete_cb(uint8_t itf, uint8_t const* report, uint8_t len)
 // Invoked when received GET_REPORT control request
 // Application must fill buffer report's content and return its length.
 // Return zero will cause the stack to STALL request
-uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
+uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
 {
   // TODO not Implemented
+  (void) itf;
   (void) report_id;
   (void) report_type;
   (void) buffer;
@@ -252,9 +253,10 @@ uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type,
 
 // Invoked when received SET_REPORT control request or
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
-void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
+void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
 {
   // TODO set LED based on CAPLOCK, NUMLOCK etc...
+  (void) itf;
   (void) report_id;
   (void) report_type;
   (void) buffer;

--- a/examples/device/hid_composite/src/usb_descriptors.c
+++ b/examples/device/hid_composite/src/usb_descriptors.c
@@ -82,8 +82,9 @@ uint8_t const desc_hid_report[] =
 // Invoked when received GET HID REPORT DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
-uint8_t const * tud_hid_descriptor_report_cb(void)
+uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf)
 {
+  (void) itf;
   return desc_hid_report;
 }
 

--- a/examples/device/hid_composite_freertos/src/main.c
+++ b/examples/device/hid_composite_freertos/src/main.c
@@ -299,9 +299,10 @@ void tud_hid_report_complete_cb(uint8_t itf, uint8_t const* report, uint8_t len)
 // Invoked when received GET_REPORT control request
 // Application must fill buffer report's content and return its length.
 // Return zero will cause the stack to STALL request
-uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
+uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
 {
   // TODO not Implemented
+  (void) itf;
   (void) report_id;
   (void) report_type;
   (void) buffer;
@@ -312,9 +313,10 @@ uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type,
 
 // Invoked when received SET_REPORT control request or
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
-void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
+void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
 {
   // TODO set LED based on CAPLOCK, NUMLOCK etc...
+  (void) itf;
   (void) report_id;
   (void) report_type;
   (void) buffer;

--- a/examples/device/hid_composite_freertos/src/usb_descriptors.c
+++ b/examples/device/hid_composite_freertos/src/usb_descriptors.c
@@ -82,7 +82,7 @@ uint8_t const desc_hid_report[] =
 // Invoked when received GET HID REPORT DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
-uint8_t const * tud_hid_descriptor_report_cb(void)
+uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf)
 {
   return desc_hid_report;
 }

--- a/examples/device/hid_composite_freertos/src/usb_descriptors.c
+++ b/examples/device/hid_composite_freertos/src/usb_descriptors.c
@@ -84,6 +84,7 @@ uint8_t const desc_hid_report[] =
 // Descriptor contents must exist long enough for transfer to complete
 uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf)
 {
+  (void) itf;
   return desc_hid_report;
 }
 

--- a/examples/device/hid_generic_inout/src/main.c
+++ b/examples/device/hid_generic_inout/src/main.c
@@ -121,9 +121,10 @@ void tud_resume_cb(void)
 // Invoked when received GET_REPORT control request
 // Application must fill buffer report's content and return its length.
 // Return zero will cause the stack to STALL request
-uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
+uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
 {
   // TODO not Implemented
+  (void) itf;
   (void) report_id;
   (void) report_type;
   (void) buffer;
@@ -134,9 +135,10 @@ uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type,
 
 // Invoked when received SET_REPORT control request or
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
-void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
+void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
 {
   // This example doesn't use multiple report and report ID
+  (void) itf;
   (void) report_id;
   (void) report_type;
 

--- a/examples/device/hid_generic_inout/src/usb_descriptors.c
+++ b/examples/device/hid_generic_inout/src/usb_descriptors.c
@@ -78,8 +78,9 @@ uint8_t const desc_hid_report[] =
 // Invoked when received GET HID REPORT DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
-uint8_t const * tud_hid_descriptor_report_cb(void)
+uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf)
 {
+  (void) itf;
   return desc_hid_report;
 }
 

--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -251,11 +251,7 @@ bool hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t
       }
       else if (request->bRequest == TUSB_REQ_GET_DESCRIPTOR && desc_type == HID_DESC_TYPE_REPORT)
       {
-        uint8_t const * desc_report = tud_hid_descriptor_report_cb(
-            #if CFG_TUD_HID > 1
-            hid_itf // TODO for backward compatible callback, remove later when appropriate
-            #endif
-        );
+        uint8_t const * desc_report = tud_hid_descriptor_report_cb(hid_itf);
         tud_control_xfer(rhport, request, (void*) desc_report, p_hid->report_desc_len);
       }
       else
@@ -275,12 +271,7 @@ bool hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t
           uint8_t const report_type = tu_u16_high(request->wValue);
           uint8_t const report_id   = tu_u16_low(request->wValue);
 
-          uint16_t xferlen  = tud_hid_get_report_cb(
-              #if CFG_TUD_HID > 1
-              hid_itf, // TODO for backward compatible callback, remove later when appropriate
-              #endif
-              report_id, (hid_report_type_t) report_type, p_hid->epin_buf, request->wLength
-          );
+          uint16_t xferlen = tud_hid_get_report_cb(hid_itf, report_id, (hid_report_type_t) report_type, p_hid->epin_buf, request->wLength);
           TU_ASSERT( xferlen > 0 );
 
           tud_control_xfer(rhport, request, p_hid->epin_buf, xferlen);
@@ -298,12 +289,7 @@ bool hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t
           uint8_t const report_type = tu_u16_high(request->wValue);
           uint8_t const report_id   = tu_u16_low(request->wValue);
 
-          tud_hid_set_report_cb(
-              #if CFG_TUD_HID > 1
-              hid_itf, // TODO for backward compatible callback, remove later when appropriate
-              #endif
-              report_id, (hid_report_type_t) report_type, p_hid->epout_buf, request->wLength
-          );
+          tud_hid_set_report_cb(hid_itf, report_id, (hid_report_type_t) report_type, p_hid->epout_buf, request->wLength);
         }
       break;
 
@@ -314,12 +300,7 @@ bool hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t
           if ( tud_hid_set_idle_cb )
           {
             // stall request if callback return false
-            TU_VERIFY( tud_hid_set_idle_cb(
-                            #if CFG_TUD_HID > 1
-                            hid_itf, // TODO for backward compatible callback, remove later when appropriate
-                            #endif
-                            p_hid->idle_rate)
-            );
+            TU_VERIFY( tud_hid_set_idle_cb( hid_itf, p_hid->idle_rate) );
           }
 
           tud_control_status(rhport, request);
@@ -354,12 +335,7 @@ bool hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t
         {
           if (tud_hid_boot_mode_cb)
           {
-            tud_hid_boot_mode_cb(
-                #if CFG_TUD_HID > 1
-                hid_itf, // TODO for backward compatible callback, remove later when appropriate
-                #endif
-                p_hid->boot_mode
-            );
+            tud_hid_boot_mode_cb(hid_itf, p_hid->boot_mode);
           }
         }
       break;
@@ -400,12 +376,7 @@ bool hidd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
   // Received report
   else if (ep_addr == p_hid->ep_out)
   {
-    tud_hid_set_report_cb(
-        #if CFG_TUD_HID > 1
-        itf, // TODO for backward compatible callback, remove later when appropriate
-        #endif
-        0, HID_REPORT_TYPE_INVALID, p_hid->epout_buf, xferred_bytes
-    );
+    tud_hid_set_report_cb(itf, 0, HID_REPORT_TYPE_INVALID, p_hid->epout_buf, xferred_bytes);
     TU_ASSERT(usbd_edpt_xfer(rhport, p_hid->ep_out, p_hid->epout_buf, sizeof(p_hid->epout_buf)));
   }
 

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -88,8 +88,6 @@ static inline bool tud_hid_mouse_report(uint8_t report_id, uint8_t buttons, int8
 // Callbacks (Weak is optional)
 //--------------------------------------------------------------------+
 
-#if CFG_TUD_HID > 1
-
 // Invoked when received GET HID REPORT DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
 uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf);
@@ -110,18 +108,6 @@ TU_ATTR_WEAK void tud_hid_boot_mode_cb(uint8_t itf, uint8_t boot_mode);
 // - Idle Rate = 0 : only send report if there is changes, i.e skip duplication
 // - Idle Rate > 0 : skip duplication, but send at least 1 report every idle rate (in unit of 4 ms).
 TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t itf, uint8_t idle_rate);
-
-#else
-
-// TODO for backward compatible callback, remove later when appropriate
-uint8_t const * tud_hid_descriptor_report_cb(void);
-uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen);
-void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize);
-
-TU_ATTR_WEAK void tud_hid_boot_mode_cb(uint8_t boot_mode);
-TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t idle_rate);
-
-#endif
 
 // Invoked when sent REPORT successfully to host
 // Application can use this to send the next report


### PR DESCRIPTION
**Describe the PR**
Follow up to #524, this PR remove backward-compatible single ITF callback when `CFG_TUD_HID=1`. This makes it clearer for user to notice that stack support multiple instance of HID interfaces and simplify the #ifelse in application should it choose to enable multiple HID. Following API signature is changed and required updated in application. 
- tud_hid_descriptor_report_cb()
- tud_hid_get_report_cb()
- tud_hid_set_report_cb()
- tud_hid_boot_mode_cb()
- tud_hid_set_idle_cb()
