### PR TITLE
msp430x5xx: Set base of transmit_packet buffer earlier to avoid incre…

### DIFF
--- a/src/portable/ti/msp430x5xx/dcd_msp430x5xx.c
+++ b/src/portable/ti/msp430x5xx/dcd_msp430x5xx.c
@@ -547,6 +547,7 @@ static void transmit_packet(uint8_t ep_num)
   }
 
   // Then actually commit to transmit a packet.
+  uint8_t * base = (xfer->buffer + xfer->queued_len);
   uint16_t remaining = xfer->total_len - xfer->queued_len;
   uint8_t xfer_size = (xfer->max_size < xfer->total_len) ? xfer->max_size : remaining;
 
@@ -560,7 +561,6 @@ static void transmit_packet(uint8_t ep_num)
   if(ep_num == 0)
   {
     volatile uint8_t * ep0in_buf = &USBIEP0BUF;
-    uint8_t * base = (xfer->buffer + xfer->queued_len);
     for(uint16_t i = 0; i < xfer_size; i++)
     {
       ep0in_buf[i] = base[i];
@@ -582,7 +582,6 @@ static void transmit_packet(uint8_t ep_num)
     else
 #endif
     {
-      uint8_t * base = (xfer->buffer + xfer->queued_len);
       for(int i = 0; i < xfer_size; i++)
       {
         ep_buf[i] = base[i];


### PR DESCRIPTION
…menting past unsent data. Closes #1105.

FWIW, I found this via a bisect; commit a5d7b62 introduced the breaking change. MSP430 USB doesn't support iso xfers, so I'm not sure if that code should even be in there, but since it's commented out, I'll leave it alone for now.