### PR TITLE
Esp32sx compliance

### DIFF
--- a/examples/device/hid_composite_freertos/src/tusb_config.h
+++ b/examples/device/hid_composite_freertos/src/tusb_config.h
@@ -67,8 +67,9 @@
 // This examples use FreeRTOS
 #define CFG_TUSB_OS               OPT_OS_FREERTOS
 
-// CFG_TUSB_DEBUG is defined by compiler in DEBUG build
-// #define CFG_TUSB_DEBUG           0
+#ifndef CFG_TUSB_DEBUG
+#define CFG_TUSB_DEBUG           0
+#endif
 
 /* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
  * Tinyusb use follows macros to declare transferring memory so that they can be put

--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -380,7 +380,7 @@ static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint3
   }
 
   // not found return the key value in hex
-  sprintf(not_found, "0x%08lX", key);
+  sprintf(not_found, "0x%08lX", (unsigned long) key);
 
   return not_found;
 }

--- a/src/portable/espressif/esp32sx/dcd_esp32sx.c
+++ b/src/portable/espressif/esp32sx/dcd_esp32sx.c
@@ -92,11 +92,12 @@ static void bus_reset(void)
     USB0.out_ep_reg[ep_num].doepctl |= USB_DO_SNAK0_M; // DOEPCTL0_SNAK
   }
 
-  USB0.dcfg &= ~USB_DEVADDR_M; // reset address
+  // clear device address
+  USB0.dcfg &= ~USB_DEVADDR_M;
 
-  USB0.daintmsk |= USB_OUTEPMSK0_M | USB_INEPMSK0_M;
-  USB0.doepmsk |= USB_SETUPMSK_M | USB_XFERCOMPLMSK;
-  USB0.diepmsk |= USB_TIMEOUTMSK_M | USB_DI_XFERCOMPLMSK_M /*| USB_INTKNTXFEMPMSK_M*/;
+  USB0.daintmsk = USB_OUTEPMSK0_M | USB_INEPMSK0_M;
+  USB0.doepmsk  = USB_SETUPMSK_M | USB_XFERCOMPLMSK;
+  USB0.diepmsk  = USB_TIMEOUTMSK_M | USB_DI_XFERCOMPLMSK_M /*| USB_INTKNTXFEMPMSK_M*/;
 
   // "USB Data FIFOs" section in reference manual
   // Peripheral FIFO architecture
@@ -260,9 +261,10 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const *desc_edpt)
   xfer->max_size = desc_edpt->wMaxPacketSize.size;
 
   if (dir == TUSB_DIR_OUT) {
-    out_ep[epnum].doepctl |= USB_USBACTEP0_M |
-                             desc_edpt->bmAttributes.xfer << USB_EPTYPE0_S |
-                             desc_edpt->wMaxPacketSize.size << USB_MPS0_S;
+    out_ep[epnum].doepctl |= USB_USBACTEP1_M |
+                             desc_edpt->bmAttributes.xfer << USB_EPTYPE1_S |
+                             (desc_edpt->bmAttributes.xfer != TUSB_XFER_ISOCHRONOUS ? USB_DO_SETD0PID1_M : 0) |
+                             desc_edpt->wMaxPacketSize.size << USB_MPS1_S;
     USB0.daintmsk |= (1 << (16 + epnum));
   } else {
     // "USB Data FIFOs" section in reference manual
@@ -315,7 +317,25 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const *desc_edpt)
 void dcd_edpt_close_all(uint8_t rhport)
 {
   (void) rhport;
-  // TODO implement dcd_edpt_close_all()
+
+  usb_out_endpoint_t *out_ep = &(USB0.out_ep_reg[0]);
+  usb_in_endpoint_t *in_ep = &(USB0.in_ep_reg[0]);
+
+  // Disable non-control interrupt
+  USB0.daintmsk = USB_OUTEPMSK0_M | USB_INEPMSK0_M;
+
+  for(uint8_t n = 1; n < EP_MAX; n++)
+  {
+    // disable OUT endpoint
+    out_ep[n].doepctl = 0;
+    xfer_status[n][TUSB_DIR_OUT].max_size = 0;
+
+    // disable IN endpoint
+    in_ep[n].diepctl = 0;
+    xfer_status[n][TUSB_DIR_IN].max_size = 0;
+  }
+
+  _allocated_fifos = 1;
 }
 
 bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t total_bytes)
@@ -367,49 +387,6 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t to
 bool dcd_edpt_xfer_fifo (uint8_t rhport, uint8_t ep_addr, tu_fifo_t * ff, uint16_t total_bytes)
 {
   (void)rhport;
-
-  // USB buffers always work in bytes so to avoid unnecessary divisions we demand item_size = 1
-  TU_ASSERT(ff->item_size == 1);
-
-  uint8_t const epnum = tu_edpt_number(ep_addr);
-  uint8_t const dir   = tu_edpt_dir(ep_addr);
-
-  xfer_ctl_t * xfer = XFER_CTL_BASE(epnum, dir);
-  xfer->buffer       = NULL;
-  xfer->ff           = ff;
-  xfer->total_len    = total_bytes;
-  xfer->queued_len   = 0;
-  xfer->short_packet = false;
-
-  uint16_t num_packets = (total_bytes / xfer->max_size);
-  uint8_t short_packet_size = total_bytes % xfer->max_size;
-
-  // Zero-size packet is special case.
-  if (short_packet_size > 0 || (total_bytes == 0)) {
-    num_packets++;
-  }
-
-  ESP_LOGV(TAG, "Transfer <-> EP%i, %s, pkgs: %i, bytes: %i",
-           epnum, ((dir == TUSB_DIR_IN) ? "USB0.HOST (in)" : "HOST->DEV (out)"),
-           num_packets, total_bytes);
-
-  // IN and OUT endpoint xfers are interrupt-driven, we just schedule them
-  // here.
-  if (dir == TUSB_DIR_IN) {
-    // A full IN transfer (multiple packets, possibly) triggers XFRC.
-    USB0.in_ep_reg[epnum].dieptsiz = (num_packets << USB_D_PKTCNT0_S) | total_bytes;
-    USB0.in_ep_reg[epnum].diepctl |= USB_D_EPENA1_M | USB_D_CNAK1_M; // Enable | CNAK
-
-    // Enable fifo empty interrupt only if there are something to put in the fifo.
-    if(total_bytes != 0) {
-      USB0.dtknqr4_fifoemptymsk |= (1 << epnum);
-    }
-  } else {
-    // Each complete packet for OUT xfers triggers XFRC.
-    USB0.out_ep_reg[epnum].doeptsiz |= USB_PKTCNT0_M | ((xfer->max_size & USB_XFERSIZE0_V) << USB_XFERSIZE0_S);
-    USB0.out_ep_reg[epnum].doepctl  |= USB_EPENA0_M | USB_CNAK0_M;
-  }
-  return true;
 }
 #endif
 


### PR DESCRIPTION
**Describe the PR**
Get esp32sx to fully compliant to USBCV #1059, changes mostly follow #1077 since esp32sx also use synopsys controller.
- implement dcd_edpt_close_all()
- reset PID to DATA0 when open endpoint
- implement dcd_remote_wakeup() and temporarily enable SOF for bus resume detection.


