### PR TITLE
Implement functions to allow for DMA usage in audio driver.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@
   - Rename tud_midi_receive() to tud_midi_packet_read()
   - Rename tud_midi_send() to tud_midi_packet_write()
 - New board stm32f072-eval
+- Breaking changes
+  - tud_cdc_peek(), tud_vendor_peek() dropped position parameter. If needed, tu_fifo_get_read_info() can be used to peek
+    at random offset.
 
 ## 0.9.0 - 2021.03.12
 

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -55,9 +55,9 @@
 //--------------------------------------------------------------------+
 // INCLUDE
 //--------------------------------------------------------------------+
-#include "audio_device.h"
-#include "class/audio/audio.h"
 #include "device/usbd_pvt.h"
+#include "audio_device.h"
+//#include "common/tusb_fifo.h"
 
 //--------------------------------------------------------------------+
 // MACRO CONSTANT TYPEDEF

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -447,26 +447,38 @@ bool tud_audio_n_clear_ep_out_ff(uint8_t func_id)
   return tu_fifo_clear(&_audiod_fct[func_id].ep_out_ff);
 }
 
+tu_fifo_t* tud_audio_n_get_ep_out_ff(uint8_t func_id)
+{
+  if(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL) return &_audiod_fct[func_id].ep_out_ff;
+  return NULL;
+}
+
 #endif
 
 #if CFG_TUD_AUDIO_ENABLE_DECODING && CFG_TUD_AUDIO_ENABLE_EP_OUT
 // Delete all content in the support RX FIFOs
 bool tud_audio_n_clear_rx_support_ff(uint8_t func_id, uint8_t ff_idx)
 {
-  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL, ff_idx < _audiod_fct[func_id].n_rx_supp_ff);
+  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL && ff_idx < _audiod_fct[func_id].n_rx_supp_ff);
   return tu_fifo_clear(&_audiod_fct[func_id].rx_supp_ff[ff_idx]);
 }
 
 uint16_t tud_audio_n_available_support_ff(uint8_t func_id, uint8_t ff_idx)
 {
-  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL, ff_idx < _audiod_fct[func_id].n_rx_supp_ff);
+  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL && ff_idx < _audiod_fct[func_id].n_rx_supp_ff);
   return tu_fifo_count(&_audiod_fct[func_id].rx_supp_ff[ff_idx]);
 }
 
 uint16_t tud_audio_n_read_support_ff(uint8_t func_id, uint8_t ff_idx, void* buffer, uint16_t bufsize)
 {
-  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL, ff_idx < _audiod_fct[func_id].n_rx_supp_ff);
+  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL && ff_idx < _audiod_fct[func_id].n_rx_supp_ff);
   return tu_fifo_read_n(&_audiod_fct[func_id].rx_supp_ff[ff_idx], buffer, bufsize);
+}
+
+tu_fifo_t* tud_audio_n_get_rx_support_ff(uint8_t func_id, uint8_t ff_idx)
+{
+  if(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL && ff_idx < _audiod_fct[func_id].n_rx_supp_ff) return &_audiod_fct[func_id].rx_supp_ff[ff_idx];
+  return NULL;
 }
 #endif
 
@@ -635,32 +647,26 @@ static bool audiod_decode_type_I_pcm(uint8_t rhport, audiod_function_t* audio, u
   uint8_t cnt_ff;
 
   // Decode
-  void * dst;
+  void * dst, * dst_wrap;
   uint8_t * src;
   uint8_t * dst_end;
-  uint16_t len;
+  uint16_t len, len_wrap;
 
   for (cnt_ff = 0; cnt_ff < n_ff_used; cnt_ff++)
   {
     src = &audio->lin_buf_out[cnt_ff*audio->n_channels_per_ff_rx * audio->n_bytes_per_sampe_rx];
-
-    len = tu_fifo_get_linear_write_info(&audio->rx_supp_ff[cnt_ff], 0, &dst, nBytesPerFFToRead);
-    tu_fifo_advance_write_pointer(&audio->rx_supp_ff[cnt_ff], len);
+    len = tu_fifo_get_linear_write_info(&audio->rx_supp_ff[cnt_ff], 0, nBytesPerFFToRead, &dst, &len_wrap, &dst_wrap);
 
     dst_end = dst + len;
-
     src = audiod_interleaved_copy_bytes_fast_decode(nBytesToCopy, dst, dst_end, src, n_ff_used);
 
     // Handle wrapped part of FIFO
-    if (len < nBytesPerFFToRead)
+    if (len_wrap != 0)
     {
-      len = tu_fifo_get_linear_write_info(&audio->rx_supp_ff[cnt_ff], 0, &dst, nBytesPerFFToRead - len);
-      tu_fifo_advance_write_pointer(&audio->rx_supp_ff[cnt_ff], len);
-
-      dst_end = dst + len;
-
-      audiod_interleaved_copy_bytes_fast_decode(nBytesToCopy, dst, dst_end, src, n_ff_used);
+      dst_end = dst_wrap + len_wrap;
+      audiod_interleaved_copy_bytes_fast_decode(nBytesToCopy, dst_wrap, dst_end, src, n_ff_used);
     }
+    tu_fifo_advance_write_pointer(&audio->rx_supp_ff[cnt_ff], len + len_wrap);
   }
 
   // Number of bytes should be a multiple of CFG_TUD_AUDIO_N_BYTES_PER_SAMPLE_RX * CFG_TUD_AUDIO_N_CHANNELS_RX but checking makes no sense - no way to correct it
@@ -699,9 +705,16 @@ bool tud_audio_n_clear_ep_in_ff(uint8_t func_id)                          // Del
   return tu_fifo_clear(&_audiod_fct[func_id].ep_in_ff);
 }
 
+tu_fifo_t* tud_audio_n_get_ep_in_ff(uint8_t func_id)
+{
+  if(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL) return &_audiod_fct[func_id].ep_in_ff;
+  return NULL;
+}
+
 #endif
 
 #if CFG_TUD_AUDIO_ENABLE_ENCODING && CFG_TUD_AUDIO_ENABLE_EP_IN
+
 uint16_t tud_audio_n_flush_tx_support_ff(uint8_t func_id)                 // Force all content in the support TX FIFOs to be written into linear buffer and schedule a transmit
 {
   TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL);
@@ -719,15 +732,22 @@ uint16_t tud_audio_n_flush_tx_support_ff(uint8_t func_id)                 // For
 
 bool tud_audio_n_clear_tx_support_ff(uint8_t func_id, uint8_t ff_idx)
 {
-  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL, ff_idx < _audiod_fct[func_id].n_tx_supp_ff);
+  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL && ff_idx < _audiod_fct[func_id].n_tx_supp_ff);
   return tu_fifo_clear(&_audiod_fct[func_id].tx_supp_ff[ff_idx]);
 }
 
 uint16_t tud_audio_n_write_support_ff(uint8_t func_id, uint8_t ff_idx, const void * data, uint16_t len)
 {
-  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL, ff_idx < _audiod_fct[func_id].n_tx_supp_ff);
+  TU_VERIFY(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL && ff_idx < _audiod_fct[func_id].n_tx_supp_ff);
   return tu_fifo_write_n(&_audiod_fct[func_id].tx_supp_ff[ff_idx], data, len);
 }
+
+tu_fifo_t* tud_audio_n_get_tx_support_ff(uint8_t func_id, uint8_t ff_idx)
+{
+  if(func_id < CFG_TUD_AUDIO && _audiod_fct[func_id].p_desc != NULL && ff_idx < _audiod_fct[func_id].n_tx_supp_ff) return &_audiod_fct[func_id].tx_supp_ff[ff_idx];
+  return NULL;
+}
+
 #endif
 
 
@@ -751,6 +771,7 @@ uint16_t tud_audio_int_ctr_n_write(uint8_t func_id, uint8_t const* buffer, uint1
 
   return true;
 }
+
 #endif
 
 
@@ -952,32 +973,28 @@ static uint16_t audiod_encode_type_I_pcm(uint8_t rhport, audiod_function_t* audi
   nBytesPerFFToSend = (nBytesPerFFToSend / nBytesToCopy) * nBytesToCopy;
 
   // Encode
-  void * src;
+  void * src, * src_wrap;
   uint8_t * dst;
   uint8_t * src_end;
-  uint16_t len;
+  uint16_t len, len_wrap;
 
   for (cnt_ff = 0; cnt_ff < n_ff_used; cnt_ff++)
   {
     dst = &audio->lin_buf_in[cnt_ff*audio->n_channels_per_ff_tx*audio->n_bytes_per_sampe_tx];
 
-    len = tu_fifo_get_linear_read_info(&audio->tx_supp_ff[cnt_ff], 0, &src, nBytesPerFFToSend);
-    tu_fifo_advance_read_pointer(&audio->tx_supp_ff[cnt_ff], len);
+    len = tu_fifo_get_linear_read_info(&audio->tx_supp_ff[cnt_ff], 0, nBytesPerFFToSend, &src, &len_wrap, &src_wrap);
 
     src_end = src + len;
-
     dst = audiod_interleaved_copy_bytes_fast_encode(nBytesToCopy, src, src_end, dst, n_ff_used);
 
     // Handle wrapped part of FIFO
-    if (len < nBytesPerFFToSend)
+    if (len_wrap != 0)
     {
-      len = tu_fifo_get_linear_read_info(&audio->tx_supp_ff[cnt_ff], 0, &src, nBytesPerFFToSend - len);
-      tu_fifo_advance_read_pointer(&audio->tx_supp_ff[cnt_ff], len);
-
-      src_end = src + len;
-
-      audiod_interleaved_copy_bytes_fast_encode(nBytesToCopy, src, src_end, dst, n_ff_used);
+      src_end = src_wrap + len_wrap;
+      audiod_interleaved_copy_bytes_fast_encode(nBytesToCopy, src_wrap, src_end, dst, n_ff_used);
     }
+
+    tu_fifo_advance_read_pointer(&audio->tx_supp_ff[cnt_ff], len + len_wrap);
   }
 
   return nBytesPerFFToSend * n_ff_used;

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -985,12 +985,18 @@ static uint16_t audiod_encode_type_I_pcm(uint8_t rhport, audiod_function_t* audi
   {
     dst = &audio->lin_buf_in[cnt_ff*audio->n_channels_per_ff_tx*audio->n_bytes_per_sampe_tx];
 
-    tu_fifo_get_read_info(&audio->tx_supp_ff[cnt_ff], &info, nBytesPerFFToSend);
+    tu_fifo_get_read_info(&audio->tx_supp_ff[cnt_ff], &info);
 
-    if (info.ptr_lin != 0)
+    // Limit up to desired length
+    info.len_lin = tu_min16(nBytesPerFFToSend, info.len_lin);
+
+    if (info.len_lin != 0)
     {
       src_end = info.ptr_lin + info.len_lin;
       dst = audiod_interleaved_copy_bytes_fast_encode(nBytesToCopy, info.ptr_lin, src_end, dst, n_ff_used);
+
+      // Limit up to desired length
+      info.len_wrap = tu_min16(nBytesPerFFToSend - info.len_lin, info.len_wrap);
 
       // Handle wrapped part of FIFO
       if (info.len_wrap != 0)

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -650,7 +650,7 @@ static bool audiod_decode_type_I_pcm(uint8_t rhport, audiod_function_t* audio, u
   void * dst, * dst_wrap;
   uint8_t * src;
   uint8_t * dst_end;
-  uint16_t len, len_wrap;
+  uint16_t len, len_wrap = 0;
 
   for (cnt_ff = 0; cnt_ff < n_ff_used; cnt_ff++)
   {
@@ -976,7 +976,7 @@ static uint16_t audiod_encode_type_I_pcm(uint8_t rhport, audiod_function_t* audi
   void * src, * src_wrap;
   uint8_t * dst;
   uint8_t * src_end;
-  uint16_t len, len_wrap;
+  uint16_t len, len_wrap = 0;           // Give len_wrap a value such that compiler does not complain - although it gets initialized in any case...
 
   for (cnt_ff = 0; cnt_ff < n_ff_used; cnt_ff++)
   {

--- a/src/class/audio/audio_device.h
+++ b/src/class/audio/audio_device.h
@@ -33,6 +33,7 @@
 #include "device/usbd.h"
 
 #include "audio.h"
+#include "tusb_fifo.h"
 
 //--------------------------------------------------------------------+
 // Class Driver Configuration
@@ -364,23 +365,27 @@ bool     tud_audio_n_mounted    (uint8_t func_id);
 uint16_t tud_audio_n_available                    (uint8_t func_id);
 uint16_t tud_audio_n_read                         (uint8_t func_id, void* buffer, uint16_t bufsize);
 bool     tud_audio_n_clear_ep_out_ff              (uint8_t func_id);                          // Delete all content in the EP OUT FIFO
+tu_fifo_t*   tud_audio_n_get_ep_out_ff            (uint8_t func_id);
 #endif
 
 #if CFG_TUD_AUDIO_ENABLE_EP_OUT && CFG_TUD_AUDIO_ENABLE_DECODING
 bool     tud_audio_n_clear_rx_support_ff          (uint8_t func_id, uint8_t ff_idx);       // Delete all content in the support RX FIFOs
 uint16_t tud_audio_n_available_support_ff         (uint8_t func_id, uint8_t ff_idx);
 uint16_t tud_audio_n_read_support_ff              (uint8_t func_id, uint8_t ff_idx, void* buffer, uint16_t bufsize);
+tu_fifo_t* tud_audio_n_get_rx_support_ff          (uint8_t func_id, uint8_t ff_idx);
 #endif
 
 #if CFG_TUD_AUDIO_ENABLE_EP_IN && !CFG_TUD_AUDIO_ENABLE_ENCODING
 uint16_t tud_audio_n_write                        (uint8_t func_id, const void * data, uint16_t len);
 bool     tud_audio_n_clear_ep_in_ff               (uint8_t func_id);                          // Delete all content in the EP IN FIFO
+tu_fifo_t*   tud_audio_n_get_ep_in_ff             (uint8_t func_id);
 #endif
 
 #if CFG_TUD_AUDIO_ENABLE_EP_IN && CFG_TUD_AUDIO_ENABLE_ENCODING
 uint16_t tud_audio_n_flush_tx_support_ff          (uint8_t func_id);      // Force all content in the support TX FIFOs to be written into EP SW FIFO
 bool     tud_audio_n_clear_tx_support_ff          (uint8_t func_id, uint8_t ff_idx);
 uint16_t tud_audio_n_write_support_ff             (uint8_t func_id, uint8_t ff_idx, const void * data, uint16_t len);
+tu_fifo_t* tud_audio_n_get_tx_support_ff          (uint8_t func_id, uint8_t ff_idx);
 #endif
 
 #if CFG_TUD_AUDIO_INT_CTR_EPSIZE_IN
@@ -399,12 +404,14 @@ static inline bool         tud_audio_mounted                (void);
 static inline uint16_t     tud_audio_available              (void);
 static inline bool         tud_audio_clear_ep_out_ff        (void);                       // Delete all content in the EP OUT FIFO
 static inline uint16_t     tud_audio_read                   (void* buffer, uint16_t bufsize);
+static inline tu_fifo_t*   tud_audio_get_ep_out_ff          (void);
 #endif
 
 #if CFG_TUD_AUDIO_ENABLE_EP_OUT && CFG_TUD_AUDIO_ENABLE_DECODING
 static inline bool     tud_audio_clear_rx_support_ff        (uint8_t ff_idx);
 static inline uint16_t tud_audio_available_support_ff       (uint8_t ff_idx);
 static inline uint16_t tud_audio_read_support_ff            (uint8_t ff_idx, void* buffer, uint16_t bufsize);
+static inline tu_fifo_t* tud_audio_get_rx_support_ff        (uint8_t ff_idx);
 #endif
 
 // TX API
@@ -412,12 +419,14 @@ static inline uint16_t tud_audio_read_support_ff            (uint8_t ff_idx, voi
 #if CFG_TUD_AUDIO_ENABLE_EP_IN && !CFG_TUD_AUDIO_ENABLE_ENCODING
 static inline uint16_t tud_audio_write                      (const void * data, uint16_t len);
 static inline bool 	   tud_audio_clear_ep_in_ff             (void);
+static inline tu_fifo_t* tud_audio_get_ep_in_ff             (void);
 #endif
 
 #if CFG_TUD_AUDIO_ENABLE_EP_IN && CFG_TUD_AUDIO_ENABLE_ENCODING
 static inline uint16_t tud_audio_flush_tx_support_ff        (void);
 static inline uint16_t tud_audio_clear_tx_support_ff        (uint8_t ff_idx);
 static inline uint16_t tud_audio_write_support_ff           (uint8_t ff_idx, const void * data, uint16_t len);
+static inline tu_fifo_t* tud_audio_get_tx_support_ff        (uint8_t ff_idx);
 #endif
 
 // INT CTR API
@@ -514,6 +523,11 @@ static inline bool tud_audio_clear_ep_out_ff(void)
   return tud_audio_n_clear_ep_out_ff(0);
 }
 
+static inline tu_fifo_t* tud_audio_get_ep_out_ff(void)
+{
+  return tud_audio_n_get_ep_out_ff(0);
+}
+
 #endif
 
 #if CFG_TUD_AUDIO_ENABLE_EP_OUT && CFG_TUD_AUDIO_ENABLE_DECODING
@@ -533,6 +547,11 @@ static inline uint16_t tud_audio_read_support_ff(uint8_t ff_idx, void* buffer, u
   return tud_audio_n_read_support_ff(0, ff_idx, buffer, bufsize);
 }
 
+static inline tu_fifo_t* tud_audio_get_rx_support_ff(uint8_t ff_idx)
+{
+  return tud_audio_n_get_rx_support_ff(0, ff_idx);
+}
+
 #endif
 
 // TX API
@@ -547,6 +566,11 @@ static inline uint16_t tud_audio_write(const void * data, uint16_t len)
 static inline bool tud_audio_clear_ep_in_ff(void)
 {
   return tud_audio_n_clear_ep_in_ff(0);
+}
+
+static inline tu_fifo_t* tud_audio_get_ep_in_ff(void)
+{
+  return tud_audio_n_get_ep_in_ff(0);
 }
 
 #endif
@@ -566,6 +590,11 @@ static inline uint16_t tud_audio_clear_tx_support_ff(uint8_t ff_idx)
 static inline uint16_t tud_audio_write_support_ff(uint8_t ff_idx, const void * data, uint16_t len)
 {
   return tud_audio_n_write_support_ff(0, ff_idx, data, len);
+}
+
+static inline tu_fifo_t* tud_audio_get_tx_support_ff(uint8_t ff_idx)
+{
+  return tud_audio_n_get_tx_support_ff(0, ff_idx);
 }
 
 #endif

--- a/src/class/audio/audio_device.h
+++ b/src/class/audio/audio_device.h
@@ -33,7 +33,7 @@
 #include "device/usbd.h"
 
 #include "audio.h"
-#include "tusb_fifo.h"
+#include "common/tusb_fifo.h"
 
 //--------------------------------------------------------------------+
 // Class Driver Configuration

--- a/src/class/audio/audio_device.h
+++ b/src/class/audio/audio_device.h
@@ -33,7 +33,6 @@
 #include "device/usbd.h"
 
 #include "audio.h"
-#include "common/tusb_fifo.h"
 
 //--------------------------------------------------------------------+
 // Class Driver Configuration

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -146,9 +146,9 @@ uint32_t tud_cdc_n_read(uint8_t itf, void* buffer, uint32_t bufsize)
   return num_read;
 }
 
-bool tud_cdc_n_peek(uint8_t itf, int pos, uint8_t* chr)
+bool tud_cdc_n_peek(uint8_t itf, uint8_t* chr)
 {
-  return tu_fifo_peek_at(&_cdcd_itf[itf].rx_ff, pos, chr);
+  return tu_fifo_peek(&_cdcd_itf[itf].rx_ff, chr);
 }
 
 void tud_cdc_n_read_flush (uint8_t itf)

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -117,7 +117,7 @@ static inline uint32_t tud_cdc_available       (void);
 static inline int32_t  tud_cdc_read_char       (void);
 static inline uint32_t tud_cdc_read            (void* buffer, uint32_t bufsize);
 static inline void     tud_cdc_read_flush      (void);
-static inline bool     tud_cdc_peek            (int pos, uint8_t* u8);
+static inline bool     tud_cdc_peek            (uint8_t* u8);
 
 static inline uint32_t tud_cdc_write_char      (char ch);
 static inline uint32_t tud_cdc_write           (void const* buffer, uint32_t bufsize);
@@ -207,9 +207,9 @@ static inline void tud_cdc_read_flush (void)
   tud_cdc_n_read_flush(0);
 }
 
-static inline bool tud_cdc_peek (int pos, uint8_t* u8)
+static inline bool tud_cdc_peek (uint8_t* u8)
 {
-  return tud_cdc_n_peek(0, pos, u8);
+  return tud_cdc_n_peek(u8);
 }
 
 static inline uint32_t tud_cdc_write_char (char ch)

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -83,7 +83,7 @@ int32_t  tud_cdc_n_read_char       (uint8_t itf);
 void     tud_cdc_n_read_flush      (uint8_t itf);
 
 // Get a byte from FIFO at the specified position without removing it
-bool     tud_cdc_n_peek            (uint8_t itf, int pos, uint8_t* u8);
+bool     tud_cdc_n_peek            (uint8_t itf, uint8_t* u8);
 
 // Write bytes to TX FIFO, data may remain in the FIFO for a while
 uint32_t tud_cdc_n_write           (uint8_t itf, void const* buffer, uint32_t bufsize);

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -209,7 +209,7 @@ static inline void tud_cdc_read_flush (void)
 
 static inline bool tud_cdc_peek (uint8_t* u8)
 {
-  return tud_cdc_n_peek(u8);
+  return tud_cdc_n_peek(0, u8);
 }
 
 static inline uint32_t tud_cdc_write_char (char ch)

--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -72,9 +72,9 @@ uint32_t tud_vendor_n_available (uint8_t itf)
   return tu_fifo_count(&_vendord_itf[itf].rx_ff);
 }
 
-bool tud_vendor_n_peek(uint8_t itf, int pos, uint8_t* u8)
+bool tud_vendor_n_peek(uint8_t itf, uint8_t* u8)
 {
-  return tu_fifo_peek_at(&_vendord_itf[itf].rx_ff, pos, u8);
+  return tu_fifo_peek(&_vendord_itf[itf].rx_ff, u8);
 }
 
 //--------------------------------------------------------------------+

--- a/src/class/vendor/vendor_device.h
+++ b/src/class/vendor/vendor_device.h
@@ -45,7 +45,7 @@ bool     tud_vendor_n_mounted         (uint8_t itf);
 
 uint32_t tud_vendor_n_available       (uint8_t itf);
 uint32_t tud_vendor_n_read            (uint8_t itf, void* buffer, uint32_t bufsize);
-bool     tud_vendor_n_peek            (uint8_t itf, int pos, uint8_t* u8);
+bool     tud_vendor_n_peek            (uint8_t itf, uint8_t* u8);
 
 uint32_t tud_vendor_n_write           (uint8_t itf, void const* buffer, uint32_t bufsize);
 uint32_t tud_vendor_n_write_available (uint8_t itf);

--- a/src/class/vendor/vendor_device.h
+++ b/src/class/vendor/vendor_device.h
@@ -59,7 +59,7 @@ uint32_t tud_vendor_n_write_str       (uint8_t itf, char const* str);
 static inline bool     tud_vendor_mounted         (void);
 static inline uint32_t tud_vendor_available       (void);
 static inline uint32_t tud_vendor_read            (void* buffer, uint32_t bufsize);
-static inline bool     tud_vendor_peek            (int pos, uint8_t* u8);
+static inline bool     tud_vendor_peek            (uint8_t* u8);
 static inline uint32_t tud_vendor_write           (void const* buffer, uint32_t bufsize);
 static inline uint32_t tud_vendor_write_str       (char const* str);
 static inline uint32_t tud_vendor_write_available (void);
@@ -95,9 +95,9 @@ static inline uint32_t tud_vendor_read (void* buffer, uint32_t bufsize)
   return tud_vendor_n_read(0, buffer, bufsize);
 }
 
-static inline bool tud_vendor_peek (int pos, uint8_t* u8)
+static inline bool tud_vendor_peek (uint8_t* u8)
 {
-  return tud_vendor_n_peek(0, pos, u8);
+  return tud_vendor_n_peek(0, u8);
 }
 
 static inline uint32_t tud_vendor_write (void const* buffer, uint32_t bufsize)

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -884,12 +884,9 @@ void tu_fifo_advance_read_pointer(tu_fifo_t *f, uint16_t n)
 
    Returns the length and pointer from which bytes can be read in a linear manner.
    This is of major interest for DMA transmissions. If returned length is zero the
-   corresponding pointer is invalid. The returned length is limited to the number
-   of ITEMS n which the user wants to write into the buffer.
-   The write pointer does NOT get advanced, use tu_fifo_advance_read_pointer() to
-   do so! If the length returned is less than n i.e. len<n, then a wrap occurs
-   and you need to execute this function a second time to get a pointer to the
-   wrapped part!
+   corresponding pointer is invalid.
+   The read pointer does NOT get advanced, use tu_fifo_advance_read_pointer() to
+   do so!
    @param[in]       f
                     Pointer to FIFO
    @param[out]      *info
@@ -951,8 +948,8 @@ void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info)
 /*!
    @brief Get linear write info
 
-   Returns the length and pointer from which bytes can be written into buffer array in a linear manner.
-   This is of major interest for DMA transmissions not using circular mode. If returned length is zero the
+   Returns the length and pointer to which bytes can be written into FIFO in a linear manner.
+   This is of major interest for DMA transmissions not using circular mode. If a returned length is zero the
    corresponding pointer is invalid. The returned length is limited to the number of BYTES n which the user
    wants to write into the buffer.
    The write pointer does NOT get advanced, use tu_fifo_advance_write_pointer() to do so! If the length
@@ -979,7 +976,6 @@ void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t 
     info->ptr_wrap = NULL;
     return;
   }
-
 
   // We need n here because we must enforce the read and write pointers to be not more separated than 2*depth!
   if (!f->overwritable)

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -896,7 +896,7 @@ void tu_fifo_advance_read_pointer(tu_fifo_t *f, uint16_t n)
                     Pointer to struct which holds the desired infos
  */
 /******************************************************************************/
-void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n)
+void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info)
 {
   // Operate on temporary values in case they change in between
   uint16_t w = f->wr_idx, r = f->rd_idx;
@@ -923,8 +923,6 @@ void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n
     return;
   }
 
-  if (cnt < n) n = cnt;
-
   // Get relative pointers
   w = get_relative_pointer(f, w);
   r = get_relative_pointer(f, r);
@@ -935,14 +933,14 @@ void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n
   // Check if there is a wrap around necessary
   if (w > r) {
     // Non wrapping case
-    info->len_lin = tu_min16(n, w - r);            // Limit to required length
+    info->len_lin = cnt;
     info->len_wrap = 0;
     info->ptr_wrap = NULL;
   }
   else
   {
-    info->len_lin = tu_min16(n, f->depth - r);   // Also the case if FIFO was full
-    info->len_wrap = n-info->len_lin;
+    info->len_lin = f->depth - r;                 // Also the case if FIFO was full
+    info->len_wrap = cnt - info->len_lin;
     info->ptr_wrap = f->buffer;
   }
 

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -396,7 +396,7 @@ static inline void _tu_fifo_correct_read_pointer(tu_fifo_t* f, uint16_t wAbs)
 
 // Works on local copies of w and r
 // Must be protected by mutexes since in case of an overflow read pointer gets modified
-static bool _tu_fifo_peek_at(tu_fifo_t* f, void * p_buffer, uint16_t wAbs, uint16_t rAbs)
+static bool _tu_fifo_peek(tu_fifo_t* f, void * p_buffer, uint16_t wAbs, uint16_t rAbs)
 {
   uint16_t cnt = _tu_fifo_count(f, wAbs, rAbs);
 
@@ -420,7 +420,7 @@ static bool _tu_fifo_peek_at(tu_fifo_t* f, void * p_buffer, uint16_t wAbs, uint1
 
 // Works on local copies of w and r
 // Must be protected by mutexes since in case of an overflow read pointer gets modified
-static uint16_t _tu_fifo_peek_at_n(tu_fifo_t* f, void * p_buffer, uint16_t n, uint16_t wAbs, uint16_t rAbs, tu_fifo_copy_mode_t copy_mode)
+static uint16_t _tu_fifo_peek_n(tu_fifo_t* f, void * p_buffer, uint16_t n, uint16_t wAbs, uint16_t rAbs, tu_fifo_copy_mode_t copy_mode)
 {
   uint16_t cnt = _tu_fifo_count(f, wAbs, rAbs);
 
@@ -496,7 +496,7 @@ static uint16_t _tu_fifo_read_n(tu_fifo_t* f, void * buffer, uint16_t n, tu_fifo
   _ff_lock(f->mutex_rd);
 
   // Peek the data
-  n = _tu_fifo_peek_at_n(f, buffer, n, f->wr_idx, f->rd_idx, copy_mode);        // f->rd_idx might get modified in case of an overflow so we can not use a local variable
+  n = _tu_fifo_peek_n(f, buffer, n, f->wr_idx, f->rd_idx, copy_mode);        // f->rd_idx might get modified in case of an overflow so we can not use a local variable
 
   // Advance read pointer
   f->rd_idx = advance_pointer(f, f->rd_idx, n);
@@ -634,7 +634,7 @@ bool tu_fifo_read(tu_fifo_t* f, void * buffer)
   _ff_lock(f->mutex_rd);
 
   // Peek the data
-  bool ret = _tu_fifo_peek_at(f, buffer, f->wr_idx, f->rd_idx);    // f->rd_idx might get modified in case of an overflow so we can not use a local variable
+  bool ret = _tu_fifo_peek(f, buffer, f->wr_idx, f->rd_idx);    // f->rd_idx might get modified in case of an overflow so we can not use a local variable
 
   // Advance pointer
   f->rd_idx = advance_pointer(f, f->rd_idx, ret);
@@ -684,10 +684,10 @@ uint16_t tu_fifo_read_n_const_addr_full_words(tu_fifo_t* f, void * buffer, uint1
     @returns TRUE if the queue is not empty
  */
 /******************************************************************************/
-bool tu_fifo_peek_at(tu_fifo_t* f, void * p_buffer)
+bool tu_fifo_peek(tu_fifo_t* f, void * p_buffer)
 {
   _ff_lock(f->mutex_rd);
-  bool ret = _tu_fifo_peek_at(f, p_buffer, f->wr_idx, f->rd_idx);
+  bool ret = _tu_fifo_peek(f, p_buffer, f->wr_idx, f->rd_idx);
   _ff_unlock(f->mutex_rd);
   return ret;
 }
@@ -707,10 +707,10 @@ bool tu_fifo_peek_at(tu_fifo_t* f, void * p_buffer)
     @returns Number of bytes written to p_buffer
  */
 /******************************************************************************/
-uint16_t tu_fifo_peek_at_n(tu_fifo_t* f, void * p_buffer, uint16_t n)
+uint16_t tu_fifo_peek_n(tu_fifo_t* f, void * p_buffer, uint16_t n)
 {
   _ff_lock(f->mutex_rd);
-  bool ret = _tu_fifo_peek_at_n(f, p_buffer, n, f->wr_idx, f->rd_idx, TU_FIFO_COPY_INC);
+  bool ret = _tu_fifo_peek_n(f, p_buffer, n, f->wr_idx, f->rd_idx, TU_FIFO_COPY_INC);
   _ff_unlock(f->mutex_rd);
   return ret;
 }

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -142,7 +142,7 @@ void     tu_fifo_advance_read_pointer   (tu_fifo_t *f, uint16_t n);
 // This functions deliver a pointer to start reading/writing from/to and a valid linear length along which no wrap occurs.
 
 void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info);
-void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n);
+void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info);
 
 static inline uint16_t tu_fifo_depth(tu_fifo_t* f)
 {

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -80,6 +80,14 @@ typedef struct
 
 } tu_fifo_t;
 
+typedef struct
+{
+  uint16_t len_lin                      ; ///< linear length in item size
+  uint16_t len_wrap                     ; ///< wrapped length in item size
+  void * ptr_lin                        ; ///< linear part start pointer
+  void * ptr_wrap                       ; ///< wrapped part start pointer
+} tu_fifo_linear_wr_info;
+
 #define TU_FIFO_INIT(_buffer, _depth, _type, _overwritable) \
 {                                                           \
   .buffer               = _buffer,                          \
@@ -136,8 +144,8 @@ void     tu_fifo_advance_read_pointer   (tu_fifo_t *f, uint16_t n);
 // tu_fifo_advance_read_pointer()/tu_fifo_advance_write_pointer and conduct a second read/write operation
 // TODO - update comments
 
-uint16_t tu_fifo_get_linear_read_info(tu_fifo_t *f, uint16_t offset, uint16_t n, void **ptr_lin, uint16_t *len_wrap, void **ptr_wrap);
-uint16_t tu_fifo_get_linear_write_info(tu_fifo_t *f, uint16_t offset, uint16_t n, void **ptr_lin, uint16_t *len_wrap, void **ptr_wrap);
+tu_fifo_linear_wr_info tu_fifo_get_linear_read_info(tu_fifo_t *f, uint16_t offset, uint16_t n);
+tu_fifo_linear_wr_info tu_fifo_get_linear_write_info(tu_fifo_t *f, uint16_t offset, uint16_t n);
 
 static inline bool tu_fifo_peek(tu_fifo_t* f, void * p_buffer)
 {

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -123,8 +123,8 @@ bool     tu_fifo_read                   (tu_fifo_t* f, void * p_buffer);
 uint16_t tu_fifo_read_n                 (tu_fifo_t* f, void * p_buffer, uint16_t n);
 uint16_t tu_fifo_read_n_const_addr_full_words     (tu_fifo_t* f, void * buffer, uint16_t n);
 
-bool     tu_fifo_peek_at                (tu_fifo_t* f, void * p_buffer);
-uint16_t tu_fifo_peek_at_n              (tu_fifo_t* f, void * p_buffer, uint16_t n);
+bool     tu_fifo_peek                   (tu_fifo_t* f, void * p_buffer);
+uint16_t tu_fifo_peek_n                 (tu_fifo_t* f, void * p_buffer, uint16_t n);
 
 uint16_t tu_fifo_count                  (tu_fifo_t* f);
 bool     tu_fifo_empty                  (tu_fifo_t* f);
@@ -146,11 +146,6 @@ void     tu_fifo_advance_read_pointer   (tu_fifo_t *f, uint16_t n);
 
 void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n);
 void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n);
-
-static inline bool tu_fifo_peek(tu_fifo_t* f, void * p_buffer)
-{
-  return tu_fifo_peek_at(f, p_buffer);
-}
 
 static inline uint16_t tu_fifo_depth(tu_fifo_t* f)
 {

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -144,7 +144,7 @@ void     tu_fifo_advance_read_pointer   (tu_fifo_t *f, uint16_t n);
 // tu_fifo_advance_read_pointer()/tu_fifo_advance_write_pointer and conduct a second read/write operation
 // TODO - update comments
 
-void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n);
+void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info);
 void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n);
 
 static inline uint16_t tu_fifo_depth(tu_fifo_t* f)

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -123,8 +123,8 @@ bool     tu_fifo_read                   (tu_fifo_t* f, void * p_buffer);
 uint16_t tu_fifo_read_n                 (tu_fifo_t* f, void * p_buffer, uint16_t n);
 uint16_t tu_fifo_read_n_const_addr_full_words     (tu_fifo_t* f, void * buffer, uint16_t n);
 
-bool     tu_fifo_peek_at                (tu_fifo_t* f, uint16_t pos, void * p_buffer);
-uint16_t tu_fifo_peek_at_n              (tu_fifo_t* f, uint16_t pos, void * p_buffer, uint16_t n);
+bool     tu_fifo_peek_at                (tu_fifo_t* f, void * p_buffer);
+uint16_t tu_fifo_peek_at_n              (tu_fifo_t* f, void * p_buffer, uint16_t n);
 
 uint16_t tu_fifo_count                  (tu_fifo_t* f);
 bool     tu_fifo_empty                  (tu_fifo_t* f);
@@ -149,7 +149,7 @@ void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t 
 
 static inline bool tu_fifo_peek(tu_fifo_t* f, void * p_buffer)
 {
-  return tu_fifo_peek_at(f, 0, p_buffer);
+  return tu_fifo_peek_at(f, p_buffer);
 }
 
 static inline uint16_t tu_fifo_depth(tu_fifo_t* f)

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -25,10 +25,6 @@
  * This file is part of the TinyUSB stack.
  */
 
-/** \ingroup Group_Common
- * \defgroup group_fifo fifo
- *  @{ */
-
 #ifndef _TUSB_FIFO_H_
 #define _TUSB_FIFO_H_
 
@@ -62,16 +58,16 @@ extern "C" {
  */
 typedef struct
 {
-  uint8_t* buffer                        ; ///< buffer pointer
-  uint16_t depth                         ; ///< max items
-  uint16_t item_size                     ; ///< size of each item
-  bool overwritable                      ;
+  uint8_t* buffer               ; ///< buffer pointer
+  uint16_t depth                ; ///< max items
+  uint16_t item_size            ; ///< size of each item
+  bool overwritable             ;
 
-  uint16_t non_used_index_space          ; ///< required for non-power-of-two buffer length
-  uint16_t max_pointer_idx               ; ///< maximum absolute pointer index
+  uint16_t non_used_index_space ; ///< required for non-power-of-two buffer length
+  uint16_t max_pointer_idx      ; ///< maximum absolute pointer index
 
-  volatile uint16_t wr_idx               ; ///< write pointer
-  volatile uint16_t rd_idx               ; ///< read pointer
+  volatile uint16_t wr_idx      ; ///< write pointer
+  volatile uint16_t rd_idx      ; ///< read pointer
 
 #if CFG_FIFO_MUTEX
   tu_fifo_mutex_t mutex_wr;
@@ -82,10 +78,10 @@ typedef struct
 
 typedef struct
 {
-  uint16_t len_lin                      ; ///< linear length in item size
-  uint16_t len_wrap                     ; ///< wrapped length in item size
-  void * ptr_lin                        ; ///< linear part start pointer
-  void * ptr_wrap                       ; ///< wrapped part start pointer
+  uint16_t len_lin  ; ///< linear length in item size
+  uint16_t len_wrap ; ///< wrapped length in item size
+  void * ptr_lin    ; ///< linear part start pointer
+  void * ptr_wrap   ; ///< wrapped part start pointer
 } tu_fifo_buffer_info_t;
 
 #define TU_FIFO_INIT(_buffer, _depth, _type, _overwritable) \
@@ -133,21 +129,22 @@ uint16_t tu_fifo_remaining              (tu_fifo_t* f);
 bool     tu_fifo_overflowed             (tu_fifo_t* f);
 void     tu_fifo_correct_read_pointer   (tu_fifo_t* f);
 
+static inline uint16_t tu_fifo_depth(tu_fifo_t* f)
+{
+  return f->depth;
+}
+
 // Pointer modifications intended to be used in combinations with DMAs.
 // USE WITH CARE - NO SAFTY CHECKS CONDUCTED HERE! NOT MUTEX PROTECTED!
 void     tu_fifo_advance_write_pointer  (tu_fifo_t *f, uint16_t n);
 void     tu_fifo_advance_read_pointer   (tu_fifo_t *f, uint16_t n);
 
-// If you want to read/write from/to the FIFO by use of a DMA, you may need to conduct two copies to handle a possible wrapping part
-// This functions deliver a pointer to start reading/writing from/to and a valid linear length along which no wrap occurs.
-
-void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info);
+// If you want to read/write from/to the FIFO by use of a DMA, you may need to conduct two copies
+// to handle a possible wrapping part. These functions deliver a pointer to start
+// reading/writing from/to and a valid linear length along which no wrap occurs.
+void tu_fifo_get_read_info (tu_fifo_t *f, tu_fifo_buffer_info_t *info);
 void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info);
 
-static inline uint16_t tu_fifo_depth(tu_fifo_t* f)
-{
-  return f->depth;
-}
 
 #ifdef __cplusplus
 }

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -134,8 +134,10 @@ void     tu_fifo_advance_read_pointer   (tu_fifo_t *f, uint16_t n);
 // This functions deliver a pointer to start reading/writing from/to and a valid linear length along which no wrap occurs.
 // In case not all of your data is available within one read/write, update the read/write pointer by
 // tu_fifo_advance_read_pointer()/tu_fifo_advance_write_pointer and conduct a second read/write operation
-uint16_t tu_fifo_get_linear_read_info   (tu_fifo_t *f, uint16_t offset, void **ptr, uint16_t n);
-uint16_t tu_fifo_get_linear_write_info  (tu_fifo_t *f, uint16_t offset, void **ptr, uint16_t n);
+// TODO - update comments
+
+uint16_t tu_fifo_get_linear_read_info(tu_fifo_t *f, uint16_t offset, uint16_t n, void **ptr_lin, uint16_t *len_wrap, void **ptr_wrap);
+uint16_t tu_fifo_get_linear_write_info(tu_fifo_t *f, uint16_t offset, uint16_t n, void **ptr_lin, uint16_t *len_wrap, void **ptr_wrap);
 
 static inline bool tu_fifo_peek(tu_fifo_t* f, void * p_buffer)
 {

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -86,7 +86,7 @@ typedef struct
   uint16_t len_wrap                     ; ///< wrapped length in item size
   void * ptr_lin                        ; ///< linear part start pointer
   void * ptr_wrap                       ; ///< wrapped part start pointer
-} tu_fifo_linear_wr_info;
+} tu_fifo_buffer_info_t;
 
 #define TU_FIFO_INIT(_buffer, _depth, _type, _overwritable) \
 {                                                           \
@@ -144,8 +144,8 @@ void     tu_fifo_advance_read_pointer   (tu_fifo_t *f, uint16_t n);
 // tu_fifo_advance_read_pointer()/tu_fifo_advance_write_pointer and conduct a second read/write operation
 // TODO - update comments
 
-tu_fifo_linear_wr_info tu_fifo_get_linear_read_info(tu_fifo_t *f, uint16_t offset, uint16_t n);
-tu_fifo_linear_wr_info tu_fifo_get_linear_write_info(tu_fifo_t *f, uint16_t offset, uint16_t n);
+void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n);
+void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n);
 
 static inline bool tu_fifo_peek(tu_fifo_t* f, void * p_buffer)
 {

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -140,9 +140,6 @@ void     tu_fifo_advance_read_pointer   (tu_fifo_t *f, uint16_t n);
 
 // If you want to read/write from/to the FIFO by use of a DMA, you may need to conduct two copies to handle a possible wrapping part
 // This functions deliver a pointer to start reading/writing from/to and a valid linear length along which no wrap occurs.
-// In case not all of your data is available within one read/write, update the read/write pointer by
-// tu_fifo_advance_read_pointer()/tu_fifo_advance_write_pointer and conduct a second read/write operation
-// TODO - update comments
 
 void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info);
 void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info, uint16_t n);

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -993,7 +993,7 @@ static bool dcd_write_packet_memory_ff(tu_fifo_t * ff, uint16_t dst, uint16_t wN
   // Since we copy from a ring buffer FIFO, a wrap might occur making it necessary to conduct two copies
   // Check for first linear part
   void * src;
-  uint16_t len = tu_fifo_get_linear_read_info(ff, 0, &src, wNBytes);  // We want to read from the FIFO
+  uint16_t len = tu_fifo_get_linear_read_info(ff, 0, &src, wNBytes);  // We want to read from the FIFO        - THIS FUNCTION CHANGED!!!
   TU_VERIFY(len && dcd_write_packet_memory(dst, src, len));           // and write it into the PMA
   tu_fifo_advance_read_pointer(ff, len);
 
@@ -1075,7 +1075,7 @@ static bool dcd_read_packet_memory_ff(tu_fifo_t * ff, uint16_t src, uint16_t wNB
   // Since we copy into a ring buffer FIFO, a wrap might occur making it necessary to conduct two copies
   // Check for first linear part
   void * dst;
-  uint16_t len = tu_fifo_get_linear_write_info(ff, 0, &dst, wNBytes);
+  uint16_t len = tu_fifo_get_linear_write_info(ff, 0, &dst, wNBytes);           // THIS FUNCTION CHANGED!!!!
   TU_VERIFY(len && dcd_read_packet_memory(dst, src, len));
   tu_fifo_advance_write_pointer(ff, len);
 

--- a/test/test/test_fifo.c
+++ b/test/test/test_fifo.c
@@ -24,15 +24,19 @@
  * This file is part of the TinyUSB stack.
  */
 
+#include <string.h>
 #include "unity.h"
 #include "tusb_fifo.h"
 
 #define FIFO_SIZE 10
-TU_FIFO_DEF(ff, FIFO_SIZE, uint8_t, false);
+TU_FIFO_DEF(tu_ff, FIFO_SIZE, uint8_t, false);
+tu_fifo_t* ff = &tu_ff;
+tu_fifo_buffer_info_t info;
 
 void setUp(void)
 {
-  tu_fifo_clear(&ff);
+  tu_fifo_clear(ff);
+  memset(&info, 0, sizeof(tu_fifo_buffer_info_t));
 }
 
 void tearDown(void)
@@ -44,12 +48,12 @@ void tearDown(void)
 //--------------------------------------------------------------------+
 void test_normal(void)
 {
-  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(&ff, &i);
+  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(ff, &i);
 
   for(uint8_t i=0; i < FIFO_SIZE; i++)
   {
     uint8_t c;
-    tu_fifo_read(&ff, &c);
+    tu_fifo_read(ff, &c);
     TEST_ASSERT_EQUAL(i, c);
   }
 }
@@ -86,30 +90,30 @@ void test_read_n(void)
   uint8_t data[20];
   for(int i=0; i<sizeof(data); i++) data[i] = i;
 
-  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(&ff, data+i);
+  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(ff, data+i);
 
   uint8_t rd[10];
   uint16_t rd_count;
 
   // case 1: Read index + count < depth
   // read 0 -> 4
-  rd_count = tu_fifo_read_n(&ff, rd, 5);
+  rd_count = tu_fifo_read_n(ff, rd, 5);
   TEST_ASSERT_EQUAL( 5, rd_count );
   TEST_ASSERT_EQUAL_MEMORY( data, rd, rd_count ); // 0 -> 4
 
   // case 2: Read index + count > depth
   // write 10, 11, 12
-  tu_fifo_write(&ff, data+10);
-  tu_fifo_write(&ff, data+11);
-  tu_fifo_write(&ff, data+12);
+  tu_fifo_write(ff, data+10);
+  tu_fifo_write(ff, data+11);
+  tu_fifo_write(ff, data+12);
 
-  rd_count = tu_fifo_read_n(&ff, rd, 7);
+  rd_count = tu_fifo_read_n(ff, rd, 7);
   TEST_ASSERT_EQUAL( 7, rd_count );
 
   TEST_ASSERT_EQUAL_MEMORY( data+5, rd, rd_count ); // 5 -> 11
 
   // Should only read until empty
-  TEST_ASSERT_EQUAL( 1, tu_fifo_read_n(&ff, rd, 100) );
+  TEST_ASSERT_EQUAL( 1, tu_fifo_read_n(ff, rd, 100) );
 }
 
 void test_write_n(void)
@@ -119,52 +123,172 @@ void test_write_n(void)
   for(int i=0; i<sizeof(data); i++) data[i] = i;
 
   // case 1: wr + count < depth
-  tu_fifo_write_n(&ff, data, 8); // wr = 8, count = 8
+  tu_fifo_write_n(ff, data, 8); // wr = 8, count = 8
 
   uint8_t rd[10];
   uint16_t rd_count;
 
-  rd_count = tu_fifo_read_n(&ff, rd, 5); // wr = 8, count = 3
+  rd_count = tu_fifo_read_n(ff, rd, 5); // wr = 8, count = 3
   TEST_ASSERT_EQUAL( 5, rd_count );
   TEST_ASSERT_EQUAL_MEMORY( data, rd, rd_count ); // 0 -> 4
 
   // case 2: wr + count > depth
-  tu_fifo_write_n(&ff, data+8, 6); // wr = 3, count = 9
+  tu_fifo_write_n(ff, data+8, 6); // wr = 3, count = 9
 
-  for(rd_count=0; rd_count<7; rd_count++) tu_fifo_read(&ff, rd+rd_count); // wr = 3, count = 2
+  for(rd_count=0; rd_count<7; rd_count++) tu_fifo_read(ff, rd+rd_count); // wr = 3, count = 2
 
   TEST_ASSERT_EQUAL_MEMORY( data+5, rd, rd_count); // 5 -> 11
 
-  TEST_ASSERT_EQUAL(2, tu_fifo_count(&ff));
+  TEST_ASSERT_EQUAL(2, tu_fifo_count(ff));
 }
 
 void test_peek(void)
 {
   uint8_t temp;
 
-  temp = 10; tu_fifo_write(&ff, &temp);
-  temp = 20; tu_fifo_write(&ff, &temp);
-  temp = 30; tu_fifo_write(&ff, &temp);
+  temp = 10; tu_fifo_write(ff, &temp);
+  temp = 20; tu_fifo_write(ff, &temp);
+  temp = 30; tu_fifo_write(ff, &temp);
 
   temp = 0;
 
-  tu_fifo_peek(&ff, &temp);
+  tu_fifo_peek(ff, &temp);
   TEST_ASSERT_EQUAL(10, temp);
+
+  tu_fifo_read(ff, &temp);
+  tu_fifo_read(ff, &temp);
+
+  tu_fifo_peek(ff, &temp);
+  TEST_ASSERT_EQUAL(30, temp);
+}
+
+void test_get_read_info_when_no_wrap()
+{
+  uint8_t ch = 1;
+
+  // write 6 items
+  for(uint8_t i=0; i < 6; i++) tu_fifo_write(ff, &ch);
+
+  // read 2 items
+  tu_fifo_read(ff, &ch);
+  tu_fifo_read(ff, &ch);
+
+  tu_fifo_get_read_info(ff, &info);
+
+  TEST_ASSERT_EQUAL(4, info.len_lin);
+  TEST_ASSERT_EQUAL(0, info.len_wrap);
+
+  TEST_ASSERT_EQUAL_PTR(ff->buffer+2, info.ptr_lin);
+  TEST_ASSERT_NULL(info.ptr_wrap);
+}
+
+void test_get_read_info_when_wrapped()
+{
+  uint8_t ch = 1;
+
+  // make fifo full
+  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(ff, &ch);
+
+  // read 6 items
+  for(uint8_t i=0; i < 6; i++) tu_fifo_read(ff, &ch);
+
+  // write 2 items
+  tu_fifo_write(ff, &ch);
+  tu_fifo_write(ff, &ch);
+
+  tu_fifo_get_read_info(ff, &info);
+
+  TEST_ASSERT_EQUAL(FIFO_SIZE-6, info.len_lin);
+  TEST_ASSERT_EQUAL(2, info.len_wrap);
+
+  TEST_ASSERT_EQUAL_PTR(ff->buffer+6, info.ptr_lin);
+  TEST_ASSERT_EQUAL_PTR(ff->buffer, info.ptr_wrap);
+}
+
+void test_get_write_info_when_no_wrap()
+{
+  uint8_t ch = 1;
+
+  // write 2 items
+  tu_fifo_write(ff, &ch);
+  tu_fifo_write(ff, &ch);
+
+  tu_fifo_get_write_info(ff, &info);
+
+  TEST_ASSERT_EQUAL(FIFO_SIZE-2, info.len_lin);
+  TEST_ASSERT_EQUAL(0, info.len_wrap);
+
+  TEST_ASSERT_EQUAL_PTR(ff->buffer+2, info .ptr_lin);
+  // application should check len instead of ptr.
+  // TEST_ASSERT_NULL(info.ptr_wrap);
+}
+
+void test_get_write_info_when_wrapped()
+{
+  uint8_t ch = 1;
+
+  // write 6 items
+  for(uint8_t i=0; i < 6; i++) tu_fifo_write(ff, &ch);
+
+  // read 2 items
+  tu_fifo_read(ff, &ch);
+  tu_fifo_read(ff, &ch);
+
+  tu_fifo_get_write_info(ff, &info);
+
+  TEST_ASSERT_EQUAL(FIFO_SIZE-6, info.len_lin);
+  TEST_ASSERT_EQUAL(2, info.len_wrap);
+
+  TEST_ASSERT_EQUAL_PTR(ff->buffer+6, info .ptr_lin);
+  TEST_ASSERT_EQUAL_PTR(ff->buffer, info.ptr_wrap);
 }
 
 void test_empty(void)
 {
   uint8_t temp;
-  TEST_ASSERT_TRUE(tu_fifo_empty(&ff));
-  tu_fifo_write(&ff, &temp);
-  TEST_ASSERT_FALSE(tu_fifo_empty(&ff));
+  TEST_ASSERT_TRUE(tu_fifo_empty(ff));
+
+  // read info
+  tu_fifo_get_read_info(ff, &info);
+
+  TEST_ASSERT_EQUAL(0, info.len_lin);
+  TEST_ASSERT_EQUAL(0, info.len_wrap);
+
+  TEST_ASSERT_NULL(info.ptr_lin);
+  TEST_ASSERT_NULL(info.ptr_wrap);
+
+  // write info
+  tu_fifo_get_write_info(ff, &info);
+
+  TEST_ASSERT_EQUAL(FIFO_SIZE, info.len_lin);
+  TEST_ASSERT_EQUAL(0, info.len_wrap);
+
+  TEST_ASSERT_EQUAL_PTR(ff->buffer, info .ptr_lin);
+  // application should check len instead of ptr.
+  // TEST_ASSERT_NULL(info.ptr_wrap);
+
+  // write 1 then re-check empty
+  tu_fifo_write(ff, &temp);
+  TEST_ASSERT_FALSE(tu_fifo_empty(ff));
 }
 
 void test_full(void)
 {
-  TEST_ASSERT_FALSE(tu_fifo_full(&ff));
+  TEST_ASSERT_FALSE(tu_fifo_full(ff));
 
-  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(&ff, &i);
+  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(ff, &i);
 
-  TEST_ASSERT_TRUE(tu_fifo_full(&ff));
+  TEST_ASSERT_TRUE(tu_fifo_full(ff));
+
+  // read info
+  tu_fifo_get_read_info(ff, &info);
+
+  TEST_ASSERT_EQUAL(FIFO_SIZE, info.len_lin);
+  TEST_ASSERT_EQUAL(0, info.len_wrap);
+
+  TEST_ASSERT_EQUAL_PTR(ff->buffer, info.ptr_lin);
+  // skip this, application must check len instead of buffer
+  // TEST_ASSERT_NULL(info.ptr_wrap);
+
+  // write info
 }

--- a/test/test/test_fifo.c
+++ b/test/test/test_fifo.c
@@ -150,9 +150,6 @@ void test_peek(void)
 
   tu_fifo_peek(&ff, &temp);
   TEST_ASSERT_EQUAL(10, temp);
-
-  tu_fifo_peek_at(&ff, 1, &temp);
-  TEST_ASSERT_EQUAL(20, temp);
 }
 
 void test_empty(void)


### PR DESCRIPTION
**Describe the PR**
Follow the discussion in #593, this attempts to implement functions to allow for DMA usage in audio functions.

- Add tud_audio_n_get_ep_out_ff(), tud_audio_n_get_ep_in_ff(),
tud_audio_n_get_rx_support_ff(), and tud_audio_n_get_tx_support_ff()
- Change get_linear_read/write_info() to return linear and wrapped part
at once
- Adjusted affected code in audio_device.c and tested with
audio_4_channel.
