### PR TITLE
fix for endpoint bitfield problem in big endian mode

### DIFF
--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -334,6 +334,13 @@ typedef struct TU_ATTR_PACKED
 
 TU_VERIFY_STATIC( sizeof(tusb_desc_interface_t) == 9, "size is not correct");
 
+/// Helper definition fpr USB Endpoint Descriptor
+typedef struct TU_ATTR_PACKED {
+  uint16_t size           : 11; ///< Maximum packet size this endpoint is capable of sending or receiving when this configuration is selected. \n For isochronous endpoints, this value is used to reserve the bus time in the schedule, required for the per-(micro)frame data payloads. The pipe may, on an ongoing basis, actually use less bandwidth than that reserved. The device reports, if necessary, the actual bandwidth used via its normal, non-USB defined mechanisms. \n For all endpoints, bits 10..0 specify the maximum packet size (in bytes). \n For high-speed isochronous and interrupt endpoints: \n Bits 12..11 specify the number of additional transaction opportunities per microframe: \n- 00 = None (1 transaction per microframe) \n- 01 = 1 additional (2 per microframe) \n- 10 = 2 additional (3 per microframe) \n- 11 = Reserved \n Bits 15..13 are reserved and must be set to zero.
+  uint16_t hs_period_mult : 2;
+  uint16_t TU_RESERVED    : 3;
+} wMaxPacketSize_t;
+
 /// USB Endpoint Descriptor
 typedef struct TU_ATTR_PACKED
 {
@@ -349,16 +356,7 @@ typedef struct TU_ATTR_PACKED
     uint8_t       : 2;
   } bmAttributes     ; ///< This field describes the endpoint's attributes when it is configured using the bConfigurationValue. \n Bits 1..0: Transfer Type \n- 00 = Control \n- 01 = Isochronous \n- 10 = Bulk \n- 11 = Interrupt \n If not an isochronous endpoint, bits 5..2 are reserved and must be set to zero. If isochronous, they are defined as follows: \n Bits 3..2: Synchronization Type \n- 00 = No Synchronization \n- 01 = Asynchronous \n- 10 = Adaptive \n- 11 = Synchronous \n Bits 5..4: Usage Type \n- 00 = Data endpoint \n- 01 = Feedback endpoint \n- 10 = Implicit feedback Data endpoint \n- 11 = Reserved \n Refer to Chapter 5 of USB 2.0 specification for more information. \n All other bits are reserved and must be reset to zero. Reserved bits must be ignored by the host.
 
-  struct TU_ATTR_PACKED {
-#if defined(__CCRX__)
-    //FIXME the original defined bit field has a problem with the CCRX toolchain, so only a size field is defined
-    uint16_t size;
-#else
-    uint16_t size           : 11; ///< Maximum packet size this endpoint is capable of sending or receiving when this configuration is selected. \n For isochronous endpoints, this value is used to reserve the bus time in the schedule, required for the per-(micro)frame data payloads. The pipe may, on an ongoing basis, actually use less bandwidth than that reserved. The device reports, if necessary, the actual bandwidth used via its normal, non-USB defined mechanisms. \n For all endpoints, bits 10..0 specify the maximum packet size (in bytes). \n For high-speed isochronous and interrupt endpoints: \n Bits 12..11 specify the number of additional transaction opportunities per microframe: \n- 00 = None (1 transaction per microframe) \n- 01 = 1 additional (2 per microframe) \n- 10 = 2 additional (3 per microframe) \n- 11 = Reserved \n Bits 15..13 are reserved and must be set to zero.
-    uint16_t hs_period_mult : 2;
-    uint16_t TU_RESERVED    : 3;
-#endif
-  }wMaxPacketSize;
+  wMaxPacketSize_t wMaxPacketSize;
 
   uint8_t  bInterval        ; ///< Interval for polling endpoint for data transfers. Expressed in frames or microframes depending on the device operating speed (i.e., either 1 millisecond or 125 us units). \n- For full-/high-speed isochronous endpoints, this value must be in the range from 1 to 16. The bInterval value is used as the exponent for a \f$ 2^(bInterval-1) \f$ value; e.g., a bInterval of 4 means a period of 8 (\f$ 2^(4-1) \f$). \n- For full-/low-speed interrupt endpoints, the value of this field may be from 1 to 255. \n- For high-speed interrupt endpoints, the bInterval value is used as the exponent for a \f$ 2^(bInterval-1) \f$ value; e.g., a bInterval of 4 means a period of 8 (\f$ 2^(4-1) \f$) . This value must be from 1 to 16. \n- For high-speed bulk/control OUT endpoints, the bInterval must specify the maximum NAK rate of the endpoint. A value of 0 indicates the endpoint never NAKs. Other values indicate at most 1 NAK each bInterval number of microframes. This value must be in the range from 0 to 255. \n Refer to Chapter 5 of USB 2.0 specification for more information.
 } tusb_desc_endpoint_t;


### PR DESCRIPTION

I could track down the problem with the bitfield "wMaxPacketSize" in the file "usb_types.h"
https://github.com/hathach/tinyusb/blob/32bdf3b79d27ed9f0851440df35b6a72bcd8bff8/src/common/tusb_types.h#L352-L361
and the CCRX toolchain building in big endian mode. The problem does not occurs if the CCRX toolchain is building in little endian mode.

The bitfield "wMaxPacketSize" is a member of the "tusb_desc_endpoint_t" struct definition, which is used to make the access to the USB descriptor easier. The USB descriptor is a constant and it's descriptor fields must be always in little endian and the bitfield order must be always lower-bit (or right). An access with a controller working in big endian is possible as long as the endian change on an access to the descriptor fields is possible.

It is not possible to tell the CCRX that the constant USB descriptor (which is an array of bytes) is defined in little endian and the struct definition that is mapped over it must force the access in little endian.

Have we look at the situation how it looks in the memory (only the bitfield "wMaxPacketSize") on a little endian configuration:

Allocation of the bitfields in "right" (or lower-bit) :
 ```
Bit: 15   13 12  11 10           0
      +------+------+-------------+
      |  :3  |  :2  |     :11     |
      +------+------+-------------+
```

```
typedef struct {
  uint16_t size           : 11;  // bits 0 - 10
  uint16_t hs_period_mult : 2;   // bits 11 - 12
  uint16_t TU_RESERVED    : 3;   // bits 13 - 15
} wMaxPacketSize;
```

The U16_TO_U8S_LE macro (which is used in the TUD_CDC_DESCRIPTOR macro) creates the the following content in the memory at "Adr" if a value of 0x40 (01000000b) is used

```
     +-----+----------+----------+
     | Adr |     n    |    n+1   |
     +-----+----------+----------+ 
           |   0x40   |   0x00   |
           +----------+----------+
           | 01000000 | 00000000 |
           +----------+----------+           
```
           

Loading this content as a 16 bit word into a register of the RX controller gives the value of 0x40 (01000000b) because of the little endian configuration of the RX CPU.

Mapping the struct "wMaxPacketSize" over it looks like this

```
 Bit: 15   13 12  11 10           0
      +------+------+-------------+
      |  :3  |  :2  |     :11     |
      +------+------+-------------+
      | 000  |  00  | 00001000000 | <- value of size field 0x40 
      +------+------+-------------+
```


Doing the same in big endian configuration
Loading this content as a 16 bit word into a register of the RX controller gives the value of 0x4000 (01000000 00000000b) because of the big endian configuration of the RX CPU.

Mapping the struct "wMaxPacketSize" over it looks like this

```
 Bit: 15   13 12  11 10           0
      +------+------+-------------+
      |  :3  |  :2  |     :11     |
      +------+------+-------------+
      | 010  |  00  | 00000000000 | <- value of size field 0x0 
      +------+------+-------------+
```


Conclusion
This PR solves this issue with the use of a helper struct, which is used to change the endian if required and then access the bitfields correctly.