### PR TITLE
CDC : Add xfer_fifo & DMA support 

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -75,7 +75,7 @@ enum
 };
 
 // Separate buffers in order to save RAM when align is applied,
-// since struct always aligned to most aligned member
+// as space between 2 elements of _cdcd_itf[] is wasted
 typedef struct
 {
 #if USE_LINEAR_BUFFER
@@ -120,7 +120,7 @@ typedef struct
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
-CFG_TUSB_MEM_SECTION static cdcd_interface_t _cdcd_itf[CFG_TUD_CDC];
+static cdcd_interface_t _cdcd_itf[CFG_TUD_CDC];
 CFG_TUSB_MEM_SECTION static cdcd_intf_buf_t  _cdcd_buf[CFG_TUD_CDC];
 
 static void _prep_out_transaction (cdcd_interface_t* p_cdc)
@@ -595,6 +595,7 @@ tu_fifo_t* tud_cdc_n_get_tx_ff (uint8_t itf)
   return &_cdcd_itf[itf].tx_ff;
 }
 
+// Need to be called when fifo read is finished, in order to schedule next transfer
 void tud_cdc_n_rx_ff_read_done (uint8_t itf)
 {
   cdcd_interface_t* p_cdc = &_cdcd_itf[itf];

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -481,4 +481,18 @@ bool cdcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
   return true;
 }
 
+// Get the Receive FIFO (for DMA transfer)
+tu_fifo_t* tud_cdc_n_get_rx_ff (uint8_t itf)
+{
+  TU_ASSERT(itf < CFG_TUD_CDC);
+  return &_cdcd_itf[itf].rx_ff;
+}
+
+// Get the transmit FIFO (for DMA transfer)
+tu_fifo_t* tud_cdc_n_get_tx_ff (uint8_t itf)
+{
+  TU_ASSERT(itf < CFG_TUD_CDC);
+  return &_cdcd_itf[itf].tx_ff;
+}
+
 #endif

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -110,6 +110,7 @@ tu_fifo_t* tud_cdc_n_get_rx_ff (uint8_t itf);
 // Get the transmit FIFO (for DMA transfer)
 tu_fifo_t* tud_cdc_n_get_tx_ff (uint8_t itf);
 
+// Need to be called when fifo read is finished, in order to schedule next transfer
 void tud_cdc_n_rx_ff_read_done (uint8_t itf);
 //--------------------------------------------------------------------+
 // Application API (Single Port)
@@ -248,14 +249,12 @@ static inline bool tud_cdc_write_clear(void)
   return tud_cdc_n_write_clear(0);
 }
 
-// Get the Receive FIFO
-static inline tu_fifo_t* tud_cdc_get_rx_ff (uint8_t itf)
+static inline tu_fifo_t* tud_cdc_get_rx_ff (void)
 {
   return tud_cdc_n_get_rx_ff(0);
 }
 
-// Get the transmit FIFO
-static inline tu_fifo_t* tud_cdc_get_tx_ff (uint8_t itf)
+static inline tu_fifo_t* tud_cdc_get_tx_ff (void)
 {
   return tud_cdc_n_get_tx_ff(0);
 }

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -104,6 +104,12 @@ uint32_t tud_cdc_n_write_available (uint8_t itf);
 // Clear the transmit FIFO
 bool tud_cdc_n_write_clear (uint8_t itf);
 
+// Get the Receive FIFO (for DMA transfer)
+tu_fifo_t* tud_cdc_n_get_rx_ff (uint8_t itf);
+
+// Get the transmit FIFO (for DMA transfer)
+tu_fifo_t* tud_cdc_n_get_tx_ff (uint8_t itf);
+
 //--------------------------------------------------------------------+
 // Application API (Single Port)
 //--------------------------------------------------------------------+
@@ -239,6 +245,18 @@ static inline uint32_t tud_cdc_write_available(void)
 static inline bool tud_cdc_write_clear(void)
 {
   return tud_cdc_n_write_clear(0);
+}
+
+// Get the Receive FIFO
+static inline tu_fifo_t* tud_cdc_get_rx_ff (uint8_t itf)
+{
+  return tud_cdc_n_get_rx_ff(0);
+}
+
+// Get the transmit FIFO
+static inline tu_fifo_t* tud_cdc_get_tx_ff (uint8_t itf)
+{
+  return tud_cdc_n_get_tx_ff(0);
 }
 
 /** @} */

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -114,7 +114,7 @@ void tud_cdc_n_get_write_buffer (uint8_t itf, tu_fifo_buffer_info_t * info);
 void tud_cdc_n_read_buffer_done (uint8_t itf, uint32_t readsize);
 
 // Need to be called when buffer write is finished
-void tud_cdc_n_write_buffer_done (uint8_t itf, uint32_t readsize);
+void tud_cdc_n_write_buffer_done (uint8_t itf, uint32_t writesize);
 
 //--------------------------------------------------------------------+
 // Application API (Single Port)
@@ -268,9 +268,9 @@ static inline void tud_cdc_read_buffer_done (uint32_t readsize)
   tud_cdc_n_read_buffer_done(0, readsize);
 }
 
-static inline void tud_cdc_write_buffer_done (uint32_t readsize)
+static inline void tud_cdc_write_buffer_done (uint32_t writesize)
 {
-  tud_cdc_n_write_buffer_done(0, readsize);
+  tud_cdc_n_write_buffer_done(0, writesize);
 }
 
 /** @} */

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -104,14 +104,18 @@ uint32_t tud_cdc_n_write_available (uint8_t itf);
 // Clear the transmit FIFO
 bool tud_cdc_n_write_clear (uint8_t itf);
 
-// Get the Receive FIFO (for DMA transfer)
-tu_fifo_t* tud_cdc_n_get_rx_ff (uint8_t itf);
+// Get the Receive buffer infomation (for DMA transfer)
+void tud_cdc_n_get_read_buffer (uint8_t itf, tu_fifo_buffer_info_t * info);
 
-// Get the transmit FIFO (for DMA transfer)
-tu_fifo_t* tud_cdc_n_get_tx_ff (uint8_t itf);
+// Get the transmit buffer infomation (for DMA transfer)
+void tud_cdc_n_get_write_buffer (uint8_t itf, tu_fifo_buffer_info_t * info);
 
-// Need to be called when fifo read is finished, in order to schedule next transfer
-void tud_cdc_n_rx_ff_read_done (uint8_t itf);
+// Need to be called when buffer read is finished, in order to schedule next transfer
+void tud_cdc_n_read_buffer_done (uint8_t itf, uint32_t readsize);
+
+// Need to be called when buffer write is finished
+void tud_cdc_n_write_buffer_done (uint8_t itf, uint32_t readsize);
+
 //--------------------------------------------------------------------+
 // Application API (Single Port)
 //--------------------------------------------------------------------+
@@ -249,19 +253,24 @@ static inline bool tud_cdc_write_clear(void)
   return tud_cdc_n_write_clear(0);
 }
 
-static inline tu_fifo_t* tud_cdc_get_rx_ff (void)
+static inline void tud_cdc_get_read_buffer (tu_fifo_buffer_info_t * info)
 {
-  return tud_cdc_n_get_rx_ff(0);
+  tud_cdc_n_get_read_buffer(0, info);
 }
 
-static inline tu_fifo_t* tud_cdc_get_tx_ff (void)
+static inline void tud_cdc_get_write_buffer (tu_fifo_buffer_info_t * info)
 {
-  return tud_cdc_n_get_tx_ff(0);
+  tud_cdc_n_get_write_buffer(0, info);
 }
 
-static inline void tud_cdc_rx_ff_read_done (void)
+static inline void tud_cdc_read_buffer_done (uint32_t readsize)
 {
-  tud_cdc_n_rx_ff_read_done(0);
+  tud_cdc_n_read_buffer_done(0, readsize);
+}
+
+static inline void tud_cdc_write_buffer_done (uint32_t readsize)
+{
+  tud_cdc_n_write_buffer_done(0, readsize);
 }
 
 /** @} */

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -110,6 +110,7 @@ tu_fifo_t* tud_cdc_n_get_rx_ff (uint8_t itf);
 // Get the transmit FIFO (for DMA transfer)
 tu_fifo_t* tud_cdc_n_get_tx_ff (uint8_t itf);
 
+void tud_cdc_n_rx_ff_read_done (uint8_t itf);
 //--------------------------------------------------------------------+
 // Application API (Single Port)
 //--------------------------------------------------------------------+
@@ -257,6 +258,11 @@ static inline tu_fifo_t* tud_cdc_get_rx_ff (uint8_t itf)
 static inline tu_fifo_t* tud_cdc_get_tx_ff (uint8_t itf)
 {
   return tud_cdc_n_get_tx_ff(0);
+}
+
+static inline void tud_cdc_rx_ff_read_done (void)
+{
+  tud_cdc_n_rx_ff_read_done(0);
 }
 
 /** @} */


### PR DESCRIPTION
**Describe the PR**
3rd part of #926

- Add xfer_fifo to CDC class like UAC2.
- Export tu_fifo_buffer_info_t for DMA support.


tud_cdc_rx_wanted_cb is WIP, it needs backward write pointer.