### PR TITLE
Added support for Black Magic Probe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ latex
 .env
 .settings/
 .idea/
+.gdb_history
 /examples/*/*/build*
 test_old/
 tests_obsolete/

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -57,6 +57,7 @@ CROSS_COMPILE ?= arm-none-eabi-
 
 CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)g++
+GDB = $(CROSS_COMPILE)gdb
 OBJCOPY = $(CROSS_COMPILE)objcopy
 SIZE = $(CROSS_COMPILE)size
 MKDIR = mkdir

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -170,6 +170,12 @@ flash-pyocd: $(BUILD)/$(PROJECT).hex
 	pyocd flash -t $(PYOCD_TARGET) $<
 	pyocd reset -t $(PYOCD_TARGET)
 
+# flash with Black Magic Probe
+flash-bmp: $(BUILD)/$(PROJECT).elf
+	$(GDB) --batch -ex 'target extended-remote /dev/ttyBmpGdb' -ex 'monitor swdp_scan' -ex 'attach 1' -ex load  $<
+
+debug-bmp: $(BUILD)/$(PROJECT).elf
+	$(GDB) -ex 'target extended-remote /dev/ttyBmpGdb' -ex 'monitor swdp_scan' -ex 'attach 1' $<
 
 #-------------- Artifacts --------------
 

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -170,9 +170,11 @@ flash-pyocd: $(BUILD)/$(PROJECT).hex
 	pyocd flash -t $(PYOCD_TARGET) $<
 	pyocd reset -t $(PYOCD_TARGET)
 
-BMP ?= /dev/ttyBmpGdb # This symlink is created by https://github.com/blacksphere/blackmagic/blob/master/driver/99-blackmagic.rules
-
 # flash with Black Magic Probe
+
+# This symlink is created by https://github.com/blacksphere/blackmagic/blob/master/driver/99-blackmagic.rules
+BMP ?= /dev/ttyBmpGdb
+
 flash-bmp: $(BUILD)/$(PROJECT).elf
 	$(GDB) --batch -ex 'target extended-remote $(BMP)' -ex 'monitor swdp_scan' -ex 'attach 1' -ex load  $<
 

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -170,12 +170,14 @@ flash-pyocd: $(BUILD)/$(PROJECT).hex
 	pyocd flash -t $(PYOCD_TARGET) $<
 	pyocd reset -t $(PYOCD_TARGET)
 
+BMP ?= /dev/ttyBmpGdb # This symlink is created by https://github.com/blacksphere/blackmagic/blob/master/driver/99-blackmagic.rules
+
 # flash with Black Magic Probe
 flash-bmp: $(BUILD)/$(PROJECT).elf
-	$(GDB) --batch -ex 'target extended-remote /dev/ttyBmpGdb' -ex 'monitor swdp_scan' -ex 'attach 1' -ex load  $<
+	$(GDB) --batch -ex 'target extended-remote $(BMP)' -ex 'monitor swdp_scan' -ex 'attach 1' -ex load  $<
 
 debug-bmp: $(BUILD)/$(PROJECT).elf
-	$(GDB) -ex 'target extended-remote /dev/ttyBmpGdb' -ex 'monitor swdp_scan' -ex 'attach 1' $<
+	$(GDB) -ex 'target extended-remote $(BMP)' -ex 'monitor swdp_scan' -ex 'attach 1' $<
 
 #-------------- Artifacts --------------
 


### PR DESCRIPTION
Added flash-bmp and debug-bmp make targets to allow flashing and debugging with the [Black Magic Probe](https://github.com/blacksphere/blackmagic)
