### PR TITLE
net_lwip_webserver: allow users to enable LWIP_IP6 if desired

### DIFF
--- a/examples/device/net_lwip_webserver/Makefile
+++ b/examples/device/net_lwip_webserver/Makefile
@@ -4,9 +4,8 @@ include ../../../tools/top.mk
 include ../../make.mk
 
 CFLAGS += \
-  -DPBUF_POOL_SIZE=2 \
-  -DTCP_WND=2*TCP_MSS \
-  -DHTTPD_USE_CUSTOM_FSDATA=0
+  -Wno-error=unused-parameter \
+  -Wno-error=unused-variable
 
 INC += \
   src \
@@ -50,6 +49,15 @@ SRC_C += \
   lib/lwip/src/core/ipv4/ip4.c \
   lib/lwip/src/core/ipv4/ip4_addr.c \
   lib/lwip/src/core/ipv4/ip4_frag.c \
+  lib/lwip/src/core/ipv6/dhcp6.c \
+  lib/lwip/src/core/ipv6/ethip6.c \
+  lib/lwip/src/core/ipv6/icmp6.c \
+  lib/lwip/src/core/ipv6/inet6.c \
+  lib/lwip/src/core/ipv6/ip6.c \
+  lib/lwip/src/core/ipv6/ip6_addr.c \
+  lib/lwip/src/core/ipv6/ip6_frag.c \
+  lib/lwip/src/core/ipv6/mld6.c \
+  lib/lwip/src/core/ipv6/nd6.c \
   lib/lwip/src/netif/ethernet.c \
   lib/lwip/src/netif/slipif.c \
   lib/lwip/src/apps/http/httpd.c \

--- a/examples/device/net_lwip_webserver/src/lwipopts.h
+++ b/examples/device/net_lwip_webserver/src/lwipopts.h
@@ -42,11 +42,14 @@
 #define LWIP_ICMP                       1
 #define LWIP_UDP                        1
 #define LWIP_TCP                        1
+#define LWIP_IPV4                       1
+#define LWIP_IPV6                       0
 #define ETH_PAD_SIZE                    0
 #define LWIP_IP_ACCEPT_UDP_PORT(p)      ((p) == PP_NTOHS(67))
 
 #define TCP_MSS                         (1500 /*mtu*/ - 20 /*iphdr*/ - 20 /*tcphhr*/)
 #define TCP_SND_BUF                     (2 * TCP_MSS)
+#define TCP_WND                         (TCP_MSS)
 
 #define ETHARP_SUPPORT_STATIC_ENTRIES   1
 
@@ -55,5 +58,14 @@
 #define LWIP_HTTPD_SSI_INCLUDE_TAG      0
 
 #define LWIP_SINGLE_NETIF               1
+
+#define PBUF_POOL_SIZE                  2
+
+#define HTTPD_USE_CUSTOM_FSDATA         0
+
+#define LWIP_MULTICAST_PING             1
+#define LWIP_BROADCAST_PING             1
+#define LWIP_IPV6_MLD                   0
+#define LWIP_IPV6_SEND_ROUTER_SOLICIT   0
 
 #endif /* __LWIPOPTS_H__ */

--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -50,7 +50,10 @@ try changing the first byte of tud_network_mac_address[] below from 0x02 to 0x00
 #include "dnserver.h"
 #include "lwip/init.h"
 #include "lwip/timeouts.h"
+#include "lwip/ethip6.h"
 #include "httpd.h"
+
+#define INIT_IP4(a,b,c,d) { PP_HTONL(LWIP_MAKEU32(a,b,c,d)) }
 
 /* lwip context */
 static struct netif netif_data;
@@ -64,24 +67,24 @@ static struct pbuf *received_frame;
 const uint8_t tud_network_mac_address[6] = {0x02,0x02,0x84,0x6A,0x96,0x00};
 
 /* network parameters of this MCU */
-static const ip_addr_t ipaddr  = IPADDR4_INIT_BYTES(192, 168, 7, 1);
-static const ip_addr_t netmask = IPADDR4_INIT_BYTES(255, 255, 255, 0);
-static const ip_addr_t gateway = IPADDR4_INIT_BYTES(0, 0, 0, 0);
+static const ip4_addr_t ipaddr  = INIT_IP4(192, 168, 7, 1);
+static const ip4_addr_t netmask = INIT_IP4(255, 255, 255, 0);
+static const ip4_addr_t gateway = INIT_IP4(0, 0, 0, 0);
 
 /* database IP addresses that can be offered to the host; this must be in RAM to store assigned MAC addresses */
 static dhcp_entry_t entries[] =
 {
     /* mac ip address                          lease time */
-    { {0}, IPADDR4_INIT_BYTES(192, 168, 7, 2), 24 * 60 * 60 },
-    { {0}, IPADDR4_INIT_BYTES(192, 168, 7, 3), 24 * 60 * 60 },
-    { {0}, IPADDR4_INIT_BYTES(192, 168, 7, 4), 24 * 60 * 60 },
+    { {0}, INIT_IP4(192, 168, 7, 2), 24 * 60 * 60 },
+    { {0}, INIT_IP4(192, 168, 7, 3), 24 * 60 * 60 },
+    { {0}, INIT_IP4(192, 168, 7, 4), 24 * 60 * 60 },
 };
 
 static const dhcp_config_t dhcp_config =
 {
-    .router = IPADDR4_INIT_BYTES(0, 0, 0, 0),  /* router address (if any) */
+    .router = INIT_IP4(0, 0, 0, 0),            /* router address (if any) */
     .port = 67,                                /* listen port */
-    .dns = IPADDR4_INIT_BYTES(192, 168, 7, 1), /* dns server (if any) */
+    .dns = INIT_IP4(192, 168, 7, 1),           /* dns server (if any) */
     "usb",                                     /* dns suffix */
     TU_ARRAY_SIZE(entries),                    /* num entry */
     entries                                    /* entries */
@@ -108,10 +111,17 @@ static err_t linkoutput_fn(struct netif *netif, struct pbuf *p)
   }
 }
 
-static err_t output_fn(struct netif *netif, struct pbuf *p, const ip_addr_t *addr)
+static err_t ip4_output_fn(struct netif *netif, struct pbuf *p, const ip4_addr_t *addr)
 {
   return etharp_output(netif, p, addr);
 }
+
+#if LWIP_IPV6
+static err_t ip6_output_fn(struct netif *netif, struct pbuf *p, const ip6_addr_t *addr)
+{
+  return ethip6_output(netif, p, addr);
+}
+#endif
 
 static err_t netif_init_cb(struct netif *netif)
 {
@@ -122,7 +132,10 @@ static err_t netif_init_cb(struct netif *netif)
   netif->name[0] = 'E';
   netif->name[1] = 'X';
   netif->linkoutput = linkoutput_fn;
-  netif->output = output_fn;
+  netif->output = ip4_output_fn;
+#if LWIP_IPV6
+  netif->output_ip6 = ip6_output_fn;
+#endif
   return ERR_OK;
 }
 
@@ -138,11 +151,14 @@ static void init_lwip(void)
   netif->hwaddr[5] ^= 0x01;
 
   netif = netif_add(netif, &ipaddr, &netmask, &gateway, NULL, netif_init_cb, ip_input);
+#if LWIP_IPV6
+  netif_create_ip6_linklocal_address(netif, 1);
+#endif
   netif_set_default(netif);
 }
 
 /* handle any DNS requests from dns-server */
-bool dns_query_proc(const char *name, ip_addr_t *addr)
+bool dns_query_proc(const char *name, ip4_addr_t *addr)
 {
   if (0 == strcmp(name, "tiny.usb"))
   {
@@ -218,7 +234,7 @@ int main(void)
   init_lwip();
   while (!netif_is_up(&netif_data));
   while (dhserv_init(&dhcp_config) != ERR_OK);
-  while (dnserv_init(&ipaddr, 53, dns_query_proc) != ERR_OK);
+  while (dnserv_init(IP_ADDR_ANY, 53, dns_query_proc) != ERR_OK);
   httpd_init();
 
   while (1)

--- a/lib/networking/dhserver.c
+++ b/lib/networking/dhserver.c
@@ -96,19 +96,19 @@ static const dhcp_config_t *config = NULL;
 
 char magic_cookie[] = {0x63,0x82,0x53,0x63};
 
-static ip_addr_t get_ip(const uint8_t *pnt)
+static ip4_addr_t get_ip(const uint8_t *pnt)
 {
-  ip_addr_t result;
+  ip4_addr_t result;
   memcpy(&result, pnt, sizeof(result));
   return result;
 }
 
-static void set_ip(uint8_t *pnt, ip_addr_t value)
+static void set_ip(uint8_t *pnt, ip4_addr_t value)
 {
   memcpy(pnt, &value.addr, sizeof(value.addr));
 }
 
-static dhcp_entry_t *entry_by_ip(ip_addr_t ip)
+static dhcp_entry_t *entry_by_ip(ip4_addr_t ip)
 {
 	int i;
 	for (i = 0; i < config->num_entry; i++)
@@ -162,11 +162,11 @@ uint8_t *find_dhcp_option(uint8_t *attrs, int size, uint8_t attr)
 int fill_options(void *dest,
 	uint8_t msg_type,
 	const char *domain,
-	ip_addr_t dns,
+	ip4_addr_t dns,
 	int lease_time,
-	ip_addr_t serverid,
-	ip_addr_t router,
-	ip_addr_t subnet)
+	ip4_addr_t serverid,
+	ip4_addr_t router,
+	ip4_addr_t subnet)
 {
 	uint8_t *ptr = (uint8_t *)dest;
 	/* ACK message type */

--- a/lib/networking/dhserver.h
+++ b/lib/networking/dhserver.h
@@ -41,16 +41,16 @@
 
 typedef struct dhcp_entry
 {
-	uint8_t  mac[6];
-	ip_addr_t addr;
-	uint32_t lease;
+	uint8_t    mac[6];
+	ip4_addr_t addr;
+	uint32_t   lease;
 } dhcp_entry_t;
 
 typedef struct dhcp_config
 {
-	ip_addr_t     router;
+	ip4_addr_t    router;
 	uint16_t      port;
-	ip_addr_t     dns;
+	ip4_addr_t    dns;
 	const char   *domain;
 	int           num_entry;
 	dhcp_entry_t *entries;

--- a/lib/networking/dnserver.c
+++ b/lib/networking/dnserver.c
@@ -136,7 +136,7 @@ static void udp_recv_proc(void *arg, struct udp_pcb *upcb, struct pbuf *p, const
 	dns_header_t *header;
 	static dns_query_t query;
 	struct pbuf *out;
-	ip_addr_t host_addr;
+	ip4_addr_t host_addr;
 	dns_answer_t *answer;
 
 	(void)arg;

--- a/lib/networking/dnserver.h
+++ b/lib/networking/dnserver.h
@@ -39,7 +39,7 @@
 #include "lwip/udp.h"
 #include "netif/etharp.h"
 
-typedef bool (*dns_query_proc_t)(const char *name, ip_addr_t *addr);
+typedef bool (*dns_query_proc_t)(const char *name, ip4_addr_t *addr);
 
 err_t dnserv_init(const ip_addr_t *bind, uint16_t port, dns_query_proc_t query_proc);
 void  dnserv_free(void);


### PR DESCRIPTION
net_lwip_webserver and ./lib/networking/ code is tweaked to allow the user to enable LWIP_IP6 if desired.

To allow legacy code to compile, lwip's ip_addr_t maps into the newer ip4_addr_t type when LWIP_IP4 is enabled but LWIP_IP6 is not enabled.  However, if both LWIP_IP4 and LWIP_IP6 are enabled, ip_addr_t maps to a struct with a union for both ip4_addr_t and ip6_addr_t.  Since the ./lib/networking/ code was written for IPv4 only and presumes IP4-only lwip, the previous code breaks.  Some tweaking was needed to use the newer ip4_addr_t in preference to the previous ip_addr_t usage.
