### PR TITLE
Remove unused-parameter errors when LOGGER=swo

### DIFF
--- a/hw/bsp/board.c
+++ b/hw/bsp/board.c
@@ -126,6 +126,8 @@ TU_ATTR_USED int sys_write (int fhdl, const void *buf, size_t count)
 TU_ATTR_USED int sys_read (int fhdl, char *buf, size_t count)
 {
   (void) fhdl;
+  (void) buf;
+  (void) count;
   return 0;
 }
 


### PR DESCRIPTION
**Describe the PR**
Remove errors when compiling with LOGGER=swo.
All arguments of sys_read() must be used in function, otherwise it triggers "unused-parameter" errors.

**Additional context**
Before this patch, error was:

hw/bsp/board.c: In function '_read':
hw/bsp/board.c:126:44: error: unused parameter 'buf' [-Werror=unused-parameter]
  126 | TU_ATTR_USED int sys_read (int fhdl, char *buf, size_t count)
      |                                      ~~~~~~^~~
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors