### PR TITLE
fix uac2_headset example

### DIFF
--- a/examples/device/uac2_headset/src/main.c
+++ b/examples/device/uac2_headset/src/main.c
@@ -149,7 +149,7 @@ typedef struct TU_ATTR_PACKED
     uint8_t bmRequestType;
   };
 
-  audio_cs_req_t bRequest;
+  uint8_t bRequest;  ///< Request type audio_cs_req_t
   uint8_t bChannelNumber;
   uint8_t bControlSelector;
   union


### PR DESCRIPTION
**Describe the PR**

type of bRequest should be uint8_t, not enumerate...

size of a enum is dynamic, it will break the program in some complier(such as xtensa-esp32s2-elf-gcc), error logging like: 

```
Get request not handled, entity = 0, selector = 8, request = 131330
```

