### PR TITLE
Fix host rp2040 with low speed device

### DIFF
--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -307,25 +307,40 @@ void tu_print_var(uint8_t const* buf, uint32_t bufsize)
   for(uint32_t i=0; i<bufsize; i++) tu_printf("%02X ", buf[i]);
 }
 
-// Log with debug level 1
+// Log with Level
+#define TU_LOG(n, ...)        TU_LOG##n(__VA_ARGS__)
+#define TU_LOG_MEM(n, ...)    TU_LOG##n##_MEM(__VA_ARGS__)
+#define TU_LOG_VAR(n, ...)    TU_LOG##n##_VAR(__VA_ARGS__)
+#define TU_LOG_INT(n, ...)    TU_LOG##n##_INT(__VA_ARGS__)
+#define TU_LOG_HEX(n, ...)    TU_LOG##n##_HEX(__VA_ARGS__)
+#define TU_LOG_LOCATION()     tu_printf("%s: %d:\r\n", __PRETTY_FUNCTION__, __LINE__)
+#define TU_LOG_FAILED()       tu_printf("%s: %d: Failed\r\n", __PRETTY_FUNCTION__, __LINE__)
+
+
+// Log Level 1: Error
 #define TU_LOG1               tu_printf
 #define TU_LOG1_MEM           tu_print_mem
 #define TU_LOG1_VAR(_x)       tu_print_var((uint8_t const*)(_x), sizeof(*(_x)))
 #define TU_LOG1_INT(_x)       tu_printf(#_x " = %ld\n", (uint32_t) (_x) )
 #define TU_LOG1_HEX(_x)       tu_printf(#_x " = %lX\n", (uint32_t) (_x) )
-#define TU_LOG1_LOCATION()    tu_printf("%s: %d:\r\n", __PRETTY_FUNCTION__, __LINE__)
-#define TU_LOG1_FAILED()      tu_printf("%s: %d: Failed\r\n", __PRETTY_FUNCTION__, __LINE__)
 
-// Log with debug level 2
-#if CFG_TUSB_DEBUG > 1
+// Log Level 2: Warn
+#if CFG_TUSB_DEBUG >= 2
   #define TU_LOG2             TU_LOG1
   #define TU_LOG2_MEM         TU_LOG1_MEM
   #define TU_LOG2_VAR         TU_LOG1_VAR
   #define TU_LOG2_INT         TU_LOG1_INT
   #define TU_LOG2_HEX         TU_LOG1_HEX
-  #define TU_LOG2_LOCATION()  TU_LOG1_LOCATION()
 #endif
 
+// Log Level 3: Info
+#if CFG_TUSB_DEBUG >= 3
+  #define TU_LOG3             TU_LOG1
+  #define TU_LOG3_MEM         TU_LOG1_MEM
+  #define TU_LOG3_VAR         TU_LOG1_VAR
+  #define TU_LOG3_INT         TU_LOG1_INT
+  #define TU_LOG3_HEX         TU_LOG1_HEX
+#endif
 
 typedef struct
 {
@@ -368,6 +383,15 @@ static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint3
   #define TU_LOG2_INT(...)
   #define TU_LOG2_HEX(...)
   #define TU_LOG2_LOCATION()
+#endif
+
+#ifndef TU_LOG3
+  #define TU_LOG3(...)
+  #define TU_LOG3_MEM(...)
+  #define TU_LOG3_VAR(...)
+  #define TU_LOG3_INT(...)
+  #define TU_LOG3_HEX(...)
+  #define TU_LOG3_LOCATION()
 #endif
 
 #ifdef __cplusplus

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -452,6 +452,7 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * 
     if (ep_addr != ep->ep_addr)
     {
         // Direction has flipped so re init it but with same properties
+        // TODO treat IN and OUT as invidual endpoints
         _hw_endpoint_init(ep, dev_addr, ep_addr, ep->wMaxPacketSize, ep->transfer_type, 0);
     }
 
@@ -531,6 +532,7 @@ bool hcd_edpt_busy(uint8_t dev_addr, uint8_t ep_addr)
 bool hcd_edpt_stalled(uint8_t dev_addr, uint8_t ep_addr)
 {
     panic("hcd_pipe_stalled");
+    return false;
 }
 
 bool hcd_edpt_clear_stall(uint8_t dev_addr, uint8_t ep_addr)

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -212,6 +212,7 @@ static void hcd_rp2040_irq(void)
     if (status & USB_INTS_BUFF_STATUS_BITS)
     {
         handled |= USB_INTS_BUFF_STATUS_BITS;
+        // print_bufctrl32(*epx.buffer_control);
         hw_handle_buff_status();
     }
 
@@ -233,6 +234,7 @@ static void hcd_rp2040_irq(void)
     if (status & USB_INTS_ERROR_DATA_SEQ_BITS)
     {
         usb_hw_clear->sie_status = USB_SIE_STATUS_DATA_SEQ_ERROR_BITS;
+        // print_bufctrl32(*epx.buffer_control);
         panic("Data Seq Error \n");
     }
 

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -210,6 +210,7 @@ void _hw_endpoint_xfer_sync(struct hw_endpoint *ep)
     uint16_t transferred_bytes = buf_ctrl & USB_BUF_CTRL_LEN_MASK;
 
 #if TUSB_OPT_HOST_ENABLED
+    // RP2040-E4
     // tag::host_buf_sel_fix[]
     // TODO need changes to support double buffering
     if (ep->buf_sel == 1)

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -136,6 +136,7 @@ void _hw_endpoint_start_next_buffer(struct hw_endpoint *ep)
     // Special case with control status stage where PID is always DATA1
     if ( ep->transfer_size == 0 )
     {
+      // ZLP also toggle data
       ep->next_pid ^= 1u;
     }else
     {

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -16,8 +16,6 @@
 #define TUD_OPT_RP2040_USB_DEVICE_ENUMERATION_FIX PICO_RP2040_USB_DEVICE_ENUMERATION_FIX
 #endif
 
-// For memset
-#include <string.h>
 
 #if false && !defined(NDEBUG)
 #define pico_trace(format,args...) printf(format, ## args)
@@ -78,7 +76,7 @@ struct hw_endpoint
 #if TUSB_OPT_HOST_ENABLED
     // Only needed for host mode
     bool last_buf;
-    // HOST BUG. Host will incorrect write status to top half of buffer
+    // RP2040-E4: HOST BUG. Host will incorrect write status to top half of buffer
     // control register when doing transfers > 1 packet
     uint8_t buf_sel;
     // Only needed for host
@@ -118,5 +116,45 @@ static inline uintptr_t hw_data_offset(uint8_t *buf)
 }
 
 extern const char *ep_dir_string[];
+
+typedef union TU_ATTR_PACKED
+{
+  uint16_t u16;
+  struct TU_ATTR_PACKED
+  {
+    uint16_t xfer_len     : 10;
+    uint16_t available    : 1;
+    uint16_t stall        : 1;
+    uint16_t reset_bufsel : 1;
+    uint16_t data_toggle  : 1;
+    uint16_t last_buf     : 1;
+    uint16_t full         : 1;
+  };
+} rp2040_buffer_control_t;
+
+TU_VERIFY_STATIC(sizeof(rp2040_buffer_control_t) == 2, "size is not correct");
+
+static inline void print_bufctrl16(uint32_t u16)
+{
+  rp2040_buffer_control_t bufctrl;
+
+  bufctrl.u16 = u16;
+
+  TU_LOG(2, "len = %u, available = %u, stall = %u, reset = %u, toggle = %u, last = %u, full = %u\r\n",
+         bufctrl.xfer_len, bufctrl.available, bufctrl.stall, bufctrl.reset_bufsel, bufctrl.data_toggle, bufctrl.last_buf, bufctrl.full);
+}
+
+static inline void print_bufctrl32(uint32_t u32)
+{
+  uint16_t u16;
+
+  u16 = u32 >> 16;
+  TU_LOG(2, "Buffer Control 1 0x%x: ", u16);
+  print_bufctrl16(u16);
+
+  u16 = u32 & 0x0000ffff;
+  TU_LOG(2, "Buffer Control 0 0x%x: ", u16);
+  print_bufctrl16(u16);
+}
 
 #endif


### PR DESCRIPTION
**Describe the PR**
Fix host rp2040 when mounting low speed device (e.g keyboard) with max packet size = 8
- Correct Data Toggle by number of packet: e.g  64 bytes = 8 x 8 bytes --> Data Toggle should not be flipped in the next buffer.  
- Improve RP2040-E4 (host buf sel) fix to prevent panic with already available.

Fix #709, also replace https://github.com/raspberrypi/tinyusb/pull/7 as the fix