### PR TITLE
USBTMC: remove reference to visa DLL (which only was for windows, and…

### DIFF
--- a/examples/device/usbtmc/visaQuery.py
+++ b/examples/device/usbtmc/visaQuery.py
@@ -143,7 +143,7 @@ def test_stall_ep0():
 	assert (inst.read_stb() == 0)
 
 
-rm = visa.ResourceManager("/c/Windows/system32/visa64.dll")
+rm = visa.ResourceManager()
 reslist = rm.list_resources("USB?::?*::INSTR")
 print(reslist)
 


### PR DESCRIPTION
USBTMC: Remove reference reference to windows path of VISA DLL (let pyvisa auto-select it).

If manual selection is needed, user may create .pyvisarc file with as documented by pyvisa.

Closes: #732 