### PR TITLE
Changed order of struct initializer to avoid compiler error

### DIFF
--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -86,8 +86,8 @@ typedef struct
   .depth                = _depth,                           \
   .item_size            = sizeof(_type),                    \
   .overwritable         = _overwritable,                    \
-  .max_pointer_idx      = 2*(_depth)-1,                     \
   .non_used_index_space = UINT16_MAX - (2*(_depth)-1),      \
+  .max_pointer_idx      = 2*(_depth)-1,                     \
 }
 
 #define TU_FIFO_DEF(_name, _depth, _type, _overwritable)                      \


### PR DESCRIPTION
**Describe the PR**
This re-orders the order of two of the designators in a struct initializer to match the struct field declaration order to avoid compiler errors.

**Additional context**
I'm compiling for an Arm Cortex-M0, and my compiler threw an error because the designator order was different in the initializer than in the struct declaration.
