### PR TITLE
samd21: enable SysTick only if running w/o OS

### DIFF
--- a/hw/bsp/samd21/family.c
+++ b/hw/bsp/samd21/family.c
@@ -75,7 +75,9 @@ void board_init(void)
   // Update SystemCoreClock since it is hard coded with asf4 and not correct
   // Init 1ms tick timer (samd SystemCoreClock may not correct)
   SystemCoreClock = CONF_CPU_FREQUENCY;
+#if CFG_TUSB_OS  == OPT_OS_NONE
   SysTick_Config(CONF_CPU_FREQUENCY / 1000);
+#endif
 
   // Led init
 #ifdef LED_PIN


### PR DESCRIPTION
When using FreeRTOS, with the `SysTick` being active, there is a race condition between the elapsing of the first tick and execution of `vTaskStartScheduler()`.
