### PR TITLE
net_lwip_webserver: utilize pbuf_copy_partial()

### DIFF
--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -181,9 +181,7 @@ uint16_t tud_network_xmit_cb(uint8_t *dst, void *ref, uint16_t arg)
 
   (void)arg; /* unused for this example */
 
-  pbuf_copy_partial(p, dst, p->tot_len, 0);
-
-  return p->tot_len;
+  return pbuf_copy_partial(p, dst, p->tot_len, 0);
 }
 
 static void service_traffic(void)

--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -178,21 +178,12 @@ bool tud_network_recv_cb(const uint8_t *src, uint16_t size)
 uint16_t tud_network_xmit_cb(uint8_t *dst, void *ref, uint16_t arg)
 {
   struct pbuf *p = (struct pbuf *)ref;
-  struct pbuf *q;
-  uint16_t len = 0;
 
   (void)arg; /* unused for this example */
 
-  /* traverse the "pbuf chain"; see ./lwip/src/core/pbuf.c for more info */
-  for(q = p; q != NULL; q = q->next)
-  {
-    memcpy(dst, (char *)q->payload, q->len);
-    dst += q->len;
-    len += q->len;
-    if (q->len == q->tot_len) break;
-  }
+  pbuf_copy_partial(p, dst, p->tot_len, 0);
 
-  return len;
+  return p->tot_len;
 }
 
 static void service_traffic(void)


### PR DESCRIPTION
The existing example code duplicates functionality that it turns out can be achieved with an existing function in lwIP (pbuf_copy_partial).  Using pbuf_copy_partial() saves about 24 bytes in the net_lwip_webserver executable size and results in ever so slightly less code to maintain.