### PR TITLE
Issue #709 

### DIFF
--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -161,7 +161,10 @@ void _hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t t
     // Fill in info now that we're kicking off the hw
     ep->total_len = total_len;
     ep->len = 0;
-    ep->transfer_size = tu_min16(total_len, ep->wMaxPacketSize);
+    // The following limits the TOTAL transfer size to 64 bytes.
+    // This is not the maximum size of the individual data packets,
+    // so it does not need to be limited to 8 for low-speed devices.
+    ep->transfer_size = total_len > 64 ? 64 : total_len;
     ep->active = true;
     ep->user_buf = buffer;
 #if TUSB_OPT_HOST_ENABLED


### PR DESCRIPTION
Revert a change that was made to rp2040_usb.c that causes slow speed devices to not get configured by the host. It seems likely it is the same as Issue #709.

A low-speed mouse that works with the old TinyUSB source code in the Pico SDK  does not work with the latest master from the main repo. This pull request reverts the change that causes this problem. After this line is changed, the mouse works with either version of code.

The reverted change limits the entire data transfer to only 8 bytes for low-speed devices, not just the data packets. So, when the higher level logic requests the 18 byte Device Descriptor, this line of code reduces it to 8 bytes. Lower-level code requests an 8 byte IN packet and signals Last Transfer to the USB controller. Higher-level code may then try to request the remaining 10 bytes, but whatever happens results in a STALL from the device and a DATA SEQ error from the USB controller.