### PR TITLE
add tud_vendor_control_request_cb() to poisoned list

### DIFF
--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -83,6 +83,10 @@
   #define TU_BSWAP16(u16) (__builtin_bswap16(u16))
   #define TU_BSWAP32(u32) (__builtin_bswap32(u32))
 
+  // List of obsolete callback function that is renamed and should not be defined.
+  // Put it here since only gcc support this pragma
+  #pragma GCC poison tud_vendor_control_request_cb
+
 #elif defined(__TI_COMPILER_VERSION__)
   #define TU_ATTR_ALIGNED(Bytes)        __attribute__ ((aligned(Bytes)))
   #define TU_ATTR_SECTION(sec_name)     __attribute__ ((section(#sec_name)))


### PR DESCRIPTION
**Describe the PR**
Add poisoned list (only gcc) for renamed callbacks, so that it make it easier to spot and fix the issue. Otherwise it can be under radar with the only warning is function not used. Original idea comes from https://github.com/hathach/tinyusb/discussions/921 

Put to tusb_compiler.h since gcc seem to be the only compiler to support this, update/expand/refactor later on when needed.