### PR TITLE
Update hcd_rp2040.c

### DIFF
--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -487,7 +487,6 @@ bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet
     // EP0 out
     _hw_endpoint_init(ep, dev_addr, 0x00, ep->wMaxPacketSize, 0, 0);
     assert(ep->configured);
-    assert(ep->num == 0 && !ep->in);
     ep->total_len = 8;
     ep->transfer_size = 8;
     ep->active = true;


### PR DESCRIPTION
Remove reference to the deprecated "num" and "in" members  of struct hw_endpoint which still existed in an assert statement that would break DEBUG builds.

