### PR TITLE
Added support for Microchip Curiosity Nano SAMD21 board (DM320119)

### DIFF
--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -170,7 +170,7 @@ flash-stlink: $(BUILD)/$(PROJECT).elf
 
 # flash with pyocd
 flash-pyocd: $(BUILD)/$(PROJECT).hex
-	pyocd flash -t $(PYOCD_TARGET) -O dap_protocol=swd $<
+	pyocd flash -t $(PYOCD_TARGET) $(PYOCD_OPTION) $<
 	pyocd reset -t $(PYOCD_TARGET)
 
 # flash with Black Magic Probe

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -170,7 +170,7 @@ flash-stlink: $(BUILD)/$(PROJECT).elf
 
 # flash with pyocd
 flash-pyocd: $(BUILD)/$(PROJECT).hex
-	pyocd flash -t $(PYOCD_TARGET) $<
+	pyocd flash -t $(PYOCD_TARGET) -O dap_protocol=swd $<
 	pyocd reset -t $(PYOCD_TARGET)
 
 # flash with Black Magic Probe

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -169,6 +169,7 @@ flash-stlink: $(BUILD)/$(PROJECT).elf
 	STM32_Programmer_CLI --connect port=swd --write $< --go
 
 # flash with pyocd
+PYOCD_OPTION ?=
 flash-pyocd: $(BUILD)/$(PROJECT).hex
 	pyocd flash -t $(PYOCD_TARGET) $(PYOCD_OPTION) $<
 	pyocd reset -t $(PYOCD_TARGET)

--- a/hw/bsp/samd21/boards/curiosity_nano/board.h
+++ b/hw/bsp/samd21/boards/curiosity_nano/board.h
@@ -1,0 +1,50 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020, Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+// LED
+#define LED_PIN               (32 + 10) // PB10
+#define LED_STATE_ON          0
+
+// Button
+#define BUTTON_PIN            (0  + 11) // PB11
+#define BUTTON_STATE_ACTIVE   0
+
+// UART
+#define UART_RX_PIN           31	// CDC5_RX
+#define UART_TX_PIN           37	// CDC5_TX
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* BOARD_H_ */

--- a/hw/bsp/samd21/boards/curiosity_nano/board.mk
+++ b/hw/bsp/samd21/boards/curiosity_nano/board.mk
@@ -1,4 +1,4 @@
-CFLAGS += -D__SAMD21G17A__
+CFLAGS += -D__SAMD21G17A__ -DCFG_EXAMPLE_MSC_READONLY
 
 # All source paths should be relative to the top level.
 LD_FILE = $(BOARD_PATH)/samd21g17a_flash.ld

--- a/hw/bsp/samd21/boards/curiosity_nano/board.mk
+++ b/hw/bsp/samd21/boards/curiosity_nano/board.mk
@@ -1,0 +1,13 @@
+CFLAGS += -D__SAMD21G17A__
+
+# All source paths should be relative to the top level.
+LD_FILE = $(BOARD_PATH)/samd21g17a_flash.ld
+
+# For flash-jlink target
+JLINK_DEVICE = atsamd21g17a
+
+# flash using jlink (options are: jlink/cmsisdap/stlink/dfu)
+#flash: flash-jlink
+
+PYOCD_TARGET = atsamd21g17a
+flash: flash-pyocd

--- a/hw/bsp/samd21/boards/curiosity_nano/board.mk
+++ b/hw/bsp/samd21/boards/curiosity_nano/board.mk
@@ -10,4 +10,5 @@ JLINK_DEVICE = atsamd21g17a
 #flash: flash-jlink
 
 PYOCD_TARGET = atsamd21g17a
+PYOCD_OPTION = -O dap_protocol=swd
 flash: flash-pyocd

--- a/hw/bsp/samd21/boards/curiosity_nano/samd21g17a_flash.ld
+++ b/hw/bsp/samd21/boards/curiosity_nano/samd21g17a_flash.ld
@@ -1,0 +1,144 @@
+/**
+ * \file
+ *
+ * \brief Linker script for running in internal FLASH on the SAMD21G17A/D
+ *
+ * Copyright (c) 2017 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+  rom      (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00020000
+  ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00004000
+}
+
+/* The stack size used by the application. NOTE: you need to adjust according to your application. */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : DEFINED(__stack_size__) ? __stack_size__ : 0x1000;
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > rom
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+        end = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    . = ALIGN(4);
+    _end = . ;
+}

--- a/tools/build_family.py
+++ b/tools/build_family.py
@@ -98,21 +98,28 @@ def build_size(example, board):
 def skip_example(example, board):
     ex_dir = 'examples/' + example
     
+    # Check if example is skipped by family or board directory
+    skip_file = ".skip." + example.replace('/', '.');
+    if os.path.isfile("hw/bsp/{}/{}".format(family, skip_file)) or os.path.isfile("hw/bsp/{}/boards/{}/{}".format(family, board, skip_file)):
+        return 1
+
+    # Otherwise check if mcu is excluded by example directory
+
     # family CMake
-    board_mk = 'hw/bsp/{}/family.cmake'.format(family)
+    family_mk = 'hw/bsp/{}/family.cmake'.format(family)
 
     # family.mk
-    if not os.path.exists(board_mk):
-        board_mk = 'hw/bsp/{}/family.mk'.format(family)
+    if not os.path.exists(family_mk):
+        family_mk = 'hw/bsp/{}/family.mk'.format(family)
 
-    with open(board_mk) as mk:
+    with open(family_mk) as mk:
         mk_contents = mk.read()
 
         # Skip all OPT_MCU_NONE these are WIP port
         if 'CFG_TUSB_MCU=OPT_MCU_NONE' in mk_contents:
             return 1
 
-        # Skip if CFG_TUSB_MCU in board.mk to match skip file
+        # Skip if CFG_TUSB_MCU in family.mk to match skip file
         for skip_file in glob.iglob(ex_dir + '/.skip.MCU_*'):
             mcu_cflag = 'CFG_TUSB_MCU=OPT_' + os.path.basename(skip_file).split('.')[2]
             if mcu_cflag in mk_contents:


### PR DESCRIPTION
Added support for Microchip Curiosity Nano SAMD21 board (DM320119) under hw/bsp/samd21/boards/curiosity_nano
The nEDBG on this board requires dap_protocol be specified as SWD (changed in examples/rules.mk)

NOTE: requires entry (03eb:2175) for VID:PID of nEDBG be added to /etc/udev/rules for pyocd

**Describe the PR**
A clear and concise description of what this PR solve.

**Additional context**
If applicable, add any other context about the PR and/or screenshots here.
