### PR TITLE
Add macro for unaligned access.

### DIFF
--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -81,6 +81,27 @@
   #define TU_BSWAP16(u16) (__builtin_bswap16(u16))
   #define TU_BSWAP32(u32) (__builtin_bswap32(u32))
 
+  #define TU_UNALIGNED_GET(var, ptr, type)  \
+  do                                        \
+  {                                         \
+    struct __attribute__((__packed__))      \
+    {                                       \
+      type __v;                             \
+    } *__p = (void*) (ptr);                 \
+    (var) = __p->__v;                       \
+  } while(0)
+
+  #define TU_UNALIGNED_PUT(var, ptr, type)  \
+  do                                        \
+  {							                            \
+    struct __attribute__((__packed__))      \
+    {                                       \
+      type __v;                             \
+    } *__p = (void*) (ptr);                 \
+    __p->__v = (var);                       \
+    __asm__ __volatile__ ("" ::: "memory"); \
+  } while(0)
+
 #elif defined(__TI_COMPILER_VERSION__)
   #define TU_ATTR_ALIGNED(Bytes)        __attribute__ ((aligned(Bytes)))
   #define TU_ATTR_SECTION(sec_name)     __attribute__ ((section(#sec_name)))
@@ -100,6 +121,27 @@
 
   #define TU_BSWAP16(u16) (__builtin_bswap16(u16))
   #define TU_BSWAP32(u32) (__builtin_bswap32(u32))
+
+  #define TU_UNALIGNED_GET(var, ptr, type)  \
+  do                                        \
+  {                                         \
+    struct __attribute__((__packed__))      \
+    {                                       \
+      type __v;                             \
+    } *__p = (void*) (ptr);                 \
+    (var) = __p->__v;                       \
+  } while(0)
+
+  #define TU_UNALIGNED_PUT(var, ptr, type)  \
+  do                                        \
+  {							                            \
+    struct __attribute__((__packed__))      \
+    {                                       \
+      type __v;                             \
+    } *__p = (void*) (ptr);                 \
+    __p->__v = (var);                       \
+    __asm__ __volatile__ ("" ::: "memory"); \
+  } while(0)
 
 #elif defined(__ICCARM__)
   #include <intrinsics.h>
@@ -121,6 +163,23 @@
 
   #define TU_BSWAP16(u16) (__iar_builtin_REV16(u16))
   #define TU_BSWAP32(u32) (__iar_builtin_REV(u32))
+
+  #define TU_UNALIGNED_GET(var, ptr, type)   \
+  do                                         \
+  {                                          \
+    _Pragma ("diag_suppress=Pa039");         \
+    (var) = *(__packed type*)(ptr);          \
+    _Pragma ("diag_default=Pa039");          \
+  } while (0);
+    
+  #define TU_UNALIGNED_PUT(var, ptr, type)   \
+  do                                         \
+  {                                          \
+    _Pragma ("diag_suppress=Pa039");         \
+    *(__packed type*)(ptr) = (var);          \
+    _Pragma ("diag_default=Pa039");          \
+  } while (0);
+
 #else 
   #error "Compiler attribute porting is required"
 #endif


### PR DESCRIPTION
**Describe the PR**
A proposition for unaligned access macro.

Then we can refactor unaligned accesses, for example:
```
uint16_t total_len;
// Use offsetof to avoid pointer to the odd/misaligned address
memcpy(&total_len, (uint8_t*) desc_bos + offsetof(tusb_desc_bos_t, wTotalLength), 2);
```
Into
```
uint16_t total_len;
TU_UNALIGNED_GET(total_len, &desc_bos->wTotalLength, uint16_t);
```

**Additional context**
It *should* works on TI compiler, need test.