### PR TITLE
Fix nuc126 buffer copy with IAR

### DIFF
--- a/src/portable/nuvoton/nuc120/dcd_nuc120.c
+++ b/src/portable/nuvoton/nuc120/dcd_nuc120.c
@@ -99,6 +99,11 @@ static void usb_detach(void)
   USBD->DRVSE0 |= USBD_DRVSE0_DRVSE0_Msk;
 }
 
+static inline void usb_memcpy(uint8_t *dest, uint8_t *src, uint16_t size)
+{
+  while(size--) *dest++ = *src++;
+}
+
 static void usb_control_send_zlp(void)
 {
   USBD->EP[PERIPH_EP0].CFG |= USBD_CFG_DSQ_SYNC_Msk;
@@ -151,7 +156,8 @@ static void dcd_in_xfer(struct xfer_ctl_t *xfer, USBD_EP_T *ep)
   else
 #endif
   {
-    memcpy((uint8_t *)(USBD_BUF_BASE + ep->BUFSEG), xfer->data_ptr, bytes_now);
+    // USB SRAM seems to only support byte access and memcpy could possibly do it by words
+    usb_memcpy((uint8_t *)(USBD_BUF_BASE + ep->BUFSEG), xfer->data_ptr, bytes_now);
   }
 
   ep->MXPLD = bytes_now;
@@ -246,7 +252,7 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc)
   /* mine the data for the information we need */
   int const dir = tu_edpt_dir(p_endpoint_desc->bEndpointAddress);
   int const size = p_endpoint_desc->wMaxPacketSize.size;
-  tusb_xfer_type_t const type = p_endpoint_desc->bmAttributes.xfer;
+  tusb_xfer_type_t const type = (tusb_xfer_type_t) p_endpoint_desc->bmAttributes.xfer;
   struct xfer_ctl_t *xfer = &xfer_table[ep - USBD->EP];
 
   /* allocate buffer from USB RAM */
@@ -439,7 +445,8 @@ void dcd_int_handler(uint8_t rhport)
           else
 #endif
           {
-            memcpy(xfer->data_ptr, (uint8_t *)(USBD_BUF_BASE + ep->BUFSEG), available_bytes);
+            // USB SRAM seems to only support byte access and memcpy could possibly do it by words
+            usb_memcpy(xfer->data_ptr, (uint8_t *)(USBD_BUF_BASE + ep->BUFSEG), available_bytes);
             xfer->data_ptr += available_bytes;
           }
 

--- a/src/portable/nuvoton/nuc121/dcd_nuc121.c
+++ b/src/portable/nuvoton/nuc121/dcd_nuc121.c
@@ -101,7 +101,7 @@ static void usb_detach(void)
   USBD->SE0 |= USBD_SE0_SE0_Msk;
 }
 
-static void usb_memcpy(uint8_t *dest, uint8_t *src, uint16_t size)
+static inline void usb_memcpy(uint8_t *dest, uint8_t *src, uint16_t size)
 {
   while(size--) *dest++ = *src++;
 }
@@ -158,6 +158,7 @@ static void dcd_in_xfer(struct xfer_ctl_t *xfer, USBD_EP_T *ep)
   else
 #endif
   {
+    // USB SRAM seems to only support byte access and memcpy could possibly do it by words
     usb_memcpy((uint8_t *)(USBD_BUF_BASE + ep->BUFSEG), xfer->data_ptr, bytes_now);
   }
 
@@ -257,7 +258,7 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc)
   /* mine the data for the information we need */
   int const dir = tu_edpt_dir(p_endpoint_desc->bEndpointAddress);
   int const size = p_endpoint_desc->wMaxPacketSize.size;
-  tusb_xfer_type_t const type = (tusb_xfer_type_t)p_endpoint_desc->bmAttributes.xfer;
+  tusb_xfer_type_t const type = (tusb_xfer_type_t) p_endpoint_desc->bmAttributes.xfer;
   struct xfer_ctl_t *xfer = &xfer_table[ep - USBD->EP];
 
   /* allocate buffer from USB RAM */
@@ -455,6 +456,7 @@ void dcd_int_handler(uint8_t rhport)
           else
 #endif
           {
+            // USB SRAM seems to only support byte access and memcpy could possibly do it by words
             usb_memcpy(xfer->data_ptr, (uint8_t *)(USBD_BUF_BASE + ep->BUFSEG), available_bytes);
             xfer->data_ptr += available_bytes;
           }


### PR DESCRIPTION
**Describe the PR**
DCD buffer copy doesn't work correctly with IAR, after investigation IAR use optimized STM/LDM instructions in `memcpy` but there must be some access restrictions on USB buffer just like STM32 fsdev.

Use byte copy just like StdDriver.

And fix a warning.