### PR TITLE
correct midi available with already stream read

### DIFF
--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -123,7 +123,7 @@ uint32_t tud_midi_n_available(uint8_t itf, uint8_t cable_num)
 {
   (void) cable_num;
 
-  midid_interface_t const* midi = &_midid_itf[itf];
+  midid_interface_t* midi = &_midid_itf[itf];
   midid_stream_t const* stream = &midi->stream_read;
 
   // when using with packet API stream total & index are both zero

--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -122,7 +122,12 @@ static void _prep_out_transaction (midid_interface_t* p_midi)
 uint32_t tud_midi_n_available(uint8_t itf, uint8_t cable_num)
 {
   (void) cable_num;
-  return tu_fifo_count(&_midid_itf[itf].rx_ff);
+
+  midid_interface_t const* midi = &_midid_itf[itf];
+  midid_stream_t const* stream = &midi->stream_read;
+
+  // when using with packet API stream total & index are both zero
+  return tu_fifo_count(&midi->rx_ff) + (stream->total - stream->index);
 }
 
 uint32_t tud_midi_n_stream_read(uint8_t itf, uint8_t cable_num, void* buffer, uint32_t bufsize)

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -323,8 +323,6 @@ static uint16_t advance_pointer(tu_fifo_t* f, uint16_t p, uint16_t offset)
   // We limit the index space of p such that a correct wrap around happens
   // Check for a wrap around or if we are in unused index space - This has to be checked first!!
   // We are exploiting the wrap around to the correct index
-
-  // TODO warning: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Wstrict-overflow]
   if ((p > (uint16_t)(p + offset)) || ((uint16_t)(p + offset) > f->max_pointer_idx))
   {
     p = (p + offset) + f->non_used_index_space;


### PR DESCRIPTION
**Describe the PR**
midi stream read() is often called with 1 byte buffer each. Correct the available() to also take in account of previous byte read from packet (not yet consumed). Reported by  https://github.com/adafruit/Adafruit_TinyUSB_Arduino/issues/64