### PR TITLE
usbd: Workaround for non standard device descriptor request

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -971,9 +971,11 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
 
       uint16_t len = sizeof(tusb_desc_device_t);
 
-      // Only send up to EP0 Packet Size if not addressed
+      // Only send up to EP0 Packet Size if not addressed and host requested more data
+      // that device descriptor has.
       // This only happens with the very first get device descriptor and EP0 size = 8 or 16.
-      if ((CFG_TUD_ENDPOINT0_SIZE < sizeof(tusb_desc_device_t)) && !_usbd_dev.addressed)
+      if ((CFG_TUD_ENDPOINT0_SIZE < sizeof(tusb_desc_device_t)) && !_usbd_dev.addressed &&
+          ((tusb_control_request_t*) p_request)->wLength > sizeof(tusb_desc_device_t))
       {
         len = CFG_TUD_ENDPOINT0_SIZE;
 


### PR DESCRIPTION
**Describe the PR**
Windows and Linux host during enumeration requests device
descriptor with request size set to 64 bytes when device
was in default state (no address).
Those systems do not want 64 bytes though since usb descriptors is
only 18 bytes long so they silently expect that only one packet
will be received possibly 18 bytes for EPS > 16 or 8 or 16 bytes
for smaller EP0.

For devices with CFG_TUD_ENDPOINT0_SIZE size 8 or 16 there was
workaround that reduced request size to CFG_TUD_ENDPOINT0_SIZE
and that was enough to satisfy Windows and Linux hosts.

However USBCV testing application also requests device descriptor
but with size set to 18 bytes. Workaround for Window/Linux
prevented USBVC to tests devices with 8 bytes EP0 size since it
send only 8 bytes while application did wanted 18 bytes.

Solution that satisfies both cases it to check if in default state device
descriptor request wants more bytes than descriptor size (18).
If so host is expecting to receive less bytes then requested
and workaround would be applied since Linux/Windows only try
to read one packet.
If 18 bytes was requested as is the case for USBCV, core returns
descriptor in 2 or 3 packets as application expects.

