### PR TITLE
update doc for BOARD name, add note for udev on Linux

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,6 +47,8 @@ $ git submodule update --init lib
 
 In addition, MCU driver submodule is also needed to provide low-level MCU peripheral's driver. Luckily, it will be fetched if needed when you run the `make` to build your board.
 
+Note: some examples especially those that uses Vendor class (e.g webUSB) may requires udev permission on Linux (and/or macOS) to access usb device. It depends on your OS distro, typically copy `/examples/device/99-tinyusb.rules` file to /etc/udev/rules.d/ then run `sudo udevadm control --reload-rules && sudo udevadm trigger` is good enough.
+
 ### Build
 
 To build example, first change directory to an example folder. 
@@ -60,6 +62,8 @@ Then compile with `make BOARD=[board_name] all`, for example
 ```
 $ make BOARD=feather_nrf52840_express all
 ```
+
+Note: `BOARD` can be found as directory name in `hw/bsp`, either in its family/boards or directly under bsp (no family).
 
 #### Port Selection
 

--- a/examples/device/99-tinyusb.rules
+++ b/examples/device/99-tinyusb.rules
@@ -12,7 +12,3 @@ ATTRS{idVendor}=="cafe", MODE="0666", GROUP="dialout"
 
 # Rule to blacklist TinyUSB example from being manipulated by ModemManager.
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="cafe", ENV{ID_MM_DEVICE_IGNORE}="1"
-
-# Xplained Pro SamG55 Device
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2111", MODE="0666", GROUP="users", ENV{ID_MM_DEVICE_IGNORE}="1"
-SUBSYSTEMS=="tty", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2111", MODE="0666", GROUP="users", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/examples/device/webusb_serial/src/main.c
+++ b/examples/device/webusb_serial/src/main.c
@@ -23,6 +23,26 @@
  *
  */
 
+/* This example demonstrates WebUSB as web serial with browser with WebUSB support (e.g Chrome).
+ * After enumerated successfully, browser will pop-up notification
+ * with URL to landing page, click on it to test
+ *  - Click "Connect" and select device, When connected the on-board LED will litted up.
+ *  - Any charters received from either webusb/Serial will be echo back to webusb and Serial
+ *
+ * Note:
+ * - The WebUSB landing page notification is currently disabled in Chrome
+ * on Windows due to Chromium issue 656702 (https://crbug.com/656702). You have to
+ * go to landing page (below) to test
+ *
+ * - On Windows 7 and prior: You need to use Zadig tool to manually bind the
+ * WebUSB interface with the WinUSB driver for Chrome to access. From windows 8 and 10, this
+ * is done automatically by firmware.
+ *
+ * - On Linux/macOS, udev permission may need to be updated by
+ *   - copying '/examples/device/99-tinyusb.rules' file to /etc/udev/rules.d/ then
+ *   - run 'sudo udevadm control --reload-rules && sudo udevadm trigger'
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
**Describe the PR**
Update docs to mention how to find out `BOARD` and udev for webusb example. Fix  #481 
