### PR TITLE
Fix ep struct trace statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ cov-int
 # cppcheck build directories
 *-build-dir
 /_bin/
+examples/host/cdc_msc_hid/setup.bat

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ cov-int
 # cppcheck build directories
 *-build-dir
 /_bin/
-examples/host/cdc_msc_hid/setup.bat

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -306,8 +306,8 @@ static void _hw_endpoint_init(struct hw_endpoint *ep, uint8_t dev_addr, uint8_t 
     ep->wMaxPacketSize = wMaxPacketSize;
     ep->transfer_type = transfer_type;
 
-    pico_trace("hw_endpoint_init dev %d ep %d %s xfer %d\n", ep->dev_addr, ep->num, ep_dir_string[ep->in], ep->transfer_type);
-    pico_trace("dev %d ep %d %s setup buffer @ 0x%p\n", ep->dev_addr, ep->num, ep_dir_string[ep->in], ep->hw_data_buf);
+    pico_trace("hw_endpoint_init dev %d ep %d %s xfer %d\n", ep->dev_addr, tu_edpt_number(ep->ep_addr), ep_dir_string[tu_edpt_dir(ep->ep_addr)], ep->transfer_type);
+    pico_trace("dev %d ep %d %s setup buffer @ 0x%p\n", ep->dev_addr, tu_edpt_number(ep->ep_addr), ep_dir_string[tu_edpt_dir(ep->ep_addr)], ep->hw_data_buf);
     uint dpram_offset = hw_data_offset(ep->hw_data_buf);
     // Bits 0-5 should be 0
     assert(!(dpram_offset & 0b111111));


### PR DESCRIPTION
Updated some pico_trace statements that were using deprecated elements of the hw_endpoint structure.
