### PR TITLE
Prevent buffer overflow in bth_device.c

### DIFF
--- a/src/class/bth/bth_device.c
+++ b/src/class/bth/bth_device.c
@@ -214,7 +214,7 @@ bool btd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t c
     }
     else return false;
 
-    return tud_control_xfer(rhport, request, &_btd_itf.hci_cmd, request->wLength);
+    return tud_control_xfer(rhport, request, &_btd_itf.hci_cmd, sizeof(_btd_itf.hci_cmd));
   }
   else if ( stage == CONTROL_STAGE_DATA )
   {

--- a/src/class/bth/bth_device.c
+++ b/src/class/bth/bth_device.c
@@ -221,7 +221,7 @@ bool btd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t c
     // Handle class request only
     TU_VERIFY(request->bmRequestType_bit.type == TUSB_REQ_TYPE_CLASS);
 
-    if (tud_bt_hci_cmd_cb) tud_bt_hci_cmd_cb(&_btd_itf.hci_cmd, request->wLength);
+    if (tud_bt_hci_cmd_cb) tud_bt_hci_cmd_cb(&_btd_itf.hci_cmd, tu_min16(request->wLength, sizeof(_btd_itf.hci_cmd)));
   }
 
   return true;


### PR DESCRIPTION
Address possible buffer overflow in bth_device.c as described in issue #880 (btd_control_xfer_cb).

Passing size of _btd_itf.hci_cmd as len parameter to tud_control_xfer so that actual _ctrl_xfer.data_len will be set to minimum of buffer size and request wLength.