### PR TITLE
Update main.c

### DIFF
--- a/examples/host/cdc_msc_hid/src/main.c
+++ b/examples/host/cdc_msc_hid/src/main.c
@@ -262,7 +262,7 @@ void hid_task(void)
     if ( !tuh_hid_keyboard_is_busy(addr) )
     {
       process_kbd_report(&usb_keyboard_report);
-      tuh_hid_keyboard_get_report(addr, &usb_mouse_report);
+      tuh_hid_keyboard_get_report(addr, &usb_keyboard_report);
     }
   }
 #endif


### PR DESCRIPTION
Fix code in host example where HID keyboard was being stuffed into the HID mouse buffer.

I haven't tested this, but it seems obviously wrong. The HID mouse report buffer was being used for HID keyboard reports.