### PR TITLE
Properly handle Program Change and Channel Aftertouch messages

### DIFF
--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -279,6 +279,12 @@ uint32_t tud_midi_n_stream_write(uint8_t itf, uint8_t cable_num, uint8_t const* 
         stream->buffer[0] = (cable_num << 4) | msg;
         stream->total = 4;
       }
+      else if ( msg == 0xC || msg == 0xD)
+      {
+        // Channel Voice Messages, two-byte variants (Program Change and Channel Pressure)
+        stream->buffer[0] = (cable_num << 4) | msg;
+        stream->total = 3;
+      }
       else if ( msg == 0xf )
       {
         // System message


### PR DESCRIPTION
**Describe the PR**
MIDI Program Change and Channel Aftertouch messages are not currently handled. They are sent correctly by accident, depending on leniency of host OS version and if `tud_midi_n_stream_write()` is called with a buffer containing a whole message buffer and not byte-by-byte. These types of MIDI messages are 2-bytes long (instead of the common 3-bytes) and `tud_midi_n_stream_write()` doesn't have case to handle them.  This PR adds that case.

**Additional context**
See issues https://github.com/adafruit/Adafruit_TinyUSB_Arduino/issues/130 and https://github.com/adafruit/Adafruit_CircuitPython_MIDI/issues/37 for backstory.
Also see [this TinyUSB test program ](https://gist.github.com/todbot/7364354a25fcf6a3313b4e581cc204fa) based off of `midi_test`.  