### PR TITLE
Tusb host gamepad add additional ps4 compatible vid pid combos

### DIFF
--- a/examples/host/hid_controller/src/hid_app.c
+++ b/examples/host/hid_controller/src/hid_app.c
@@ -111,7 +111,7 @@ static inline bool is_sony_ds4(uint8_t dev_addr)
   uint16_t vid, pid;
   tuh_vid_pid_get(dev_addr, &vid, &pid);
 
-  return (vid == 0x054c && pid == 0x09cc);
+  return ( (vid == 0x054c && (pid == 0x09cc || pid == 0x05c4)) ); // Sony DualShock4 
 }
 
 //--------------------------------------------------------------------+

--- a/examples/host/hid_controller/src/hid_app.c
+++ b/examples/host/hid_controller/src/hid_app.c
@@ -111,7 +111,9 @@ static inline bool is_sony_ds4(uint8_t dev_addr)
   uint16_t vid, pid;
   tuh_vid_pid_get(dev_addr, &vid, &pid);
 
-  return ( (vid == 0x054c && (pid == 0x09cc || pid == 0x05c4)) ); // Sony DualShock4 
+  return ( (vid == 0x054c && (pid == 0x09cc || pid == 0x05c4)) // Sony DualShock4 
+           || (vid == 0x0f0d && pid == 0x005e)                 // Hori FC4 
+         );
 }
 
 //--------------------------------------------------------------------+

--- a/examples/host/hid_controller/src/hid_app.c
+++ b/examples/host/hid_controller/src/hid_app.c
@@ -113,6 +113,7 @@ static inline bool is_sony_ds4(uint8_t dev_addr)
 
   return ( (vid == 0x054c && (pid == 0x09cc || pid == 0x05c4)) // Sony DualShock4 
            || (vid == 0x0f0d && pid == 0x005e)                 // Hori FC4 
+           || (vid == 0x1f4f && pid == 0x1002)                 // ASW GG xrd controller
          );
 }
 


### PR DESCRIPTION
**Describe the PR**
It adds the first DualShock4 revision, Hori FC4 and ASW Xrd limited edition controller vid/pid combinations to `is_sony_ds4` after having confirmed them working with the current example code (when in ps4 mode).

This may help others to see that at least adding different ps4 compatible devices is rather trivial.
