### PR TITLE
Fixed very slow implementation of _ff_mod

### DIFF
--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -87,8 +87,15 @@ bool tu_fifo_config(tu_fifo_t *f, void* buffer, uint16_t depth, uint16_t item_si
 
 static inline uint16_t _ff_mod(uint16_t idx, uint16_t depth)
 {
-  while ( idx >= depth) idx -= depth;
-  return idx;
+  //detect power of 2 case
+  if (depth & (depth-1)) {
+    return idx % depth;
+  }
+  else 
+  {
+    //power of 2 case, fast path
+    return idx & (depth-1);
+  }
 }
 
 // send one item to FIFO WITHOUT updating write pointer


### PR DESCRIPTION


**Describe the PR**
Fixed very slow implementation. Symptoms are that the USB transfers take more and more time, then become fast again as the index (uint16_t)  wraps around

I appreciate the fact that some MPUs don't have a hardware divide, so I provided a fast path if the fifo depth is a power of 2. 
