### PR TITLE
Remove submodule pico sdk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,12 @@ jobs:
     - name: Checkout common submodules in lib
       run: git submodule update --init lib/FreeRTOS-Kernel lib/lwip lib/sct_neopixel
 
+    - name: Checkout pico-sdk
+      if: ${{ matrix.family }} == 'rp2040'
+      run: |
+        git clone --depth 1 https://github.com/raspberrypi/pico-sdk ~/pico-sdk
+        echo >> $GITHUB_ENV PICO_SDK_PATH=~/pico-sdk
+
     - name: Set Toolchain URL
       run: echo >> $GITHUB_ENV TOOLCHAIN_URL=https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v10.2.1-1.1/xpack-arm-none-eabi-gcc-10.2.1-1.1-linux-x64.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       run: git submodule update --init lib/FreeRTOS-Kernel lib/lwip lib/sct_neopixel
 
     - name: Checkout pico-sdk
-      if: ${{ matrix.family }} == 'rp2040'
+      if: matrix.family == 'rp2040'
       run: |
         git clone --depth 1 https://github.com/raspberrypi/pico-sdk ~/pico-sdk
         echo >> $GITHUB_ENV PICO_SDK_PATH=~/pico-sdk

--- a/.gitmodules
+++ b/.gitmodules
@@ -103,10 +103,6 @@
 [submodule "lib/sct_neopixel"]
 	path = lib/sct_neopixel
 	url = https://github.com/gsteiert/sct_neopixel
-[submodule "hw/mcu/raspberrypi/pico-sdk"]
-	path = hw/mcu/raspberrypi/pico-sdk
-	url = https://github.com/raspberrypi/pico-sdk.git
-	fetchRecurseSubmodules = false
 [submodule "lib/FreeRTOS-Kernel"]
 	path = lib/FreeRTOS-Kernel
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git

--- a/examples/device/audio_test/CMakeLists.txt
+++ b/examples/device/audio_test/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/board_test/CMakeLists.txt
+++ b/examples/device/board_test/CMakeLists.txt
@@ -16,9 +16,7 @@ if(FAMILY STREQUAL "esp32s2")
 elseif(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/cdc_dual_ports/CMakeLists.txt
+++ b/examples/device/cdc_dual_ports/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
 
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/cdc_msc/CMakeLists.txt
+++ b/examples/device/cdc_msc/CMakeLists.txt
@@ -14,8 +14,8 @@ if(FAMILY STREQUAL "esp32s2")
 
 elseif(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
+
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
     

--- a/examples/device/dfu_runtime/CMakeLists.txt
+++ b/examples/device/dfu_runtime/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/dynamic_configuration/CMakeLists.txt
+++ b/examples/device/dynamic_configuration/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
 
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)  
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/hid_composite/CMakeLists.txt
+++ b/examples/device/hid_composite/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
 
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)  
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/hid_generic_inout/CMakeLists.txt
+++ b/examples/device/hid_generic_inout/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/hid_multiple_interface/CMakeLists.txt
+++ b/examples/device/hid_multiple_interface/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/midi_test/CMakeLists.txt
+++ b/examples/device/midi_test/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/msc_dual_lun/CMakeLists.txt
+++ b/examples/device/msc_dual_lun/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/net_lwip_webserver/CMakeLists.txt
+++ b/examples/device/net_lwip_webserver/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/uac2_headset/CMakeLists.txt
+++ b/examples/device/uac2_headset/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/usbtmc/CMakeLists.txt
+++ b/examples/device/usbtmc/CMakeLists.txt
@@ -9,9 +9,8 @@ get_filename_component(TOP "${TOP}" REALPATH)
 # Check for -DFAMILY=
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)  
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/device/webusb_serial/CMakeLists.txt
+++ b/examples/device/webusb_serial/CMakeLists.txt
@@ -10,9 +10,7 @@ get_filename_component(TOP "${TOP}" REALPATH)
 if(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/examples/host/cdc_msc_hid/CMakeLists.txt
+++ b/examples/host/cdc_msc_hid/CMakeLists.txt
@@ -15,9 +15,7 @@ if(FAMILY STREQUAL "esp32s2")
 elseif(FAMILY STREQUAL "rp2040")
   cmake_minimum_required(VERSION 3.12)
   
-  set(PICO_SDK_PATH ${TOP}/hw/mcu/raspberrypi/pico-sdk)
-  include(${PICO_SDK_PATH}/pico_sdk_init.cmake)
-  
+  include(${TOP}/hw/bsp/${FAMILY}/pico_sdk_import.cmake)
   project(${PROJECT})
   add_executable(${PROJECT})
 

--- a/hw/bsp/rp2040/family.mk
+++ b/hw/bsp/rp2040/family.mk
@@ -1,5 +1,3 @@
-DEPS_SUBMODULES += hw/mcu/raspberrypi/pico-sdk
-
 JLINK_DEVICE = rp2040_m0_0
 PYOCD_TARGET = rp2040
 

--- a/hw/bsp/rp2040/pico_sdk_import.cmake
+++ b/hw/bsp/rp2040/pico_sdk_import.cmake
@@ -1,0 +1,62 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+
+# This can be dropped into an external project to help locate this SDK
+# It should be include()ed prior to project()
+
+if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+    set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+    message("Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
+    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
+endif ()
+
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
+set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+
+if (NOT PICO_SDK_PATH)
+    if (PICO_SDK_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PICO_SDK_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        FetchContent_Declare(
+                pico_sdk
+                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                GIT_TAG master
+        )
+        if (NOT pico_sdk)
+            message("Downloading Raspberry Pi Pico SDK")
+            FetchContent_Populate(pico_sdk)
+            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    else ()
+        message(FATAL_ERROR
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                )
+    endif ()
+endif ()
+
+get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+if (NOT EXISTS ${PICO_SDK_PATH})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif ()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
+endif ()
+
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})


### PR DESCRIPTION
**Describe the PR**
remove pico-sdk from submodules list, user should install pico-sdk by themself or set environment `PICO_SDK_PATH` to correct location. close #659 

related https://github.com/raspberrypi/pico-sdk/pull/321