### PR TITLE
Allow TU_BREAKPOINT() to break for a Cortex-M0+ also

### DIFF
--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -83,8 +83,8 @@
   #define _MESS_FAILED() do {} while (0)
 #endif
 
-// Halt CPU (breakpoint) when hitting error, only apply for Cortex M3, M4, M7
-#if defined(__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__)
+// Halt CPU (breakpoint) when hitting error, only apply for Cortex M0+, M3, M4, M7
+#if defined(__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__) || defined(__ARM_ARCH_6M__)
   #define TU_BREAKPOINT() do                                                                                \
   {                                                                                                         \
     volatile uint32_t* ARM_CM_DHCSR =  ((volatile uint32_t*) 0xE000EDF0UL); /* Cortex M CoreDebug->DHCSR */ \


### PR DESCRIPTION
**Describe the PR**
The Cortex-M0+ (Arm architecture 6M) also supports the
DHCSR.C_DEBUGEN bit (bit 0) to tell whether a debugger is attached.
This PR adds that architecture to TU_BREAKPOINT().

**Additional context**
If applicable, add any other context about the PR and/or screenshots here.
