### PR TITLE
nrf5x: Fix race condition during startup

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -1059,7 +1059,13 @@ void tusb_hal_nrf_power_event (uint32_t event)
 
       // Enable interrupt, priorities should be set by application
       NVIC_ClearPendingIRQ(USBD_IRQn);
-      NVIC_EnableIRQ(USBD_IRQn);
+      // Don't enable USBD interrupt yet, if dcd_init() did not finish yet
+      // Interrupt will be enabled by tud_init(), when USB stack is ready
+      // to handle interrupts.
+      if (tud_inited())
+      {
+        NVIC_EnableIRQ(USBD_IRQn);
+      }
 
       // Wait for HFCLK
       while ( !hfclk_running() ) { }


### PR DESCRIPTION
**Describe the PR**
When NRF5x device is reset by software (after DFU for example),
power event is ready from the beginning.
When power interrupt is triggered before tud_init() finished
USBD_IRQn is enabled before it would be enabled in tud_init().
This in turn may result in BUS RESET event being sent from
USB interrupt to USB task when queue is not initialized yet.
This scenario often happens in Mynewt build where queue creation
takes more time.

To prevent this scenario USBD_IRQn is not enabled in power event
interrupt handler before dcd_init() was called.

**Additional context**
Fixes #1154 

This solution is simple enough but I'm opened to other solutions.
