### PR TITLE
Create a new make rule for checking out submodules.

### DIFF
--- a/examples/make.mk
+++ b/examples/make.mk
@@ -46,9 +46,11 @@ else
 endif
 
 # Fetch submodules depended by family
-fetch_submodule_if_empty = $(if $(wildcard $(TOP)/$1/*),,$(info $(shell git -C $(TOP) submodule update --init $1)))
 ifdef DEPS_SUBMODULES
-  $(foreach s,$(DEPS_SUBMODULES),$(call fetch_submodule_if_empty,$(s)))
+$(foreach s,$(DEPS_SUBMODULES), $(TOP)/$(s)/submodule.mk):
+	for module in $(DEPS_SUBMODULES); do git -C $(TOP) submodule update --init $$module && touch $(TOP)/$$module/submodule.mk; done
+
+include $(foreach s,$(DEPS_SUBMODULES), $(TOP)/$(s)/submodule.mk)
 endif
 
 #-------------- Cross Compiler  ------------


### PR DESCRIPTION
Currently, if you do a fresh checkout of the tinyusb project and try to build a FreeRTOS example you get an error like this on the first run:

```
......
LINK _build/seeeduino_xiao/seeeduino_xiao-cdc_msc_freertos.elf
arm-none-eabi-gcc: error: _build/seeeduino_xiao/obj/lib/FreeRTOS-Kernel/list.o: No such file or directory
arm-none-eabi-gcc: error: _build/seeeduino_xiao/obj/lib/FreeRTOS-Kernel/queue.o: No such file or directory
arm-none-eabi-gcc: error: _build/seeeduino_xiao/obj/lib/FreeRTOS-Kernel/tasks.o: No such file or directory
arm-none-eabi-gcc: error: _build/seeeduino_xiao/obj/lib/FreeRTOS-Kernel/timers.o: No such file or directory
```

You have to run make again, which is a nuisance.

When you run make the first time the files `list.c`, `queue.c`, `tasks.c` and `timers.c` don't exist under `lib/FreeRTOS-Kernel`, so there are no rules to build the corresponding `*.o` files.

This patch creates a new rule for checking out submodules, instead of doing it in the `$(shell)` function. The rule initialises every submodule directory and create an empty submodule.mk file in it. These empty files are included into the main makefile, forcing make to re-read everything and rebuild all rules after this stage.  As a result, make works successfully on the first run.