### PR TITLE
Add interface set protocol function

### DIFF
--- a/examples/host/cdc_msc_hid/src/main.c
+++ b/examples/host/cdc_msc_hid/src/main.c
@@ -268,12 +268,22 @@ void hid_task(void)
 #endif
 
 #if CFG_TUH_HID_MOUSE
+
+  static bool boot_protocol_set = false;
+
   if ( tuh_hid_mouse_is_mounted(addr) )
   {
     if ( !tuh_hid_mouse_is_busy(addr) )
     {
-      process_mouse_report(&usb_mouse_report);
-      tuh_hid_mouse_get_report(addr, &usb_mouse_report);
+      if (boot_protocol_set) 
+      {
+        process_mouse_report(&usb_mouse_report);
+        tuh_hid_mouse_get_report(addr, &usb_mouse_report);
+      } 
+      else 
+      {
+        boot_protocol_set = tuh_hid_mouse_set_protocol(addr,true);
+      }
     }
   }
 #endif

--- a/examples/host/cdc_msc_hid/src/main.c
+++ b/examples/host/cdc_msc_hid/src/main.c
@@ -269,20 +269,20 @@ void hid_task(void)
 
 #if CFG_TUH_HID_MOUSE
 
-  static bool boot_protocol_set = false;
+  static bool mouse_boot_protocol_set = false;
 
   if ( tuh_hid_mouse_is_mounted(addr) )
   {
     if ( !tuh_hid_mouse_is_busy(addr) )
     {
-      if (boot_protocol_set) 
+      if (mouse_boot_protocol_set) 
       {
         process_mouse_report(&usb_mouse_report);
         tuh_hid_mouse_get_report(addr, &usb_mouse_report);
       } 
       else 
       {
-        boot_protocol_set = tuh_hid_mouse_set_protocol(addr,true);
+        mouse_boot_protocol_set = tuh_hid_mouse_set_protocol(addr,true);
       }
     }
   }

--- a/src/class/hid/hid_host.h
+++ b/src/class/hid/hid_host.h
@@ -78,6 +78,16 @@ bool tuh_hid_keyboard_is_busy(uint8_t dev_addr);
  */
 tusb_error_t  tuh_hid_keyboard_get_report(uint8_t dev_addr, void * p_report);
 
+/** \brief        Perform a set the report format for the keyboard (BOOT or REPORT)
+ * \param[in]		  dev_addr device address
+ * \param[in]     boot true for the simple standard keyboard report, false for the device specific report defined by the report descriptor   
+ * \returns       \ref tusb_error_t type to indicate success or error condition.
+ * \retval        true if device is configured and the Set Protoocol was sent
+ * \retval        false if the device is not configured or some other issue
+ * \note          This function is non-blocking and returns immediately. The function does not have a callback implemented
+*/
+bool tuh_hid_keyboard_set_protocol(uint8_t dev_addr, bool boot);
+
 //------------- Application Callback -------------//
 /** \brief      Callback function that is invoked when an transferring event occurred
  * \param[in]		dev_addr	Address of device
@@ -142,6 +152,16 @@ bool          tuh_hid_mouse_is_busy(uint8_t dev_addr);
  * \note          This function is non-blocking and returns immediately. The result of usb transfer will be reported by the interface's callback function
  */
 tusb_error_t  tuh_hid_mouse_get_report(uint8_t dev_addr, void* p_report);
+
+/** \brief        Perform a set the report format for the mouse (BOOT or REPORT)
+ * \param[in]		  dev_addr device address
+ * \param[in]     boot true for the simple standard mouse report, false for the device specific report defined by the report descriptor   
+ * \returns       \ref tusb_error_t type to indicate success or error condition.
+ * \retval        true if device is configured and the Set Protoocol was sent
+ * \retval        false if the device is not configured or some other issue
+ * \note          This function is non-blocking and returns immediately. The function does not have a callback implemented
+*/
+bool tuh_hid_mouse_set_protocol(uint8_t dev_addr, bool boot);
 
 //------------- Application Callback -------------//
 /** \brief      Callback function that is invoked when an transferring event occurred


### PR DESCRIPTION
Adds a function so an application can set the mouse or keyboard report format to the standardized Boot format. HID devices that support the Boot format do not always use it by default.   