### PR TITLE
da1469x_dk_pro: Fix button setup

### DIFF
--- a/hw/bsp/da1469x_dk_pro/da1469x-dk-pro.c
+++ b/hw/bsp/da1469x_dk_pro/da1469x-dk-pro.c
@@ -80,7 +80,7 @@ void board_init(void)
   hal_gpio_init_out(5, 0);
 
   // Button
-  hal_gpio_init_in(BUTTON_PIN, HAL_GPIO_PULL_NONE);
+  hal_gpio_init_in(BUTTON_PIN, HAL_GPIO_PULL_UP);
 
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);


### PR DESCRIPTION
**Describe the PR**
Button on board has 1k resistor to ground when pressed.
When not pressed pin 6 is floating.

This forces MCU pull-up for this pin for correct behavior.

**Additional context**
