### PR TITLE
Clean up Host HCD API

### DIFF
--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -96,24 +96,26 @@ bool tuh_cdc_serial_is_mounted(uint8_t dev_addr)
 
 bool tuh_cdc_send(uint8_t dev_addr, void const * p_data, uint32_t length, bool is_notify)
 {
+  (void) is_notify;
   TU_VERIFY( tuh_cdc_mounted(dev_addr) );
   TU_VERIFY( p_data != NULL && length, TUSB_ERROR_INVALID_PARA);
 
   uint8_t const ep_out = cdch_data[dev_addr-1].ep_out;
   if ( hcd_edpt_busy(dev_addr, ep_out) ) return false;
 
-  return hcd_pipe_xfer(dev_addr, ep_out, (void *) p_data, length, is_notify);
+  return usbh_edpt_xfer(dev_addr, ep_out, (void *) p_data, length);
 }
 
 bool tuh_cdc_receive(uint8_t dev_addr, void * p_buffer, uint32_t length, bool is_notify)
 {
+  (void) is_notify;
   TU_VERIFY( tuh_cdc_mounted(dev_addr) );
   TU_VERIFY( p_buffer != NULL && length, TUSB_ERROR_INVALID_PARA);
 
   uint8_t const ep_in = cdch_data[dev_addr-1].ep_in;
   if ( hcd_edpt_busy(dev_addr, ep_in) ) return false;
 
-  return hcd_pipe_xfer(dev_addr, ep_in, p_buffer, length, is_notify);
+  return usbh_edpt_xfer(dev_addr, ep_in, p_buffer, length);
 }
 
 bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_control_complete_cb_t complete_cb)

--- a/src/class/cdc/cdc_rndis_host.c
+++ b/src/class/cdc/cdc_rndis_host.c
@@ -239,7 +239,7 @@ static tusb_error_t send_message_get_response_subtask( uint8_t dev_addr, cdch_da
   if ( TUSB_ERROR_NONE != error )   STASK_RETURN(error);
 
   //------------- waiting for Response Available notification -------------//
-  (void) hcd_pipe_xfer(p_cdc->pipe_notification, msg_notification[dev_addr-1], 8, true);
+  (void) usbh_edpt_xfer(p_cdc->pipe_notification, msg_notification[dev_addr-1], 8);
   osal_semaphore_wait(rndish_data[dev_addr-1].sem_notification_hdl, OSAL_TIMEOUT_NORMAL, &error);
   if ( TUSB_ERROR_NONE != error )   STASK_RETURN(error);
   STASK_ASSERT(msg_notification[dev_addr-1][0] == 1);

--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -225,7 +225,7 @@ uint16_t hidd_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, uint1
   {
     if ( !usbd_edpt_xfer(rhport, p_hid->ep_out, p_hid->epout_buf, sizeof(p_hid->epout_buf)) )
     {
-      TU_LOG1_FAILED();
+      TU_LOG_FAILED();
       TU_BREAKPOINT();
     }
   }

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -172,7 +172,7 @@ uint16_t mscd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint1
   // Prepare for Command Block Wrapper
   if ( !usbd_edpt_xfer(rhport, p_msc->ep_out, (uint8_t*) &p_msc->cbw, sizeof(msc_cbw_t)) )
   {
-    TU_LOG1_FAILED();
+    TU_LOG_FAILED();
     TU_BREAKPOINT();
   }
 

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -71,7 +71,8 @@ CFG_TUSB_MEM_SECTION static msch_interface_t _msch_itf[CFG_TUSB_HOST_DEVICE_MAX]
 
 // buffer used to read scsi information when mounted
 // largest response data currently is inquiry TODO Inquiry is not part of enum anymore
-CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4) static uint8_t _msch_buffer[sizeof(scsi_inquiry_resp_t)];
+CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4)
+static uint8_t _msch_buffer[sizeof(scsi_inquiry_resp_t)];
 
 static inline msch_interface_t* get_itf(uint8_t dev_addr)
 {
@@ -438,7 +439,7 @@ static bool config_test_unit_ready_complete(uint8_t dev_addr, msc_cbw_t const* c
   {
     // Unit is ready, read its capacity
     TU_LOG2("SCSI Read Capacity\r\n");
-    tuh_msc_read_capacity(dev_addr, cbw->lun, (scsi_read_capacity10_resp_t*) _msch_buffer, config_read_capacity_complete);
+    tuh_msc_read_capacity(dev_addr, cbw->lun, (scsi_read_capacity10_resp_t*) ((void*) _msch_buffer), config_read_capacity_complete);
   }else
   {
     // Note: During enumeration, some device fails Test Unit Ready and require a few retries
@@ -465,7 +466,7 @@ static bool config_read_capacity_complete(uint8_t dev_addr, msc_cbw_t const* cbw
   msch_interface_t* p_msc = get_itf(dev_addr);
 
   // Capacity response field: Block size and Last LBA are both Big-Endian
-  scsi_read_capacity10_resp_t* resp = (scsi_read_capacity10_resp_t*) _msch_buffer;
+  scsi_read_capacity10_resp_t* resp = (scsi_read_capacity10_resp_t*) ((void*) _msch_buffer);
   p_msc->capacity[cbw->lun].block_count = tu_ntohl(resp->last_lba) + 1;
   p_msc->capacity[cbw->lun].block_size = tu_ntohl(resp->block_size);
 

--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -195,7 +195,7 @@ uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, ui
   // Prepare for incoming data
   if ( !usbd_edpt_xfer(rhport, p_vendor->ep_out, p_vendor->epout_buf, sizeof(p_vendor->epout_buf)) )
   {
-    TU_LOG1_FAILED();
+    TU_LOG_FAILED();
     TU_BREAKPOINT();
   }
 

--- a/src/class/vendor/vendor_host.c
+++ b/src/class/vendor/vendor_host.c
@@ -66,7 +66,7 @@ tusb_error_t tusbh_custom_read(uint8_t dev_addr, uint16_t vendor_id, uint16_t pr
     return TUSB_ERROR_INTERFACE_IS_BUSY;
   }
 
-  (void) hcd_pipe_xfer( custom_interface[dev_addr-1].pipe_in, p_buffer, length, true);
+  (void) usbh_edpt_xfer( custom_interface[dev_addr-1].pipe_in, p_buffer, length);
 
   return TUSB_ERROR_NONE;
 }
@@ -80,7 +80,7 @@ tusb_error_t tusbh_custom_write(uint8_t dev_addr, uint16_t vendor_id, uint16_t p
     return TUSB_ERROR_INTERFACE_IS_BUSY;
   }
 
-  (void) hcd_pipe_xfer( custom_interface[dev_addr-1].pipe_out, p_data, length, true);
+  (void) usbh_edpt_xfer( custom_interface[dev_addr-1].pipe_out, p_data, length);
 
   return TUSB_ERROR_NONE;
 }

--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -24,10 +24,6 @@
  * This file is part of the TinyUSB stack.
  */
 
-/** \ingroup Group_Common
- *  \defgroup Group_CommonH common.h
- *  @{ */
-
 #ifndef _TUSB_COMMON_H_
 #define _TUSB_COMMON_H_
 
@@ -288,8 +284,9 @@ TU_ATTR_ALWAYS_INLINE static inline void     tu_unaligned_write16 (void* mem, ui
 
 // CFG_TUSB_DEBUG for debugging
 // 0 : no debug
-// 1 : print when there is error
-// 2 : print out log
+// 1 : print error
+// 2 : print warning
+// 3 : print info
 #if CFG_TUSB_DEBUG
 
 void tu_print_mem(void const *buf, uint32_t count, uint8_t indent);
@@ -315,7 +312,6 @@ void tu_print_var(uint8_t const* buf, uint32_t bufsize)
 #define TU_LOG_HEX(n, ...)    TU_LOG##n##_HEX(__VA_ARGS__)
 #define TU_LOG_LOCATION()     tu_printf("%s: %d:\r\n", __PRETTY_FUNCTION__, __LINE__)
 #define TU_LOG_FAILED()       tu_printf("%s: %d: Failed\r\n", __PRETTY_FUNCTION__, __LINE__)
-
 
 // Log Level 1: Error
 #define TU_LOG1               tu_printf
@@ -366,6 +362,17 @@ static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint3
 
 #endif // CFG_TUSB_DEBUG
 
+#ifndef TU_LOG
+#define TU_LOG(n, ...)
+#define TU_LOG_MEM(n, ...)
+#define TU_LOG_VAR(n, ...)
+#define TU_LOG_INT(n, ...)
+#define TU_LOG_HEX(n, ...)
+#define TU_LOG_LOCATION()
+#define TU_LOG_FAILED()
+#endif
+
+// TODO replace all TU_LOGn with TU_LOG(n)
 #ifndef TU_LOG1
   #define TU_LOG1(...)
   #define TU_LOG1_MEM(...)
@@ -395,5 +402,3 @@ static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint3
 #endif
 
 #endif /* _TUSB_COMMON_H_ */
-
-/**  @} */

--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -372,8 +372,6 @@ static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint3
   #define TU_LOG1_VAR(...)
   #define TU_LOG1_INT(...)
   #define TU_LOG1_HEX(...)
-  #define TU_LOG1_LOCATION()
-  #define TU_LOG1_FAILED()
 #endif
 
 #ifndef TU_LOG2
@@ -382,7 +380,6 @@ static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint3
   #define TU_LOG2_VAR(...)
   #define TU_LOG2_INT(...)
   #define TU_LOG2_HEX(...)
-  #define TU_LOG2_LOCATION()
 #endif
 
 #ifndef TU_LOG3
@@ -391,7 +388,6 @@ static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint3
   #define TU_LOG3_VAR(...)
   #define TU_LOG3_INT(...)
   #define TU_LOG3_HEX(...)
-  #define TU_LOG3_LOCATION()
 #endif
 
 #ifdef __cplusplus

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -108,15 +108,8 @@ void hcd_int_enable (uint8_t rhport);
 // Disable USB interrupt
 void hcd_int_disable(uint8_t rhport);
 
-// Get micro frame number (125 us)
-uint32_t hcd_uframe_number(uint8_t rhport);
-
 // Get frame number (1ms)
-TU_ATTR_ALWAYS_INLINE static inline
-uint32_t hcd_frame_number(uint8_t rhport)
-{
-  return hcd_uframe_number(rhport) >> 3;
-}
+uint32_t hcd_frame_number(uint8_t rhport);
 
 //--------------------------------------------------------------------+
 // Port API

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -143,20 +143,11 @@ void hcd_device_close(uint8_t rhport, uint8_t dev_addr);
 
 bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet[8]);
 bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const * ep_desc);
+bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t buflen);
 
 bool hcd_edpt_busy(uint8_t dev_addr, uint8_t ep_addr);
 bool hcd_edpt_stalled(uint8_t dev_addr, uint8_t ep_addr);
 bool hcd_edpt_clear_stall(uint8_t dev_addr, uint8_t ep_addr);
-
-// TODO merge with pipe_xfer
-bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t buflen);
-
-//--------------------------------------------------------------------+
-// PIPE API - TODO remove later
-//--------------------------------------------------------------------+
-// TODO control xfer should be used via usbh layer
-bool hcd_pipe_queue_xfer(uint8_t dev_addr, uint8_t ep_addr, uint8_t buffer[], uint16_t total_bytes); // only queue, not transferring yet
-bool hcd_pipe_xfer(uint8_t dev_addr, uint8_t ep_addr, uint8_t buffer[], uint16_t total_bytes, bool int_on_complete);
 
 //--------------------------------------------------------------------+
 // Event API (implemented by stack)

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -28,6 +28,8 @@
 #define _TUSB_HCD_H_
 
 #include "common/tusb_common.h"
+#include "osal/osal.h"
+#include "common/tusb_fifo.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -144,7 +144,6 @@ bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp, tuh_con
 void hub_init(void)
 {
   tu_memclr(hub_data, CFG_TUSB_HOST_DEVICE_MAX*sizeof( hub_interface_t));
-//  hub_enum_sem_hdl = osal_semaphore_create( OSAL_SEM_REF(hub_enum_semaphore) );
 }
 
 bool hub_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *itf_desc, uint16_t *p_length)
@@ -169,19 +168,56 @@ bool hub_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *itf
   return true;
 }
 
+void hub_close(uint8_t dev_addr)
+{
+  tu_memclr(&hub_data[dev_addr-1], sizeof( hub_interface_t));
+}
+
+bool hub_status_pipe_queue(uint8_t dev_addr)
+{
+  hub_interface_t * p_hub = &hub_data[dev_addr-1];
+  return usbh_edpt_xfer(dev_addr, p_hub->ep_in, &p_hub->status_change, 1);
+}
+
+
 //--------------------------------------------------------------------+
 // Set Configure
 //--------------------------------------------------------------------+
 
-static bool config_get_hub_desc_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result);
+static bool config_set_port_power (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result);
 static bool config_port_power_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result);
 
-static bool config_get_hub_desc_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result)
+bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
+{
+   hub_interface_t* p_hub = &hub_data[dev_addr-1];
+  TU_ASSERT(itf_num == p_hub->itf_num);
+
+  // Get Hub Descriptor
+  tusb_control_request_t const request =
+  {
+    .bmRequestType_bit =
+    {
+      .recipient = TUSB_REQ_RCPT_DEVICE,
+      .type      = TUSB_REQ_TYPE_CLASS,
+      .direction = TUSB_DIR_IN
+    },
+    .bRequest = HUB_REQUEST_GET_DESCRIPTOR,
+    .wValue   = 0,
+    .wIndex   = 0,
+    .wLength  = sizeof(descriptor_hub_desc_t)
+  };
+
+  TU_ASSERT( tuh_control_xfer(dev_addr, &request, _hub_buffer, config_set_port_power) );
+
+  return true;
+}
+
+static bool config_set_port_power (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result)
 {
   (void) request;
   TU_ASSERT(XFER_RESULT_SUCCESS == result);
 
-   hub_interface_t* p_hub = &hub_data[dev_addr-1];
+  hub_interface_t* p_hub = &hub_data[dev_addr-1];
 
   // only use number of ports in hub descriptor
   descriptor_hub_desc_t const* desc_hub = (descriptor_hub_desc_t const*) _hub_buffer;
@@ -189,26 +225,9 @@ static bool config_get_hub_desc_complete (uint8_t dev_addr, tusb_control_request
 
   // May need to GET_STATUS
 
-  // Set Port Power to be able to detect connection
-  tusb_control_request_t const new_request =
-  {
-    .bmRequestType_bit =
-    {
-      .recipient = TUSB_REQ_RCPT_OTHER,
-      .type      = TUSB_REQ_TYPE_CLASS,
-      .direction = TUSB_DIR_OUT
-    },
-    .bRequest = HUB_REQUEST_SET_FEATURE,
-    .wValue   = HUB_FEATURE_PORT_POWER,
-    .wIndex   = 1, // starting with port 1
-    .wLength  = 0
-  };
-
-  TU_LOG(2, "HUB Set Port Power: port = %u\r\n", new_request.wIndex);
-
-  TU_ASSERT( tuh_control_xfer(dev_addr, &new_request, NULL, config_port_power_complete) );
-
-  return true;
+  // Set Port Power to be able to detect connection, starting with port 1
+  uint8_t const hub_port = 1;
+  return hub_port_set_feature(dev_addr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete);
 }
 
 static bool config_port_power_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result)
@@ -225,38 +244,10 @@ static bool config_port_power_complete (uint8_t dev_addr, tusb_control_request_t
     usbh_driver_set_config_complete(dev_addr, p_hub->itf_num);
   }else
   {
-    tusb_control_request_t new_request = *request;
-    new_request.wIndex++; // power next port
-
-    TU_LOG(2, "HUB Set Port Power: port = %u\r\n", new_request.wIndex);
-
-    TU_ASSERT( tuh_control_xfer(dev_addr, &new_request, NULL, config_port_power_complete) );
+    // power next port
+    uint8_t const hub_port = (uint8_t) (request->wIndex + 1);
+    return hub_port_set_feature(dev_addr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete);
   }
-
-  return true;
-}
-
-bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
-{
-   hub_interface_t* p_hub = &hub_data[dev_addr-1];
-  TU_ASSERT(itf_num == p_hub->itf_num);
-
-  //------------- Get Hub Descriptor -------------//
-  tusb_control_request_t request =
-  {
-    .bmRequestType_bit =
-    {
-      .recipient = TUSB_REQ_RCPT_DEVICE,
-      .type      = TUSB_REQ_TYPE_CLASS,
-      .direction = TUSB_DIR_IN
-    },
-    .bRequest = HUB_REQUEST_GET_DESCRIPTOR,
-    .wValue   = 0,
-    .wIndex   = 0,
-    .wLength  = sizeof(descriptor_hub_desc_t)
-  };
-
-  TU_ASSERT( tuh_control_xfer(dev_addr, &request, _hub_buffer, config_get_hub_desc_complete) );
 
   return true;
 }
@@ -265,30 +256,59 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
 // Connection Changes
 //--------------------------------------------------------------------+
 
-static bool connection_clear_conn_change_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result);
 static bool connection_get_status_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result);
+static bool connection_clear_conn_change_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result);
 static bool connection_port_reset_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result);
 
-static bool connection_port_reset_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result)
+// callback as response of interrupt endpoint polling
+bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
 {
+  (void) xferred_bytes; // TODO can be more than 1 for hub with lots of ports
+  (void) ep_addr;
   TU_ASSERT(result == XFER_RESULT_SUCCESS);
 
-  // usbh_hub_t * p_hub = &hub_data[dev_addr-1];
+  hub_interface_t * p_hub = &hub_data[dev_addr-1];
+
+  TU_LOG2("  Port Status Change = 0x%02X\r\n", p_hub->status_change);
+
+  // Hub ignore bit0 in status change
+  for (uint8_t port=1; port <= p_hub->port_count; port++)
+  {
+    if ( tu_bit_test(p_hub->status_change, port) )
+    {
+      hub_port_get_status(dev_addr, port, &p_hub->port_status, connection_get_status_complete);
+      break;
+    }
+  }
+
+  // NOTE: next status transfer is queued by usbh.c after handling this request
+
+  return true;
+}
+
+static bool connection_get_status_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result)
+{
+  TU_ASSERT(result == XFER_RESULT_SUCCESS);
+  hub_interface_t * p_hub = &hub_data[dev_addr-1];
   uint8_t const port_num = (uint8_t) request->wIndex;
 
-  // submit attach event
-  hcd_event_t event =
+  // Connection change
+  if (p_hub->port_status.change.connection)
   {
-    .rhport     = usbh_get_rhport(dev_addr),
-    .event_id   = HCD_EVENT_DEVICE_ATTACH,
-    .connection =
-    {
-      .hub_addr = dev_addr,
-      .hub_port = port_num
-    }
-  };
+    // Port is powered and enabled
+    //TU_VERIFY(port_status.status_current.port_power && port_status.status_current.port_enable, );
 
-  hcd_event_handler(&event, false);
+    // Acknowledge Port Connection Change
+    hub_port_clear_feature(dev_addr, port_num, HUB_FEATURE_PORT_CONNECTION_CHANGE, connection_clear_conn_change_complete);
+  }else
+  {
+    // Other changes are: Enable, Suspend, Over Current, Reset, L1 state
+    // TODO clear change
+
+    // prepare for next hub status
+    // TODO continue with status_change, or maybe we can do it again with status
+    hub_status_pipe_queue(dev_addr);
+  }
 
   return true;
 }
@@ -324,70 +344,28 @@ static bool connection_clear_conn_change_complete (uint8_t dev_addr, tusb_contro
   return true;
 }
 
-static bool connection_get_status_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result)
+static bool connection_port_reset_complete (uint8_t dev_addr, tusb_control_request_t const * request, xfer_result_t result)
 {
   TU_ASSERT(result == XFER_RESULT_SUCCESS);
-  hub_interface_t * p_hub = &hub_data[dev_addr-1];
+
+  // usbh_hub_t * p_hub = &hub_data[dev_addr-1];
   uint8_t const port_num = (uint8_t) request->wIndex;
 
-  // Connection change
-  if (p_hub->port_status.change.connection)
+  // submit attach event
+  hcd_event_t event =
   {
-    // Port is powered and enabled
-    //TU_VERIFY(port_status.status_current.port_power && port_status.status_current.port_enable, );
-
-    // Acknowledge Port Connection Change
-    hub_port_clear_feature(dev_addr, port_num, HUB_FEATURE_PORT_CONNECTION_CHANGE, connection_clear_conn_change_complete);
-  }else
-  {
-    // Other changes are: Enable, Suspend, Over Current, Reset, L1 state
-    // TODO clear change
-
-    // prepare for next hub status
-    // TODO continue with status_change, or maybe we can do it again with status
-    hub_status_pipe_queue(dev_addr);
-  }
-
-  return true;
-}
-
-// is the response of interrupt endpoint polling
-#include "usbh_hcd.h" // FIXME remove
-bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
-{
-  (void) xferred_bytes; // TODO can be more than 1 for hub with lots of ports
-  (void) ep_addr;
-  TU_ASSERT( result == XFER_RESULT_SUCCESS);
-
-  hub_interface_t * p_hub = &hub_data[dev_addr-1];
-
-  TU_LOG2("  Port Status Change = 0x%02X\r\n", p_hub->status_change);
-
-  // Hub ignore bit0 in status change
-  for (uint8_t port=1; port <= p_hub->port_count; port++)
-  {
-    if ( tu_bit_test(p_hub->status_change, port) )
+    .rhport     = usbh_get_rhport(dev_addr),
+    .event_id   = HCD_EVENT_DEVICE_ATTACH,
+    .connection =
     {
-      hub_port_get_status(dev_addr, port, &p_hub->port_status, connection_get_status_complete);
-      break;
+      .hub_addr = dev_addr,
+      .hub_port = port_num
     }
-  }
+  };
 
-  // NOTE: next status transfer is queued by usbh.c after handling this request
+  hcd_event_handler(&event, false);
 
   return true;
 }
-
-void hub_close(uint8_t dev_addr)
-{
-  tu_memclr(&hub_data[dev_addr-1], sizeof( hub_interface_t));
-}
-
-bool hub_status_pipe_queue(uint8_t dev_addr)
-{
-  hub_interface_t * p_hub = &hub_data[dev_addr-1];
-  return usbh_edpt_xfer(dev_addr, p_hub->ep_in, &p_hub->status_change, 1);
-}
-
 
 #endif

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -352,7 +352,7 @@ void hub_close(uint8_t dev_addr)
 bool hub_status_pipe_queue(uint8_t dev_addr)
 {
   usbh_hub_t * p_hub = &hub_data[dev_addr-1];
-  return hcd_pipe_xfer(dev_addr, p_hub->ep_in, &p_hub->status_change, 1, true);
+  return usbh_edpt_xfer(dev_addr, p_hub->ep_in, &p_hub->status_change, 1);
 }
 
 

--- a/src/host/hub.h
+++ b/src/host/hub.h
@@ -171,9 +171,11 @@ typedef struct {
 
 TU_VERIFY_STATIC( sizeof(hub_port_status_response_t) == 4, "size is not correct");
 
+bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature, tuh_control_complete_cb_t complete_cb);
+bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature, tuh_control_complete_cb_t complete_cb);
+
 bool hub_port_reset(uint8_t hub_addr, uint8_t hub_port, tuh_control_complete_cb_t complete_cb);
 bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp, tuh_control_complete_cb_t complete_cb);
-bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature, tuh_control_complete_cb_t complete_cb);
 bool hub_status_pipe_queue(uint8_t dev_addr);
 
 //--------------------------------------------------------------------+

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -455,7 +455,7 @@ void hcd_event_device_attach(uint8_t rhport, bool in_isr)
 {
   hcd_event_t event =
   {
-    .rhport = rhport,
+    .rhport   = rhport,
     .event_id = HCD_EVENT_DEVICE_ATTACH
   };
 
@@ -469,7 +469,7 @@ void hcd_event_device_remove(uint8_t hostid, bool in_isr)
 {
   hcd_event_t event =
   {
-    .rhport = hostid,
+    .rhport   = hostid,
     .event_id = HCD_EVENT_DEVICE_REMOVE
   };
 

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -378,6 +378,8 @@ bool usbh_edpt_xfer(uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_
 
 bool usbh_edpt_control_open(uint8_t dev_addr, uint8_t max_packet_size)
 {
+  TU_LOG2("Open EP Control with Size = %u\r\n", max_packet_size);
+
   tusb_desc_endpoint_t ep0_desc =
   {
     .bLength          = sizeof(tusb_desc_endpoint_t),

--- a/src/host/usbh_control.c
+++ b/src/host/usbh_control.c
@@ -108,7 +108,7 @@ bool usbh_control_xfer_cb (uint8_t dev_addr, uint8_t ep_addr, xfer_result_t resu
         _ctrl_xfer.stage = STAGE_DATA;
         if (request->wLength)
         {
-          // Note: initial data toggle is always 1
+          // DATA stage: initial data toggle is always 1
           hcd_edpt_xfer(rhport, dev_addr, tu_edpt_addr(0, request->bmRequestType_bit.direction), _ctrl_xfer.buffer, request->wLength);
           return true;
         }
@@ -123,7 +123,7 @@ bool usbh_control_xfer_cb (uint8_t dev_addr, uint8_t ep_addr, xfer_result_t resu
           TU_LOG2_MEM(_ctrl_xfer.buffer, request->wLength, 2);
         }
 
-        // data toggle is always 1
+        // ACK stage: toggle is always 1
         hcd_edpt_xfer(rhport, dev_addr, tu_edpt_addr(0, 1-request->bmRequestType_bit.direction), NULL, 0);
       break;
 

--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -302,7 +302,6 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * 
   uint8_t const epnum = tu_edpt_number(ep_addr);
   uint8_t const dir   = tu_edpt_dir(ep_addr);
 
-  // FIXME control only for now
   if ( epnum == 0 )
   {
     ehci_qhd_t* qhd = qhd_control(dev_addr);

--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -65,7 +65,6 @@ typedef struct
 
   volatile uint32_t uframe_number;
 }ehci_data_t;
-
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
@@ -125,10 +124,10 @@ static inline ehci_link_t* list_next (ehci_link_t *p_link_pointer);
 // HCD API
 //--------------------------------------------------------------------+
 
-uint32_t hcd_uframe_number(uint8_t rhport)
+uint32_t hcd_frame_number(uint8_t rhport)
 {
   (void) rhport;
-  return ehci_data.uframe_number + ehci_data.regs->frame_index;
+  return (ehci_data.uframe_number + ehci_data.regs->frame_index) >> 3;
 }
 
 void hcd_port_reset(uint8_t rhport)

--- a/src/portable/ehci/ehci.h
+++ b/src/portable/ehci/ehci.h
@@ -24,12 +24,6 @@
  * This file is part of the TinyUSB stack.
  */
 
-/** \ingroup Group_HCD
- * @{
- *  \defgroup EHCI
- *  \brief EHCI driver. All documents sources mentioned here (eg section 3.5) is referring to EHCI Specs unless state otherwise
- *  @{ */
-
 #ifndef _TUSB_EHCI_H_
 #define _TUSB_EHCI_H_
 
@@ -309,12 +303,11 @@ enum ehci_usbcmd_pos_ {
 
 enum ehci_portsc_change_mask_{
   EHCI_PORTSC_MASK_CURRENT_CONNECT_STATUS = TU_BIT(0),
-  EHCI_PORTSC_MASK_CONNECT_STATUS_CHANGE = TU_BIT(1),
-  EHCI_PORTSC_MASK_PORT_EANBLED = TU_BIT(2),
-  EHCI_PORTSC_MASK_PORT_ENABLE_CHAGNE = TU_BIT(3),
-  EHCI_PORTSC_MASK_OVER_CURRENT_CHANGE = TU_BIT(5),
-
-  EHCI_PORTSC_MASK_PORT_RESET = TU_BIT(8),
+  EHCI_PORTSC_MASK_CONNECT_STATUS_CHANGE  = TU_BIT(1),
+  EHCI_PORTSC_MASK_PORT_EANBLED           = TU_BIT(2),
+  EHCI_PORTSC_MASK_PORT_ENABLE_CHAGNE     = TU_BIT(3),
+  EHCI_PORTSC_MASK_OVER_CURRENT_CHANGE    = TU_BIT(5),
+  EHCI_PORTSC_MASK_PORT_RESET             = TU_BIT(8),
 
   EHCI_PORTSC_MASK_ALL =
       EHCI_PORTSC_MASK_CONNECT_STATUS_CHANGE |
@@ -425,36 +418,8 @@ typedef volatile struct
   };
 }ehci_registers_t;
 
-//--------------------------------------------------------------------+
-// EHCI Data Organization
-//--------------------------------------------------------------------+
-typedef struct
-{
-  ehci_link_t period_framelist[EHCI_FRAMELIST_SIZE];
-
-  // for NXP ECHI, only implement 1 ms & 2 ms & 4 ms, 8 ms (framelist)
-  // [0] : 1ms, [1] : 2ms, [2] : 4ms, [3] : 8 ms
-  ehci_qhd_t period_head_arr[4];
-
-  // Note control qhd of dev0 is used as head of async list
-  struct {
-    ehci_qhd_t qhd;
-    ehci_qtd_t qtd;
-  }control[CFG_TUSB_HOST_DEVICE_MAX+1];
-
-  ehci_qhd_t qhd_pool[HCD_MAX_ENDPOINT];
-  ehci_qtd_t qtd_pool[HCD_MAX_XFER] TU_ATTR_ALIGNED(32);
-
-  ehci_registers_t* regs;
-
-  volatile uint32_t uframe_number;
-}ehci_data_t;
-
 #ifdef __cplusplus
  }
 #endif
 
 #endif /* _TUSB_EHCI_H_ */
-
-/** @} */
-/** @} */

--- a/src/portable/ohci/ohci.c
+++ b/src/portable/ohci/ohci.c
@@ -84,23 +84,23 @@ enum {
 };
 
 enum {
-  OHCI_RHPORT_CURRENT_CONNECT_STATUS_MASK      = TU_BIT(0),
-  OHCI_RHPORT_PORT_ENABLE_STATUS_MASK          = TU_BIT(1),
-  OHCI_RHPORT_PORT_SUSPEND_STATUS_MASK         = TU_BIT(2),
-  OHCI_RHPORT_PORT_OVER_CURRENT_INDICATOR_MASK = TU_BIT(3),
-  OHCI_RHPORT_PORT_RESET_STATUS_MASK           = TU_BIT(4), ///< write '1' to reset port
+  RHPORT_CURRENT_CONNECT_STATUS_MASK      = TU_BIT(0),
+  RHPORT_PORT_ENABLE_STATUS_MASK          = TU_BIT(1),
+  RHPORT_PORT_SUSPEND_STATUS_MASK         = TU_BIT(2),
+  RHPORT_PORT_OVER_CURRENT_INDICATOR_MASK = TU_BIT(3),
+  RHPORT_PORT_RESET_STATUS_MASK           = TU_BIT(4), ///< write '1' to reset port
 
-  OHCI_RHPORT_PORT_POWER_STATUS_MASK           = TU_BIT(8),
-  OHCI_RHPORT_LOW_SPEED_DEVICE_ATTACHED_MASK   = TU_BIT(9),
+  RHPORT_PORT_POWER_STATUS_MASK           = TU_BIT(8),
+  RHPORT_LOW_SPEED_DEVICE_ATTACHED_MASK   = TU_BIT(9),
 
-  OHCI_RHPORT_CONNECT_STATUS_CHANGE_MASK       = TU_BIT(16),
-  OHCI_RHPORT_PORT_ENABLE_CHANGE_MASK          = TU_BIT(17),
-  OHCI_RHPORT_PORT_SUSPEND_CHANGE_MASK         = TU_BIT(18),
-  OHCI_RHPORT_OVER_CURRENT_CHANGE_MASK         = TU_BIT(19),
-  OHCI_RHPORT_PORT_RESET_CHANGE_MASK           = TU_BIT(20),
+  RHPORT_CONNECT_STATUS_CHANGE_MASK       = TU_BIT(16),
+  RHPORT_PORT_ENABLE_CHANGE_MASK          = TU_BIT(17),
+  RHPORT_PORT_SUSPEND_CHANGE_MASK         = TU_BIT(18),
+  RHPORT_OVER_CURRENT_CHANGE_MASK         = TU_BIT(19),
+  RHPORT_PORT_RESET_CHANGE_MASK           = TU_BIT(20),
 
-  OHCI_RHPORT_ALL_CHANGE_MASK = OHCI_RHPORT_CONNECT_STATUS_CHANGE_MASK | OHCI_RHPORT_PORT_ENABLE_CHANGE_MASK |
-    OHCI_RHPORT_PORT_SUSPEND_CHANGE_MASK | OHCI_RHPORT_OVER_CURRENT_CHANGE_MASK | OHCI_RHPORT_PORT_RESET_CHANGE_MASK
+  RHPORT_ALL_CHANGE_MASK = RHPORT_CONNECT_STATUS_CHANGE_MASK | RHPORT_PORT_ENABLE_CHANGE_MASK |
+    RHPORT_PORT_SUSPEND_CHANGE_MASK | RHPORT_OVER_CURRENT_CHANGE_MASK | RHPORT_PORT_RESET_CHANGE_MASK
 };
 
 enum {
@@ -215,7 +215,7 @@ uint32_t hcd_frame_number(uint8_t rhport)
 void hcd_port_reset(uint8_t hostid)
 {
   (void) hostid;
-  OHCI_REG->rhport_status[0] = OHCI_RHPORT_PORT_RESET_STATUS_MASK;
+  OHCI_REG->rhport_status[0] = RHPORT_PORT_RESET_STATUS_MASK;
 }
 
 bool hcd_port_connect_status(uint8_t hostid)
@@ -626,16 +626,16 @@ void hcd_int_handler(uint8_t hostid)
   //------------- RootHub status -------------//
   if ( int_status & OHCI_INT_RHPORT_STATUS_CHANGE_MASK )
   {
-    uint32_t const rhport_status = OHCI_REG->rhport_status[0] & OHCI_RHPORT_ALL_CHANGE_MASK;
+    uint32_t const rhport_status = OHCI_REG->rhport_status[0] & RHPORT_ALL_CHANGE_MASK;
 
     // TODO dual port is not yet supported
-    if ( rhport_status & OHCI_RHPORT_CONNECT_STATUS_CHANGE_MASK )
+    if ( rhport_status & RHPORT_CONNECT_STATUS_CHANGE_MASK )
     {
       // TODO check if remote wake-up
       if ( OHCI_REG->rhport_status_bit[0].current_connect_status )
       {
         // TODO reset port immediately, without this controller will got 2-3 (debouncing connection status change)
-        OHCI_REG->rhport_status[0] = OHCI_RHPORT_PORT_RESET_STATUS_MASK;
+        OHCI_REG->rhport_status[0] = RHPORT_PORT_RESET_STATUS_MASK;
         hcd_event_device_attach(hostid, true);
       }else
       {
@@ -643,7 +643,7 @@ void hcd_int_handler(uint8_t hostid)
       }
     }
 
-    if ( rhport_status & OHCI_RHPORT_PORT_SUSPEND_CHANGE_MASK)
+    if ( rhport_status & RHPORT_PORT_SUSPEND_CHANGE_MASK)
     {
 
     }

--- a/src/portable/ohci/ohci.c
+++ b/src/portable/ohci/ohci.c
@@ -123,6 +123,23 @@ enum {
   OHCI_INT_ON_COMPLETE_YES = 0,
   OHCI_INT_ON_COMPLETE_NO  = TU_BIN8(111)
 };
+
+enum {
+  GTD_DT_TOGGLE_CARRY = 0,
+  GTD_DT_DATA0 = TU_BIT(1) | 0,
+  GTD_DT_DATA1 = TU_BIT(1) | 1,
+};
+
+enum {
+  PID_SETUP = 0,
+  PID_OUT,
+  PID_IN,
+};
+
+enum {
+  PID_FROM_TD = 0,
+};
+
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
@@ -185,10 +202,10 @@ bool hcd_init(uint8_t rhport)
   return true;
 }
 
-uint32_t hcd_uframe_number(uint8_t rhport)
+uint32_t hcd_frame_number(uint8_t rhport)
 {
   (void) rhport;
-  return (ohci_data.frame_number_hi << 16 | OHCI_REG->frame_number) << 3;
+  return (ohci_data.frame_number_hi << 16) | OHCI_REG->frame_number;
 }
 
 
@@ -248,12 +265,12 @@ void hcd_device_close(uint8_t rhport, uint8_t dev_addr)
 //--------------------------------------------------------------------+
 static inline tusb_xfer_type_t ed_get_xfer_type(ohci_ed_t const * const p_ed)
 {
-  return (p_ed->ep_number == 0 ) ? TUSB_XFER_CONTROL     :
-         (p_ed->is_iso               ) ? TUSB_XFER_ISOCHRONOUS :
-         (p_ed->is_interrupt_xfer    ) ? TUSB_XFER_INTERRUPT   : TUSB_XFER_BULK;
+  return (p_ed->ep_number == 0   ) ? TUSB_XFER_CONTROL     :
+         (p_ed->is_iso           ) ? TUSB_XFER_ISOCHRONOUS :
+         (p_ed->is_interrupt_xfer) ? TUSB_XFER_INTERRUPT   : TUSB_XFER_BULK;
 }
 
-static void ed_init(ohci_ed_t *p_ed, uint8_t dev_addr, uint16_t max_packet_size, uint8_t endpoint_addr, uint8_t xfer_type, uint8_t interval)
+static void ed_init(ohci_ed_t *p_ed, uint8_t dev_addr, uint16_t ep_size, uint8_t ep_addr, uint8_t xfer_type, uint8_t interval)
 {
   (void) interval;
 
@@ -263,18 +280,18 @@ static void ed_init(ohci_ed_t *p_ed, uint8_t dev_addr, uint16_t max_packet_size,
     tu_memclr(p_ed, sizeof(ohci_ed_t));
   }
 
-  p_ed->dev_addr    = dev_addr;
-  p_ed->ep_number   = endpoint_addr & 0x0F;
-  p_ed->pid         = (xfer_type == TUSB_XFER_CONTROL) ? OHCI_PID_SETUP : ( (endpoint_addr & TUSB_DIR_IN_MASK) ? OHCI_PID_IN : OHCI_PID_OUT );
+  p_ed->dev_addr          = dev_addr;
+  p_ed->ep_number         = ep_addr & 0x0F;
+  p_ed->pid               = (xfer_type == TUSB_XFER_CONTROL) ? PID_FROM_TD : (tu_edpt_dir(ep_addr) ? PID_IN : PID_OUT);
   p_ed->speed             = _usbh_devices[dev_addr].speed;
   p_ed->is_iso            = (xfer_type == TUSB_XFER_ISOCHRONOUS) ? 1 : 0;
-  p_ed->max_packet_size  = max_packet_size;
+  p_ed->max_packet_size   = ep_size;
 
   p_ed->used              = 1;
   p_ed->is_interrupt_xfer = (xfer_type == TUSB_XFER_INTERRUPT ? 1 : 0);
 }
 
-static void gtd_init(ohci_gtd_t* p_td, void* data_ptr, uint16_t total_bytes)
+static void gtd_init(ohci_gtd_t* p_td, uint8_t* data_ptr, uint16_t total_bytes)
 {
   tu_memclr(p_td, sizeof(ohci_gtd_t));
 
@@ -286,28 +303,7 @@ static void gtd_init(ohci_gtd_t* p_td, void* data_ptr, uint16_t total_bytes)
   p_td->condition_code         = OHCI_CCODE_NOT_ACCESSED;
 
   p_td->current_buffer_pointer = data_ptr;
-  p_td->buffer_end             = total_bytes ? (((uint8_t*) data_ptr) + total_bytes-1) : NULL;
-}
-
-bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet[8])
-{
-  (void) rhport;
-
-  ohci_ed_t* p_ed = &ohci_data.control[dev_addr].ed;
-  ohci_gtd_t *p_setup  = &ohci_data.control[dev_addr].gtd;
-
-  gtd_init(p_setup, (void*) setup_packet, 8);
-  p_setup->index       = dev_addr;
-  p_setup->pid         = OHCI_PID_SETUP;
-  p_setup->data_toggle = TU_BIN8(10); // DATA0
-  p_setup->delay_interrupt = OHCI_INT_ON_COMPLETE_YES;
-
-  //------------- Attach TDs list to Control Endpoint -------------//
-  p_ed->td_head.address = (uint32_t) p_setup;
-
-  OHCI_REG->command_status_bit.control_list_filled = 1;
-
-  return true;
+  p_td->buffer_end             = total_bytes ? (data_ptr + total_bytes-1) : data_ptr;
 }
 
 static ohci_ed_t * ed_from_addr(uint8_t dev_addr, uint8_t ep_addr)
@@ -319,7 +315,7 @@ static ohci_ed_t * ed_from_addr(uint8_t dev_addr, uint8_t ep_addr)
   for(uint32_t i=0; i<HCD_MAX_ENDPOINT; i++)
   {
     if ( (ed_pool[i].dev_addr == dev_addr) &&
-          ep_addr == tu_edpt_addr(ed_pool[i].ep_number, ed_pool[i].pid == OHCI_PID_IN) )
+          ep_addr == tu_edpt_addr(ed_pool[i].ep_number, ed_pool[i].pid == PID_IN) )
     {
       return &ed_pool[i];
     }
@@ -430,6 +426,27 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const 
   return true;
 }
 
+bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet[8])
+{
+  (void) rhport;
+
+  ohci_ed_t* ed   = &ohci_data.control[dev_addr].ed;
+  ohci_gtd_t *qtd = &ohci_data.control[dev_addr].gtd;
+
+  gtd_init(qtd, (uint8_t*) setup_packet, 8);
+  qtd->index           = dev_addr;
+  qtd->pid             = PID_SETUP;
+  qtd->data_toggle     = GTD_DT_DATA0;
+  qtd->delay_interrupt = 0;
+
+  //------------- Attach TDs list to Control Endpoint -------------//
+  ed->td_head.address = (uint32_t) qtd;
+
+  OHCI_REG->command_status_bit.control_list_filled = 1;
+
+  return true;
+}
+
 bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t buflen)
 {
   (void) rhport;
@@ -437,7 +454,6 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * 
   uint8_t const epnum = tu_edpt_number(ep_addr);
   uint8_t const dir   = tu_edpt_dir(ep_addr);
 
-  // FIXME control only for now
   if ( epnum == 0 )
   {
     ohci_ed_t*  ed  = &ohci_data.control[dev_addr].ed;
@@ -446,9 +462,9 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * 
     gtd_init(gtd, buffer, buflen);
 
     gtd->index           = dev_addr;
-    gtd->pid             = dir ? OHCI_PID_IN : OHCI_PID_OUT;
-    gtd->data_toggle     = 3; // Both Data and Ack stage start with DATA1
-    gtd->delay_interrupt = OHCI_INT_ON_COMPLETE_YES;
+    gtd->pid             = dir ? PID_IN : PID_OUT;
+    gtd->data_toggle     = GTD_DT_DATA1; // Both Data and Ack stage start with DATA1
+    gtd->delay_interrupt = 0;
 
     ed->td_head.address = (uint32_t) gtd;
 
@@ -462,7 +478,7 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * 
 
     gtd_init(gtd, buffer, buflen);
     gtd->index = ed-ohci_data.ed_pool;
-    gtd->delay_interrupt = OHCI_INT_ON_COMPLETE_YES;
+    gtd->delay_interrupt = 0;
 
     td_insert_to_ed(ed, gtd);
 
@@ -539,7 +555,12 @@ static inline ohci_ed_t* gtd_get_ed(ohci_gtd_t const * const p_qtd)
 }
 
 static inline uint32_t gtd_xfer_byte_left(uint32_t buffer_end, uint32_t current_buffer)
-{ // 5.2.9 OHCI sample code
+{
+  // 5.2.9 OHCI sample code
+
+  // CBP is 0 mean all data is transferred
+  if (current_buffer == 0) return 0;
+
   return (tu_align4k(buffer_end ^ current_buffer) ? 0x1000 : 0) +
       tu_offset4k(buffer_end) - tu_offset4k(current_buffer) + 1;
 }
@@ -555,16 +576,16 @@ static void done_queue_isr(uint8_t hostid)
   {
     // TODO check if td_head is iso td
     //------------- Non ISO transfer -------------//
-    ohci_gtd_t * const p_qtd = (ohci_gtd_t *) td_head;
-    xfer_result_t const event = (p_qtd->condition_code == OHCI_CCODE_NO_ERROR) ? XFER_RESULT_SUCCESS :
-                                (p_qtd->condition_code == OHCI_CCODE_STALL) ? XFER_RESULT_STALLED : XFER_RESULT_FAILED;
+    ohci_gtd_t * const qtd = (ohci_gtd_t *) td_head;
+    xfer_result_t const event = (qtd->condition_code == OHCI_CCODE_NO_ERROR) ? XFER_RESULT_SUCCESS :
+                                (qtd->condition_code == OHCI_CCODE_STALL) ? XFER_RESULT_STALLED : XFER_RESULT_FAILED;
 
-    p_qtd->used = 0; // free TD
-    if ( (p_qtd->delay_interrupt == OHCI_INT_ON_COMPLETE_YES) || (event != XFER_RESULT_SUCCESS) )
+    qtd->used = 0; // free TD
+    if ( (qtd->delay_interrupt == OHCI_INT_ON_COMPLETE_YES) || (event != XFER_RESULT_SUCCESS) )
     {
-      ohci_ed_t * const p_ed  = gtd_get_ed(p_qtd);
+      ohci_ed_t * const ed  = gtd_get_ed(qtd);
 
-      uint32_t const xferred_bytes = p_qtd->expected_bytes - gtd_xfer_byte_left((uint32_t) p_qtd->buffer_end, (uint32_t) p_qtd->current_buffer_pointer);
+      uint32_t const xferred_bytes = qtd->expected_bytes - gtd_xfer_byte_left((uint32_t) qtd->buffer_end, (uint32_t) qtd->current_buffer_pointer);
 
       // NOTE Assuming the current list is BULK and there is no other EDs in the list has queued TDs.
       // When there is a error resulting this ED is halted, and this EP still has other queued TD
@@ -575,14 +596,14 @@ static void done_queue_isr(uint8_t hostid)
       // the TailP must be set back to NULL for processing remaining TDs
       if ((event != XFER_RESULT_SUCCESS))
       {
-        p_ed->td_tail &= 0x0Ful;
-        p_ed->td_tail |= tu_align16(p_ed->td_head.address); // mark halted EP as empty queue
-        if ( event == XFER_RESULT_STALLED ) p_ed->is_stalled = 1;
+        ed->td_tail &= 0x0Ful;
+        ed->td_tail |= tu_align16(ed->td_head.address); // mark halted EP as empty queue
+        if ( event == XFER_RESULT_STALLED ) ed->is_stalled = 1;
       }
 
-      hcd_event_xfer_complete(p_ed->dev_addr,
-                              tu_edpt_addr(p_ed->ep_number, p_ed->pid == OHCI_PID_IN),
-                              xferred_bytes, event, true);
+      uint8_t dir = (ed->ep_number == 0) ? (qtd->pid == PID_IN) : (ed->pid == PID_IN);
+
+      hcd_event_xfer_complete(ed->dev_addr, tu_edpt_addr(ed->ep_number, dir), xferred_bytes, event, true);
     }
 
     td_head = (ohci_td_item_t*) td_head->next;
@@ -631,7 +652,7 @@ void hcd_int_handler(uint8_t hostid)
   }
 
   //------------- Transfer Complete -------------//
-  if ( int_status & OHCI_INT_WRITEBACK_DONEHEAD_MASK)
+  if (int_status & OHCI_INT_WRITEBACK_DONEHEAD_MASK)
   {
     done_queue_isr(hostid);
   }

--- a/src/portable/ohci/ohci.h
+++ b/src/portable/ohci/ohci.h
@@ -24,12 +24,6 @@
  * This file is part of the TinyUSB stack.
  */
 
-/** \ingroup Group_HCD
- * @{
- *  \defgroup OHCI
- *  \brief OHCI driver. All documents sources mentioned here (eg section 3.5) is referring to OHCI Specs unless state otherwise
- *  @{ */
-
 #ifndef _TUSB_OHCI_H_
 #define _TUSB_OHCI_H_
 
@@ -46,12 +40,6 @@
 // TODO merge OHCI with EHCI
 enum {
   OHCI_MAX_ITD = 4
-};
-
-enum {
-  OHCI_PID_SETUP = 0,
-  OHCI_PID_OUT,
-  OHCI_PID_IN,
 };
 
 //--------------------------------------------------------------------+
@@ -72,7 +60,6 @@ typedef struct {
   volatile uint32_t next;
   uint32_t reserved2;
 }ohci_td_item_t;
-
 
 typedef struct TU_ATTR_ALIGNED(16)
 {
@@ -105,7 +92,7 @@ typedef struct TU_ATTR_ALIGNED(16)
   // Word 0
 	uint32_t dev_addr          : 7;
 	uint32_t ep_number         : 4;
-	uint32_t pid               : 2; // 00b from TD, 01b Out, 10b In
+	uint32_t pid               : 2;
 	uint32_t speed             : 1;
 	uint32_t skip              : 1;
 	uint32_t is_iso            : 1;
@@ -286,6 +273,3 @@ TU_VERIFY_STATIC( sizeof(ohci_registers_t) == 0x5c, "size is not correct");
 #endif
 
 #endif /* _TUSB_OHCI_H_ */
-
-/** @} */
-/** @} */

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -543,14 +543,4 @@ bool hcd_edpt_clear_stall(uint8_t dev_addr, uint8_t ep_addr)
     return true;
 }
 
-bool hcd_pipe_xfer(uint8_t dev_addr, uint8_t ep_addr, uint8_t buffer[], uint16_t total_bytes, bool int_on_complete)
-{
-    pico_trace("hcd_pipe_xfer dev_addr %d, ep_addr 0x%x, total_bytes %d, int_on_complete %d\n",
-        dev_addr, ep_addr, total_bytes, int_on_complete);
-
-    // Same logic as hcd_edpt_xfer as far as I am concerned
-    hcd_edpt_xfer(0, dev_addr, ep_addr, buffer, total_bytes);
-
-    return true;
-}
 #endif

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -504,10 +504,9 @@ bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet
     return true;
 }
 
-uint32_t hcd_uframe_number(uint8_t rhport)
+uint32_t hcd_frame_number(uint8_t rhport)
 {
-    // Microframe number is (125us) but we are max full speed so return miliseconds * 8
-    return usb_hw->sof_rd * 8;
+    return usb_hw->sof_rd;
 }
 
 bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const * ep_desc)


### PR DESCRIPTION
**Describe the PR**
Clean up , update some of host HCD API. Still there is plenty of host work.
- remove obsolete hcd_pipe_queue_xfer()/hcd_pipe_xfer()
- update hub driver
- change hcd hcd_uframe_number() --> hcd_frame_number() , micro can be retrieved by optional API on high speed host if needed.
- Update, fix endpoint number and transfer size on OHCI driver.