### PR TITLE
nuc126: fix set_address & disable sof

### DIFF
--- a/src/portable/nuvoton/nuc121/dcd_nuc121.c
+++ b/src/portable/nuvoton/nuc121/dcd_nuc121.c
@@ -245,6 +245,7 @@ void dcd_int_disable(uint8_t rhport)
 void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
 {
   (void) rhport;
+  (void) dev_addr;
   usb_control_send_zlp(); /* SET_ADDRESS is the one exception where TinyUSB doesn't use dcd_edpt_xfer() to generate a ZLP */
 
   // DCD can only set address after status for this request is complete.


### PR DESCRIPTION
**Describe the PR**

- Use `dcd_edpt0_status_complete` to set address.
- Disable SOF interrupt.