### PR TITLE
Fix invalid assert in RP2040 host mode when compiled in debug mode

### DIFF
--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -160,12 +160,11 @@ static void hw_handle_buff_status(void)
 
 static void hw_trans_complete(void)
 {
-  struct hw_endpoint *ep = &epx;
-  assert(ep->active);
-
   if (usb_hw->sie_ctrl & USB_SIE_CTRL_SEND_SETUP_BITS)
   {
     pico_trace("Sent setup packet\n");
+    struct hw_endpoint *ep = &epx;
+    assert(ep->active);
     hw_xfer_complete(ep, XFER_RESULT_SUCCESS);
   }
   else


### PR DESCRIPTION
RP2040 HCD: Move invalid ep->active assert in hw_trans_complete. The ep->active should only happen if a setup packet was just sent. Otherwise the transaction is handled in hw_handle_buff_status. Fixes https://github.com/raspberrypi/pico-sdk/issues/649

