### PR TITLE
correct newline usage keycode (ENTER 0x28)

### DIFF
--- a/src/class/hid/hid.h
+++ b/src/class/hid/hid.h
@@ -871,10 +871,10 @@ enum
     {0, 0                     }, /* 0x07           */ \
     {0, HID_KEY_BACKSPACE     }, /* 0x08 Backspace */ \
     {0, HID_KEY_TAB           }, /* 0x09 Tab       */ \
-    {0, HID_KEY_RETURN        }, /* 0x0A Line Feed */ \
+    {0, HID_KEY_ENTER         }, /* 0x0A Line Feed */ \
     {0, 0                     }, /* 0x0B           */ \
     {0, 0                     }, /* 0x0C           */ \
-    {0, HID_KEY_RETURN        }, /* 0x0D CR        */ \
+    {0, HID_KEY_ENTER         }, /* 0x0D CR        */ \
     {0, 0                     }, /* 0x0E           */ \
     {0, 0                     }, /* 0x0F           */ \
     {0, 0                     }, /* 0x10           */ \


### PR DESCRIPTION
**Describe the PR**
HID_KEY_RETURN (0x9E) is not correct one, originally from https://github.com/adafruit/Adafruit_TinyUSB_Arduino/pull/118
