### PR TITLE
Implement dcd_edpt_close_all() and fix dcd_edpt_clear_stall() for frdm_kl25z

### DIFF
--- a/hw/bsp/frdm_kl25z/board.mk
+++ b/hw/bsp/frdm_kl25z/board.mk
@@ -8,8 +8,12 @@ CFLAGS += \
   -DCPU_MKL25Z128VLK4 \
   -DCFG_TUSB_MCU=OPT_MCU_MKL25ZXX
 
+LDFLAGS += \
+  -Wl,--defsym,__stack_size__=0x400 \
+  -Wl,--defsym,__heap_size__=0
+
 # mcu driver cause following warnings
-CFLAGS += -Wno-error=unused-parameter
+CFLAGS += -Wno-error=unused-parameter -Wno-error=format
 
 MCU_DIR = $(SDK_DIR)/devices/MKL25Z4
 

--- a/hw/bsp/frdm_kl25z/frdm_kl25z.c
+++ b/hw/bsp/frdm_kl25z/frdm_kl25z.c
@@ -84,7 +84,7 @@ void board_init(void)
   PORT_SetPinMux(LED_PIN_PORT, LED_PIN, LED_PIN_FUNCTION);
   gpio_pin_config_t led_config = { kGPIO_DigitalOutput, 0 };
   GPIO_PinInit(LED_PORT, LED_PIN, &led_config);
-  board_led_write(true);
+  board_led_write(false);
 
   // UART
   CLOCK_EnableClock(UART_PIN_CLOCK);

--- a/hw/bsp/frdm_kl25z/frdm_kl25z.c
+++ b/hw/bsp/frdm_kl25z/frdm_kl25z.c
@@ -54,6 +54,14 @@ void USB0_IRQHandler(void)
 #define LED_PIN_FUNCTION      kPORT_MuxAsGpio
 #define LED_STATE_ON          0
 
+// Button
+#define BUTTON_PORT           GPIOC
+#define BUTTON_PIN_CLOCK      kCLOCK_PortC
+#define BUTTON_PIN_PORT       PORTC
+#define BUTTON_PIN            9U
+#define BUTTON_PIN_FUNCTION   kPORT_MuxAsGpio
+#define BUTTON_STATE_ACTIVE   0
+
 // UART
 #define UART_PORT             UART0
 #define UART_PIN_CLOCK        kCLOCK_PortA
@@ -85,6 +93,18 @@ void board_init(void)
   gpio_pin_config_t led_config = { kGPIO_DigitalOutput, 0 };
   GPIO_PinInit(LED_PORT, LED_PIN, &led_config);
   board_led_write(false);
+
+#if defined(BUTTON_PORT) && defined(BUTTON_PIN)
+  // Button
+  CLOCK_EnableClock(BUTTON_PIN_CLOCK);
+  port_pin_config_t button_port = {
+    .pullSelect = kPORT_PullUp, 
+    .mux = BUTTON_PIN_FUNCTION,
+  };
+  PORT_SetPinConfig(BUTTON_PIN_PORT, BUTTON_PIN, &button_port);
+  gpio_pin_config_t button_config = { kGPIO_DigitalInput, 0 };
+  GPIO_PinInit(BUTTON_PORT, BUTTON_PIN, &button_config);
+#endif
 
   // UART
   CLOCK_EnableClock(UART_PIN_CLOCK);
@@ -119,6 +139,9 @@ void board_led_write(bool state)
 
 uint32_t board_button_read(void)
 {
+#if defined(BUTTON_PORT) && defined(BUTTON_PIN)
+  return BUTTON_STATE_ACTIVE == GPIO_ReadPinInput(BUTTON_PORT, BUTTON_PIN);
+#endif
   return 0;
 }
 

--- a/src/portable/nxp/khci/dcd_khci.c
+++ b/src/portable/nxp/khci/dcd_khci.c
@@ -192,7 +192,7 @@ static void process_tokdne(uint8_t rhport)
   dcd_event_xfer_complete(rhport,
                           tu_edpt_addr(epnum, dir),
                           length - remaining, XFER_RESULT_SUCCESS, true);
-  if (0 == (s & USB_STAT_ENDP_MASK) && 0 == length) {
+  if (0 == epnum && 0 == length) {
     /* After completion a ZLP of control transfer,
      * it prepares for the next steup transfer. */
     if (_dcd.addr) {


### PR DESCRIPTION
**Describe the PR**
- Implement `dcd_edpt_close_all()` function.
- Fix `dcd_edpt_close_all()` function. This function worked for endpoint 0 but others.

**Additional context**
- Chapter 9 tests pass with the exception of four tests regarding suspend/resume/remote-wakeup. frdm_kl25z does not have any switches, so these tests cannot be tried.
- All HID tests pass.
- The MSC tests pass ~~with the exception of five tests: error-recovery/case 4,8,10/required-command. Not investigated yet~~.