### PR TITLE
GCC 11 build fix for nrf5x

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -787,7 +787,7 @@ static bool hfclk_running(void)
 #ifdef SOFTDEVICE_PRESENT
   if ( is_sd_enabled() )
   {
-    uint32_t is_running;
+    uint32_t is_running = 0;
     (void) sd_clock_hfclk_is_running(&is_running);
     return (is_running ? true : false);
   }


### PR DESCRIPTION
**Describe the PR**
During Adafruit Bootloader compilation, I spotted bellow error which do not allow me build their project.
It's simple fix so I decided to do it by myself. 

``` c
    inlined from 'hfclk_running' at lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c:785:13:
lib/tinyusb/src/portable/nordic/nrf5x/dcd_nrf5x.c:792:31: error: 'is_running' may be used uninitialized [-Werror=maybe-uninitialized]
  792 |     return (is_running ? true : false);
      |            ~~~~~~~~~~~~~~~~~~~^~~~~~~~
```

