### PR TITLE
fix enum walkaround forever check for SE0 when pull up is disabled

### DIFF
--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -80,8 +80,8 @@ bool __no_inline_not_in_flash_func(get_bootsel_button)() {
 #if defined(LOGGER_RTT)
 
 // Logging with RTT
-// If RTT Control Block is not found by 'Auto Detection`
-// try to use 'Search Range` with '0x20000000 0x10000'
+// - If RTT Control Block is not found by 'Auto Detection` try to use 'Search Range` with '0x20000000 0x10000'
+// - SWD speed is rather slow around 1000Khz
 
 #include "pico/stdio/driver.h"
 #include "SEGGER_RTT.h"

--- a/hw/bsp/rp2040/family.mk
+++ b/hw/bsp/rp2040/family.mk
@@ -1,3 +1,4 @@
 FAMILY_SUBMODULES = hw/mcu/raspberrypi/pico-sdk
 
 JLINK_DEVICE = rp2040_m0_0
+PYOCD_TARGET = rp2040

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -60,8 +60,11 @@ void rp2040_usb_init(void)
     memset(usb_hw, 0, sizeof(*usb_hw));
     memset(usb_dpram, 0, sizeof(*usb_dpram));
 
-    // Mux to phy
+    // Mux the controller to the onboard usb phy
     usb_hw->muxing    = USB_USB_MUXING_TO_PHY_BITS    | USB_USB_MUXING_SOFTCON_BITS;
+
+    // Force VBUS detect so the device thinks it is plugged into a host
+    // TODO support VBUs detect
     usb_hw->pwr       = USB_USB_PWR_VBUS_DETECT_BITS  | USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN_BITS;
 }
 


### PR DESCRIPTION
**Describe the PR**
This issue is discovered while troubleshooting https://github.com/adafruit/circuitpython/issues/4066#issuecomment-789524956

Part of enumeration walkaround is waiting for bus reset to complete i.e line state != SE0. 
https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c#L61

However, when pull-up is disabled e.g application call `tud_disconnect()` to soft disconnect from Host (while still physically plugged in). SE0 will be permanent present causing the walkround forever checking for the state unitl `tud_connect()` (pullup is enabled) or cpu reset. Worse if `PICO_TIME_DEFAULT_ALARM_POOL_DISABLED = 1`, the walkaround will blockingly wait --> sort of hanged there.

To reproduce, add this to any of the example, press the button, rp2040 will disconnect but forever hanged if PICO_TIME_DEFAULT_ALARM_POOL_DISABLED=1
```
if ( board_button_read() )
{
  printf("Disconnect\n");
  tud_disconnect();
  board_delay(2000);
  printf("Re-connect\n");
  tud_connect();
}
```

**Solution**

Only run enumeration walkaround if pull-up is enabled. 

**Additional Context**

I add a bit of TODO for VBus detect and Suspend & Resume later on. Note to myself: the pico schematic use GPIO24 which is is actually VBUS over current detection (FUN9), will need a jump wire to test later on.