### PR TITLE
fix for nrf52840 epout dma race condition

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -273,6 +273,18 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
 
   xfer_td_t* xfer = get_td(epnum, dir);
 
+  if (dir == TUSB_DIR_OUT) {
+    // hw auto ack'd xfer so wait until it's done
+    // fix for https://github.com/adafruit/Adafruit_nRF52_Bootloader/issues/195
+    // FIXME: need a cleaner way kick off DMA with write to SIZE.EPOUT when starting
+    // FIXME: a sequence of HOST->ENDPOINT transfers
+    uint32_t timeout = 0;
+    while (!xfer->data_received && (timeout < 100)) {
+      NRFX_DELAY_US(1);
+	  timeout++;
+    }
+  }
+
   xfer->buffer     = buffer;
   xfer->total_len  = total_bytes;
   xfer->actual_len = 0;


### PR DESCRIPTION
Fix for https://github.com/adafruit/Adafruit_nRF52_Bootloader/issues/195.

Addresses race condition between writing SIZE.EPOUT=0 and xfer->data_received flag.  Since NR52840 always auto ACKs after DMA completion the code should always wait for data_received to be sure the transfer is complete.  This doesn't work when starting a sequence of transfers so timeout and write SIZE.EPOUT in this case.  If one could differentiate the start/end of a packet sequence at this level of the code then the timeout could be avoided (though always a good idea when spin waiting on anything).