### PR TITLE
fix uac2_headset example

### DIFF
--- a/examples/device/uac2_headset/src/main.c
+++ b/examples/device/uac2_headset/src/main.c
@@ -332,13 +332,14 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const * p_reque
   return true;
 }
 
-bool tud_audio_rx_done_cb(uint8_t rhport, uint8_t *buffer, uint16_t buf_size)
+bool tud_audio_rx_done_pre_read_cb(uint8_t rhport, uint16_t n_bytes_received, uint8_t func_id, uint8_t ep_out, uint8_t cur_alt_setting)
 {
   (void)rhport;
+  (void)func_id;
+  (void)ep_out;
+  (void)cur_alt_setting;
 
-  spk_data_size = buf_size;
-  memcpy(spk_buf, buffer, buf_size);
-
+  spk_data_size = tud_audio_read(spk_buf, n_bytes_received);
   return true;
 }
 


### PR DESCRIPTION
**Describe the PR**
fix uac2_headset example

tud_audio_rx_done_cb() is departed, replace with
tud_audio_rx_done_pre_read_cb()

**Additional context**
test OK on esp32s2(with patch #552 , and run `tud_task()` in a separate task)

test method:
generate sine wave to uac device with python script:

```
# refer: https://pythonaudiosynthesisbasics.com/
import numpy as np
import sounddevice as sd

sample_rate = 44100
duration = 120.0
frequency = 440.0

x = np.linspace(0, duration * 2 * np.pi, int(duration * sample_rate))
sinewave_data = np.sin(frequency * x)

# best to attenuate it before playing, they can get very loud
sinewave_data = sinewave_data * 0.3

while True:
    sd.play(sinewave_data, sample_rate)
    sd.wait()
```

in audacity, record:

![image](https://user-images.githubusercontent.com/5947186/119600350-73ba9680-be19-11eb-8c74-fe4c73ec01f8.png)
