### PR TITLE
dcd_da146xx: Add VBUS handling

### DIFF
--- a/hw/bsp/da14695_dk_usb/da14695_dk_usb.c
+++ b/hw/bsp/da14695_dk_usb/da14695_dk_usb.c
@@ -53,6 +53,9 @@ void UnhandledIRQ(void)
   while(1);
 }
 
+// DA146xx driver function that must be called whenever VBUS changes.
+extern void tusb_vbus_changed(bool present);
+
 void board_init(void)
 {
   // LED
@@ -70,7 +73,10 @@ void board_init(void)
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
 
-  NVIC_SetPriority(USB_IRQn, 2);
+#if TUSB_OPT_DEVICE_ENABLED
+  // This board is USB powered there is no need to monitor
+  // VBUS line.  Notify driver that VBUS is present.
+  tusb_vbus_changed(true);
 
   /* Setup USB IRQ */
   NVIC_SetPriority(USB_IRQn, 2);
@@ -81,6 +87,7 @@ void board_init(void)
 
   mcu_gpio_set_pin_function(14, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
   mcu_gpio_set_pin_function(15, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
+#endif
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/da1469x_dk_pro/da1469x-dk-pro.c
+++ b/hw/bsp/da1469x_dk_pro/da1469x-dk-pro.c
@@ -36,6 +36,21 @@ void USB_IRQHandler(void)
   tud_int_handler(0);
 }
 
+#if TUSB_OPT_DEVICE_ENABLED
+// DA146xx driver function that must be called whenever VBUS changes
+extern void tusb_vbus_changed(bool present);
+
+// VBUS change interrupt handler
+void VBUS_IRQHandler(void)
+{
+  bool present = (CRG_TOP->ANA_STATUS_REG & CRG_TOP_ANA_STATUS_REG_VBUS_AVAILABLE_Msk) != 0;
+  // Clear VBUS interrupt
+  CRG_TOP->VBUS_IRQ_CLEAR_REG = 1;
+
+  tusb_vbus_changed(present);
+}
+#endif
+
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM
 //--------------------------------------------------------------------+
@@ -70,7 +85,15 @@ void board_init(void)
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
 
-  NVIC_SetPriority(USB_IRQn, 2);
+#if TUSB_OPT_DEVICE_ENABLED
+  // Setup interrupt for both connect and disconnect
+  CRG_TOP->VBUS_IRQ_MASK_REG = CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_FALL_Msk |
+                               CRG_TOP_VBUS_IRQ_MASK_REG_VBUS_IRQ_EN_RISE_Msk;
+  NVIC_SetPriority(VBUS_IRQn, 2);
+  // Trigger interrupt at the start to inform driver about VBUS state at start
+  // otherwise it could go unnoticed.
+  NVIC_SetPendingIRQ(VBUS_IRQn);
+  NVIC_EnableIRQ(VBUS_IRQn);
 
   /* Setup USB IRQ */
   NVIC_SetPriority(USB_IRQn, 2);
@@ -81,6 +104,7 @@ void board_init(void)
 
   mcu_gpio_set_pin_function(14, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
   mcu_gpio_set_pin_function(15, MCU_GPIO_MODE_INPUT, MCU_GPIO_FUNC_USB);
+#endif
 }
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
DA146xx are Bluetooth devices that may be battery
powered and when not connected to USB host there
is no need for USB peripheral to be running.

This change allows to enable USB peripheral when
VBUS is present otherwise USB is down reducing
power consumption.

`tud_vsub_changed()` function must be called
whenever VBUS change was detected.
For bus-powered devices this function should be called
at startup since VBUS must be present while device
is working.

Two BSP were updated to reflect driver change.

Most of the driver code that touches registers is unchanged just
moved from `dcd_init()` to `dcd_connect()`

**Additional context**
This is fallow up of #1019
Now that NRF and DA146xx have VBUS/power handling it could
be considered to make some sort of API for this.
Both NRF and DA146xx notification functions are not even
present in header files which makes usage awkward.
