### PR TITLE
dcd_da146xx: Remove registers pointer from xfer_ctl_t

### DIFF
--- a/src/portable/dialog/da146xx/dcd_da146xx.c
+++ b/src/portable/dialog/da146xx/dcd_da146xx.c
@@ -939,6 +939,7 @@ void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr)
       }
     }
   }
+  tu_memclr(xfer, sizeof(*xfer));
 }
 
 bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes)


### PR DESCRIPTION
**Describe the PR**

xfer_ctl_t structure keeps all dynamic data connected with transfer.
It used to have pointer to register set that was constant and was there
for convenience only.
Removing register pointer from structure makes cleanup easier as whole
structure can be erased with memset-like function.

In many cases functions were using local variable regs and xfer->regs which
were same, that could be confusing so this part is unified.

Few macros were added for easy conversion between epnum, xfer, and regs.

dcd_edpt_close() now clears xfer and can be used in dcd_edpt_close_all()
with expected behavior.

Apart from the above PR does not change any logic in driver.

**Additional context**
Endpoint close updated to much what #1096 expects.

