### PR TITLE
Update bth for IAD support

### DIFF
--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -763,8 +763,8 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
 #define CFG_TUD_BTH_ISO_ALT_COUNT 0
 #endif
 
-// Length of template descriptor: 30 bytes + number of ISO alternatives * 23
-#define TUD_BTH_DESC_LEN (9 + 7 + 7 + 7 + (CFG_TUD_BTH_ISO_ALT_COUNT) * (9 + 7 + 7))
+// Length of template descriptor: 38 bytes + number of ISO alternatives * 23
+#define TUD_BTH_DESC_LEN (8 + 9 + 7 + 7 + 7 + (CFG_TUD_BTH_ISO_ALT_COUNT) * (9 + 7 + 7))
 
 /* Primary Interface */
 #define TUD_BTH_PRI_ITF(_itfnum, _stridx, _ep_evt, _ep_evt_size, _ep_evt_interval, _ep_in, _ep_out, _ep_size) \
@@ -806,6 +806,8 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
 // Interface number, string index, attributes, event endpoint, event endpoint size, interval, data in, data out, data endpoint size, iso endpoint sizes
 // TODO BTH should also use IAD like CDC for composite device
 #define TUD_BTH_DESCRIPTOR(_itfnum, _stridx, _ep_evt, _ep_evt_size, _ep_evt_interval, _ep_in, _ep_out, _ep_size,...) \
+  /* Interface Associate */\
+  8, TUSB_DESC_INTERFACE_ASSOCIATION, _itfnum, 2, TUD_BT_APP_CLASS, TUD_BT_APP_SUBCLASS, TUD_BT_PROTOCOL_PRIMARY_CONTROLLER, 0,\
   TUD_BTH_PRI_ITF(_itfnum, _stridx, _ep_evt, _ep_evt_size, _ep_evt_interval, _ep_in, _ep_out, _ep_size) \
   TUD_BTH_ISO_ITFS(_itfnum + 1, _ep_in + 1, _ep_out + 1, __VA_ARGS__)
 


### PR DESCRIPTION
**Describe the PR**
**IAD** was missing from BT interface descriptor macro.
This in itself did not matter much but it is in the specification so descriptor is updated now.

With missing **IAD** BT driver handled open separately for both interfaces.
For some time now BT is assumed to have 2 associated interfaces even when IAD is missing.
This inferred association resulted in only one call to **btd_open()** and second interface was no
handled at all.
This in turn resulted in assertion failure in **process_set_config()**.

Now single call to **btd_open()** checks for presence of both interfaces as expected by
**process_set_config()**.

This only changes conditions and how **itf_desc** is modified in the middle of **btd_open()**,
rest is just indentation change due to if () removal