### PR TITLE
set DCFG_XCVRDLY when using external ULPI highspeed phy

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -443,11 +443,15 @@ static void phy_hs_init(dwc2_regs_t * dwc2)
   dwc2_phy_update(dwc2, dwc2->ghwcfg2_bm.hs_phy_type);
 
   // Set max speed
-  dwc2->dcfg = (dwc2->dcfg & ~DCFG_DSPD_Msk) | (DCFG_DSPD_HS << DCFG_DSPD_Pos);
+  uint32_t dcfg = dwc2->dcfg;
+  dcfg &= ~DCFG_DSPD_Msk;
+  dcfg |= DCFG_DSPD_HS << DCFG_DSPD_Pos;
 
   // XCVRDLY: transceiver delay between xcvr_sel and txvalid during device chirp is required
   // when using with some PHYs such as USB334x (USB3341, USB3343, USB3346, USB3347)
-  if (dwc2->ghwcfg2_bm.hs_phy_type == HS_PHY_TYPE_ULPI) dwc2->dcfg |= DCFG_XCVRDLY;
+  if (dwc2->ghwcfg2_bm.hs_phy_type == HS_PHY_TYPE_ULPI) dcfg |= DCFG_XCVRDLY;
+
+  dwc2->dcfg = dcfg;
 }
 
 static bool check_dwc2(dwc2_regs_t * dwc2)

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -444,6 +444,10 @@ static void phy_hs_init(dwc2_regs_t * dwc2)
 
   // Set max speed
   dwc2->dcfg = (dwc2->dcfg & ~DCFG_DSPD_Msk) | (DCFG_DSPD_HS << DCFG_DSPD_Pos);
+
+  // XCVRDLY: transceiver delay between xcvr_sel and txvalid during device chirp is required
+  // when using with some PHYs such as USB334x (USB3341, USB3343, USB3346, USB3347)
+  if (dwc2->ghwcfg2_bm.hs_phy_type == HS_PHY_TYPE_ULPI) dwc2->dcfg |= DCFG_XCVRDLY;
 }
 
 static bool check_dwc2(dwc2_regs_t * dwc2)

--- a/src/portable/synopsys/dwc2/dwc2_type.h
+++ b/src/portable/synopsys/dwc2/dwc2_type.h
@@ -416,6 +416,10 @@ TU_VERIFY_STATIC(offsetof(dwc2_regs_t, fifo   ) == 0x1000, "incorrect size");
 #define DCFG_PFIVL_0                     (0x1UL << DCFG_PFIVL_Pos)                // 0x00000800 */
 #define DCFG_PFIVL_1                     (0x2UL << DCFG_PFIVL_Pos)                // 0x00001000 */
 
+#define DCFG_XCVRDLY_Pos                 (14U)
+#define DCFG_XCVRDLY_Msk                 (0x1UL << DCFG_XCVRDLY_Pos)             /*!< 0x00004000 */
+#define DCFG_XCVRDLY                     DCFG_XCVRDLY_Msk                        // Enables delay between xcvr_sel and txvalid during device chirp
+
 #define DCFG_PERSCHIVL_Pos               (24U)
 #define DCFG_PERSCHIVL_Msk               (0x3UL << DCFG_PERSCHIVL_Pos)            // 0x03000000 */
 #define DCFG_PERSCHIVL                   DCFG_PERSCHIVL_Msk                       // Periodic scheduling interval */


### PR DESCRIPTION
**Describe the PR**
Fix #496 by setting DCFG_XCVRDLY when using with external ULPI phy. It has no impact with H743 and currently-working older phy USB3320 (probably a fraction of ms delay). So I guess it is safe to just set it in all cases.