### PR TITLE
Fix cxd56 msc

### DIFF
--- a/examples/make.mk
+++ b/examples/make.mk
@@ -61,15 +61,16 @@ GDB = $(CROSS_COMPILE)gdb
 OBJCOPY = $(CROSS_COMPILE)objcopy
 SIZE = $(CROSS_COMPILE)size
 MKDIR = mkdir
-PYTHON = python
 
 ifeq ($(CMDEXE),1)
   CP = copy
   RM = del
+  PYTHON = python
 else
   SED = sed
   CP = cp
   RM = rm
+  PYTHON = python3
 endif
 
 #-------------- Source files and compiler flags --------------

--- a/examples/make.mk
+++ b/examples/make.mk
@@ -61,6 +61,7 @@ GDB = $(CROSS_COMPILE)gdb
 OBJCOPY = $(CROSS_COMPILE)objcopy
 SIZE = $(CROSS_COMPILE)size
 MKDIR = mkdir
+PYTHON = python
 
 ifeq ($(CMDEXE),1)
   CP = copy

--- a/hw/bsp/spresense/board.mk
+++ b/hw/bsp/spresense/board.mk
@@ -70,4 +70,5 @@ $(BUILD)/$(PROJECT).spk: $(MKSPK)
 
 # flash
 flash: $(BUILD)/$(PROJECT).spk
-	@$(TOP)/hw/mcu/sony/cxd56/tools/flash_writer.py -s -c $(SERIAL) -d -b 115200 -n $<
+	@echo FLASH $<
+	@$(PYTHON) $(TOP)/hw/mcu/sony/cxd56/tools/flash_writer.py -s -c $(SERIAL) -d -b 115200 -n $<

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -601,10 +601,10 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
     // skip status if epin is currently stalled, will do it when received Clear Stall request
     if ( !usbd_edpt_stalled(rhport,  p_msc->ep_in) )
     {
-      if ( (p_msc->total_len > p_msc->xferred_len) && is_data_in(p_cbw->dir) )
+      if ( (p_cbw->total_bytes > p_msc->xferred_len) && is_data_in(p_cbw->dir) )
       {
         // 6.7 The 13 Cases: case 5 (Hi > Di): STALL before status
-        TU_LOG(MSC_DEBUG, "  SCSI case 5 (Hi > Di): %lu > %lu\r\n", p_msc->total_len, p_msc->xferred_len);
+        TU_LOG(MSC_DEBUG, "  SCSI case 5 (Hi > Di): %lu > %lu\r\n", p_cbw->total_bytes, p_msc->xferred_len);
         usbd_edpt_stall(rhport, p_msc->ep_in);
       }else
       {

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -611,6 +611,17 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
         TU_ASSERT( send_csw(rhport, p_msc) );
       }
     }
+
+    #if TU_CHECK_MCU(CXD56)
+    // WORKAROUND: cxd56 has its own nuttx usb stack which does not forward Set/ClearFeature(Endpoint) to DCD.
+    // There is no way for us to know when EP is un-stall, therefore we will unconditionally un-stall here and
+    // hope everything will work
+    if ( usbd_edpt_stalled(rhport, p_msc->ep_in) )
+    {
+      usbd_edpt_clear_stall(rhport, p_msc->ep_in);
+      send_csw(rhport, p_msc);
+    }
+    #endif
   }
 
   return true;


### PR DESCRIPTION
**Describe the PR**

Revert changes in #1070 , fix the root cause of the issue with cxd56. Following is the explanation (copied from other pr)

@kamtom480 the stall condition (before PR logic) is indeed correct here, according to the MSC BOT 13 cases. this particular if is for case 5 when Host expect more data than Device could send. In this particular case is Read Format Capacity command, where host expect 252 bytes, and we only send 12 bytes in response. Device really need to send an STALL first, then resume to send SCSI status afterwards when received clearing stall request https://github.com/hathach/tinyusb/blob/master/src/class/msc/msc_device.c#L318.  Doing differently by this PR will cause MSC compliance test suite to fail.

![image](https://user-images.githubusercontent.com/249515/132203178-9bf9e2db-ffdf-4d0c-950a-9ac77e22c4c8.png)

![image](https://user-images.githubusercontent.com/249515/132202611-a73db369-f9a7-4d44-883b-06cd82312969.png)

The issue is spresense has its own usb stack under nuttx system, and it **Doesn't** forward the Clear Feature (Endpoint) request toward tinyusb. https://github.com/sonydevworld/spresense-nuttx/blob/2ffe58b6dcb8ca7e83a4d2acec5622276f7c6f5d/arch/arm/src/cxd56xx/cxd56_usbdev.c#L1367

It is quite troublesome, since most of the msc recover is based on the Clear Stall request. I will try to figure an way. In general the setup seem to be conditionally forwards (most but not all), and Status stage can also be auto ACKed. Which could cause race condition where next setup arrive while tinyusb task doesn't fully process previous packet hence the setup queue.

**WALKAROUND**

The workaround is unconditionally unstall the status endpoints for cxd56 and hope for the best, which won't pass compliance test suite, but will work for most of the case with sensible host driver.