### PR TITLE
Renesas RX reset PID to DATA0 when open endpoint

### DIFF
--- a/src/portable/renesas/usba/dcd_usba.c
+++ b/src/portable/renesas/usba/dcd_usba.c
@@ -711,7 +711,7 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * ep_desc)
   USB0.PIPESEL.WORD  = num;
   USB0.PIPEMAXP.WORD = mps;
   volatile uint16_t *ctr = get_pipectr(num);
-  *ctr = USB_PIPECTR_ACLRM;
+  *ctr = USB_PIPECTR_ACLRM | USB_PIPECTR_SQCLR;
   *ctr = 0;
   unsigned cfg = (dir << 4) | epn;
   if (xfer == TUSB_XFER_BULK) {


### PR DESCRIPTION
**Describe the PR**
This changes allow rx6Xn to pass MSC compliance test suite. The test sequence from "Error REcovery Test" --> "Case 1 Test" relies on SET_CONFIGURATION() request to reset all endpoints including data toggle to DATA0. With the changes cdc_msc can pass the test suite easily.