### PR TITLE
RP2040 double buffer

### DIFF
--- a/examples/host/cdc_msc_hid/src/hid_app.c
+++ b/examples/host/cdc_msc_hid/src/hid_app.c
@@ -30,7 +30,8 @@
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
 //--------------------------------------------------------------------+
 
-// If your host terminal support ansi escape code, it can be use to simulate mouse cursor
+// If your host terminal support ansi escape code such as TeraTerm
+// it can be use to simulate mouse cursor movement within terminal
 #define USE_ANSI_ESCAPE   0
 
 #define MAX_REPORT  4
@@ -113,6 +114,13 @@ void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t cons
     return;
   }
 
+  // For complete list of Usage Page & Usage checkout src/class/hid/hid.h. For examples:
+  // - Keyboard                     : Desktop, Keyboard
+  // - Mouse                        : Desktop, Mouse
+  // - Gamepad                      : Desktop, Gamepad
+  // - Consumer Control (Media Key) : Consumer, Consumer Control
+  // - System Control (Power key)   : Desktop, System Control
+  // - Generic (vendor)             : 0xFFxx, xx
   if ( rpt_info->usage_page == HID_USAGE_PAGE_DESKTOP )
   {
     switch (rpt_info->usage)
@@ -164,7 +172,7 @@ static void process_kbd_report(hid_keyboard_report_t const *report)
       }else
       {
         // not existed in previous report means the current key is pressed
-        bool const is_shift =  report->modifier & (KEYBOARD_MODIFIER_LEFTSHIFT | KEYBOARD_MODIFIER_RIGHTSHIFT);
+        bool const is_shift = report->modifier & (KEYBOARD_MODIFIER_LEFTSHIFT | KEYBOARD_MODIFIER_RIGHTSHIFT);
         uint8_t ch = keycode2ascii[report->keycode[i]][is_shift ? 1 : 0];
         putchar(ch);
         if ( ch == '\r' ) putchar('\n'); // added new line for enter key

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -76,7 +76,7 @@
 
 #define CFG_TUH_HUB                 1
 #define CFG_TUH_CDC                 1
-#define CFG_TUH_HID                 2
+#define CFG_TUH_HID                 4
 #define CFG_TUH_MSC                 1
 #define CFG_TUH_VENDOR              0
 

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -37,16 +37,6 @@
 // MACRO CONSTANT TYPEDEF
 //--------------------------------------------------------------------+
 
-/*
- "KEYBOARD"               : in_len=8 , out_len=1, usage_page=0x01, usage=0x06   # Generic Desktop, Keyboard
- "MOUSE"                  : in_len=4 , out_len=0, usage_page=0x01, usage=0x02   # Generic Desktop, Mouse
- "CONSUMER"               : in_len=2 , out_len=0, usage_page=0x0C, usage=0x01   # Consumer, Consumer Control
- "SYS_CONTROL"            : in_len=1 , out_len=0, usage_page=0x01, usage=0x80   # Generic Desktop, Sys Control
- "GAMEPAD"                : in_len=6 , out_len=0, usage_page=0x01, usage=0x05   # Generic Desktop, Game Pad
- "DIGITIZER"              : in_len=5 , out_len=0, usage_page=0x0D, usage=0x02   # Digitizers, Pen
- "XAC_COMPATIBLE_GAMEPAD" : in_len=3 , out_len=0, usage_page=0x01, usage=0x05   # Generic Desktop, Game Pad
- "RAW"                    : in_len=64, out_len=0, usage_page=0xFFAF, usage=0xAF # Vendor 0xFFAF "Adafruit", 0xAF
- */
 typedef struct
 {
   uint8_t itf_num;

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -442,9 +442,9 @@ uint8_t tuh_hid_parse_report_descriptor(tuh_hid_report_info_t* report_info_arr, 
 
     uint8_t const data8 = desc_report[0];
 
-    TU_LOG2("tag = %d, type = %d, size = %d, data = ", tag, type, size);
-    for(uint32_t i=0; i<size; i++) TU_LOG2("%02X ", desc_report[i]);
-    TU_LOG2("\r\n");
+    TU_LOG(3, "tag = %d, type = %d, size = %d, data = ", tag, type, size);
+    for(uint32_t i=0; i<size; i++) TU_LOG(3, "%02X ", desc_report[i]);
+    TU_LOG(3, "\r\n");
 
     switch(type)
     {

--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -123,7 +123,7 @@ TU_ATTR_ALWAYS_INLINE static inline uint32_t tu_align4k (uint32_t value) { retur
 TU_ATTR_ALWAYS_INLINE static inline uint32_t tu_offset4k(uint32_t value) { return (value & 0xFFFUL); }
 
 //------------- Mathematics -------------//
-TU_ATTR_ALWAYS_INLINE static inline uint32_t tu_abs(int32_t value) { return (uint32_t)((value < 0) ? (-value) : value); }
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tu_div_ceil(uint32_t v, uint32_t d) { return (v + d -1)/d; }
 
 /// inclusive range checking TODO remove
 TU_ATTR_ALWAYS_INLINE static inline bool tu_within(uint32_t lower, uint32_t value, uint32_t upper)

--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -317,8 +317,8 @@ void tu_print_var(uint8_t const* buf, uint32_t bufsize)
 #define TU_LOG1               tu_printf
 #define TU_LOG1_MEM           tu_print_mem
 #define TU_LOG1_VAR(_x)       tu_print_var((uint8_t const*)(_x), sizeof(*(_x)))
-#define TU_LOG1_INT(_x)       tu_printf(#_x " = %ld\n", (uint32_t) (_x) )
-#define TU_LOG1_HEX(_x)       tu_printf(#_x " = %lX\n", (uint32_t) (_x) )
+#define TU_LOG1_INT(_x)       tu_printf(#_x " = %ld\r\n", (uint32_t) (_x) )
+#define TU_LOG1_HEX(_x)       tu_printf(#_x " = %lX\r\n", (uint32_t) (_x) )
 
 // Log Level 2: Warn
 #if CFG_TUSB_DEBUG >= 2

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -75,7 +75,7 @@
 #if CFG_TUSB_DEBUG
   #include <stdio.h>
   #define _MESS_ERR(_err)   tu_printf("%s %d: failed, error = %s\r\n", __func__, __LINE__, tusb_strerr[_err])
-  #define _MESS_FAILED()    tu_printf("%s %d: assert failed\r\n", __func__, __LINE__)
+  #define _MESS_FAILED()    tu_printf("%s %d: ASSERT FAILED\r\n", __func__, __LINE__)
 #else
   #define _MESS_ERR(_err) do {} while (0)
   #define _MESS_FAILED() do {} while (0)

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1254,14 +1254,13 @@ bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
 
   if ( dcd_edpt_xfer(rhport, ep_addr, buffer, total_bytes) )
   {
-    TU_LOG2("OK\r\n");
     return true;
   }else
   {
     // DCD error, mark endpoint as ready to allow next transfer
     _usbd_dev.ep_status[epnum][dir].busy = false;
     _usbd_dev.ep_status[epnum][dir].claimed = 0;
-    TU_LOG2("failed\r\n");
+    TU_LOG2("FAILED\r\n");
     TU_BREAKPOINT();
     return false;
   }

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -795,6 +795,8 @@ static bool enum_get_addr0_device_desc_complete(uint8_t dev_addr, tusb_control_r
     return false;
   }
 
+  TU_ASSERT(tu_desc_type(_usbh_ctrl_buf) == TUSB_DESC_DEVICE);
+
   // Reset device again before Set Address
   TU_LOG2("Port reset \r\n");
 
@@ -938,7 +940,7 @@ static bool enum_get_config_desc_complete(uint8_t dev_addr, tusb_control_request
 
   // Parse configuration & set up drivers
   // Driver open aren't allowed to make any usb transfer yet
-  parse_configuration_descriptor(dev_addr, (tusb_desc_configuration_t*) _usbh_ctrl_buf);
+  TU_ASSERT( parse_configuration_descriptor(dev_addr, (tusb_desc_configuration_t*) _usbh_ctrl_buf) );
 
   TU_LOG2("Set Configuration = %d\r\n", CONFIG_NUM);
   tusb_control_request_t const new_request =
@@ -988,49 +990,53 @@ static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configura
   // parse each interfaces
   while( p_desc < _usbh_ctrl_buf + desc_cfg->wTotalLength )
   {
-    // skip until we see interface descriptor
-    if ( TUSB_DESC_INTERFACE != tu_desc_type(p_desc) )
-    {
-      p_desc = tu_desc_next(p_desc); // skip the descriptor, increase by the descriptor's length
-    }else
-    {
-      tusb_desc_interface_t const* desc_itf = (tusb_desc_interface_t const*) p_desc;
+    tusb_desc_interface_assoc_t const * desc_itf_assoc = NULL;
 
-      // Check if class is supported
-      uint8_t drv_id;
-      for (drv_id = 0; drv_id < USBH_CLASS_DRIVER_COUNT; drv_id++)
-      {
-        if ( usbh_class_drivers[drv_id].class_code == desc_itf->bInterfaceClass ) break;
-      }
+    // Class will always starts with Interface Association (if any) and then Interface descriptor
+    if ( TUSB_DESC_INTERFACE_ASSOCIATION == tu_desc_type(p_desc) )
+    {
+      desc_itf_assoc = (tusb_desc_interface_assoc_t const *) p_desc;
+      p_desc = tu_desc_next(p_desc); // next to Interface
+    }
 
-      if( drv_id >= USBH_CLASS_DRIVER_COUNT )
+    TU_ASSERT( TUSB_DESC_INTERFACE == tu_desc_type(p_desc) );
+
+    tusb_desc_interface_t const* desc_itf = (tusb_desc_interface_t const*) p_desc;
+
+    // Check if class is supported
+    uint8_t drv_id;
+    for (drv_id = 0; drv_id < USBH_CLASS_DRIVER_COUNT; drv_id++)
+    {
+      if ( usbh_class_drivers[drv_id].class_code == desc_itf->bInterfaceClass ) break;
+    }
+
+    if( drv_id >= USBH_CLASS_DRIVER_COUNT )
+    {
+      // skip unsupported class
+      p_desc = tu_desc_next(p_desc);
+    }
+    else
+    {
+      usbh_class_driver_t const * driver = &usbh_class_drivers[drv_id];
+
+      // Interface number must not be used already TODO alternate interface
+      TU_ASSERT( dev->itf2drv[desc_itf->bInterfaceNumber] == 0xff );
+      dev->itf2drv[desc_itf->bInterfaceNumber] = drv_id;
+
+      if (desc_itf->bInterfaceClass == TUSB_CLASS_HUB && dev->hub_addr != 0)
       {
-        // skip unsupported class
+        // TODO Attach hub to Hub is not currently supported
+        // skip this interface
         p_desc = tu_desc_next(p_desc);
       }
       else
       {
-        usbh_class_driver_t const * driver = &usbh_class_drivers[drv_id];
+        TU_LOG2("%s open\r\n", driver->name);
 
-        // Interface number must not be used already TODO alternate interface
-        TU_ASSERT( dev->itf2drv[desc_itf->bInterfaceNumber] == 0xff );
-        dev->itf2drv[desc_itf->bInterfaceNumber] = drv_id;
-
-        if (desc_itf->bInterfaceClass == TUSB_CLASS_HUB && dev->hub_addr != 0)
-        {
-          // TODO Attach hub to Hub is not currently supported
-          // skip this interface
-          p_desc = tu_desc_next(p_desc);
-        }
-        else
-        {
-          TU_LOG2("%s open\r\n", driver->name);
-
-          uint16_t itf_len = 0;
-          TU_ASSERT( driver->open(dev->rhport, dev_addr, desc_itf, &itf_len) );
-          TU_ASSERT( itf_len >= sizeof(tusb_desc_interface_t) );
-          p_desc += itf_len;
-        }
+        uint16_t itf_len = 0;
+        TU_ASSERT( driver->open(dev->rhport, dev_addr, desc_itf, &itf_len) );
+        TU_ASSERT( itf_len >= sizeof(tusb_desc_interface_t) );
+        p_desc += itf_len;
       }
     }
   }

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -990,13 +990,14 @@ static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configura
   // parse each interfaces
   while( p_desc < _usbh_ctrl_buf + desc_cfg->wTotalLength )
   {
-    tusb_desc_interface_assoc_t const * desc_itf_assoc = NULL;
+    // TODO Do we need to use IAD
+    // tusb_desc_interface_assoc_t const * desc_itf_assoc = NULL;
 
     // Class will always starts with Interface Association (if any) and then Interface descriptor
     if ( TUSB_DESC_INTERFACE_ASSOCIATION == tu_desc_type(p_desc) )
     {
-      desc_itf_assoc = (tusb_desc_interface_assoc_t const *) p_desc;
-      p_desc = tu_desc_next(p_desc); // next to Interface
+      // desc_itf_assoc = (tusb_desc_interface_assoc_t const *) p_desc;
+      p_desc = tu_desc_next(p_desc);
     }
 
     TU_ASSERT( TUSB_DESC_INTERFACE == tu_desc_type(p_desc) );

--- a/src/host/usbh_control.c
+++ b/src/host/usbh_control.c
@@ -68,7 +68,7 @@ bool tuh_control_xfer (uint8_t dev_addr, tusb_control_request_t const* request, 
   _ctrl_xfer.stage       = STAGE_SETUP;
   _ctrl_xfer.complete_cb = complete_cb;
 
-  TU_LOG2("Control Setup: ");
+  TU_LOG2("Send Setup to address %u: ", dev_addr);
   TU_LOG2_VAR(request);
   TU_LOG2("\r\n");
 

--- a/src/host/usbh_control.c
+++ b/src/host/usbh_control.c
@@ -68,7 +68,7 @@ bool tuh_control_xfer (uint8_t dev_addr, tusb_control_request_t const* request, 
   _ctrl_xfer.stage       = STAGE_SETUP;
   _ctrl_xfer.complete_cb = complete_cb;
 
-  TU_LOG2("Send Setup to address %u: ", dev_addr);
+  TU_LOG2("Control Setup (addr = %u): ", dev_addr);
   TU_LOG2_VAR(request);
   TU_LOG2("\r\n");
 
@@ -119,7 +119,7 @@ bool usbh_control_xfer_cb (uint8_t dev_addr, uint8_t ep_addr, xfer_result_t resu
 
         if (request->wLength)
         {
-          TU_LOG2("Control data:\r\n");
+          TU_LOG2("Control data (addr = %u):\r\n", dev_addr);
           TU_LOG2_MEM(_ctrl_xfer.buffer, request->wLength, 2);
         }
 

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -198,10 +198,10 @@ static void hw_endpoint_init(uint8_t ep_addr, uint16_t wMaxPacketSize, uint8_t b
     _hw_endpoint_init(ep, ep_addr, wMaxPacketSize, bmAttributes);
 }
 
-static void hw_endpoint_xfer(uint8_t ep_addr, uint8_t *buffer, uint16_t total_bytes, bool start)
+static void hw_endpoint_xfer(uint8_t ep_addr, uint8_t *buffer, uint16_t total_bytes)
 {
     struct hw_endpoint *ep = hw_endpoint_get_by_addr(ep_addr);
-    _hw_endpoint_xfer(ep, buffer, total_bytes, start);
+    _hw_endpoint_xfer_start(ep, buffer, total_bytes);
 }
 
 static void hw_handle_buff_status(void)
@@ -251,7 +251,7 @@ static void ep0_0len_status(void)
 {
     // Send 0len complete response on EP0 IN
     reset_ep0();
-    hw_endpoint_xfer(0x80, NULL, 0, true);
+    hw_endpoint_xfer(0x80, NULL, 0);
 }
 
 static void _hw_endpoint_stall(struct hw_endpoint *ep)
@@ -477,7 +477,7 @@ void dcd_edpt0_status_complete(uint8_t rhport, tusb_control_request_t const * re
         request->bmRequestType_bit.type == TUSB_REQ_TYPE_STANDARD &&
         request->bRequest == TUSB_REQ_SET_ADDRESS)
     {
-        pico_trace("Set HW address %d\n", assigned_address);
+        pico_trace("Set HW address %d\n", request->wValue);
         usb_hw->dev_addr_ctrl = (uint8_t) request->wValue;
     }
 
@@ -496,7 +496,7 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t t
 {
     assert(rhport == 0);
     // True means start new xfer
-    hw_endpoint_xfer(ep_addr, buffer, total_bytes, true);
+    hw_endpoint_xfer(ep_addr, buffer, total_bytes);
     return true;
 }
 

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -201,7 +201,7 @@ static void hw_endpoint_init(uint8_t ep_addr, uint16_t wMaxPacketSize, uint8_t b
 static void hw_endpoint_xfer(uint8_t ep_addr, uint8_t *buffer, uint16_t total_bytes)
 {
     struct hw_endpoint *ep = hw_endpoint_get_by_addr(ep_addr);
-    _hw_endpoint_xfer_start(ep, buffer, total_bytes);
+    hw_endpoint_xfer_start(ep, buffer, total_bytes);
 }
 
 static void hw_handle_buff_status(void)
@@ -221,7 +221,7 @@ static void hw_handle_buff_status(void)
             // IN transfer for even i, OUT transfer for odd i
             struct hw_endpoint *ep = hw_endpoint_get_by_num(i >> 1u, !(i & 1u));
             // Continue xfer
-            bool done = _hw_endpoint_xfer_continue(ep);
+            bool done = hw_endpoint_xfer_continue(ep);
             if (done)
             {
                 // Notify

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -225,7 +225,7 @@ static void hw_handle_buff_status(void)
             if (done)
             {
                 // Notify
-                dcd_event_xfer_complete(0, ep->ep_addr, ep->len, XFER_RESULT_SUCCESS, true);
+                dcd_event_xfer_complete(0, ep->ep_addr, ep->xferred_len, XFER_RESULT_SUCCESS, true);
                 hw_endpoint_reset_transfer(ep);
             }
             remaining_buffers &= ~bit;

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -67,8 +67,11 @@ static void _hw_endpoint_alloc(struct hw_endpoint *ep)
   // size must be multiple of 64
   uint16_t size = tu_div_ceil(ep->wMaxPacketSize, 64) * 64u;
 
-  // double buffered for non-ISO endpoint
-  if ( ep->transfer_type != TUSB_XFER_ISOCHRONOUS ) size *= 2u;
+  // double buffered for Control and Bulk endpoint
+  if ( ep->transfer_type == TUSB_XFER_CONTROL || ep->transfer_type == TUSB_XFER_BULK)
+  {
+    size *= 2u;
+  }
 
   ep->hw_data_buf = next_buffer_ptr;
   next_buffer_ptr += size;
@@ -445,18 +448,17 @@ void dcd_connect(uint8_t rhport)
 
 void dcd_edpt0_status_complete(uint8_t rhport, tusb_control_request_t const * request)
 {
-    pico_trace("dcd_edpt0_status_complete %d\n", rhport);
-    assert(rhport == 0);
+  (void) rhport;
 
-    if (request->bmRequestType_bit.recipient == TUSB_REQ_RCPT_DEVICE &&
-        request->bmRequestType_bit.type == TUSB_REQ_TYPE_STANDARD &&
-        request->bRequest == TUSB_REQ_SET_ADDRESS)
-    {
-        pico_trace("Set HW address %d\n", request->wValue);
-        usb_hw->dev_addr_ctrl = (uint8_t) request->wValue;
-    }
+  if ( request->bmRequestType_bit.recipient == TUSB_REQ_RCPT_DEVICE &&
+       request->bmRequestType_bit.type == TUSB_REQ_TYPE_STANDARD &&
+       request->bRequest == TUSB_REQ_SET_ADDRESS )
+  {
+    pico_trace("Set HW address %d\n", request->wValue);
+    usb_hw->dev_addr_ctrl = (uint8_t) request->wValue;
+  }
 
-    reset_ep0();
+  reset_ep0();
 }
 
 bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -151,7 +151,6 @@ static void hw_handle_buff_status(void)
         {
           TU_LOG(3, "Single Buffered: ");
         }
-
         TU_LOG_HEX(3, ep_ctrl);
 
         _handle_buff_status_bit(bit, ep);

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -115,7 +115,7 @@ static void hw_xfer_complete(struct hw_endpoint *ep, xfer_result_t xfer_result)
     // Mark transfer as done before we tell the tinyusb stack
     uint8_t dev_addr = ep->dev_addr;
     uint8_t ep_addr = ep->ep_addr;
-    uint xferred_len = ep->len;
+    uint xferred_len = ep->xferred_len;
     hw_endpoint_reset_transfer(ep);
     hcd_event_xfer_complete(dev_addr, ep_addr, xferred_len, xfer_result, true);
 }
@@ -542,7 +542,7 @@ bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet
     _hw_endpoint_init(ep, dev_addr, 0x00, ep->wMaxPacketSize, 0, 0);
     assert(ep->configured);
 
-    ep->total_len     = 8;
+    ep->remaining_len = 8;
     ep->transfer_size = 8;
     ep->active        = true;
     ep->sent_setup    = true;

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -146,15 +146,13 @@ static void hw_handle_buff_status(void)
         uint32_t ep_ctrl = *ep->endpoint_control;
         if (ep_ctrl & EP_CTRL_DOUBLE_BUFFERED_BITS)
         {
-          TU_LOG(2, "Double Buffered ");
+          TU_LOG(3, "Double Buffered: ");
         }else
         {
-          TU_LOG(2, "Single Buffered ");
+          TU_LOG(3, "Single Buffered: ");
         }
 
-        if (ep_ctrl & EP_CTRL_INTERRUPT_PER_DOUBLE_BUFFER) TU_LOG(2, "Interrupt per double ");
-        if (ep_ctrl & EP_CTRL_INTERRUPT_PER_BUFFER) TU_LOG(2, "Interrupt per single ");
-        TU_LOG_HEX(2, ep_ctrl);
+        TU_LOG_HEX(3, ep_ctrl);
 
         _handle_buff_status_bit(bit, ep);
     }

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -194,7 +194,7 @@ void hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t to
 
   // Fill in info now that we're kicking off the hw
   ep->remaining_len = total_len;
-  ep->xferred_len           = 0;
+  ep->xferred_len   = 0;
   ep->active        = true;
   ep->user_buf      = buffer;
 

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -189,7 +189,7 @@ void hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t to
   if ( ep->active )
   {
     // TODO: Is this acceptable for interrupt packets?
-    pico_warn("WARN: starting new transfer on already active ep %d %s\n", tu_edpt_number(ep->ep_addr),
+    TU_LOG(1, "WARN: starting new transfer on already active ep %d %s\n", tu_edpt_number(ep->ep_addr),
               ep_dir_string[tu_edpt_dir(ep->ep_addr)]);
 
     hw_endpoint_reset_transfer(ep);

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -73,9 +73,6 @@ void hw_endpoint_reset_transfer(struct hw_endpoint *ep)
 {
   ep->stalled = false;
   ep->active = false;
-#if TUSB_OPT_HOST_ENABLED
-  ep->sent_setup = false;
-#endif
   ep->remaining_len = 0;
   ep->xferred_len = 0;
   ep->user_buf = 0;

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -65,12 +65,6 @@ struct hw_endpoint
     uint16_t remaining_len;
     uint16_t xferred_len;
 
-    // Amount of data with the hardware
-    uint16_t buflen[2];
-
-    uint16_t transfer_size; // buf0_len;
-    uint16_t buf_1_len;
-
     // User buffer in main memory
     uint8_t *user_buf;
 
@@ -80,12 +74,6 @@ struct hw_endpoint
     uint8_t transfer_type;
     
 #if TUSB_OPT_HOST_ENABLED
-    // Only needed for host mode
-    bool last_buf;
-
-    // RP2040-E4: HOST BUG. Host will incorrect write status to top half of buffer
-    // control register when doing transfers > 1 packet
-    uint8_t buf_sel;
     // Only needed for host
     uint8_t dev_addr;
     bool sent_setup;

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -120,8 +120,8 @@ static inline void print_bufctrl16(uint32_t u16)
       .u16 = u16
   };
 
-  TU_LOG(3, "len = %u, available = %u, stall = %u, reset = %u, toggle = %u, last = %u, full = %u\r\n",
-         bufctrl.xfer_len, bufctrl.available, bufctrl.stall, bufctrl.reset_bufsel, bufctrl.data_toggle, bufctrl.last_buf, bufctrl.full);
+  TU_LOG(3, "len = %u, available = %u, full = %u, last = %u, stall = %u, reset = %u, toggle = %u\r\n",
+         bufctrl.xfer_len, bufctrl.available, bufctrl.full, bufctrl.last_buf, bufctrl.stall, bufctrl.reset_bufsel, bufctrl.data_toggle);
 }
 
 static inline void print_bufctrl32(uint32_t u32)

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -29,12 +29,6 @@
 #define pico_info(format,...) ((void)0)
 #endif
 
-#if false && !defined(NDEBUG)
-#define pico_warn(format,args...) printf(format, ## args)
-#else
-#define pico_warn(format,...) ((void)0)
-#endif
-
 // Hardware information per endpoint
 struct hw_endpoint
 {
@@ -127,13 +121,14 @@ typedef union TU_ATTR_PACKED
 
 TU_VERIFY_STATIC(sizeof(rp2040_buffer_control_t) == 2, "size is not correct");
 
-static inline void print_bufctrl16(uint32_t __unused u16)
+#if CFG_TUSB_DEBUG >= 3
+static inline void print_bufctrl16(uint32_t u16)
 {
-  rp2040_buffer_control_t __unused bufctrl = {
+  rp2040_buffer_control_t bufctrl = {
       .u16 = u16
   };
 
-  TU_LOG(2, "len = %u, available = %u, stall = %u, reset = %u, toggle = %u, last = %u, full = %u\r\n",
+  TU_LOG(3, "len = %u, available = %u, stall = %u, reset = %u, toggle = %u, last = %u, full = %u\r\n",
          bufctrl.xfer_len, bufctrl.available, bufctrl.stall, bufctrl.reset_bufsel, bufctrl.data_toggle, bufctrl.last_buf, bufctrl.full);
 }
 
@@ -142,12 +137,19 @@ static inline void print_bufctrl32(uint32_t u32)
   uint16_t u16;
 
   u16 = u32 >> 16;
-  TU_LOG(2, "  Buffer Control 1 0x%x: ", u16);
+  TU_LOG(3, "  Buffer Control 1 0x%x: ", u16);
   print_bufctrl16(u16);
 
   u16 = u32 & 0x0000ffff;
-  TU_LOG(2, "  Buffer Control 0 0x%x: ", u16);
+  TU_LOG(3, "  Buffer Control 0 0x%x: ", u16);
   print_bufctrl16(u16);
 }
+
+#else
+
+#define print_bufctrl16(u16)
+#define print_bufctrl32(u32)
+
+#endif
 
 #endif

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -62,10 +62,12 @@ struct hw_endpoint
 
     // Current transfer information
     bool active;
-    uint16_t total_len;
-    uint16_t len;
+    uint16_t remaining_len;
+    uint16_t xferred_len;
 
     // Amount of data with the hardware
+    uint16_t buflen[2];
+
     uint16_t transfer_size; // buf0_len;
     uint16_t buf_1_len;
 

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -94,11 +94,9 @@ struct hw_endpoint
 
 void rp2040_usb_init(void);
 
+void hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t total_len);
+bool hw_endpoint_xfer_continue(struct hw_endpoint *ep);
 void hw_endpoint_reset_transfer(struct hw_endpoint *ep);
-void _hw_endpoint_start_next_buffer(struct hw_endpoint *ep);
-void _hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t total_len);
-void _hw_endpoint_xfer_sync(struct hw_endpoint *ep);
-bool _hw_endpoint_xfer_continue(struct hw_endpoint *ep);
 
 void _hw_endpoint_buffer_control_update32(struct hw_endpoint *ep, uint32_t and_mask, uint32_t or_mask);
 static inline uint32_t _hw_endpoint_buffer_control_get_value32(struct hw_endpoint *ep) {

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -55,13 +55,14 @@ struct hw_endpoint
 
     // Data needed from EP descriptor
     uint16_t wMaxPacketSize;
+
     // Interrupt, bulk, etc
     uint8_t transfer_type;
     
 #if TUSB_OPT_HOST_ENABLED
     // Only needed for host
     uint8_t dev_addr;
-    bool sent_setup;
+
     // If interrupt endpoint
     uint8_t interrupt_num;
 #endif

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -17,17 +17,8 @@
 #endif
 
 
-#if true || false && !defined(NDEBUG)
-#define pico_trace(format,args...) printf(format, ## args)
-#else
-#define pico_trace(format,...) ((void)0)
-#endif
-
-#if false && !defined(NDEBUG)
-#define pico_info(format,args...) printf(format, ## args)
-#else
-#define pico_info(format,...) ((void)0)
-#endif
+#define pico_info(...)  TU_LOG(2, __VA_ARGS__)
+#define pico_trace(...) TU_LOG(3, __VA_ARGS__)
 
 // Hardware information per endpoint
 struct hw_endpoint


### PR DESCRIPTION
**Describe the PR**
This PR implements double buffered for RP2040, rework/refactor the existing quite a log
- we don't have to deal with RP2040-E4 hardware our of synce
- faster transfer for control and bulk 
- Should help https://github.com/raspberrypi/pico-sdk/issues/442 with logitech universal receiver (8-byte control in Fullspeed) and wired keyboard with 8byte control in Lowspeed
- Lots of internal rp2040 usb renaming
- Testing with device stack, cdc_msc, hid_composite running fine as normal. 
- There is an issue with net_lwip_webserver example when there is a short packet on buffer0 (i.e < 64 bytes) while we expect data on both buffer. At the hanlding time (currently triggered per 2 buffer), the buffer1 is probably filled with data from the next transfer (not current one). For now we disable double buffered for device OUT.  

PR is tested on both host and device mode and should be ready for review and merge. @kilograham @liamfraser please let me know if changes look good to you and it would be great if you could have some time to test it out.