### PR TITLE
da1469x: Handle VBUS interrupt

### DIFF
--- a/hw/bsp/da14695_dk_usb/da14695_dk_usb.c
+++ b/hw/bsp/da14695_dk_usb/da14695_dk_usb.c
@@ -46,6 +46,14 @@ void USB_IRQHandler(void)
 
 #define BUTTON_PIN      6
 
+extern void tusb_vbus_changed(bool present);
+
+void VBUS_IRQHandler(void)
+{
+  CRG_TOP->VBUS_IRQ_CLEAR_REG = 1;
+  tusb_vbus_changed((CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_VBUS_AVAILABLE_Msk) != 0);
+}
+
 void UnhandledIRQ(void)
 {
   CRG_TOP->SYS_CTRL_REG = 0x80;
@@ -75,6 +83,12 @@ void board_init(void)
   /* Setup USB IRQ */
   NVIC_SetPriority(USB_IRQn, 2);
   NVIC_EnableIRQ(USB_IRQn);
+
+  /* Setup VBUS IRQ */
+  CRG_TOP->VBUS_IRQ_MASK_REG = CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_FALL_Msk |
+                               CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_RISE_Msk;
+  NVIC_SetPriority(VBUS_IRQn, 3);
+  NVIC_EnableIRQ(VBUS_IRQn);
 
   /* Use PLL96 / 2 clock not HCLK */
   CRG_TOP->CLK_CTRL_REG &= ~CRG_TOP_CLK_CTRL_REG_USB_CLK_SRC_Msk;

--- a/hw/bsp/da1469x_dk_pro/da1469x-dk-pro.c
+++ b/hw/bsp/da1469x_dk_pro/da1469x-dk-pro.c
@@ -46,6 +46,14 @@ void USB_IRQHandler(void)
 
 #define BUTTON_PIN      6
 
+extern void tusb_vbus_changed(bool present);
+
+void VBUS_IRQHandler(void)
+{
+  CRG_TOP->VBUS_IRQ_CLEAR_REG = 1;
+  tusb_vbus_changed((CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_VBUS_AVAILABLE_Msk) != 0);
+}
+
 void UnhandledIRQ(void)
 {
   CRG_TOP->SYS_CTRL_REG = 0x80;
@@ -75,6 +83,12 @@ void board_init(void)
   /* Setup USB IRQ */
   NVIC_SetPriority(USB_IRQn, 2);
   NVIC_EnableIRQ(USB_IRQn);
+
+  /* Setup VBUS IRQ */
+  CRG_TOP->VBUS_IRQ_MASK_REG = CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_FALL_Msk |
+                               CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_RISE_Msk;
+  NVIC_SetPriority(VBUS_IRQn, 3);
+  NVIC_EnableIRQ(VBUS_IRQn);
 
   /* Use PLL96 / 2 clock not HCLK */
   CRG_TOP->CLK_CTRL_REG &= ~CRG_TOP_CLK_CTRL_REG_USB_CLK_SRC_Msk;

--- a/src/portable/dialog/da146xx/dcd_da146xx.c
+++ b/src/portable/dialog/da146xx/dcd_da146xx.c
@@ -277,6 +277,7 @@ void tusb_vbus_changed(bool present)
                            USB_USB_MAMSK_REG_USB_M_ALT_Msk |
                            USB_USB_MAMSK_REG_USB_M_WARN_Msk;
       USB->USB_ALTMSK_REG = USB_USB_ALTMSK_REG_USB_M_RESET_Msk;
+      dcd_connect(0);
     }
     else
     {
@@ -762,10 +763,9 @@ static void handle_ep0_nak(void)
  *------------------------------------------------------------------*/
 void dcd_init(uint8_t rhport)
 {
-  USB->USB_MCTRL_REG = USB_USB_MCTRL_REG_USBEN_Msk;
-  tusb_vbus_changed((CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_VBUS_AVAILABLE_Msk) != 0);
+  (void)rhport;
 
-  dcd_connect(rhport);
+  tusb_vbus_changed((CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_VBUS_AVAILABLE_Msk) != 0);
 }
 
 void dcd_int_enable(uint8_t rhport)


### PR DESCRIPTION
**Describe the PR**
For salf-powered code should handle VBUS changes.
Function tusb_vbus_chaneged() was present but not used in bsp;

dcd_connect() was called only at startup which is fine for
bus-powered devices.
If device was self-power and started without VBUS present
some registers would not be correctly set.

Now tusb_vbus_changed() is called whenever actual change on VBUS
is detected starting and stopping USB state machine.

**Additional context**
Tested only with da1469x_dk-pro (not USB stick)

