### PR TITLE
When used with FreeRTOS, lower the interrupt priority for OTG_FS_IRQn

### DIFF
--- a/hw/bsp/stm32f4/family.c
+++ b/hw/bsp/stm32f4/family.c
@@ -51,7 +51,7 @@ void board_init(void)
   SysTick_Config(SystemCoreClock / 1000);
 #elif CFG_TUSB_OS == OPT_OS_FREERTOS
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
-  //NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
+  NVIC_SetPriority(OTG_FS_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
 #endif
 
   GPIO_InitTypeDef  GPIO_InitStruct;


### PR DESCRIPTION
None of the FreeRTOS examples currently work with STM32F4, they all trigger this assert in `lib/FreeRTOS-Kernel/portable/GCC/ARM_CM4F/port.c`:

`764                     configASSERT( ucCurrentPriority >= ucMaxSysCallPriority ); `

because the interrupt priority for OTG_FS is too high (that is, the value of `ucCurrentPriority` is too low).

The (almost) correct call to `NVIC_SetPriority` was commented out in `hw/bsp/stm32f4/family.c`. 

I have a suspicion that other Cortex-M chips might be affected too, but I can only test Seeeduino Xiao and STM32F4 blackpill.

