### PR TITLE
enable ci for esp32s3 boards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
         - 'espressif_kaluga_1'
         - 'espressif_saola_1'
         # ESP32-S3
-        # - 'espressif_addax_1' # temporarily remove the board from test while espressif MR is not merged
+        - 'espressif_addax_1'
 
     steps:
     - name: Setup Python


### PR DESCRIPTION
**Describe the PR**
Enable ci for esp32s3 boards since IDF now support esp32s3. Follow up to #783 