### PR TITLE
Address compiler warnings

### DIFF
--- a/hw/bsp/rp2040/family.cmake
+++ b/hw/bsp/rp2040/family.cmake
@@ -77,7 +77,6 @@ if (NOT TARGET _rp2040_family_inclusion_marker)
 			${TOP}/src/class/video/video_device.c
 			)
 
-
 	# Base config for host mode; wrapped by SDK's tinyusb_host
 	add_library(tinyusb_host_base INTERFACE)
 	target_sources(tinyusb_host_base INTERFACE
@@ -152,5 +151,29 @@ if (NOT TARGET _rp2040_family_inclusion_marker)
 		_family_initialize_project(${PROJECT} ${DIR})
 		enable_language(C CXX ASM)
 		pico_sdk_init()
+	endfunction()
+
+	# This method must be called from the project scope to suppress known warnings in TinyUSB source files
+	function(suppress_tinyusb_warnings)
+		set_source_files_properties(
+				${PICO_TINYUSB_PATH}/src/tusb.c
+				PROPERTIES
+				COMPILE_FLAGS "-Wno-conversion")
+		set_source_files_properties(
+				${PICO_TINYUSB_PATH}/src/common/tusb_fifo.c
+				PROPERTIES
+				COMPILE_FLAGS "-Wno-conversion -Wno-cast-qual")
+		set_source_files_properties(
+				${PICO_TINYUSB_PATH}/src/device/usbd.c
+				PROPERTIES
+				COMPILE_FLAGS "-Wno-conversion -Wno-cast-qual -Wno-null-dereference")
+		set_source_files_properties(
+				${PICO_TINYUSB_PATH}/src/device/usbd_control.c
+				PROPERTIES
+				COMPILE_FLAGS "-Wno-conversion")
+		set_source_files_properties(
+				${PICO_TINYUSB_PATH}/src/class/cdc/cdc_device.c
+				PROPERTIES
+				COMPILE_FLAGS "-Wno-conversion")
 	endfunction()
 endif()

--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -106,7 +106,14 @@ typedef struct TU_ATTR_ALIGNED(4)
 void dcd_init       (uint8_t rhport);
 
 // Interrupt Handler
+#if __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wredundant-decls"
+#endif
 void dcd_int_handler(uint8_t rhport);
+#if __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 // Enable device interrupt
 void dcd_int_enable (uint8_t rhport);

--- a/src/osal/osal.h
+++ b/src/osal/osal.h
@@ -67,6 +67,10 @@ typedef void (*osal_task_func_t)( void * );
 // OSAL Porting API
 //--------------------------------------------------------------------+
 
+#if __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wredundant-decls"
+#endif
 //------------- Semaphore -------------//
 static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef);
 static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr);
@@ -84,6 +88,9 @@ static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef);
 static inline bool osal_queue_receive(osal_queue_t qhdl, void* data);
 static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr);
 static inline bool osal_queue_empty(osal_queue_t qhdl);
+#if __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #if 0  // TODO remove subtask related macros later
 // Sub Task

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -70,7 +70,7 @@ static struct hw_endpoint *hw_endpoint_get_by_addr(uint8_t ep_addr)
 static void _hw_endpoint_alloc(struct hw_endpoint *ep, uint8_t transfer_type)
 {
   // size must be multiple of 64
-  uint16_t size = tu_div_ceil(ep->wMaxPacketSize, 64) * 64u;
+  uint size = tu_div_ceil(ep->wMaxPacketSize, 64) * 64u;
 
   // double buffered Bulk endpoint
   if ( transfer_type == TUSB_XFER_BULK )
@@ -88,7 +88,7 @@ static void _hw_endpoint_alloc(struct hw_endpoint *ep, uint8_t transfer_type)
   pico_info("  Alloced %d bytes at offset 0x%x (0x%p)\r\n", size, dpram_offset, ep->hw_data_buf);
 
   // Fill in endpoint control register with buffer offset
-  uint32_t const reg = EP_CTRL_ENABLE_BITS | (transfer_type << EP_CTRL_BUFFER_TYPE_LSB) | dpram_offset;
+  uint32_t const reg = EP_CTRL_ENABLE_BITS | ((uint)transfer_type << EP_CTRL_BUFFER_TYPE_LSB) | dpram_offset;
 
   *ep->endpoint_control = reg;
 }
@@ -177,7 +177,7 @@ static void hw_handle_buff_status(void)
     uint32_t remaining_buffers = usb_hw->buf_status;
     pico_trace("buf_status = 0x%08x\n", remaining_buffers);
     uint bit = 1u;
-    for (uint i = 0; remaining_buffers && i < USB_MAX_ENDPOINTS * 2; i++)
+    for (uint8_t i = 0; remaining_buffers && i < USB_MAX_ENDPOINTS * 2; i++)
     {
         if (remaining_buffers & bit)
         {
@@ -365,19 +365,19 @@ void dcd_init (uint8_t rhport)
   dcd_connect(rhport);
 }
 
-void dcd_int_enable(uint8_t rhport)
+void dcd_int_enable(__unused uint8_t rhport)
 {
     assert(rhport == 0);
     irq_set_enabled(USBCTRL_IRQ, true);
 }
 
-void dcd_int_disable(uint8_t rhport)
+void dcd_int_disable(__unused uint8_t rhport)
 {
     assert(rhport == 0);
     irq_set_enabled(USBCTRL_IRQ, false);
 }
 
-void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
+void dcd_set_address (__unused uint8_t rhport, __unused uint8_t dev_addr)
 {
   assert(rhport == 0);
 
@@ -386,7 +386,7 @@ void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
   hw_endpoint_xfer(0x80, NULL, 0);
 }
 
-void dcd_remote_wakeup(uint8_t rhport)
+void dcd_remote_wakeup(__unused uint8_t rhport)
 {
     pico_info("dcd_remote_wakeup %d\n", rhport);
     assert(rhport == 0);
@@ -394,14 +394,14 @@ void dcd_remote_wakeup(uint8_t rhport)
 }
 
 // disconnect by disabling internal pull-up resistor on D+/D-
-void dcd_disconnect(uint8_t rhport)
+void dcd_disconnect(__unused uint8_t rhport)
 {
   (void) rhport;
   usb_hw_clear->sie_ctrl = USB_SIE_CTRL_PULLUP_EN_BITS;
 }
 
 // connect by enabling internal pull-up resistor on D+/D-
-void dcd_connect(uint8_t rhport)
+void dcd_connect(__unused uint8_t rhport)
 {
   (void) rhport;
   usb_hw_set->sie_ctrl = USB_SIE_CTRL_PULLUP_EN_BITS;
@@ -423,7 +423,7 @@ void dcd_edpt0_status_complete(uint8_t rhport, tusb_control_request_t const * re
   }
 }
 
-bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
+bool dcd_edpt_open (__unused uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
 {
     assert(rhport == 0);
     hw_endpoint_init(desc_edpt->bEndpointAddress, desc_edpt->wMaxPacketSize.size, desc_edpt->bmAttributes.xfer);
@@ -438,7 +438,7 @@ void dcd_edpt_close_all (uint8_t rhport)
   reset_non_control_endpoints();
 }
 
-bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes)
+bool dcd_edpt_xfer(__unused uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes)
 {
     assert(rhport == 0);
     hw_endpoint_xfer(ep_addr, buffer, total_bytes);

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -38,7 +38,7 @@ const char *ep_dir_string[] = {
         "in",
 };
 
-static inline void _hw_endpoint_lock_update(struct hw_endpoint *ep, int delta) {
+static inline void _hw_endpoint_lock_update(__unused struct hw_endpoint * ep, __unused int delta) {
     // todo add critsec as necessary to prevent issues between worker and IRQ...
     //  note that this is perhaps as simple as disabling IRQs because it would make
     //  sense to have worker and IRQ on same core, however I think using critsec is about equivalent.
@@ -107,7 +107,7 @@ void _hw_endpoint_buffer_control_update32(struct hw_endpoint *ep, uint32_t and_m
 static uint32_t prepare_ep_buffer(struct hw_endpoint *ep, uint8_t buf_id)
 {
   uint16_t const buflen = tu_min16(ep->remaining_len, ep->wMaxPacketSize);
-  ep->remaining_len -= buflen;
+  ep->remaining_len = (uint16_t)(ep->remaining_len - buflen);
 
   uint32_t buf_ctrl = buflen | USB_BUF_CTRL_AVAIL;
 
@@ -214,7 +214,7 @@ static uint16_t sync_ep_buffer(struct hw_endpoint *ep, uint8_t buf_id)
     // sent some data can increase the length we have sent
     assert(!(buf_ctrl & USB_BUF_CTRL_FULL));
 
-    ep->xferred_len += xferred_bytes;
+    ep->xferred_len = (uint16_t)(ep->xferred_len + xferred_bytes);
   }else
   {
     // If we have received some data, so can increase the length
@@ -222,7 +222,7 @@ static uint16_t sync_ep_buffer(struct hw_endpoint *ep, uint8_t buf_id)
     assert(buf_ctrl & USB_BUF_CTRL_FULL);
 
     memcpy(ep->user_buf, ep->hw_data_buf + buf_id*64, xferred_bytes);
-    ep->xferred_len += xferred_bytes;
+    ep->xferred_len = (uint16_t)(ep->xferred_len + xferred_bytes);
     ep->user_buf += xferred_bytes;
   }
 


### PR DESCRIPTION
Consumers of TinyUSB in the RP2040 (either directly or via our stdio support) who wish to set higher warning levels for their project along with -Werror are forced to manually suppress warnings. This change makes life much easier for them

1) physically suppress warnings in TinyUSB headers using pragmas so they don't break -Werror compilation of external C/C++ source files that include them directly or indirectly
2) fix all compiler warnings in rp2040 port
3) add cmake method to rp2040 port to allow an external project to suppress warnings in TinyUSB itself
