### PR TITLE
Add Rp2040 suspend & resume support

### DIFF
--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -152,6 +152,7 @@ bool dcd_edpt_xfer_fifo       (uint8_t rhport, uint8_t ep_addr, tu_fifo_t * ff, 
 void dcd_edpt_stall           (uint8_t rhport, uint8_t ep_addr);
 
 // clear stall, data toggle is also reset to DATA0
+// This API never calls with control endpoints, since it is auto cleared when receiving setup packet
 void dcd_edpt_clear_stall     (uint8_t rhport, uint8_t ep_addr);
 
 //--------------------------------------------------------------------+

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1191,7 +1191,8 @@ bool usbd_edpt_claim(uint8_t rhport, uint8_t ep_addr)
 {
   (void) rhport;
 
-  TU_VERIFY(tud_ready());
+  // TODO add this check later, also make sure we don't starve an out endpoint while suspending
+  // TU_VERIFY(tud_ready());
 
   uint8_t const epnum = tu_edpt_number(ep_addr);
   uint8_t const dir   = tu_edpt_dir(ep_addr);

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1191,6 +1191,8 @@ bool usbd_edpt_claim(uint8_t rhport, uint8_t ep_addr)
 {
   (void) rhport;
 
+  TU_VERIFY(tud_ready());
+
   uint8_t const epnum = tu_edpt_number(ep_addr);
   uint8_t const dir   = tu_edpt_dir(ep_addr);
 
@@ -1243,6 +1245,9 @@ bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
 {
   uint8_t const epnum = tu_edpt_number(ep_addr);
   uint8_t const dir   = tu_edpt_dir(ep_addr);
+
+  // TODO skip ready() check for now since enumeration also use this API
+  // TU_VERIFY(tud_ready());
 
   TU_LOG2("  Queue EP %02X with %u bytes ...\r\n", ep_addr, total_bytes);
 

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -284,9 +284,6 @@ static void dcd_rp2040_irq(void)
 #endif
     }
 
-#if 1
-    // TODO Enable SUSPEND & RESUME interrupt and test later on with/without VBUS detection
-
     /* Note from pico datasheet 4.1.2.6.4 (v1.2)
      * If you enable the suspend interrupt, it is likely you will see a suspend interrupt when
      * the device is first connected but the bus is idle. The bus can be idle for a few ms before
@@ -308,7 +305,6 @@ static void dcd_rp2040_irq(void)
         dcd_event_bus_signal(0, DCD_EVENT_RESUME, true);
         usb_hw_clear->sie_status = USB_SIE_STATUS_RESUME_BITS;
     }
-#endif
 
     if (status ^ handled)
     {

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -233,13 +233,6 @@ static void reset_ep0(void)
     }
 }
 
-static void ep0_0len_status(void)
-{
-    // Send 0len complete response on EP0 IN
-    reset_ep0();
-    hw_endpoint_xfer(0x80, NULL, 0);
-}
-
 static void bus_reset(void)
 {
 
@@ -405,7 +398,9 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
     assert(rhport == 0);
 
     // Can't set device address in hardware until status xfer has complete
-    ep0_0len_status();
+    // Send 0len complete response on EP0 IN
+    reset_ep0();
+    hw_endpoint_xfer(0x80, NULL, 0);
 }
 
 void dcd_remote_wakeup(uint8_t rhport)

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -61,8 +61,8 @@ static struct hw_endpoint ep_pool[1 + PICO_USB_HOST_INTERRUPT_ENDPOINTS];
 
 // Flags we set by default in sie_ctrl (we add other bits on top)
 enum {
-  SIE_CTRL_BASE = USB_SIE_CTRL_SOF_EN_BITS        | USB_SIE_CTRL_KEEP_ALIVE_EN_BITS |
-                  USB_SIE_CTRL_PULLDOWN_EN_BITS   | USB_SIE_CTRL_EP0_INT_1BUF_BITS
+  SIE_CTRL_BASE = USB_SIE_CTRL_SOF_EN_BITS      | USB_SIE_CTRL_KEEP_ALIVE_EN_BITS |
+                  USB_SIE_CTRL_PULLDOWN_EN_BITS | USB_SIE_CTRL_EP0_INT_1BUF_BITS
 };
 
 static struct hw_endpoint *get_dev_ep(uint8_t dev_addr, uint8_t ep_addr)
@@ -359,6 +359,9 @@ bool hcd_init(uint8_t rhport)
 
     // Reset any previous state
     rp2040_usb_init();
+
+    // Force VBUS detect to always present, for now we assume vbus is always provided (without using VBUS En)
+    usb_hw->pwr = USB_USB_PWR_VBUS_DETECT_BITS | USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN_BITS;
 
     irq_set_exclusive_handler(USBCTRL_IRQ, hcd_rp2040_irq);
 

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -62,11 +62,7 @@ void rp2040_usb_init(void)
   memset(usb_dpram, 0, sizeof(*usb_dpram));
 
   // Mux the controller to the onboard usb phy
-  usb_hw->muxing = USB_USB_MUXING_TO_PHY_BITS    | USB_USB_MUXING_SOFTCON_BITS;
-
-  // Force VBUS detect so the device thinks it is plugged into a host
-  // TODO support VBUs detect
-  usb_hw->pwr    = USB_USB_PWR_VBUS_DETECT_BITS  | USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN_BITS;
+  usb_hw->muxing = USB_USB_MUXING_TO_PHY_BITS | USB_USB_MUXING_SOFTCON_BITS;
 }
 
 void hw_endpoint_reset_transfer(struct hw_endpoint *ep)

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -42,7 +42,7 @@ struct hw_endpoint
     // Buffer pointer in usb dpram
     uint8_t *hw_data_buf;
 
-    // Have we been stalled
+    // Have we been stalled TODO remove later
     bool stalled;
 
     // Current transfer information


### PR DESCRIPTION
**Describe the PR**
This PR update rp2040 devvice
- Add supsend and resume support, comment out disconnection interrupt since it is not detectable since we are forcing vbus detect  
- comment / whitespace / clean up dcd rp2040 e.g stall / clear stall
- reset all endpoints upon bus_reset (previously only allocated once per power), however, device can dynamically change its configuration. It is better to enumerate with a clean state.

hopefully fix https://github.com/adafruit/circuitpython/issues/4190, https://github.com/adafruit/circuitpython/issues/5101

**Additional context**
Currently rp2040 force vbus detect making it difficult to distinguish between Disconnection and Suspend (both are idle bus). Disconnection can be determined by having extra GPIO to check vbus. In case of pico it is GPIO24, however, not all boards implement this on their schematics. 

Note: Other MCUs such as samd and esp32s2/s3 has similar issue as well, will try to find an common API to resolve this in future PR

![Screenshot from 2021-08-12 16-50-08](https://user-images.githubusercontent.com/249515/129176838-04b20507-62d9-4db7-859e-b9101f3cf655.png)