### PR TITLE
update dcd_esp32sx with correct include list

### DIFF
--- a/src/portable/espressif/esp32sx/dcd_esp32sx.c
+++ b/src/portable/espressif/esp32sx/dcd_esp32sx.c
@@ -31,7 +31,6 @@
 #if (((CFG_TUSB_MCU == OPT_MCU_ESP32S2) ||  (CFG_TUSB_MCU == OPT_MCU_ESP32S3)) && TUSB_OPT_DEVICE_ENABLED)
 
 // Espressif
-#include "driver/periph_ctrl.h"
 #include "freertos/xtensa_api.h"
 #include "esp_intr_alloc.h"
 #include "esp_log.h"
@@ -39,6 +38,7 @@
 #include "soc/dport_reg.h"
 #include "soc/gpio_sig_map.h"
 #include "soc/usb_periph.h"
+#include "soc/periph_defs.h" // for interrupt source
 
 #include "device/dcd.h"
 


### PR DESCRIPTION
**Describe the PR**
A tiny minor update. `dcd_esp32sx.c` doesn't use any APIs in periph_ctrl.h but the USB interrupt source number listed in `soc/periph_defs.h`.
