### PR TITLE
dcd_da1469x: Use mcu.h instead of MCU specific header

### DIFF
--- a/src/portable/dialog/da146xx/dcd_da146xx.c
+++ b/src/portable/dialog/da146xx/dcd_da146xx.c
@@ -28,7 +28,7 @@
 
 #if TUSB_OPT_DEVICE_ENABLED && CFG_TUSB_MCU == OPT_MCU_DA1469X
 
-#include "DA1469xAB.h"
+#include "mcu/mcu.h"
 
 #include "device/dcd.h"
 


### PR DESCRIPTION
**Describe the PR**
dcd_da1469x can work with broader range of MCUs that
share same USB core.
Specific header file that was used DA1469xAB.h now it is changed
to mcu/mcu.h which includes actual MCU specific register file.

**Additional context**
No change in code.
Only possibility to build with for other MCUs that have different name
of register file.
