### PR TITLE
house keeping update

### DIFF
--- a/docs/reference/supported.rst
+++ b/docs/reference/supported.rst
@@ -175,6 +175,12 @@ SAMD51 & SAME54
 -  `D5035-01 <https://github.com/RudolphRiedel/USB_CAN-FD>`__
 -  `Microchip SAME54 Xplained Pro <https://www.microchip.com/developmenttools/productdetails/atsame54-xpro>`__
 
+SAME7x
+^^^^^^
+
+- `Microchip SAME70 Xplained <https://www.microchip.com/en-us/development-tool/ATSAME70-XPLD>`_
+- `QMTECH ATSAME70N19 <https://www.aliexpress.com/item/1005003173783268.html>`_
+
 SAMG
 ^^^^
 

--- a/examples/device/audio_4_channel_mic/src/usb_descriptors.c
+++ b/examples/device/audio_4_channel_mic/src/usb_descriptors.c
@@ -81,12 +81,15 @@ enum
 
 #define CONFIG_TOTAL_LEN    	(TUD_CONFIG_DESC_LEN + CFG_TUD_AUDIO * TUD_AUDIO_MIC_FOUR_CH_DESC_LEN)
 
-#if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
-// LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
-// 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
-#define EPNUM_AUDIO   0x03
+#if TU_CHECK_MCU(LPC175X_6X) || TU_CHECK_MCU(LPC177X_8X) || TU_CHECK_MCU(LPC40XX)
+  // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
+  // 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
+  #define EPNUM_AUDIO   0x03
+#elif TU_CHECK_MCU(NRF5X)
+  // nRF5x ISO can only be endpoint 8
+  #define EPNUM_AUDIO   0x08
 #else
-#define EPNUM_AUDIO   0x01
+  #define EPNUM_AUDIO   0x01
 #endif
 
 uint8_t const desc_configuration[] =

--- a/examples/device/audio_4_channel_mic/src/usb_descriptors.c
+++ b/examples/device/audio_4_channel_mic/src/usb_descriptors.c
@@ -85,9 +85,11 @@ enum
   // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
   // 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
   #define EPNUM_AUDIO   0x03
+
 #elif TU_CHECK_MCU(NRF5X)
   // nRF5x ISO can only be endpoint 8
   #define EPNUM_AUDIO   0x08
+
 #else
   #define EPNUM_AUDIO   0x01
 #endif

--- a/examples/device/audio_test/src/usb_descriptors.c
+++ b/examples/device/audio_test/src/usb_descriptors.c
@@ -82,11 +82,16 @@ enum
 #define CONFIG_TOTAL_LEN    	(TUD_CONFIG_DESC_LEN + CFG_TUD_AUDIO * TUD_AUDIO_MIC_ONE_CH_DESC_LEN)
 
 #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
-// LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
-// 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
-#define EPNUM_AUDIO   0x03
+  // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
+  // 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
+  #define EPNUM_AUDIO   0x03
+
+#elif TU_CHECK_MCU(NRF5X)
+  // nRF5x ISO can only be endpoint 8
+  #define EPNUM_AUDIO   0x08
+
 #else
-#define EPNUM_AUDIO   0x01
+  #define EPNUM_AUDIO   0x01
 #endif
 
 uint8_t const desc_configuration[] =

--- a/examples/device/uac2_headset/src/usb_descriptors.c
+++ b/examples/device/uac2_headset/src/usb_descriptors.c
@@ -77,22 +77,25 @@ uint8_t const * tud_descriptor_device_cb(void)
 #define CONFIG_TOTAL_LEN    	(TUD_CONFIG_DESC_LEN + CFG_TUD_AUDIO * TUD_AUDIO_HEADSET_STEREO_DESC_LEN)
 
 #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
-// LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
-// 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
-#define EPNUM_AUDIO_IN    0x03
-#define EPNUM_AUDIO_OUT   0x03
+  // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
+  // 0 control, 1 In, 2 Bulk, 3 Iso, 4 In etc ...
+  #define EPNUM_AUDIO_IN    0x03
+  #define EPNUM_AUDIO_OUT   0x03
+
 #elif CFG_TUSB_MCU == OPT_MCU_NRF5X
-// ISO endpoints for NRF5x are fixed to 0x08 (0x88)
-#define EPNUM_AUDIO_IN    0x08
-#define EPNUM_AUDIO_OUT   0x08
+  // ISO endpoints for NRF5x are fixed to 0x08 (0x88)
+  #define EPNUM_AUDIO_IN    0x08
+  #define EPNUM_AUDIO_OUT   0x08
+
 #elif CFG_TUSB_MCU == OPT_MCU_SAMG  || CFG_TUSB_MCU ==  OPT_MCU_SAMX7X
-// SAMG & SAME70 don't support a same endpoint number with different direction IN and OUT
-//    e.g EP1 OUT & EP1 IN cannot exist together
-#define EPNUM_AUDIO_IN    0x01
-#define EPNUM_AUDIO_OUT   0x02
+  // SAMG & SAME70 don't support a same endpoint number with different direction IN and OUT
+  //    e.g EP1 OUT & EP1 IN cannot exist together
+  #define EPNUM_AUDIO_IN    0x01
+  #define EPNUM_AUDIO_OUT   0x02
+
 #else
-#define EPNUM_AUDIO_IN    0x01
-#define EPNUM_AUDIO_OUT   0x01
+  #define EPNUM_AUDIO_IN    0x01
+  #define EPNUM_AUDIO_OUT   0x01
 #endif
 
 uint8_t const desc_configuration[] =

--- a/examples/host/CMakeLists.txt
+++ b/examples/host/CMakeLists.txt
@@ -7,3 +7,4 @@ family_initialize_project(tinyusb_host_examples ${CMAKE_CURRENT_LIST_DIR})
 
 # family_add_subdirectory will filter what to actually add based on selected FAMILY
 family_add_subdirectory(cdc_msc_hid)
+family_add_subdirectory(hid_controller)

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -258,7 +258,7 @@ uint16_t mscd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint1
   // msc driver length is fixed
   uint16_t const drv_len = sizeof(tusb_desc_interface_t) + 2*sizeof(tusb_desc_endpoint_t);
 
-  // Max length mus be at least 1 interface + 2 endpoints
+  // Max length must be at least 1 interface + 2 endpoints
   TU_ASSERT(max_len >= drv_len, 0);
 
   mscd_interface_t * p_msc = &_mscd_itf;

--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -175,12 +175,12 @@ void vendord_reset(uint8_t rhport)
   }
 }
 
-uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t max_len)
+uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, uint16_t max_len)
 {
-  TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == itf_desc->bInterfaceClass, 0);
+  TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == desc_itf->bInterfaceClass, 0);
 
-  uint16_t const drv_len = sizeof(tusb_desc_interface_t) + itf_desc->bNumEndpoints*sizeof(tusb_desc_endpoint_t);
-  TU_VERIFY(max_len >= drv_len, 0);
+  uint16_t drv_len = tu_desc_len(desc_itf);
+  uint8_t const * p_desc = tu_desc_next(desc_itf);
 
   // Find available interface
   vendord_interface_t* p_vendor = NULL;
@@ -194,21 +194,29 @@ uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, ui
   }
   TU_VERIFY(p_vendor, 0);
 
-  // Open endpoint pair with usbd helper
-  TU_ASSERT(usbd_open_edpt_pair(rhport, tu_desc_next(itf_desc), 2, TUSB_XFER_BULK, &p_vendor->ep_out, &p_vendor->ep_in), 0);
-
-  p_vendor->itf_num = itf_desc->bInterfaceNumber;
-
-  // Prepare for incoming data
-  if ( !usbd_edpt_xfer(rhport, p_vendor->ep_out, p_vendor->epout_buf, sizeof(p_vendor->epout_buf)) )
+  p_vendor->itf_num = desc_itf->bInterfaceNumber;
+  if (desc_itf->bNumEndpoints)
   {
-    TU_LOG_FAILED();
-    TU_BREAKPOINT();
+    // skip non-endpoint descriptors
+    while ( (TUSB_DESC_ENDPOINT != tu_desc_type(p_desc)) && (drv_len <= max_len) )
+    {
+      drv_len += tu_desc_len(p_desc);
+      p_desc   = tu_desc_next(p_desc);
+    }
+
+    // Open endpoint pair with usbd helper
+    TU_ASSERT(usbd_open_edpt_pair(rhport, p_desc, desc_itf->bNumEndpoints, TUSB_XFER_BULK, &p_vendor->ep_out, &p_vendor->ep_in), 0);
+
+    // Prepare for incoming data
+    if ( p_vendor->ep_out )
+    {
+      TU_ASSERT(usbd_edpt_xfer(rhport, p_vendor->ep_out, p_vendor->epout_buf, sizeof(p_vendor->epout_buf)), 0);
+    }
+
+    if ( p_vendor->ep_in ) maybe_transmit(p_vendor);
   }
 
-  maybe_transmit(p_vendor);
-
-  return drv_len;
+  return (uint16_t) true;
 }
 
 bool vendord_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)

--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -207,6 +207,8 @@ uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, ui
     // Open endpoint pair with usbd helper
     TU_ASSERT(usbd_open_edpt_pair(rhport, p_desc, desc_itf->bNumEndpoints, TUSB_XFER_BULK, &p_vendor->ep_out, &p_vendor->ep_in), 0);
 
+    drv_len += desc_itf->bNumEndpoints*sizeof(tusb_desc_endpoint_t);
+
     // Prepare for incoming data
     if ( p_vendor->ep_out )
     {

--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -216,7 +216,7 @@ uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, ui
     if ( p_vendor->ep_in ) maybe_transmit(p_vendor);
   }
 
-  return (uint16_t) true;
+  return drv_len;
 }
 
 bool vendord_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -921,6 +921,17 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num)
     }
 #endif
 
+#if CFG_TUD_BTH && CFG_TUD_BTH_ISO_ALT_COUNT
+    // BTH implementation currently does not use IAD. TODO should also use IAD for composite device
+    if (1                                  == assoc_itf_count              &&
+        TUD_BT_APP_CLASS                   == desc_itf->bInterfaceClass    &&
+        TUD_BT_APP_SUBCLASS                == desc_itf->bInterfaceSubClass &&
+        TUD_BT_PROTOCOL_PRIMARY_CONTROLLER == desc_itf->bInterfaceProtocol)
+    {
+      assoc_itf_count = 2;
+    }
+#endif
+
     uint16_t const drv_len = tu_desc_get_interface_total_len(desc_itf, assoc_itf_count, desc_end-p_desc);
     TU_ASSERT(drv_len >= sizeof(tusb_desc_interface_t));
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -922,7 +922,7 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num)
 #endif
 
     uint16_t const drv_len = tu_desc_get_interface_total_len(desc_itf, assoc_itf_count, desc_end-p_desc);
-    TU_ASSERT(drv_len);
+    TU_ASSERT(drv_len >= sizeof(tusb_desc_interface_t));
 
     // Find driver for this interface
     uint8_t drv_id;

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -888,23 +888,40 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num)
 
   while( p_desc < desc_end )
   {
-    tusb_desc_interface_assoc_t const * desc_iad = NULL;
+    uint8_t assoc_itf_count = 1;
 
     // Class will always starts with Interface Association (if any) and then Interface descriptor
     if ( TUSB_DESC_INTERFACE_ASSOCIATION == tu_desc_type(p_desc) )
     {
-      desc_iad = (tusb_desc_interface_assoc_t const *) p_desc;
+      tusb_desc_interface_assoc_t const * desc_iad = (tusb_desc_interface_assoc_t const *) p_desc;
+      assoc_itf_count = desc_iad->bInterfaceCount;
+
       p_desc = tu_desc_next(p_desc); // next to Interface
+
+      // IAD's first interface number and class should match with opened interface
+      //TU_ASSERT(desc_iad->bFirstInterface == desc_itf->bInterfaceNumber &&
+      //          desc_iad->bFunctionClass  == desc_itf->bInterfaceClass);
     }
 
     TU_ASSERT( TUSB_DESC_INTERFACE == tu_desc_type(p_desc) );
-
     tusb_desc_interface_t const * desc_itf = (tusb_desc_interface_t const*) p_desc;
 
     // Interface number must not be used already
     TU_ASSERT(DRVID_INVALID == _usbd_dev.itf2drv[desc_itf->bInterfaceNumber]);
 
-    uint16_t const drv_len = tu_desc_get_interface_total_len(desc_itf, desc_iad ? desc_iad->bInterfaceCount : 1, desc_end-p_desc);
+#if CFG_TUD_MIDI
+    // MIDI has 2 interfaces (Audio Control v1 + MIDIStreaming) but does not have IAD
+    // manually increase the associated count
+    if (1                              == assoc_itf_count              &&
+        TUSB_CLASS_AUDIO               == desc_itf->bInterfaceClass    &&
+        AUDIO_SUBCLASS_CONTROL         == desc_itf->bInterfaceSubClass &&
+        AUDIO_FUNC_PROTOCOL_CODE_UNDEF == desc_itf->bInterfaceProtocol)
+    {
+      assoc_itf_count = 2;
+    }
+#endif
+
+    uint16_t const drv_len = tu_desc_get_interface_total_len(desc_itf, assoc_itf_count, desc_end-p_desc);
     TU_ASSERT(drv_len);
 
     // Find driver for this interface
@@ -915,28 +932,17 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num)
 
       if ( driver->open(rhport, desc_itf, drv_len) )
       {
-        // Open successfully, check if length is correct
+        // Open successfully
         TU_LOG2("  %s opened\r\n", driver->name);
 
-        // bind interface to found driver
-        _usbd_dev.itf2drv[desc_itf->bInterfaceNumber] = drv_id;
-
-        // If using IAD, bind all interfaces to the same driver
-        if (desc_iad)
+        // bind (associated) interfaces to found driver
+        for(uint8_t i=0; i<assoc_itf_count; i++)
         {
-          // IAD's first interface number and class should match with opened interface
-          TU_ASSERT(desc_iad->bFirstInterface == desc_itf->bInterfaceNumber &&
-                    desc_iad->bFunctionClass  == desc_itf->bInterfaceClass);
-
-          for(uint8_t i=1; i<desc_iad->bInterfaceCount; i++)
-          {
-            _usbd_dev.itf2drv[desc_itf->bInterfaceNumber+i] = drv_id;
-          }
+          _usbd_dev.itf2drv[desc_itf->bInterfaceNumber+i] = drv_id;
         }
 
         // bind all endpoints to found driver
         tu_edpt_bind_driver(_usbd_dev.ep2drv, desc_itf, drv_len, drv_id);
-
 
         break; // exit driver find loop
       }

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -178,17 +178,18 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   0x9C, 0xD2, 0x65, 0x9D, 0x9E, 0x64, 0x8A, 0x9F
 
 //--------------------------------------------------------------------+
-// Configuration & Interface Descriptor Templates
+// Configuration Descriptor Templates
 //--------------------------------------------------------------------+
 
-//------------- Configuration -------------//
 #define TUD_CONFIG_DESC_LEN   (9)
 
 // Config number, interface count, string index, total length, attribute, power in mA
 #define TUD_CONFIG_DESCRIPTOR(config_num, _itfcount, _stridx, _total_len, _attribute, _power_ma) \
   9, TUSB_DESC_CONFIGURATION, U16_TO_U8S_LE(_total_len), _itfcount, config_num, _stridx, TU_BIT(7) | _attribute, (_power_ma)/2
 
-//------------- CDC -------------//
+//--------------------------------------------------------------------+
+// CDC Descriptor Templates
+//--------------------------------------------------------------------+
 
 // Length of template descriptor: 66 bytes
 #define TUD_CDC_DESC_LEN  (8+9+5+5+4+5+7+9+7+7)
@@ -217,7 +218,9 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   /* Endpoint In */\
   7, TUSB_DESC_ENDPOINT, _epin, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0
 
-//------------- MSC -------------//
+//--------------------------------------------------------------------+
+// MSC Descriptor Templates
+//--------------------------------------------------------------------+
 
 // Length of template descriptor: 23 bytes
 #define TUD_MSC_DESC_LEN    (9 + 7 + 7)
@@ -231,7 +234,10 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   /* Endpoint In */\
   7, TUSB_DESC_ENDPOINT, _epin, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0
 
-//------------- HID -------------//
+
+//--------------------------------------------------------------------+
+// HID Descriptor Templates
+//--------------------------------------------------------------------+
 
 // Length of template descriptor: 25 bytes
 #define TUD_HID_DESC_LEN    (9 + 9 + 7)
@@ -261,8 +267,10 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   /* Endpoint In */\
   7, TUSB_DESC_ENDPOINT, _epin, TUSB_XFER_INTERRUPT, U16_TO_U8S_LE(_epsize), _ep_interval
 
-//------------- MIDI -------------//
-// MIDI v1.0 is based on Audio v1.0
+//--------------------------------------------------------------------+
+// MIDI Descriptor Templates
+// Note: MIDI v1.0 is based on Audio v1.0
+//--------------------------------------------------------------------+
 
 #define TUD_MIDI_DESC_HEAD_LEN (9 + 9 + 9 + 7)
 #define TUD_MIDI_DESC_HEAD(_itfnum,  _stridx, _numcables) \
@@ -319,7 +327,9 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   TUD_MIDI_DESC_EP(_epin, _epsize, 1),\
   TUD_MIDI_JACKID_OUT_EMB(1)
 
-//------------- AUDIO -------------//
+//--------------------------------------------------------------------+
+// Audio v2.0 Descriptor Templates
+//--------------------------------------------------------------------+
 
 /* Standard Interface Association Descriptor (IAD) */
 #define TUD_AUDIO_DESC_IAD_LEN 8
@@ -551,7 +561,10 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
     ((((_maxFrequency + ((CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 7999 : 999)) / ((CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 8000 : 1000)) + 1) * _nBytesPerSample * _nChannels)
 
 
-//------------- TUD_USBTMC/USB488 -------------//
+//--------------------------------------------------------------------+
+// USBTMC/USB488 Descriptor Templates
+//--------------------------------------------------------------------+
+
 #define TUD_USBTMC_APP_CLASS    (TUSB_CLASS_APPLICATION_SPECIFIC)
 #define TUD_USBTMC_APP_SUBCLASS 0x03u
 
@@ -581,8 +594,10 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
 
 #define TUD_USBTMC_INT_DESCRIPTOR_LEN (7u)
 
+//--------------------------------------------------------------------+
+// Vendor Descriptor Templates
+//--------------------------------------------------------------------+
 
-//------------- Vendor -------------//
 #define TUD_VENDOR_DESC_LEN  (9+7+7)
 
 // Interface number, string index, EP Out & IN address, EP size
@@ -594,7 +609,10 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   /* Endpoint In */\
   7, TUSB_DESC_ENDPOINT, _epin, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0
 
-//------------- DFU Runtime -------------//
+//--------------------------------------------------------------------+
+// DFU Runtime Descriptor Templates
+//--------------------------------------------------------------------+
+
 #define TUD_DFU_APP_CLASS    (TUSB_CLASS_APPLICATION_SPECIFIC)
 #define TUD_DFU_APP_SUBCLASS (APP_SUBCLASS_DFU_RUNTIME)
 
@@ -608,6 +626,10 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   9, TUSB_DESC_INTERFACE, _itfnum, 0, 0, TUD_DFU_APP_CLASS, TUD_DFU_APP_SUBCLASS, DFU_PROTOCOL_RT, _stridx, \
   /* Function */ \
   9, DFU_DESC_FUNCTIONAL, _attr, U16_TO_U8S_LE(_timeout), U16_TO_U8S_LE(_xfer_size), U16_TO_U8S_LE(0x0101)
+
+//--------------------------------------------------------------------+
+// DFU Descriptor Templates
+//--------------------------------------------------------------------+
 
 // Length of template descriptor: 9 bytes + number of alternatives * 9
 #define TUD_DFU_DESC_LEN(_alt_count)    (9 + (_alt_count) * 9)
@@ -654,8 +676,9 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   _TUD_DFU_ALT(_itfnum, _alt_count, _stridx),      \
   _TUD_DFU_ALT_7(_itfnum, _alt_count+1, _stridx+1)
 
-
-//------------- CDC-ECM -------------//
+//--------------------------------------------------------------------+
+// CDC-ECM Descriptor Templates
+//--------------------------------------------------------------------+
 
 // Length of template descriptor: 71 bytes
 #define TUD_CDC_ECM_DESC_LEN  (8+9+5+5+13+7+9+9+7+7)
@@ -684,8 +707,9 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   /* Endpoint Out */\
   7, TUSB_DESC_ENDPOINT, _epout, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0
 
-
-//------------- RNDIS -------------//
+//--------------------------------------------------------------------+
+// RNDIS Descriptor Templates
+//--------------------------------------------------------------------+
 
 #if 0
 /* Windows XP */
@@ -726,7 +750,10 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   /* Endpoint Out */\
   7, TUSB_DESC_ENDPOINT, _epout, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0
 
-//------------- BT Radio -------------//
+//--------------------------------------------------------------------+
+// Bluetooth Radio Descriptor Templates
+//--------------------------------------------------------------------+
+
 #define TUD_BT_APP_CLASS                    (TUSB_CLASS_WIRELESS_CONTROLLER)
 #define TUD_BT_APP_SUBCLASS                 0x01
 #define TUD_BT_PROTOCOL_PRIMARY_CONTROLLER  0x01

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -777,6 +777,7 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
 
 // BT Primary controller descriptor
 // Interface number, string index, attributes, event endpoint, event endpoint size, interval, data in, data out, data endpoint size, iso endpoint sizes
+// TODO BTH should also use IAD like CDC for composite device
 #define TUD_BTH_DESCRIPTOR(_itfnum, _stridx, _ep_evt, _ep_evt_size, _ep_evt_interval, _ep_in, _ep_out, _ep_size,...) \
   TUD_BTH_PRI_ITF(_itfnum, _stridx, _ep_evt, _ep_evt_size, _ep_evt_interval, _ep_in, _ep_out, _ep_size) \
   TUD_BTH_ISO_ITFS(_itfnum + 1, _ep_in + 1, _ep_out + 1, __VA_ARGS__)

--- a/src/device/usbd_pvt.h
+++ b/src/device/usbd_pvt.h
@@ -43,6 +43,10 @@ typedef struct
   char const* name;
   #endif
 
+  // Minimum number of Interfaces for this driver to work.
+  // Only needed for driver use 2 or more interfaces without IAD
+  uint8_t itf_count_min;
+
   void     (* init             ) (void);
   void     (* reset            ) (uint8_t rhport);
   uint16_t (* open             ) (uint8_t rhport, tusb_desc_interface_t const * desc_intf, uint16_t max_len);

--- a/src/device/usbd_pvt.h
+++ b/src/device/usbd_pvt.h
@@ -43,10 +43,6 @@ typedef struct
   char const* name;
   #endif
 
-  // Minimum number of Interfaces for this driver to work.
-  // Only needed for driver use 2 or more interfaces without IAD
-  uint8_t itf_count_min;
-
   void     (* init             ) (void);
   void     (* reset            ) (uint8_t rhport);
   uint16_t (* open             ) (uint8_t rhport, tusb_desc_interface_t const * desc_intf, uint16_t max_len);

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -989,7 +989,7 @@ static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configura
     if ( TUSB_DESC_INTERFACE_ASSOCIATION == tu_desc_type(p_desc) )
     {
       desc_iad = (tusb_desc_interface_assoc_t const *) p_desc;
-      p_desc = tu_desc_next(p_desc);
+      p_desc = tu_desc_next(p_desc); // next to Interface
     }
 
     TU_ASSERT( TUSB_DESC_INTERFACE == tu_desc_type(p_desc) );

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1016,7 +1016,7 @@ static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configura
 #endif
 
     uint16_t const drv_len = tu_desc_get_interface_total_len(desc_itf, assoc_itf_count, desc_end-p_desc);
-    TU_ASSERT(drv_len);
+    TU_ASSERT(drv_len >= sizeof(tusb_desc_interface_t));
 
     if (desc_itf->bInterfaceClass == TUSB_CLASS_HUB && dev->hub_addr != 0)
     {

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1000,9 +1000,6 @@ static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configura
     TU_ASSERT( TUSB_DESC_INTERFACE == tu_desc_type(p_desc) );
     tusb_desc_interface_t const* desc_itf = (tusb_desc_interface_t const*) p_desc;
 
-    // Interface number must not be used already
-    TU_ASSERT( DRVID_INVALID == dev->itf2drv[desc_itf->bInterfaceNumber] );
-
 #if CFG_TUH_MIDI
     // MIDI has 2 interfaces (Audio Control v1 + MIDIStreaming) but does not have IAD
     // manually increase the associated count
@@ -1040,7 +1037,11 @@ static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configura
           // bind (associated) interfaces to found driver
           for(uint8_t i=0; i<assoc_itf_count; i++)
           {
-            dev->itf2drv[desc_itf->bInterfaceNumber+i] = drv_id;
+            uint8_t const itf_num = desc_itf->bInterfaceNumber+i;
+
+            // Interface number must not be used already
+            TU_ASSERT( DRVID_INVALID == dev->itf2drv[itf_num] );
+            dev->itf2drv[itf_num] = drv_id;
           }
 
           // bind all endpoints to found driver

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -982,24 +982,40 @@ static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configura
   // parse each interfaces
   while( p_desc < desc_end )
   {
-    // TODO Do we need to use IAD
-     tusb_desc_interface_assoc_t const * desc_iad = NULL;
+    uint8_t assoc_itf_count = 1;
 
     // Class will always starts with Interface Association (if any) and then Interface descriptor
     if ( TUSB_DESC_INTERFACE_ASSOCIATION == tu_desc_type(p_desc) )
     {
-      desc_iad = (tusb_desc_interface_assoc_t const *) p_desc;
+      tusb_desc_interface_assoc_t const * desc_iad = (tusb_desc_interface_assoc_t const *) p_desc;
+      assoc_itf_count = desc_iad->bInterfaceCount;
+
       p_desc = tu_desc_next(p_desc); // next to Interface
+
+      // IAD's first interface number and class should match with opened interface
+      //TU_ASSERT(desc_iad->bFirstInterface == desc_itf->bInterfaceNumber &&
+      //          desc_iad->bFunctionClass  == desc_itf->bInterfaceClass);
     }
 
     TU_ASSERT( TUSB_DESC_INTERFACE == tu_desc_type(p_desc) );
-
     tusb_desc_interface_t const* desc_itf = (tusb_desc_interface_t const*) p_desc;
 
     // Interface number must not be used already
-    TU_ASSERT( dev->itf2drv[desc_itf->bInterfaceNumber] == DRVID_INVALID );
+    TU_ASSERT( DRVID_INVALID == dev->itf2drv[desc_itf->bInterfaceNumber] );
 
-    uint16_t const drv_len = tu_desc_get_interface_total_len(desc_itf, desc_iad ? desc_iad->bInterfaceCount : 1, desc_end-p_desc);
+#if CFG_TUH_MIDI
+    // MIDI has 2 interfaces (Audio Control v1 + MIDIStreaming) but does not have IAD
+    // manually increase the associated count
+    if (1                              == assoc_itf_count              &&
+        TUSB_CLASS_AUDIO               == desc_itf->bInterfaceClass    &&
+        AUDIO_SUBCLASS_CONTROL         == desc_itf->bInterfaceSubClass &&
+        AUDIO_FUNC_PROTOCOL_CODE_UNDEF == desc_itf->bInterfaceProtocol)
+    {
+      assoc_itf_count = 2;
+    }
+#endif
+
+    uint16_t const drv_len = tu_desc_get_interface_total_len(desc_itf, assoc_itf_count, desc_end-p_desc);
     TU_ASSERT(drv_len);
 
     if (desc_itf->bInterfaceClass == TUSB_CLASS_HUB && dev->hub_addr != 0)
@@ -1019,22 +1035,12 @@ static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configura
         if ( driver->open(dev->rhport, dev_addr, desc_itf, drv_len) )
         {
           // open successfully
-          TU_LOG2("  Opened successfully\r\n");
+          TU_LOG2("  %s opened\r\n", driver->name);
 
-          // bind interface to found driver
-          dev->itf2drv[desc_itf->bInterfaceNumber] = drv_id;
-
-          // If using IAD, bind all interfaces to the same driver
-          if (desc_iad)
+          // bind (associated) interfaces to found driver
+          for(uint8_t i=0; i<assoc_itf_count; i++)
           {
-            // IAD's first interface number and class should match with opened interface
-            TU_ASSERT(desc_iad->bFirstInterface == desc_itf->bInterfaceNumber &&
-                      desc_iad->bFunctionClass  == desc_itf->bInterfaceClass);
-
-            for(uint8_t i=1; i<desc_iad->bInterfaceCount; i++)
-            {
-              dev->itf2drv[desc_itf->bInterfaceNumber+i] = drv_id;
-            }
+            dev->itf2drv[desc_itf->bInterfaceNumber+i] = drv_id;
           }
 
           // bind all endpoints to found driver

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -121,7 +121,7 @@ void tu_edpt_bind_driver(uint8_t ep2drv[][2], tusb_desc_interface_t const* desc_
       ep2drv[tu_edpt_number(ep_addr)][tu_edpt_dir(ep_addr)] = driver_id;
     }
 
-    len    = (uint16_t)(len + tu_desc_len(p_desc));
+    len   += (uint16_t) tu_desc_len(p_desc);
     p_desc = tu_desc_next(p_desc);
   }
 }

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -278,6 +278,30 @@
   //------------- CLASS -------------//
 #endif // TUSB_OPT_HOST_ENABLED
 
+#ifndef CFG_TUH_HUB
+#define CFG_TUH_HUB    0
+#endif
+
+#ifndef CFG_TUH_CDC
+#define CFG_TUH_CDC    0
+#endif
+
+#ifndef CFG_TUH_HID
+#define CFG_TUH_HID    0
+#endif
+
+#ifndef CFG_TUH_MIDI
+#define CFG_TUH_MIDI   0
+#endif
+
+#ifndef CFG_TUH_MSC
+#define CFG_TUH_MSC    0
+#endif
+
+#ifndef CFG_TUH_VENDOR
+#define CFG_TUH_VENDOR 0
+#endif
+
 //--------------------------------------------------------------------+
 // Port Specific
 // TUP stand for TinyUSB Port (can be renamed)


### PR DESCRIPTION
**Describe the PR**
Mostly house keeping work
- Update ISO endpoint for nrf5x to be 8 for audio example
- fix #1067 
- correct drivers interface binding for MIDI and BTH, where it have 2 interfaces but does not use IAD.
- clean up usbh configuration parser a bit  
- Make vendor driver more flexible with varies of custom descriptors between Interfaces and Endpoints. Also can have 0-2 endpoints (previously fixed 2 endpoints).