### PR TITLE
Improvements for dcd_transdimension

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1379,7 +1379,13 @@ void usbd_edpt_close(uint8_t rhport, uint8_t ep_addr)
   TU_ASSERT(dcd_edpt_close, /**/);
   TU_LOG2("  CLOSING Endpoint: 0x%02X\r\n", ep_addr);
 
+  uint8_t const epnum = tu_edpt_number(ep_addr);
+  uint8_t const dir   = tu_edpt_dir(ep_addr);
+
   dcd_edpt_close(rhport, ep_addr);
+  _usbd_dev.ep_status[epnum][dir].stalled = false;
+  _usbd_dev.ep_status[epnum][dir].busy = false;
+  _usbd_dev.ep_status[epnum][dir].claimed = false;
 
   return;
 }

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1041,6 +1041,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
     break;
 
     case TUSB_DESC_DEVICE_QUALIFIER:
+    {
       TU_LOG2(" Device Qualifier\r\n");
 
       TU_VERIFY( tud_descriptor_device_qualifier_cb );
@@ -1050,6 +1051,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
 
       // first byte of descriptor is its size
       return tud_control_xfer(rhport, p_request, (void*) desc_qualifier, desc_qualifier[0]);
+    }
     break;
 
     default: return false;

--- a/src/portable/nxp/transdimension/dcd_transdimension.c
+++ b/src/portable/nxp/transdimension/dcd_transdimension.c
@@ -516,7 +516,8 @@ bool dcd_edpt_xfer_fifo (uint8_t rhport, uint8_t ep_addr, tu_fifo_t * ff, uint16
     }
     else
     {
-      // TODO we need to carry the wrapped length after the linear part complete
+      // TODO we may need to carry the wrapped length after the linear part complete
+      // for now only transfer up to linear part
     }
   }
 
@@ -560,7 +561,6 @@ static void process_edpt_complete_isr(uint8_t rhport, uint8_t epnum, uint8_t dir
   }
   
   // only number of bytes in the IOC qtd
-  // TODO there is still a case with xfer_fifo with additional wrapped buffer to fullfil the requested length
   dcd_event_xfer_complete(rhport, tu_edpt_addr(epnum, dir), xferred_bytes, result, true);
 }
 


### PR DESCRIPTION
**Describe the PR**
1st part of #926.

- Add xfer_fifo support, fifo must aligned to 4k boundary and size must be multiple of 4k.
- Add dcd_edpt_close and iso xfer.