### PR TITLE
Enhance midi

### DIFF
--- a/examples/device/dynamic_configuration/src/main.c
+++ b/examples/device/dynamic_configuration/src/main.c
@@ -186,10 +186,12 @@ void midi_task(void)
   if (previous < 0) previous = sizeof(note_sequence) - 1;
 
   // Send Note On for current position at full velocity (127) on channel 1.
-  tud_midi_write24(cable_num, 0x90 | channel, note_sequence[note_pos], 127);
+  uint8_t note_on[3] = { 0x90 | channel, note_sequence[note_pos], 127 };
+  tud_midi_stream_write(cable_num, note_on, 3);
 
   // Send Note Off for previous note.
-  tud_midi_write24(cable_num, 0x80 | channel, note_sequence[previous], 0);
+  uint8_t note_off[3] = { 0x80 | channel, note_sequence[previous], 0};
+  tud_midi_stream_write(cable_num, note_off, 3);
 
   // Increment position
   note_pos++;

--- a/examples/device/dynamic_configuration/src/main.c
+++ b/examples/device/dynamic_configuration/src/main.c
@@ -172,7 +172,7 @@ void midi_task(void)
   // regardless of these being used or not. Therefore incoming traffic should be read
   // (possibly just discarded) to avoid the sender blocking in IO
   uint8_t packet[4];
-  while(tud_midi_available()) tud_midi_receive(packet);
+  while( tud_midi_available() ) tud_midi_packet_read(packet);
 
   // send note every 1000 ms
   if (board_millis() - start_ms < 286) return; // not enough time

--- a/examples/device/midi_test/src/main.c
+++ b/examples/device/midi_test/src/main.c
@@ -132,7 +132,7 @@ void midi_task(void)
   // regardless of these being used or not. Therefore incoming traffic should be read
   // (possibly just discarded) to avoid the sender blocking in IO
   uint8_t packet[4];
-  while(tud_midi_available()) tud_midi_receive(packet);
+  while ( tud_midi_available() ) tud_midi_packet_read(packet);
 
   // send note every 1000 ms
   if (board_millis() - start_ms < 286) return; // not enough time
@@ -146,10 +146,12 @@ void midi_task(void)
   if (previous < 0) previous = sizeof(note_sequence) - 1;
 
   // Send Note On for current position at full velocity (127) on channel 1.
-  tud_midi_write24(cable_num, 0x90 | channel, note_sequence[note_pos], 127);
+  uint8_t note_on[3] = { 0x90 | channel, note_sequence[note_pos], 127 };
+  tud_midi_write(cable_num, note_on, 3);
 
   // Send Note Off for previous note.
-  tud_midi_write24(cable_num, 0x80 | channel, note_sequence[previous], 0);
+  uint8_t note_off[3] = { 0x80 | channel, note_sequence[previous], 0};
+  tud_midi_write(cable_num, note_off, 3);
 
   // Increment position
   note_pos++;

--- a/examples/device/midi_test/src/main.c
+++ b/examples/device/midi_test/src/main.c
@@ -147,11 +147,11 @@ void midi_task(void)
 
   // Send Note On for current position at full velocity (127) on channel 1.
   uint8_t note_on[3] = { 0x90 | channel, note_sequence[note_pos], 127 };
-  tud_midi_write(cable_num, note_on, 3);
+  tud_midi_stream_write(cable_num, note_on, 3);
 
   // Send Note Off for previous note.
   uint8_t note_off[3] = { 0x80 | channel, note_sequence[previous], 0};
-  tud_midi_write(cable_num, note_off, 3);
+  tud_midi_stream_write(cable_num, note_off, 3);
 
   // Increment position
   note_pos++;

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -103,7 +103,7 @@ CFLAGS += \
 
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
-  CFLAGS += -O0
+  CFLAGS += -Og
 else
   CFLAGS += -Os
 endif

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -103,7 +103,7 @@ CFLAGS += \
 
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
-  CFLAGS += -Og
+  CFLAGS += -O0
 else
   CFLAGS += -Os
 endif

--- a/src/class/midi/midi.h
+++ b/src/class/midi/midi.h
@@ -61,6 +61,51 @@ typedef enum
   MIDI_JACK_EXTERNAL = 0x02
 } midi_jack_type_t;
 
+typedef enum
+{
+  MIDI_CIN_MISC              = 0,
+  MIDI_CIN_CABLE_EVENT       = 1,
+  MIDI_CIN_SYSCOM_2BYTE      = 2, // 2 byte system common message e.g MTC, SongSelect
+  MIDI_CIN_SYSCOM_3BYTE      = 3, // 3 byte system common message e.g SPP
+  MIDI_CIN_SYSEX_START       = 4, // SysEx starts or continue
+  MIDI_CIN_SYSEX_END_1BYTE   = 5, // SysEx ends with 1 data, or 1 byte system common message
+  MIDI_CIN_SYSEX_END_2BYTE   = 6, // SysEx ends with 2 data
+  MIDI_CIN_SYSEX_END_3BYTE   = 7, // SysEx ends with 3 data
+  MIDI_CIN_NOTE_ON           = 8,
+  MIDI_CIN_NOTE_OFF          = 9,
+  MIDI_CIN_POLY_KEYPRESS     = 10,
+  MIDI_CIN_CONTROL_CHANGE    = 11,
+  MIDI_CIN_PROGRAM_CHANGE    = 12,
+  MIDI_CIN_CHANNEL_PRESSURE  = 13,
+  MIDI_CIN_PITCH_BEND_CHANGE = 14,
+  MIDI_CIN_1BYTE_DATA = 15
+} midi_code_index_number_t;
+
+// MIDI 1.0 status byte
+enum
+{
+  //------------- System Exclusive -------------//
+  MIDI_STATUS_SYSEX_START                    = 0xF0,
+  MIDI_STATUS_SYSEX_END                      = 0xF7,
+
+  //------------- System Common -------------//
+  MIDI_STATUS_SYSCOM_TIME_CODE_QUARTER_FRAME = 0xF1,
+  MIDI_STATUS_SYSCOM_SONG_POSITION_POINTER   = 0xF2,
+  MIDI_STATUS_SYSCOM_SONG_SELECT             = 0xF3,
+  // F4, F5 is undefined
+  MIDI_STATUS_SYSCOM_TUNE_REQUEST            = 0xF6,
+
+  //------------- System RealTime  -------------//
+  MIDI_STATUS_SYSREAL_TIMING_CLOCK           = 0xF8,
+  // 0xF9 is undefined
+  MIDI_STATUS_SYSREAL_START                  = 0xFA,
+  MIDI_STATUS_SYSREAL_CONTINUE               = 0xFB,
+  MIDI_STATUS_SYSREAL_STOP                   = 0xFC,
+  // 0xFD is undefined
+  MIDI_STATUS_SYSREAL_ACTIVE_SENSING         = 0xFE,
+  MIDI_STATUS_SYSREAL_SYSTEM_RESET           = 0xFF,
+};
+
 /// MIDI Interface Header Descriptor
 typedef struct TU_ATTR_PACKED
 {

--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -158,14 +158,6 @@ uint32_t tud_midi_n_read(uint8_t itf, uint8_t cable_num, void* buffer, uint32_t 
   return n;
 }
 
-void tud_midi_n_read_flush (uint8_t itf, uint8_t cable_num)
-{
-  (void) cable_num;
-  midid_interface_t* p_midi = &_midid_itf[itf];
-  tu_fifo_clear(&p_midi->rx_ff);
-  _prep_out_transaction(p_midi);
-}
-
 bool tud_midi_n_packet_read (uint8_t itf, uint8_t packet[4])
 {
   midid_interface_t* p_midi = &_midid_itf[itf];

--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -127,7 +127,7 @@ uint32_t tud_midi_n_available(uint8_t itf, uint8_t cable_num)
   return tu_fifo_count(&_midid_itf[itf].rx_ff);
 }
 
-uint32_t tud_midi_n_read(uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize)
+uint32_t tud_midi_n_stream_read(uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize)
 {
   (void) cable_num;
   midid_interface_t* midi = &_midid_itf[itf];
@@ -220,7 +220,7 @@ static uint32_t write_flush(midid_interface_t* midi)
   }
 }
 
-uint32_t tud_midi_n_write(uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
+uint32_t tud_midi_n_stream_write(uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
 {
   midid_interface_t* midi = &_midid_itf[itf];
   TU_VERIFY(midi->itf_num, 0);

--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -127,7 +127,7 @@ uint32_t tud_midi_n_read(uint8_t itf, uint8_t cable_num, void* buffer, uint32_t 
 
   // Fill empty buffer
   if (midi->read_buffer_length == 0) {
-    if (!tud_midi_n_receive(itf, midi->read_buffer)) return 0;
+    if (!tud_midi_n_packet_read(itf, midi->read_buffer)) return 0;
 
     uint8_t code_index = midi->read_buffer[0] & 0x0f;
     // We always copy over the first byte.
@@ -166,7 +166,7 @@ void tud_midi_n_read_flush (uint8_t itf, uint8_t cable_num)
   _prep_out_transaction(p_midi);
 }
 
-bool tud_midi_n_receive (uint8_t itf, uint8_t packet[4])
+bool tud_midi_n_packet_read (uint8_t itf, uint8_t packet[4])
 {
   midid_interface_t* p_midi = &_midid_itf[itf];
   uint32_t num_read = tu_fifo_read_n(&p_midi->rx_ff, packet, 4);
@@ -278,7 +278,7 @@ uint32_t tud_midi_n_write(uint8_t itf, uint8_t cable_num, uint8_t const* buffer,
   return i;
 }
 
-bool tud_midi_n_send (uint8_t itf, uint8_t const packet[4])
+bool tud_midi_n_packet_write (uint8_t itf, uint8_t const packet[4])
 {
   midid_interface_t* midi = &_midid_itf[itf];
   if (midi->itf_num == 0) {

--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -67,11 +67,7 @@ typedef struct
   // For Stream read()/write() API
   // Messages are always 4 bytes long, queue them for reading and writing so the
   // callers can use the Stream interface with single-byte read/write calls.
-  uint8_t write_buffer[4];
-  uint8_t write_buffer_length;
-  uint8_t write_target_length;
-
-//  midid_stream_t stream_write;
+  midid_stream_t stream_write;
 
   uint8_t read_buffer[4];
   uint8_t read_buffer_length;
@@ -229,7 +225,7 @@ uint32_t tud_midi_n_write(uint8_t itf, uint8_t cable_num, uint8_t const* buffer,
   midid_interface_t* midi = &_midid_itf[itf];
   TU_VERIFY(midi->itf_num, 0);
 
-//  midid_stream_t* stream = &midi->stream_write;
+  midid_stream_t* stream = &midi->stream_write;
 
   uint32_t written = 0;
   uint32_t i = 0;
@@ -237,93 +233,94 @@ uint32_t tud_midi_n_write(uint8_t itf, uint8_t cable_num, uint8_t const* buffer,
   {
     uint8_t const data = buffer[i];
 
-    if ( midi->write_buffer_length == 0 )
+    if ( stream->index == 0 )
     {
-      // new packet
+      // new event packet
 
       uint8_t const msg = data >> 4;
-      midi->write_buffer[1] = data;
-      midi->write_buffer_length = 2;
+
+      stream->index = 2;
+      stream->buffer[1] = data;
 
       // Check to see if we're still in a SysEx transmit.
-      if ( midi->write_buffer[0] == MIDI_CIN_SYSEX_START )
+      if ( stream->buffer[0] == MIDI_CIN_SYSEX_START )
       {
         if ( data == MIDI_STATUS_SYSEX_END )
         {
-          midi->write_buffer[0] = MIDI_CIN_SYSEX_END_1BYTE;
-          midi->write_target_length = 2;
+          stream->buffer[0] = MIDI_CIN_SYSEX_END_1BYTE;
+          stream->total = 2;
         }
         else
         {
-          midi->write_target_length = 4;
+          stream->total = 4;
         }
       }
       else if ( (msg >= 0x8 && msg <= 0xB) || msg == 0xE )
       {
         // Channel Voice Messages
-        midi->write_buffer[0] = (cable_num << 4) | msg;
-        midi->write_target_length = 4;
+        stream->buffer[0] = (cable_num << 4) | msg;
+        stream->total = 4;
       }
       else if ( msg == 0xf )
       {
         // System message
         if ( data == MIDI_STATUS_SYSEX_START )
         {
-          midi->write_buffer[0] = MIDI_CIN_SYSEX_START;
-          midi->write_target_length = 4;
+          stream->buffer[0] = MIDI_CIN_SYSEX_START;
+          stream->total = 4;
         }
         else if ( data == MIDI_STATUS_SYSCOM_TIME_CODE_QUARTER_FRAME || data == MIDI_STATUS_SYSCOM_SONG_SELECT )
         {
-          midi->write_buffer[0] = MIDI_CIN_SYSCOM_2BYTE;
-          midi->write_target_length = 3;
+          stream->buffer[0] = MIDI_CIN_SYSCOM_2BYTE;
+          stream->total = 3;
         }
         else if ( data == MIDI_STATUS_SYSCOM_SONG_POSITION_POINTER )
         {
-          midi->write_buffer[0] = MIDI_CIN_SYSCOM_3BYTE;
-          midi->write_target_length = 4;
+          stream->buffer[0] = MIDI_CIN_SYSCOM_3BYTE;
+          stream->total = 4;
         }
         else
         {
-          midi->write_buffer[0] = MIDI_CIN_SYSEX_END_1BYTE;
-          midi->write_target_length = 2;
+          stream->buffer[0] = MIDI_CIN_SYSEX_END_1BYTE;
+          stream->total = 2;
         }
       }
       else
       {
         // Pack individual bytes if we don't support packing them into words.
-        midi->write_buffer[0] = cable_num << 4 | 0xf;
-        midi->write_buffer[2] = 0;
-        midi->write_buffer[3] = 0;
-        midi->write_buffer_length = 2;
-        midi->write_target_length = 2;
+        stream->buffer[0] = cable_num << 4 | 0xf;
+        stream->buffer[2] = 0;
+        stream->buffer[3] = 0;
+        stream->index = 2;
+        stream->total = 2;
       }
     }
     else
     {
-      // On-going packet
+      // On-going (buffering) packet
 
-      TU_ASSERT(midi->write_buffer_length < 4, 0);
-      midi->write_buffer[midi->write_buffer_length] = data;
-      midi->write_buffer_length++;
+      TU_ASSERT(stream->index < 4, written);
+      stream->buffer[stream->index] = data;
+      stream->index++;
 
       // See if this byte ends a SysEx.
-      if ( midi->write_buffer[0] == MIDI_CIN_SYSEX_START && data == MIDI_STATUS_SYSEX_END )
+      if ( stream->buffer[0] == MIDI_CIN_SYSEX_START && data == MIDI_STATUS_SYSEX_END )
       {
-        midi->write_buffer[0] = MIDI_CIN_SYSEX_START + (midi->write_buffer_length - 1);
-        midi->write_target_length = midi->write_buffer_length;
+        stream->buffer[0] = MIDI_CIN_SYSEX_START + (stream->index - 1);
+        stream->total = stream->index;
       }
     }
 
     // Send out packet
-    if ( midi->write_buffer_length == midi->write_target_length )
+    if ( stream->index == stream->total )
     {
       // zeroes unused bytes
-      for(uint8_t idx = midi->write_target_length; idx < 4; idx++) midi->write_buffer[idx] = 0;
+      for(uint8_t idx = stream->total; idx < 4; idx++) stream->buffer[idx] = 0;
 
-      uint16_t const count = tu_fifo_write_n(&midi->tx_ff, midi->write_buffer, 4);
+      uint16_t const count = tu_fifo_write_n(&midi->tx_ff, stream->buffer, 4);
 
       // reset buffer
-      midi->write_buffer_length = midi->write_target_length = 0;
+      stream->index = stream->total = 0;
 
       // fifo overflow, here we assume FIFO is multiple of 4 and didn't check remaining before writing
       if ( count != 4 ) break;

--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -72,10 +72,6 @@ uint32_t tud_midi_n_read       (uint8_t itf, uint8_t cable_num, void* buffer, ui
 // Write byte Stream (legacy)
 uint32_t tud_midi_n_write      (uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
 
-// Write good-old 3 bytes data, this use write packet
-static inline
-uint32_t tud_midi_n_write24    (uint8_t itf, uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3);
-
 // Read event packet (4 bytes)
 bool     tud_midi_n_packet_read    (uint8_t itf, uint8_t packet[4]);
 
@@ -87,12 +83,25 @@ bool     tud_midi_n_packet_write   (uint8_t itf, uint8_t const packet[4]);
 //--------------------------------------------------------------------+
 static inline bool     tud_midi_mounted    (void);
 static inline uint32_t tud_midi_available  (void);
+
 static inline uint32_t tud_midi_read       (void* buffer, uint32_t bufsize);
 static inline uint32_t tud_midi_write      (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
-static inline uint32_t tud_midi_write24    (uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3);
 
 static inline bool     tud_midi_packet_read (uint8_t packet[4]);
 static inline bool     tud_midi_packet_write(uint8_t const packet[4]);
+
+// TODO remove after 0.10.0 release
+TU_ATTR_DEPRECATED("tud_midi_send() is renamed to tud_midi_packet_write()")
+static inline bool tud_midi_send(uint8_t packet[4])
+{
+  return tud_midi_packet_write(packet);
+}
+
+TU_ATTR_DEPRECATED("tud_midi_receive() is renamed to tud_midi_packet_read()")
+static inline bool tud_midi_receive(uint8_t packet[4])
+{
+  return tud_midi_packet_read(packet);
+}
 
 //--------------------------------------------------------------------+
 // Application Callback API (weak is optional)
@@ -102,12 +111,6 @@ TU_ATTR_WEAK void tud_midi_rx_cb(uint8_t itf);
 //--------------------------------------------------------------------+
 // Inline Functions
 //--------------------------------------------------------------------+
-
-static inline uint32_t tud_midi_n_write24 (uint8_t itf, uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3)
-{
-  uint8_t msg[3] = { b1, b2, b3 };
-  return tud_midi_n_write(itf, cable_num, msg, 3);
-}
 
 static inline bool tud_midi_mounted (void)
 {
@@ -127,12 +130,6 @@ static inline uint32_t tud_midi_read (void* buffer, uint32_t bufsize)
 static inline uint32_t tud_midi_write (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
 {
   return tud_midi_n_write(0, cable_num, buffer, bufsize);
-}
-
-static inline uint32_t tud_midi_write24 (uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3)
-{
-  uint8_t msg[3] = { b1, b2, b3 };
-  return tud_midi_write(cable_num, msg, 3);
 }
 
 static inline bool tud_midi_packet_read (uint8_t packet[4])

--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -62,7 +62,6 @@
 bool     tud_midi_n_mounted    (uint8_t itf);
 uint32_t tud_midi_n_available  (uint8_t itf, uint8_t cable_num);
 uint32_t tud_midi_n_read       (uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize);
-void     tud_midi_n_read_flush (uint8_t itf, uint8_t cable_num);
 uint32_t tud_midi_n_write      (uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
 
 static inline
@@ -77,7 +76,6 @@ bool tud_midi_n_packet_write   (uint8_t itf, uint8_t const packet[4]);
 static inline bool     tud_midi_mounted    (void);
 static inline uint32_t tud_midi_available  (void);
 static inline uint32_t tud_midi_read       (void* buffer, uint32_t bufsize);
-static inline void     tud_midi_read_flush (void);
 static inline uint32_t tud_midi_write      (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
 static inline uint32_t tud_midi_write24    (uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3);
 
@@ -112,11 +110,6 @@ static inline uint32_t tud_midi_available (void)
 static inline uint32_t tud_midi_read (void* buffer, uint32_t bufsize)
 {
   return tud_midi_n_read(0, 0, buffer, bufsize);
-}
-
-static inline void tud_midi_read_flush (void)
-{
-  tud_midi_n_read_flush(0, 0);
 }
 
 static inline uint32_t tud_midi_write (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)

--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -61,36 +61,51 @@
 //--------------------------------------------------------------------+
 
 // Check if midi interface is mounted
-bool     tud_midi_n_mounted    (uint8_t itf);
+bool     tud_midi_n_mounted      (uint8_t itf);
 
 // Get the number of bytes available for reading
-uint32_t tud_midi_n_available  (uint8_t itf, uint8_t cable_num);
+uint32_t tud_midi_n_available    (uint8_t itf, uint8_t cable_num);
 
-// Read byte stream (legacy)
-uint32_t tud_midi_n_read       (uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize);
+// Read byte stream              (legacy)
+uint32_t tud_midi_n_stream_read  (uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize);
 
-// Write byte Stream (legacy)
-uint32_t tud_midi_n_write      (uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
+// Write byte Stream             (legacy)
+uint32_t tud_midi_n_stream_write (uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
 
-// Read event packet (4 bytes)
-bool     tud_midi_n_packet_read    (uint8_t itf, uint8_t packet[4]);
+// Read event packet             (4 bytes)
+bool     tud_midi_n_packet_read  (uint8_t itf, uint8_t packet[4]);
 
-// Write event packet (4 bytes)
-bool     tud_midi_n_packet_write   (uint8_t itf, uint8_t const packet[4]);
+// Write event packet            (4 bytes)
+bool     tud_midi_n_packet_write (uint8_t itf, uint8_t const packet[4]);
 
 //--------------------------------------------------------------------+
 // Application API (Single Interface)
 //--------------------------------------------------------------------+
-static inline bool     tud_midi_mounted    (void);
-static inline uint32_t tud_midi_available  (void);
+static inline bool     tud_midi_mounted      (void);
+static inline uint32_t tud_midi_available    (void);
 
-static inline uint32_t tud_midi_read       (void* buffer, uint32_t bufsize);
-static inline uint32_t tud_midi_write      (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
+static inline uint32_t tud_midi_stream_read  (void* buffer, uint32_t bufsize);
+static inline uint32_t tud_midi_stream_write (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
 
-static inline bool     tud_midi_packet_read (uint8_t packet[4]);
-static inline bool     tud_midi_packet_write(uint8_t const packet[4]);
+static inline bool     tud_midi_packet_read  (uint8_t packet[4]);
+static inline bool     tud_midi_packet_write (uint8_t const packet[4]);
 
+//------------- Deprecated API name  -------------//
 // TODO remove after 0.10.0 release
+
+TU_ATTR_DEPRECATED("tud_midi_read() is renamed to tud_midi_stream_read()")
+static inline uint32_t tud_midi_read (void* buffer, uint32_t bufsize)
+{
+  return tud_midi_stream_read(buffer, bufsize);
+}
+
+TU_ATTR_DEPRECATED("tud_midi_write() is renamed to tud_midi_stream_write()")
+static inline uint32_t tud_midi_write(uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
+{
+  return tud_midi_stream_write(cable_num, buffer, bufsize);
+}
+
+
 TU_ATTR_DEPRECATED("tud_midi_send() is renamed to tud_midi_packet_write()")
 static inline bool tud_midi_send(uint8_t packet[4])
 {
@@ -122,14 +137,14 @@ static inline uint32_t tud_midi_available (void)
   return tud_midi_n_available(0, 0);
 }
 
-static inline uint32_t tud_midi_read (void* buffer, uint32_t bufsize)
+static inline uint32_t tud_midi_stream_read (void* buffer, uint32_t bufsize)
 {
-  return tud_midi_n_read(0, 0, buffer, bufsize);
+  return tud_midi_n_stream_read(0, 0, buffer, bufsize);
 }
 
-static inline uint32_t tud_midi_write (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
+static inline uint32_t tud_midi_stream_write (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize)
 {
-  return tud_midi_n_write(0, cable_num, buffer, bufsize);
+  return tud_midi_n_stream_write(0, cable_num, buffer, bufsize);
 }
 
 static inline bool tud_midi_packet_read (uint8_t packet[4])

--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -59,16 +59,28 @@
 // Application API (Multiple Interfaces)
 // CFG_TUD_MIDI > 1
 //--------------------------------------------------------------------+
+
+// Check if midi interface is mounted
 bool     tud_midi_n_mounted    (uint8_t itf);
+
+// Get the number of bytes available for reading
 uint32_t tud_midi_n_available  (uint8_t itf, uint8_t cable_num);
+
+// Read byte stream (legacy)
 uint32_t tud_midi_n_read       (uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize);
+
+// Write byte Stream (legacy)
 uint32_t tud_midi_n_write      (uint8_t itf, uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
 
+// Write good-old 3 bytes data, this use write packet
 static inline
 uint32_t tud_midi_n_write24    (uint8_t itf, uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3);
 
-bool tud_midi_n_packet_read    (uint8_t itf, uint8_t packet[4]);
-bool tud_midi_n_packet_write   (uint8_t itf, uint8_t const packet[4]);
+// Read event packet (4 bytes)
+bool     tud_midi_n_packet_read    (uint8_t itf, uint8_t packet[4]);
+
+// Write event packet (4 bytes)
+bool     tud_midi_n_packet_write   (uint8_t itf, uint8_t const packet[4]);
 
 //--------------------------------------------------------------------+
 // Application API (Single Interface)

--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -68,8 +68,8 @@ uint32_t tud_midi_n_write      (uint8_t itf, uint8_t cable_num, uint8_t const* b
 static inline
 uint32_t tud_midi_n_write24    (uint8_t itf, uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3);
 
-bool tud_midi_n_receive        (uint8_t itf, uint8_t packet[4]);
-bool tud_midi_n_send           (uint8_t itf, uint8_t const packet[4]);
+bool tud_midi_n_packet_read    (uint8_t itf, uint8_t packet[4]);
+bool tud_midi_n_packet_write   (uint8_t itf, uint8_t const packet[4]);
 
 //--------------------------------------------------------------------+
 // Application API (Single Interface)
@@ -80,8 +80,9 @@ static inline uint32_t tud_midi_read       (void* buffer, uint32_t bufsize);
 static inline void     tud_midi_read_flush (void);
 static inline uint32_t tud_midi_write      (uint8_t cable_num, uint8_t const* buffer, uint32_t bufsize);
 static inline uint32_t tud_midi_write24    (uint8_t cable_num, uint8_t b1, uint8_t b2, uint8_t b3);
-static inline bool     tud_midi_receive    (uint8_t packet[4]);
-static inline bool     tud_midi_send       (uint8_t const packet[4]);
+
+static inline bool     tud_midi_packet_read (uint8_t packet[4]);
+static inline bool     tud_midi_packet_write(uint8_t const packet[4]);
 
 //--------------------------------------------------------------------+
 // Application Callback API (weak is optional)
@@ -129,14 +130,14 @@ static inline uint32_t tud_midi_write24 (uint8_t cable_num, uint8_t b1, uint8_t 
   return tud_midi_write(cable_num, msg, 3);
 }
 
-static inline bool tud_midi_receive (uint8_t packet[4])
+static inline bool tud_midi_packet_read (uint8_t packet[4])
 {
-  return tud_midi_n_receive(0, packet);
+  return tud_midi_n_packet_read(0, packet);
 }
 
-static inline bool tud_midi_send (uint8_t const packet[4])
+static inline bool tud_midi_packet_write (uint8_t const packet[4])
 {
-  return tud_midi_n_send(0, packet);
+  return tud_midi_n_packet_write(0, packet);
 }
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
Fix #735. should also fix root cause of #377 . should also fix issue with https://github.com/adafruit/circuitpython/issues/4190
Root cause of the issue is TX fifo is overflow, though it is not handled safely by driver, which cause the data corruption to the usbd device control and cause the system to crash/hardfault. While fixing the issue, I have go through the whole improvement, including
- Adding MIDI_CIN_ and MIDI_STATUS_  instead of using magic number in stream API
- Rename read(), write() to stream_read(), stream_write() with deprecated warning
- Rename receive(), send() to packet_read(), packet_write() with deprecated warning
- Refactor stream read/write buffering to stream read/write struct
- Correct stream read()  behavior to read until either user buffer is full or there is no more data from fifo
- remove write24() 

