### PR TITLE
Add openinput to the 'Uses' section (aka projects that use Tusb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ TinyUSB is currently used by these other projects:
 - [Espressif IDF](https://github.com/espressif/esp-idf)
 - [MicroPython](https://github.com/micropython/micropython)
 - [mynewt](https://mynewt.apache.org)
+- [openinput](https://github.com/openinput-fw/openinput)
 - [Raspberry Pi Pico SDK](https://github.com/raspberrypi/pico-sdk)
 - [TinyUF2 Bootloader](https://github.com/adafruit/tinyuf2)
 - [TinyUSB Arduino Library](https://github.com/adafruit/Adafruit_TinyUSB_Arduino)


### PR DESCRIPTION
Signed-off-by: Rafael Silva <perigoso@riseup.net>

**Describe the PR**
The project is young, but we already rely heavily on Tusb and we are planning on working on it in foreseeable future as well as develop a community around it, so i think it makes sense to add here.

[Project documentation.](https://openinput.readthedocs.io/en/latest/)