### PR TITLE
Add dcd_edpt_xfer_fifo() for RX63N

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -86,7 +86,8 @@
     CFG_TUSB_MCU == OPT_MCU_STM32F4                               || \
     CFG_TUSB_MCU == OPT_MCU_STM32F7                               || \
     CFG_TUSB_MCU == OPT_MCU_STM32H7                               || \
-    (CFG_TUSB_MCU == OPT_MCU_STM32L4 && defined(STM32L4_SYNOPSYS))
+    (CFG_TUSB_MCU == OPT_MCU_STM32L4 && defined(STM32L4_SYNOPSYS)) || \
+    CFG_TUSB_MCU == OPT_MCU_RX63X
 #define  USE_LINEAR_BUFFER     0
 #else
 #define  USE_LINEAR_BUFFER     1

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -87,7 +87,8 @@
     CFG_TUSB_MCU == OPT_MCU_STM32F7                               || \
     CFG_TUSB_MCU == OPT_MCU_STM32H7                               || \
     (CFG_TUSB_MCU == OPT_MCU_STM32L4 && defined(STM32L4_SYNOPSYS)) || \
-    CFG_TUSB_MCU == OPT_MCU_RX63X
+    CFG_TUSB_MCU == OPT_MCU_RX63X                                 || \
+    CFG_TUSB_MCU == OPT_MCU_RX65X
 #define  USE_LINEAR_BUFFER     0
 #else
 #define  USE_LINEAR_BUFFER     1

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -88,7 +88,8 @@
     CFG_TUSB_MCU == OPT_MCU_STM32H7                               || \
     (CFG_TUSB_MCU == OPT_MCU_STM32L4 && defined(STM32L4_SYNOPSYS)) || \
     CFG_TUSB_MCU == OPT_MCU_RX63X                                 || \
-    CFG_TUSB_MCU == OPT_MCU_RX65X
+    CFG_TUSB_MCU == OPT_MCU_RX65X                                 || \
+    CFG_TUSB_MCU == OPT_MCU_RX72N
 #define  USE_LINEAR_BUFFER     0
 #else
 #define  USE_LINEAR_BUFFER     1


### PR DESCRIPTION
**Describe the PR**
Add dcd_edpt_xfer_fifo() for RX63N.

**Additional context**
I have confirmed this patch by using `uac2_headset` example. On the example, it seems that ISO IN/OUT are succeeded. But, many packets are dropped because performance issue.

`audio_test` has some issues. `audio_test` fails enumeration process. In windows 10, I needed to set 44100 into AUDIO_SAMPLE_RATE for enumeration process success. But enumeration is success, I have no observation regarding ISO IN transfers. I guess that the issues cause by windows.

I think that this branch should be after #859 merged. When #859 has been merged, I rebase and fix conflicts this branch to the HEAD of master.