### PR TITLE
mcu-link: Board support for MCU-LINK with LPC55S69JBD64

### DIFF
--- a/hw/bsp/lpc55/boards/mcu_link/board.h
+++ b/hw/bsp/lpc55/boards/mcu_link/board.h
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021, Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+// LED
+#define LED_PORT              0
+#define LED_PIN               5
+#define LED_STATE_ON          0
+
+// WAKE button (Dummy, use unused pin
+#define BUTTON_PORT           0
+#define BUTTON_PIN            30
+#define BUTTON_STATE_ACTIVE   0
+
+// UART
+#define UART_DEV              USART0
+#define UART_RX_PINMUX        0, 24, IOCON_PIO_DIG_FUNC1_EN
+#define UART_TX_PINMUX        0, 25, IOCON_PIO_DIG_FUNC1_EN
+
+// XTAL
+#define XTAL0_CLK_HZ          (16 * 1000 * 1000U)
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif

--- a/hw/bsp/lpc55/boards/mcu_link/board.mk
+++ b/hw/bsp/lpc55/boards/mcu_link/board.mk
@@ -1,0 +1,13 @@
+PORT ?= 1
+SPEED ?= high
+
+MCU_VARIANT = LPC55S69
+MCU_CORE = LPC55S69_cm33_core0
+
+CFLAGS += -DCPU_LPC55S69JBD64_cm33_core0
+
+JLINK_DEVICE = LPC55S69
+PYOCD_TARGET = LPC55S69
+
+# flash using pyocd
+flash: flash-pyocd


### PR DESCRIPTION
**Describe the PR**
Add  board support for the NXP/Embedded Artists MCU-LINK

**Additional context**
The MCU-LINK is a cheap board with a LPC55S69JBD64. It provides a level shifting JTAG/SWD and Uart connector and is delivered as CMSIS-DAP adapter. Flash is unprotected.
