### PR TITLE
Correct hid inout example

### DIFF
--- a/examples/device/hid_generic_inout/boards.js
+++ b/examples/device/hid_generic_inout/boards.js
@@ -1,4 +1,4 @@
 module.exports = {
-	"Feather_nRF52840":[0X239A,0X8029],
-	"Metro_nRF52840":[0X239A,0X803F],
+	"Adafruit Boards":[0x239A,0xFFFF],
+	"TinyUSB example":[0xCAFE,0xFFFF]
 }

--- a/examples/device/hid_generic_inout/hid_test.js
+++ b/examples/device/hid_generic_inout/hid_test.js
@@ -5,8 +5,6 @@ var HID = require('node-hid');
 var os = require('os')
 // list of supported devices
 var boards = require('./boards.js')
-
-var isWin = (os.platform() === 'win32');
 var devices = HID.devices();
 
 // this will choose any device found in the boards.js file
@@ -19,10 +17,8 @@ var message = "Hello World!"
 // This means if you have characters in your string that are not Latin-1 you will have to add additional logic for character codes above 255
 var messageBuffer = Array.from(message, function(c){return c.charCodeAt(0)});
 
-// Windows wants you to prepend a 0 to whatever you send
-if(isWin){
-	messageBuffer.unshift(0)
-}
+// HIDAPI requires us to prepend a 0 for single hid report as dummy reportID
+messageBuffer.unshift(0)
 
 // Some OSes expect that you always send a buffer that equals your report length
 // So lets fill up the rest of the buffer with zeros
@@ -66,6 +62,7 @@ function anySupportedBoard(d) {
 
 
 function isDevice(board,d){
-	return d.vendorId==board[0] && d.productId==board[1];
+	// product id 0xff is matches all
+	return d.vendorId==board[0] && (d.productId==board[1] || board[1] == 0xFFFF);
 }
 

--- a/examples/device/hid_generic_inout/hid_test.py
+++ b/examples/device/hid_generic_inout/hid_test.py
@@ -11,7 +11,10 @@ for dict in hid.enumerate(USB_VID):
     if dev:
         while True:
             # Get input from console and encode to UTF8 for array of chars.
-            str_out = input("Send text to HID Device : ").encode('utf-8')
+            # hid generic inout is single report therefore by HIDAPI requirement
+            # it must be preceeded with 0x00 as dummy reportID
+            str_out = b'\x00'
+            str_out += input("Send text to HID Device : ").encode('utf-8')
             dev.write(str_out)
             str_in = dev.read(64)
             print("Received from HID Device:", str_in, '\n')

--- a/examples/device/hid_generic_inout/src/main.c
+++ b/examples/device/hid_generic_inout/src/main.c
@@ -36,16 +36,24 @@
  *
  * There are 2 ways to test the sketch
  * 1. Using nodejs
- *    - Install nodejs and npm to your PC
- *    - Install excellent node-hid (https://github.com/node-hid/node-hid) by
- *      $ npm install node-hid
- *    - Run provided hid test script
- *      $ node hid_test.js
+ * - Install nodejs and npm to your PC
  *
- * 2. Using python hidRun
- *    - Python and `hid` package is required, for installation please follow https://pypi.org/project/hid/
- *    - Run provided hid test script to send and receive data to this device.
- *      $ python3 hid_test.py
+ * - Install excellent node-hid (https://github.com/node-hid/node-hid) by
+ *   $ npm install node-hid
+ *
+ * - Run provided hid test script
+ *   $ node hid_test.js
+ *
+ * 2. Using python
+ * - Install `hid` package (https://pypi.org/project/hid/) by
+ *   $ pip install hid
+ *
+ * - hid package replies on hidapi (https://github.com/libusb/hidapi) for backend,
+ *   which already available in Linux. However on windows, you may need to download its dlls from their release page and
+ *   copy it over to folder where python is installed.
+ *
+ * - Run provided hid test script to send and receive data to this device.
+ *   $ python3 hid_test.py
  */
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
- HIDAPI requires dummy 0x00 as reportID for single report hid device. 
- Force hid_test js/py script to always do this. also update boards.js to allow specify all productid with 0xFFFF.