### PR TITLE
use boot2_generic_03h for adafruit feather rp2040

### DIFF
--- a/examples/device/audio_test/CMakeLists.txt
+++ b/examples/device/audio_test/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/board_test/CMakeLists.txt
+++ b/examples/device/board_test/CMakeLists.txt
@@ -9,15 +9,17 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "esp32s2")
   cmake_minimum_required(VERSION 3.5)
+
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)
   project(${PROJECT})
 
 elseif(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/cdc_dual_ports/CMakeLists.txt
+++ b/examples/device/cdc_dual_ports/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/cdc_msc/CMakeLists.txt
+++ b/examples/device/cdc_msc/CMakeLists.txt
@@ -17,9 +17,8 @@ elseif(FAMILY STREQUAL "rp2040")
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
-
+    
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)
 
   # Example source

--- a/examples/device/dfu_runtime/CMakeLists.txt
+++ b/examples/device/dfu_runtime/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/dynamic_configuration/CMakeLists.txt
+++ b/examples/device/dynamic_configuration/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/hid_composite/CMakeLists.txt
+++ b/examples/device/hid_composite/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/hid_generic_inout/CMakeLists.txt
+++ b/examples/device/hid_generic_inout/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/hid_multiple_interface/CMakeLists.txt
+++ b/examples/device/hid_multiple_interface/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/midi_test/CMakeLists.txt
+++ b/examples/device/midi_test/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/msc_dual_lun/CMakeLists.txt
+++ b/examples/device/msc_dual_lun/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/net_lwip_webserver/CMakeLists.txt
+++ b/examples/device/net_lwip_webserver/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/uac2_headset/CMakeLists.txt
+++ b/examples/device/uac2_headset/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/usbtmc/CMakeLists.txt
+++ b/examples/device/usbtmc/CMakeLists.txt
@@ -11,8 +11,8 @@ if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/device/webusb_serial/CMakeLists.txt
+++ b/examples/device/webusb_serial/CMakeLists.txt
@@ -9,10 +9,11 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/examples/host/cdc_msc_hid/CMakeLists.txt
+++ b/examples/host/cdc_msc_hid/CMakeLists.txt
@@ -14,10 +14,11 @@ if(FAMILY STREQUAL "esp32s2")
 
 elseif(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
+  
   set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
   include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+  
   project(${PROJECT})
-  pico_sdk_init()
   add_executable(${PROJECT})
 
   include(${TOP}/hw/bsp/${FAMILY}/family.cmake)

--- a/hw/bsp/rp2040/boards/adafruit_feather_rp2040/board.cmake
+++ b/hw/bsp/rp2040/boards/adafruit_feather_rp2040/board.cmake
@@ -1,0 +1,1 @@
+set(PICO_DEFAULT_BOOT_STAGE2_FILE "${PICO_SDK_PATH}/src/rp2_common/boot_stage2/boot2_generic_03h.S")

--- a/hw/bsp/rp2040/boards/adafruit_itsybitsy_rp2040/board.cmake
+++ b/hw/bsp/rp2040/boards/adafruit_itsybitsy_rp2040/board.cmake
@@ -1,0 +1,1 @@
+set(PICO_DEFAULT_BOOT_STAGE2_FILE "${PICO_SDK_PATH}/src/rp2_common/boot_stage2/boot2_generic_03h.S")

--- a/hw/bsp/rp2040/boards/adafruit_qt_rp2040/board.cmake
+++ b/hw/bsp/rp2040/boards/adafruit_qt_rp2040/board.cmake
@@ -1,0 +1,1 @@
+set(PICO_DEFAULT_BOOT_STAGE2_FILE "${PICO_SDK_PATH}/src/rp2_common/boot_stage2/boot2_generic_03h.S")

--- a/hw/bsp/rp2040/boards/raspberry_pi_pico/board.cmake
+++ b/hw/bsp/rp2040/boards/raspberry_pi_pico/board.cmake
@@ -1,0 +1,1 @@
+set(PICO_DEFAULT_BOOT_STAGE2_FILE "${PICO_SDK_PATH}/src/rp2_common/boot_stage2/boot2_w25q080.S")

--- a/hw/bsp/rp2040/family.cmake
+++ b/hw/bsp/rp2040/family.cmake
@@ -1,3 +1,9 @@
+# Board specific define e.g boot stage2
+# PICO_DEFAULT_BOOT_STAGE2_FILE must be set before pico_sdk_init()
+include(${TOP}/hw/bsp/${FAMILY}/boards/${BOARD}/board.cmake)
+
+pico_sdk_init()
+
 target_link_libraries(${PROJECT}
   pico_stdlib
   pico_bootsel_via_double_reset

--- a/hw/bsp/rp2040/family.mk
+++ b/hw/bsp/rp2040/family.mk
@@ -1,5 +1,8 @@
 DEPS_SUBMODULES += hw/mcu/raspberrypi/pico-sdk
 
+JLINK_DEVICE = rp2040_m0_0
+PYOCD_TARGET = rp2040
+
 ifeq ($(DEBUG), 1)
 CMAKE_DEFSYM += -DCMAKE_BUILD_TYPE=Debug
 endif
@@ -13,9 +16,6 @@ all: $(BUILD)
 clean:
 	$(RM) -rf $(BUILD)
 
-#flash: flash-pyocd
-flash:
+flash: flash-pyocd
+flash-uf2:
 	@$(CP) $(BUILD)/$(PROJECT).uf2 /media/$(USER)/RPI-RP2
-
-JLINK_DEVICE = rp2040_m0_0
-PYOCD_TARGET = rp2040


### PR DESCRIPTION
**Describe the PR**
Get examples to run on Adafruit Feather RP2040
- also use boot2_generic_03h for now for itsy bitsy and qt rp2040
- change default flash target for rp2040 to flash-pyocd
