### PR TITLE
Add support for SAM L22 family

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
         - 'samd11'
         - 'samd21'
         - 'samd51'
+        - 'saml22'
         - 'stm32f4'
         - 'stm32f7'
         - 'stm32h7'

--- a/docs/boards.md
+++ b/docs/boards.md
@@ -47,6 +47,11 @@ This code base already had supported for a handful of following boards (sorted a
 
 - [Microchip SAMG55 Xplained Pro](https://www.microchip.com/DevelopmentTools/ProductDetails/PartNO/ATSAMG55-XPRO)
 
+### MicroChip SAML22
+
+- [SAML22 Feather](https://github.com/joeycastillo/Feather-Projects/tree/main/SAML22%20Feather)
+- [Sensor Watch](https://github.com/joeycastillo/Sensor-Watch)
+
 ### Nordic nRF5x
 
 - [Adafruit Circuit Playground Bluefruit](https://www.adafruit.com/product/4333)

--- a/hw/bsp/board_mcu.h
+++ b/hw/bsp/board_mcu.h
@@ -53,7 +53,8 @@
   #include "nrf.h"
 
 #elif CFG_TUSB_MCU == OPT_MCU_SAMD11 || CFG_TUSB_MCU == OPT_MCU_SAMD21 || \
-      CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAME5X
+      CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAME5X || \
+      CFG_TUSB_MCU == OPT_MCU_SAML22
   #include "sam.h"
 
 #elif CFG_TUSB_MCU == OPT_MCU_SAMG

--- a/hw/bsp/saml22/boards/saml22_feather/board.h
+++ b/hw/bsp/saml22/boards/saml22_feather/board.h
@@ -1,0 +1,47 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020, Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+// LED
+#define LED_PIN               PIN_PA08
+#define LED_STATE_ON          1
+
+// Button
+#define BUTTON_PIN            PIN_PA06
+#define BUTTON_STATE_ACTIVE   0
+
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* BOARD_H_ */

--- a/hw/bsp/saml22/boards/saml22_feather/board.mk
+++ b/hw/bsp/saml22/boards/saml22_feather/board.mk
@@ -1,0 +1,9 @@
+CFLAGS += -D__SAML22J18A__
+
+# All source paths should be relative to the top level.
+LD_FILE = $(BOARD_PATH)/$(BOARD).ld
+
+# For flash-jlink target
+JLINK_DEVICE = ATSAML22J18
+
+flash: flash-bossac

--- a/hw/bsp/saml22/boards/saml22_feather/saml22_feather.ld
+++ b/hw/bsp/saml22/boards/saml22_feather/saml22_feather.ld
@@ -1,0 +1,145 @@
+/**
+ * \file
+ *
+ * \brief Linker script for running in internal FLASH on the SAML22J18A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+  rom      (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00040000
+  ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+}
+
+/* The stack size used by the application. NOTE: you need to adjust according to your application. */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : DEFINED(__stack_size__) ? __stack_size__ : 0x2000;
+
+ENTRY(Reset_Handler)
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > rom
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    . = ALIGN(4);
+    _end = . ;
+}

--- a/hw/bsp/saml22/boards/sensorwatch_m0/board.h
+++ b/hw/bsp/saml22/boards/sensorwatch_m0/board.h
@@ -1,0 +1,47 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020, Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+// LED
+#define LED_PIN               PIN_PA21
+#define LED_STATE_ON          1
+
+// Button
+#define BUTTON_PIN            PIN_PA22
+#define BUTTON_STATE_ACTIVE   1
+
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* BOARD_H_ */

--- a/hw/bsp/saml22/boards/sensorwatch_m0/board.mk
+++ b/hw/bsp/saml22/boards/sensorwatch_m0/board.mk
@@ -1,0 +1,9 @@
+CFLAGS += -D__SAML22J18A__
+
+# All source paths should be relative to the top level.
+LD_FILE = $(BOARD_PATH)/$(BOARD).ld
+
+# For flash-jlink target
+JLINK_DEVICE = ATSAML22J18
+
+flash: flash-bossac

--- a/hw/bsp/saml22/boards/sensorwatch_m0/sensorwatch_m0.ld
+++ b/hw/bsp/saml22/boards/sensorwatch_m0/sensorwatch_m0.ld
@@ -1,0 +1,145 @@
+/**
+ * \file
+ *
+ * \brief Linker script for running in internal FLASH on the SAML22J18A
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+  rom      (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00040000
+  ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+}
+
+/* The stack size used by the application. NOTE: you need to adjust according to your application. */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : DEFINED(__stack_size__) ? __stack_size__ : 0x2000;
+
+ENTRY(Reset_Handler)
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > rom
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    . = ALIGN(4);
+    _end = . ;
+}

--- a/hw/bsp/saml22/family.c
+++ b/hw/bsp/saml22/family.c
@@ -1,0 +1,163 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "sam.h"
+#include "bsp/board.h"
+#include "board.h"
+
+#include "hal/include/hal_gpio.h"
+#include "hal/include/hal_init.h"
+#include "hpl/gclk/hpl_gclk_base.h"
+#include "hpl_mclk_config.h"
+
+//--------------------------------------------------------------------+
+// Forward USB interrupt events to TinyUSB IRQ Handler
+//--------------------------------------------------------------------+
+void USB_Handler(void)
+{
+  tud_int_handler(0);
+}
+
+//--------------------------------------------------------------------+
+// MACRO TYPEDEF CONSTANT ENUM DECLARATION
+//--------------------------------------------------------------------+
+
+/* Referenced GCLKs (out of 0~4), should be initialized firstly */
+#define _GCLK_INIT_1ST 0x00000000
+/* Not referenced GCLKs, initialized last */
+#define _GCLK_INIT_LAST 0x0000001F
+
+void board_init(void)
+{
+  // Clock init ( follow hpl_init.c )
+  hri_nvmctrl_set_CTRLB_RWS_bf(NVMCTRL, CONF_NVM_WAIT_STATE);
+
+  _set_performance_level(2);
+
+  _osc32kctrl_init_sources();
+  _oscctrl_init_sources();
+  _mclk_init();
+#if _GCLK_INIT_1ST
+  _gclk_init_generators_by_fref(_GCLK_INIT_1ST);
+#endif
+  _oscctrl_init_referenced_generators();
+  _gclk_init_generators_by_fref(_GCLK_INIT_LAST);
+
+#if (CONF_PORT_EVCTRL_PORT_0 | CONF_PORT_EVCTRL_PORT_1 | CONF_PORT_EVCTRL_PORT_2 | CONF_PORT_EVCTRL_PORT_3)
+  hri_port_set_EVCTRL_reg(PORT, 0, CONF_PORTA_EVCTRL);
+  hri_port_set_EVCTRL_reg(PORT, 1, CONF_PORTB_EVCTRL);
+#endif
+
+  // Update SystemCoreClock since it is hard coded with asf4 and not correct
+  // Init 1ms tick timer (samd SystemCoreClock may not correct)
+  SystemCoreClock = CONF_CPU_FREQUENCY;
+  SysTick_Config(CONF_CPU_FREQUENCY / 1000);
+
+  // Led init
+  gpio_set_pin_direction(LED_PIN, GPIO_DIRECTION_OUT);
+  gpio_set_pin_level(LED_PIN, !LED_STATE_ON);
+
+  // Button init
+  gpio_set_pin_direction(BUTTON_PIN, GPIO_DIRECTION_IN);
+  gpio_set_pin_pull_mode(BUTTON_PIN, BUTTON_STATE_ACTIVE ? GPIO_PULL_DOWN : GPIO_PULL_UP);
+
+#if CFG_TUSB_OS  == OPT_OS_FREERTOS
+  // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
+  NVIC_SetPriority(USB_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY);
+#endif
+
+  /* USB Clock init
+   * The USB module requires a GCLK_USB of 48 MHz ~ 0.25% clock
+   * for low speed and full speed operation. */
+  hri_gclk_write_PCHCTRL_reg(GCLK, USB_GCLK_ID, GCLK_PCHCTRL_GEN_GCLK1_Val | GCLK_PCHCTRL_CHEN);
+  hri_mclk_set_AHBMASK_USB_bit(MCLK);
+  hri_mclk_set_APBBMASK_USB_bit(MCLK);
+
+  // USB Pin Init
+  gpio_set_pin_direction(PIN_PA24, GPIO_DIRECTION_OUT);
+  gpio_set_pin_level(PIN_PA24, false);
+  gpio_set_pin_pull_mode(PIN_PA24, GPIO_PULL_OFF);
+  gpio_set_pin_direction(PIN_PA25, GPIO_DIRECTION_OUT);
+  gpio_set_pin_level(PIN_PA25, false);
+  gpio_set_pin_pull_mode(PIN_PA25, GPIO_PULL_OFF);
+
+  gpio_set_pin_function(PIN_PA24, PINMUX_PA24G_USB_DM);
+  gpio_set_pin_function(PIN_PA25, PINMUX_PA25G_USB_DP);
+
+  // Output 500hz PWM on PB23 (TCC0 WO[3]) so we can validate the GCLK1 clock speed
+  hri_mclk_set_APBCMASK_TCC0_bit(MCLK);
+  TCC0->PER.bit.PER = 48000000 / 1000;
+  TCC0->CC[3].bit.CC = 48000000 / 2000;
+  TCC0->CTRLA.bit.ENABLE = true;
+
+  gpio_set_pin_function(PIN_PB23, PINMUX_PB23F_TCC0_WO3);
+  hri_gclk_write_PCHCTRL_reg(GCLK, TCC0_GCLK_ID, GCLK_PCHCTRL_GEN_GCLK1_Val | GCLK_PCHCTRL_CHEN);
+}
+
+//--------------------------------------------------------------------+
+// Board porting API
+//--------------------------------------------------------------------+
+
+void board_led_write(bool state)
+{
+  gpio_set_pin_level(LED_PIN, state);
+}
+
+uint32_t board_button_read(void)
+{
+  // button is active low
+  return gpio_get_pin_level(BUTTON_PIN) ? 0 : 1;
+}
+
+int board_uart_read(uint8_t* buf, int len)
+{
+  (void) buf; (void) len;
+  return 0;
+}
+
+int board_uart_write(void const * buf, int len)
+{
+  (void) buf; (void) len;
+  return 0;
+}
+
+#if CFG_TUSB_OS  == OPT_OS_NONE
+volatile uint32_t system_ticks = 0;
+
+void SysTick_Handler (void)
+{
+  system_ticks++;
+}
+
+uint32_t board_millis(void)
+{
+  return system_ticks;
+}
+#endif
+void _init(void)
+{
+
+}

--- a/hw/bsp/saml22/family.mk
+++ b/hw/bsp/saml22/family.mk
@@ -1,0 +1,50 @@
+UF2_FAMILY_ID = 0x68ed2b88
+DEPS_SUBMODULES += hw/mcu/microchip
+
+include $(TOP)/$(BOARD_PATH)/board.mk
+
+CFLAGS += \
+  -mthumb \
+  -mabi=aapcs \
+  -mcpu=cortex-m0plus \
+  -nostdlib -nostartfiles \
+  -DCONF_OSC32K_CALIB_ENABLE=0 \
+  -DCFG_TUSB_MCU=OPT_MCU_SAML22
+
+SRC_C += \
+	src/portable/microchip/samd/dcd_samd.c \
+	hw/mcu/microchip/saml22/gcc/gcc/startup_saml22.c \
+	hw/mcu/microchip/saml22/gcc/system_saml22.c \
+	hw/mcu/microchip/saml22/hpl/gclk/hpl_gclk.c \
+	hw/mcu/microchip/saml22/hpl/mclk/hpl_mclk.c \
+	hw/mcu/microchip/saml22/hpl/pm/hpl_pm.c \
+	hw/mcu/microchip/saml22/hpl/osc32kctrl/hpl_osc32kctrl.c \
+	hw/mcu/microchip/saml22/hpl/oscctrl/hpl_oscctrl.c \
+	hw/mcu/microchip/saml22/hal/src/hal_atomic.c
+
+INC += \
+	$(TOP)/$(BOARD_PATH) \
+	$(TOP)/hw/mcu/microchip/saml22/ \
+	$(TOP)/hw/mcu/microchip/saml22/config \
+	$(TOP)/hw/mcu/microchip/saml22/include \
+	$(TOP)/hw/mcu/microchip/saml22/hal/include \
+	$(TOP)/hw/mcu/microchip/saml22/hal/utils/include \
+	$(TOP)/hw/mcu/microchip/saml22/hpl/port \
+	$(TOP)/hw/mcu/microchip/saml22/hri \
+	$(TOP)/hw/mcu/microchip/saml22/CMSIS/Core/Include
+
+# For TinyUSB port source 
+VENDOR = microchip
+CHIP_FAMILY = samd
+
+# For freeRTOS port source
+FREERTOS_PORT = ARM_CM0
+
+# flash using bossac at least version 1.8
+# can be found in arduino15/packages/arduino/tools/bossac/
+# Add it to your PATH or change BOSSAC variable to match your installation
+BOSSAC = bossac
+
+flash-bossac: $(BUILD)/$(PROJECT).bin
+	@:$(call check_defined, SERIAL, example: SERIAL=/dev/ttyACM0)
+	$(BOSSAC) --port=$(SERIAL) -U -i --offset=0x2000 -e -w $^ -R

--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -28,7 +28,8 @@
 
 #if TUSB_OPT_DEVICE_ENABLED && \
     (CFG_TUSB_MCU == OPT_MCU_SAMD11 || CFG_TUSB_MCU == OPT_MCU_SAMD21 || \
-     CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAME5X)
+     CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAME5X || \
+     CFG_TUSB_MCU == OPT_MCU_SAML22)
 
 #include "sam.h"
 #include "device/dcd.h"
@@ -123,7 +124,8 @@ void dcd_int_disable(uint8_t rhport)
   NVIC_DisableIRQ(USB_0_IRQn);
 }
 
-#elif CFG_TUSB_MCU == OPT_MCU_SAMD11 || CFG_TUSB_MCU == OPT_MCU_SAMD21
+#elif CFG_TUSB_MCU == OPT_MCU_SAMD11 || CFG_TUSB_MCU == OPT_MCU_SAMD21 || \
+      CFG_TUSB_MCU == OPT_MCU_SAML22
 
 void dcd_int_enable(uint8_t rhport)
 {

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -60,6 +60,7 @@
 #define OPT_MCU_SAMD51            201 ///< MicroChip SAMD51
 #define OPT_MCU_SAME5X            203 ///< MicroChip SAM E5x
 #define OPT_MCU_SAMG              202 ///< MicroChip SAMDG series
+#define OPT_MCU_SAML22            205 ///< MicroChip SAML22
 
 // STM32
 #define OPT_MCU_STM32F0           300 ///< ST STM32F0


### PR DESCRIPTION
**Describe the PR**
This pull request adds support for the SAM L22 family of microcontrollers.

**Additional context**
The SAM L22 is similar enough to the SAM D11/D21 that it's able to use the same implementation in dcd_samd.c, so I just added it to the platform checks in that file. Tested with just about all of the examples on the two boards I'm developing with, a [SAM L22 Feather](https://github.com/joeycastillo/Feather-Projects/tree/main/SAML22%20Feather) and the [Sensor Watch](https://github.com/joeycastillo/Sensor-Cap/tree/main/PCB/Main%20Boards) (OSO-SWAT-A1-02). 

I know that the porting guidelines say to use a readily available development board, but I don't have a SAM L22 Xplained board on hand. Both of these boards are open source designs, though. 