### PR TITLE
[msp430]: a way skip nanolib for MSP430

### DIFF
--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -93,8 +93,7 @@ INC += $(TOP)/src
 
 CFLAGS += $(addprefix -I,$(INC))
 
-# TODO Skip nanolib for MSP430
-ifeq ($(BOARD), msp_exp430f5529lp)
+ifeq ($(findstring  msp_exp430,$(BOARD)), msp_exp430)
   LDFLAGS += $(CFLAGS) -fshort-enums -Wl,-T,$(TOP)/$(LD_FILE) -Wl,-Map=$@.map -Wl,-cref -Wl,-gc-sections
 else
   LDFLAGS += $(CFLAGS) -fshort-enums -Wl,-T,$(TOP)/$(LD_FILE) -Wl,-Map=$@.map -Wl,-cref -Wl,-gc-sections -specs=nosys.specs -specs=nano.specs


### PR DESCRIPTION
I think that's a way to remove one to-do item in your code.