### PR TITLE
Improve rp2040

### DIFF
--- a/examples/device/audio_test/CMakeLists.txt
+++ b/examples/device/audio_test/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/board_test/CMakeLists.txt
+++ b/examples/device/board_test/CMakeLists.txt
@@ -37,9 +37,6 @@ elseif(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/cdc_dual_ports/CMakeLists.txt
+++ b/examples/device/cdc_dual_ports/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/cdc_msc/CMakeLists.txt
+++ b/examples/device/cdc_msc/CMakeLists.txt
@@ -39,9 +39,6 @@ elseif(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/dfu_runtime/CMakeLists.txt
+++ b/examples/device/dfu_runtime/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/dynamic_configuration/CMakeLists.txt
+++ b/examples/device/dynamic_configuration/CMakeLists.txt
@@ -34,9 +34,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/hid_composite/CMakeLists.txt
+++ b/examples/device/hid_composite/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/hid_generic_inout/CMakeLists.txt
+++ b/examples/device/hid_generic_inout/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/hid_multiple_interface/CMakeLists.txt
+++ b/examples/device/hid_multiple_interface/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/midi_test/CMakeLists.txt
+++ b/examples/device/midi_test/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/msc_dual_lun/CMakeLists.txt
+++ b/examples/device/msc_dual_lun/CMakeLists.txt
@@ -34,9 +34,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/net_lwip_webserver/CMakeLists.txt
+++ b/examples/device/net_lwip_webserver/CMakeLists.txt
@@ -80,9 +80,6 @@ if(FAMILY STREQUAL "rp2040")
     HTTPD_USE_CUSTOM_FSDATA=0
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/uac2_headset/CMakeLists.txt
+++ b/examples/device/uac2_headset/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/usbtmc/CMakeLists.txt
+++ b/examples/device/usbtmc/CMakeLists.txt
@@ -34,9 +34,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/device/webusb_serial/CMakeLists.txt
+++ b/examples/device/webusb_serial/CMakeLists.txt
@@ -33,9 +33,6 @@ if(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/host/cdc_msc_hid/CMakeLists.txt
+++ b/examples/host/cdc_msc_hid/CMakeLists.txt
@@ -38,9 +38,6 @@ elseif(FAMILY STREQUAL "rp2040")
     CFG_TUSB_OS=OPT_OS_PICO
   )
 
-  target_link_libraries(${PROJECT} pico_stdlib pico_fix_rp2040_usb_device_enumeration)
-  pico_add_extra_outputs(${PROJECT})
-
 else()
   message(FATAL_ERROR "Invalid FAMILY specified")
 endif()

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -194,6 +194,8 @@ else
 	$(RM) -rf $(BUILD)
 endif
 
+endif # GNU Make
+
 # Print out the value of a make variable.
 # https://stackoverflow.com/questions/16467718/how-to-print-out-a-variable-in-makefile
 print-%:
@@ -227,7 +229,6 @@ flash-pyocd: $(BUILD)/$(PROJECT).hex
 	pyocd flash -t $(PYOCD_TARGET) $<
 	pyocd reset -t $(PYOCD_TARGET)
 
-endif # GNU Make
 
 #-------------- Artifacts --------------
 

--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -78,7 +78,10 @@ bool __no_inline_not_in_flash_func(get_bootsel_button)() {
 
 //------------- Segger RTT retarget -------------//
 #if defined(LOGGER_RTT)
+
 // Logging with RTT
+// If RTT Control Block is not found by 'Auto Detection`
+// try to use 'Search Range` with '0x20000000 0x10000'
 
 #include "pico/stdio/driver.h"
 #include "SEGGER_RTT.h"

--- a/hw/bsp/rp2040/family.cmake
+++ b/hw/bsp/rp2040/family.cmake
@@ -5,6 +5,7 @@ target_link_libraries(${PROJECT}
 )
 
 pico_add_extra_outputs(${PROJECT})
+pico_enable_stdio_uart(${PROJECT} 1)
 
 # TinyUSB Stack source
 set(SRC_TINYUSB
@@ -50,12 +51,9 @@ target_compile_definitions(${PROJECT} PUBLIC
 
 if(DEFINED LOG)
   target_compile_definitions(${PROJECT} PUBLIC CFG_TUSB_DEBUG=${LOG} )
-  pico_enable_stdio_uart(${PROJECT} 1)
 endif()
 
 if(LOGGER STREQUAL "rtt")
-  pico_enable_stdio_uart(${PROJECT} 0)
-
   target_compile_definitions(${PROJECT} PUBLIC
     LOGGER_RTT
     SEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL

--- a/hw/bsp/rp2040/family.cmake
+++ b/hw/bsp/rp2040/family.cmake
@@ -1,3 +1,11 @@
+target_link_libraries(${PROJECT}
+  pico_stdlib
+  pico_bootsel_via_double_reset
+  pico_fix_rp2040_usb_device_enumeration
+)
+
+pico_add_extra_outputs(${PROJECT})
+
 # TinyUSB Stack source
 set(SRC_TINYUSB
 	${TOP}/src/tusb.c

--- a/hw/bsp/rp2040/family.mk
+++ b/hw/bsp/rp2040/family.mk
@@ -1,1 +1,3 @@
 FAMILY_SUBMODULES = hw/mcu/raspberrypi/pico-sdk
+
+JLINK_DEVICE = rp2040_m0_0

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -992,11 +992,15 @@ void dcd_event_handler(dcd_event_t const * event, bool in_isr)
   switch (event->event_id)
   {
     case DCD_EVENT_UNPLUGGED:
-      _usbd_dev.connected  = 0;
-      _usbd_dev.addressed  = 0;
-      _usbd_dev.cfg_num    = 0;
-      _usbd_dev.suspended  = 0;
-      osal_queue_send(_usbd_q, event, in_isr);
+      // UNPLUGGED event can be bouncing, only processing if we are currently connected
+      if ( _usbd_dev.connected )
+      {
+        _usbd_dev.connected  = 0;
+        _usbd_dev.addressed  = 0;
+        _usbd_dev.cfg_num    = 0;
+        _usbd_dev.suspended  = 0;
+        osal_queue_send(_usbd_q, event, in_isr);
+      }
     break;
 
     case DCD_EVENT_SOF:
@@ -1004,9 +1008,10 @@ void dcd_event_handler(dcd_event_t const * event, bool in_isr)
     break;
 
     case DCD_EVENT_SUSPEND:
-      // NOTE: When plugging/unplugging device, the D+/D- state are unstable and can accidentally meet the
-      // SUSPEND condition ( Idle for 3ms ). Some MCUs such as SAMD doesn't distinguish suspend vs disconnect as well.
-      // We will skip handling SUSPEND/RESUME event if not currently connected
+      // NOTE: When plugging/unplugging device, the D+/D- state are unstable and
+      // can accidentally meet the SUSPEND condition ( Bus Idle for 3ms ).
+      // In addition, some MCUs such as SAMD or boards that haven no VBUS detection cannot distinguish
+      // suspended vs disconnected. We will skip handling SUSPEND/RESUME event if not currently connected
       if ( _usbd_dev.connected )
       {
         _usbd_dev.suspended = 1;

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -317,12 +317,44 @@ static void dcd_rp2040_irq(void)
         pico_trace("BUS RESET (addr %d -> %d)\n", assigned_address, 0);
         usb_hw->dev_addr_ctrl = 0;
         handled |= USB_INTS_BUS_RESET_BITS;
-        dcd_event_bus_signal(0, DCD_EVENT_BUS_RESET, true);
+        dcd_event_bus_reset(0, TUSB_SPEED_FULL, true);
         usb_hw_clear->sie_status = USB_SIE_STATUS_BUS_RESET_BITS;
 #if TUD_OPT_RP2040_USB_DEVICE_ENUMERATION_FIX
         rp2040_usb_device_enumeration_fix();
 #endif
     }
+
+    if (status & USB_INTS_DEV_CONN_DIS_BITS)
+    {
+        handled |= USB_INTS_DEV_CONN_DIS_BITS;
+
+        if ( usb_hw->sie_status & USB_SIE_STATUS_CONNECTED_BITS )
+        {
+          // Connected: nothing to do
+        }else
+        {
+          // Disconnected
+          dcd_event_bus_signal(0, DCD_EVENT_UNPLUGGED, true);
+        }
+
+        usb_hw_clear->sie_status = USB_SIE_STATUS_CONNECTED_BITS;
+    }
+
+#if 0 // TODO Enable SUSPEND & RESUME interrupt and test later on with/without VBUS detection
+    if (status & USB_INTS_DEV_SUSPEND_BITS)
+    {
+        handled |= USB_INTS_DEV_SUSPEND_BITS;
+        dcd_event_bus_signal(0, DCD_EVENT_SUSPEND, true);
+        usb_hw_clear->sie_status = USB_SIE_STATUS_SUSPENDED_BITS;
+    }
+
+    if (status & USB_INTS_DEV_RESUME_FROM_HOST_BITS)
+    {
+        handled |= USB_INTS_DEV_RESUME_FROM_HOST_BITS;
+        dcd_event_bus_signal(0, DCD_EVENT_RESUME, true);
+        usb_hw_clear->sie_status = USB_SIE_STATUS_RESUME_BITS;
+    }
+#endif
 
     if (status ^ handled)
     {
@@ -364,8 +396,10 @@ void dcd_init (uint8_t rhport)
 
     // Enable individual controller IRQS here. Processor interrupt enable will be used
     // for the global interrupt enable...
+    // TODO Enable SUSPEND & RESUME interrupt
     usb_hw->sie_ctrl = USB_SIE_CTRL_EP0_INT_1BUF_BITS; 
-    usb_hw->inte     = USB_INTS_BUFF_STATUS_BITS | USB_INTS_BUS_RESET_BITS | USB_INTS_SETUP_REQ_BITS;
+    usb_hw->inte     = USB_INTS_BUFF_STATUS_BITS | USB_INTS_BUS_RESET_BITS | USB_INTS_SETUP_REQ_BITS |
+                       USB_INTS_DEV_CONN_DIS_BITS /* | USB_INTS_DEV_SUSPEND_BITS | USB_INTS_DEV_RESUME_FROM_HOST_BITS */  ;
 
     dcd_connect(rhport);
 }
@@ -393,8 +427,9 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
 
 void dcd_remote_wakeup(uint8_t rhport)
 {
-    pico_info("dcd_remote_wakeup %d is not supported yet\n", rhport);
+    pico_info("dcd_remote_wakeup %d\n", rhport);
     assert(rhport == 0);
+    usb_hw_set->sie_ctrl = USB_SIE_CTRL_RESUME_BITS;
 }
 
 // disconnect by disabling internal pull-up resistor on D+/D-
@@ -402,6 +437,7 @@ void dcd_disconnect(uint8_t rhport)
 {
     pico_info("dcd_disconnect %d\n", rhport);
     assert(rhport == 0);
+    //TU_LOG2("dcd_disconnect\n");
     usb_hw_clear->sie_ctrl = USB_SIE_CTRL_PULLUP_EN_BITS;
 }
 
@@ -410,6 +446,7 @@ void dcd_connect(uint8_t rhport)
 {
     pico_info("dcd_connect %d\n", rhport);
     assert(rhport == 0);
+    //TU_LOG2("dcd_connect\n");
     usb_hw_set->sie_ctrl = USB_SIE_CTRL_PULLUP_EN_BITS;
 }
 

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -437,7 +437,6 @@ void dcd_disconnect(uint8_t rhport)
 {
     pico_info("dcd_disconnect %d\n", rhport);
     assert(rhport == 0);
-    //TU_LOG2("dcd_disconnect\n");
     usb_hw_clear->sie_ctrl = USB_SIE_CTRL_PULLUP_EN_BITS;
 }
 
@@ -446,7 +445,6 @@ void dcd_connect(uint8_t rhport)
 {
     pico_info("dcd_connect %d\n", rhport);
     assert(rhport == 0);
-    //TU_LOG2("dcd_connect\n");
     usb_hw_set->sie_ctrl = USB_SIE_CTRL_PULLUP_EN_BITS;
 }
 


### PR DESCRIPTION
**Describe the PR**
- Update pico-sdk to latest of develop branch
- Enable `pico_bootsel_via_double_reset` for all examples
- Add Disconnection detection and submit UNPLUGGED event to usbd
- Add Add TODO for suspend, resume later on, since it needs a bit of time to test on board with/without vbus detection. 
- Implement dcd_remote_wakeup() (not tested since suspended is not enabled yet).
- Tested LOG with segger rtt.

All CMakelists.txt are updated, just ignore it, the interested modification is in `dcd_rp2040.c`
