### PR TITLE
add rt-thread software package support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,7 @@ TinyUSB is completely thread-safe by pushing all Interrupt Service Request (ISR)
 - **No OS**
 - **FreeRTOS**
 - **Mynewt** Due to the newt package build system, Mynewt examples are better to be on its [own repo](https://github.com/hathach/mynewt-tinyusb-example)
+- **RT-Thread**
 
 Local Docs
 ==========

--- a/SConscript
+++ b/SConscript
@@ -1,0 +1,11 @@
+# RT-Thread building script for bridge
+
+import os
+from building import *
+
+objs = []
+cwd  = GetCurrentDir()
+
+objs = objs + SConscript(cwd + '/sys/rt-thread/SConscript')
+
+Return('objs')

--- a/docs/reference/rt-thread/readme.rst
+++ b/docs/reference/rt-thread/readme.rst
@@ -1,0 +1,53 @@
+TinyUSB for RT-Thread Port
+==========================
+
+`中文 <./readme_zh.rst>`__ \| English
+
+TinyUSB is an open source cross-platform USB stack for embedded system.
+
+1、 Getting start
+-----------------
+
+The specific path in RT-Thread package manager is as follows:
+
+.. code:: text
+
+    -> RT-Thread online packages
+        -> system packages
+            --- TinyUSB (offical): an open source cross-platform USB stack for embedded system
+                (2048) TinyUSB thread stack size
+                [*]   Using USB device  ---->
+                    [*]   Using Communication Device Class (CDC)
+                    [*]   Using Mass Storage Class (MSC)
+                    ()      The name of the device used by MSC
+                      Version (latest)  --->
+
+The configuration instructions for each function are as follows:
+
+-  TinyUSB thread stack size
+-  Whether to use a USB device
+-  Using CDC
+-  Using MSC
+-  Name of the block device used for MSC read/write
+
+Then let the RT-Thread package manager automatically update, or use the
+``pkgs --update`` command to update the package to the BSP.
+
+2、Support
+----------
+
+2.1、MCU
+~~~~~~~~
+
+Currently only the STM32 family of MCUs is supported.
+
+2.2、Device class
+~~~~~~~~~~~~~~~~~
+
+-  Communication Device Class (CDC)
+-  Mass Storage Class (MSC)
+
+3、Feedback
+-----------
+
+issue: `tfx2001/tinyusb <https://github.com/tfx2001/tinyusb/issues>`__

--- a/docs/reference/rt-thread/readme_zh.rst
+++ b/docs/reference/rt-thread/readme_zh.rst
@@ -1,0 +1,54 @@
+TinyUSB for RT-Thread Port
+==========================
+
+中文 \| `English <./readme.rst>`__
+
+TinyUSB 是一个用于嵌入式设备的跨平台 USB 协议栈。
+
+1、 打开 TinyUSB
+----------------
+
+RT-Thread 包管理器中的路径如下：
+
+.. code:: text
+
+    -> RT-Thread online packages
+        -> system packages
+            --- TinyUSB (offical): an open source cross-platform USB stack for embedded system
+                (2048) TinyUSB thread stack size
+                [*]   Using USB device  ---->
+                    [*]   Using Communication Device Class (CDC)
+                    [*]   Using Mass Storage Class (MSC)
+                    ()      The name of the device used by MSC
+                      Version (latest)  --->
+
+功能配置说明如下：
+
+-  TinyUSB 线程栈大小
+-  是否使用 USB 设备
+
+   -  是否使用 CDC
+   -  是否使用 MSC
+   -  用于 MSC 读写的块设备名字
+
+然后让 RT-Thread 的包管理器自动更新，或者使用 ``pkgs --update``
+命令更新包到 BSP 中。
+
+2、支持情况
+-----------
+
+2.1、MCU
+~~~~~~~~
+
+目前仅支持 STM32 系列 MCU。
+
+2.2、设备类
+~~~~~~~~~~~
+
+-  通信设备类（CDC）
+-  大容量存储设备（MSC）
+
+3、Feedback
+-----------
+
+issue: `tfx2001/tinyusb <https://github.com/tfx2001/tinyusb/issues>`__

--- a/sys/rt-thread/SConscript
+++ b/sys/rt-thread/SConscript
@@ -1,0 +1,29 @@
+import rtconfig
+from building import *
+
+cwd     = GetCurrentDir()
+src     = Split("""
+../../src/tusb.c
+../../src/common/tusb_fifo.c
+../../src/device/usbd.c
+../../src/device/usbd_control.c
+./tinyusb_port.c
+./usb_descriptor.c
+""")
+path = [cwd, cwd + "/../../src"]
+
+# BSP
+if GetDepend(["SOC_FAMILY_STM32"]):
+    src += ["../../src/portable/st/synopsys/dcd_synopsys.c",
+            "../../src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c"]
+
+# Device class
+if GetDepend(["PKG_TINYUSB_DEVICE_CDC"]):
+    src += ["../../src/class/cdc/cdc_device.c"]
+
+if GetDepend(["PKG_TINYUSB_DEVICE_MSC"]):
+    src += ["../../src/class/msc/msc_device.c", "port/msc_device.c"]
+
+group = DefineGroup('tinyusb', src, depend = ['PKG_USING_TINYUSB'], CPPPATH = path)
+
+Return('group')

--- a/sys/rt-thread/port/msc_device.c
+++ b/sys/rt-thread/port/msc_device.c
@@ -1,0 +1,162 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifdef __RTTHREAD__
+
+#include <board.h>
+#include <rtdevice.h>
+
+#include <tusb.h>
+#include <fal.h>
+
+// whether host does safe-eject
+static bool ejected = false;
+static rt_device_t flash_device;
+
+// Invoked when received SCSI_CMD_INQUIRY
+// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
+void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {
+    (void) lun;
+
+    const char vid[] = "TinyUSB";
+    const char pid[] = "Mass Storage";
+    const char rev[] = "1.0";
+
+    memcpy(vendor_id, vid, strlen(vid));
+    memcpy(product_id, pid, strlen(pid));
+    memcpy(product_rev, rev, strlen(rev));
+}
+
+// Invoked when received Test Unit Ready command.
+// return true allowing host to read/write this LUN e.g SD card inserted
+bool tud_msc_test_unit_ready_cb(uint8_t lun) {
+    (void) lun;
+
+    // RAM disk is ready until ejected
+    if (ejected) {
+        tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3a, 0x00);
+        return false;
+    }
+
+    return true;
+}
+
+// Invoked when received SCSI_CMD_READ_CAPACITY_10 and SCSI_CMD_READ_FORMAT_CAPACITY to determine the disk size
+// Application update block count and block size
+void tud_msc_capacity_cb(uint8_t lun, uint32_t *block_count, uint16_t *block_size) {
+    (void) lun;
+    struct rt_device_blk_geometry blk_geom;
+
+    if (!flash_device) {
+        flash_device = rt_device_find(PKG_TINYUSB_DEVICE_MSC_NAME);
+    }
+    rt_device_control(flash_device, RT_DEVICE_CTRL_BLK_GETGEOME, &blk_geom);
+
+    *block_count = blk_geom.sector_count;
+    *block_size = blk_geom.bytes_per_sector;
+}
+
+// Invoked when received Start Stop Unit command
+// - Start = 0 : stopped power mode, if load_eject = 1 : unload disk storage
+// - Start = 1 : active mode, if load_eject = 1 : load disk storage
+bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject) {
+    (void) lun;
+    (void) power_condition;
+
+    if (load_eject) {
+        if (start) {
+            // load disk storage
+            flash_device = rt_device_find(PKG_TINYUSB_DEVICE_MSC_NAME);
+        } else {
+            // unload disk storage
+            ejected = true;
+        }
+    }
+
+    return true;
+}
+
+// Callback invoked when received READ10 command.
+// Copy disk's data to buffer (up to bufsize) and return number of copied bytes.
+int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset, void *buffer, uint32_t bufsize) {
+    (void) lun;
+    (void) offset;
+    (void) bufsize;
+
+    return (int32_t) rt_device_read(flash_device, (rt_off_t) lba, buffer, 1) * 4096;
+}
+
+// Callback invoked when received WRITE10 command.
+// Process data in buffer to disk's storage and return number of written bytes
+int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t *buffer, uint32_t bufsize) {
+    (void) lun;
+    (void) offset;
+    (void) bufsize;
+
+    return (int32_t) rt_device_write(flash_device, (rt_off_t) lba, buffer, 1) * 4096;
+}
+
+// Callback invoked when received an SCSI command not in built-in list below
+// - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, MODE_SENSE6, REQUEST_SENSE
+// - READ10 and WRITE10 has their own callbacks
+int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void *buffer, uint16_t bufsize) {
+    // read10 & write10 has their own callback and MUST not be handled here
+
+    void const *response = NULL;
+    uint16_t resplen = 0;
+
+    // most scsi handled is input
+    bool in_xfer = true;
+
+    switch (scsi_cmd[0]) {
+        case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
+            // Host is about to read/write etc ... better not to disconnect disk
+            resplen = 0;
+            break;
+
+        default:
+            // Set Sense = Invalid Command Operation
+            tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
+
+            // negative means error -> tinyusb could stall and/or response with failed status
+            resplen = -1;
+            break;
+    }
+
+    // return resplen must not larger than bufsize
+    if (resplen > bufsize) resplen = bufsize;
+
+    if (response && (resplen > 0)) {
+        if (in_xfer) {
+            memcpy(buffer, response, resplen);
+        } else {
+            // SCSI output
+        }
+    }
+
+    return resplen;
+}
+
+#endif

--- a/sys/rt-thread/tinyusb_port.c
+++ b/sys/rt-thread/tinyusb_port.c
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RT-Thread Development Team (rt-thread.io)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifdef __RTTHREAD__
+
+#include <rtthread.h>
+#define DBG_TAG    "TinyUSB"
+#define DBG_LVL    DBG_INFO
+#include <rtdbg.h>
+#include <tusb.h>
+
+extern int tusb_board_init(void);
+
+#ifndef RT_USING_HEAP
+/* if there is not enable heap, we should use static thread and stack. */
+static rt_uint8_t tusb_stack[PKG_TINYUSB_STACK_SIZE];
+static struct rt_thread tusb_thread;
+#endif /* RT_USING_HEAP */
+
+static void tusb_thread_entry(void *parameter) {
+    (void) parameter;
+    while (1) {
+        tud_task();
+    }
+}
+
+static int init_tinyusb(void) {
+    rt_thread_t tid;
+
+    tusb_board_init();
+    tusb_init();
+
+#ifdef RT_USING_HEAP
+    tid = rt_thread_create("tusb", tusb_thread_entry, RT_NULL,
+                           PKG_TINYUSB_STACK_SIZE, 4, 10);
+    if (tid == RT_NULL) {
+        LOG_E("Fail to create a USB stack thread");
+        return -1;
+    }
+#else
+    rt_err_t result;
+
+    tid = &tusb_thread;
+    result = rt_thread_init(tid, "tusb", tusb_thread_entry, RT_NULL,
+                            tusb_stack, sizeof(tusb_stack), 4, 10);
+    if (tid != RT_EOK) {
+        LOG_E("Fail to create a USB stack thread");
+        return -1;
+    }
+#endif
+    rt_thread_startup(tid);
+
+    return 0;
+}
+INIT_COMPONENT_EXPORT(init_tinyusb);
+
+#endif

--- a/sys/rt-thread/tusb_config.h
+++ b/sys/rt-thread/tusb_config.h
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 RT-Thread Development Team (rt-thread.io)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#include <rtconfig.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+#if  defined(SOC_SERIES_STM32F1)
+#define CFG_TUSB_MCU    OPT_MCU_STM32F1
+#elif defined(SOC_SERIES_STM32F4)
+#define CFG_TUSB_MCU    OPT_MCU_STM32F4
+#elif defined(SOC_SERIES_STM32H7)
+#define CFG_TUSB_MCU    OPT_MCU_STM32H7
+#else
+#error "No support for current MCU"
+#endif
+
+#define CFG_TUSB_OS OPT_OS_RTTHREAD
+
+// RHPort number used for device can be defined by board.mk, default to port 0
+#ifndef BOARD_DEVICE_RHPORT_NUM
+#define BOARD_DEVICE_RHPORT_NUM     0
+#endif
+
+// RHPort max operational speed can defined by board.mk
+// Default to Highspeed for MCU with internal HighSpeed PHY (can be port specific), otherwise FullSpeed
+#ifndef BOARD_DEVICE_RHPORT_SPEED
+#if (CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_LPC43XX || CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX || \
+       CFG_TUSB_MCU == OPT_MCU_NUC505  || CFG_TUSB_MCU == OPT_MCU_CXD56)
+#define BOARD_DEVICE_RHPORT_SPEED   OPT_MODE_HIGH_SPEED
+#else
+#define BOARD_DEVICE_RHPORT_SPEED   OPT_MODE_FULL_SPEED
+#endif
+#endif
+
+// Device mode with rhport and speed defined by board.mk
+#if   BOARD_DEVICE_RHPORT_NUM == 0
+#define CFG_TUSB_RHPORT0_MODE     (OPT_MODE_DEVICE | BOARD_DEVICE_RHPORT_SPEED)
+#elif BOARD_DEVICE_RHPORT_NUM == 1
+#define CFG_TUSB_RHPORT1_MODE     (OPT_MODE_DEVICE | BOARD_DEVICE_RHPORT_SPEED)
+#else
+  #error "Incorrect RHPort configuration"
+#endif
+
+// CFG_TUSB_DEBUG is defined by compiler in DEBUG build
+// #define CFG_TUSB_DEBUG           0
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN          ALIGN(4)
+#endif
+
+//--------------------------------------------------------------------
+// DEVICE CONFIGURATION
+//--------------------------------------------------------------------
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE    64
+#endif
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_CDC_RX_BUFSIZE   64
+#define CFG_TUD_CDC_TX_BUFSIZE   64
+
+#define CFG_TUD_MSC_EP_BUFSIZE    4096
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/sys/rt-thread/usb_descriptor.c
+++ b/sys/rt-thread/usb_descriptor.c
@@ -1,0 +1,165 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <tusb.h>
+
+/* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
+ * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
+ *
+ * Auto ProductID layout's Bitmap:
+ *   [MSB]         HID | MSC | CDC          [LSB]
+ */
+#define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
+#define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
+                           _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+
+//--------------------------------------------------------------------+
+// Device Descriptors
+//--------------------------------------------------------------------+
+tusb_desc_device_t const desc_device =
+        {
+                .bLength            = sizeof(tusb_desc_device_t),
+                .bDescriptorType    = TUSB_DESC_DEVICE,
+                .bcdUSB             = 0x0200,
+                .bDeviceClass       = 0x00,
+                .bDeviceSubClass    = 0x00,
+                .bDeviceProtocol    = 0x00,
+                .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
+
+                .idVendor           = 0xCafe,
+                .idProduct          = USB_PID,
+                .bcdDevice          = 0x0100,
+
+                .iManufacturer      = 0x01,
+                .iProduct           = 0x02,
+                .iSerialNumber      = 0x03,
+
+                .bNumConfigurations = 0x01
+        };
+
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const *tud_descriptor_device_cb(void) {
+    return (uint8_t const *) &desc_device;
+}
+
+//--------------------------------------------------------------------+
+// Configuration Descriptor
+//--------------------------------------------------------------------+
+
+enum {
+#if CFG_TUD_CDC
+    ITF_NUM_CDC = 0,
+    ITF_NUM_CDC_DATA,
+#endif
+#if CFG_TUD_MSC
+    ITF_NUM_MSC,
+#endif
+    ITF_NUM_TOTAL
+};
+
+#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_MSC_DESC_LEN * CFG_TUD_MSC + TUD_CDC_DESC_LEN * CFG_TUD_CDC)
+
+#define EPNUM_CDC_NOTIF   0x81
+#define EPNUM_CDC_OUT     0x02
+#define EPNUM_CDC_IN      0x82
+
+#define EPNUM_MSC_OUT     0x03
+#define EPNUM_MSC_IN      0x83
+
+uint8_t const desc_fs_configuration[] =
+        {
+                TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+#if CFG_TUD_CDC
+                TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
+#endif
+#if CFG_TUD_MSC
+                TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, 4 + CFG_TUD_CDC, EPNUM_MSC_OUT, EPNUM_MSC_IN, 64),
+#endif
+        };
+
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
+    (void) index; // for multiple configurations
+
+    return desc_fs_configuration;
+}
+
+//--------------------------------------------------------------------+
+// String Descriptors
+//--------------------------------------------------------------------+
+
+// array of pointer to string descriptors
+char const *string_desc_arr[] =
+        {
+                (const char[]) {0x09, 0x04}, // 0: is supported language is English (0x0409)
+                "TinyUSB",                     // 1: Manufacturer
+                "TinyUSB Device",              // 2: Product
+                "123456",                      // 3: Serials, should use chip ID
+#if CFG_TUD_CDC
+                "TinyUSB CDC",
+#endif
+#if CFG_TUD_MSC
+                "TinyUSB MSC",
+#endif
+        };
+
+static uint16_t desc_str[32];
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
+uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
+    (void) langid;
+
+    uint8_t chr_count;
+
+    if (index == 0) {
+        memcpy(&desc_str[1], string_desc_arr[0], 2);
+        chr_count = 1;
+    } else {
+        // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
+
+        if (index >= sizeof(string_desc_arr) / sizeof(string_desc_arr[0])) return NULL;
+
+        const char *str = string_desc_arr[index];
+
+        // Cap at max char
+        chr_count = strlen(str);
+        if (chr_count > 31) chr_count = 31;
+
+        // Convert ASCII string into UTF-16
+        for (uint8_t i = 0; i < chr_count; i++) {
+            desc_str[1 + i] = str[i];
+        }
+    }
+
+    // first byte is length (including header), second byte is string type
+    desc_str[0] = (TUSB_DESC_STRING << 8) | (2 * chr_count + 2);
+
+    return desc_str;
+}


### PR DESCRIPTION
Hi,

This PR based on #637 by supporting RT-Thread RTOS. TinyUSB has been registered to the [RT-Thread software packages center](http://packages.rt-thread.org/en/search.html?search=tinyusb). Developers can use TinyUSB more easily by installing the TinyUSB package in package manager center.

This PR includes two `SConscript` files. RT-Thread uses Scons to organize files rather than CMake or Makefile, so it will not cause any conflicts with existing Makefiles. Meanwhile, this PR also contains some drivers for interfacing with the RT-Thread device framework.

However, there is a problem that the added files contain headers (those will be used in RT-Thread side) that do not exist in this repository, which will cause errors at the CI. Is it possible to exclude the `osal/rt-thread` folder?

I would be grateful if you consider about this PR. Thanks ahead.

Frank

[https://www.rt-thread.io](https://www.rt-thread.io/)