### PR TITLE
Enable non-fifo based custom vendor device

### DIFF
--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -33,6 +33,10 @@
 
 #include "vendor_device.h"
 
+#if CFG_TUD_VENDOR_CUSTOM
+
+#else  // !CFG_TUD_VENDOR_CUSTOM
+
 //--------------------------------------------------------------------+
 // MACRO CONSTANT TYPEDEF
 //--------------------------------------------------------------------+
@@ -235,5 +239,6 @@ bool vendord_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint
 
   return true;
 }
+#endif // CFG_TUD_VENDOR_CUSTOM
 
 #endif

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -236,6 +236,10 @@
   #define CFG_TUD_VENDOR          0
 #endif
 
+#ifndef CFG_TUD_VENDOR_CUSTOM
+  #define CFG_TUD_VENDOR_CUSTOM   0
+#endif
+
 #ifndef CFG_TUD_USBTMC
   #define CFG_TUD_USBTMC          0
 #endif


### PR DESCRIPTION
Define CFG_TUD_VENDOR_CUSTOM to non-zero to use your own callbacks.


