### PR TITLE
temporarily skip s3 build on ci

### DIFF
--- a/.github/workflows/build_esp.yml
+++ b/.github/workflows/build_esp.yml
@@ -18,7 +18,8 @@ jobs:
         # ESP32-S2
         - 'espressif_saola_1'
         # ESP32-S3
-        - 'espressif_addax_1'
+        #- 'espressif_addax_1'
+        # S3 compile error with "dangerous relocation: call8: call target out of range: memcpy"
 
     steps:
     - name: Setup Python


### PR DESCRIPTION
**Describe the PR**
Temporarily skip S3 in ci build since it has strange issue

```
CMakeFiles/cdc_msc_freertos.elf.dir/project/src/device/usbd_control.c.obj: in function `usbd_control_reset':
usbd_control.c:(.text+0x1fe): dangerous relocation: call8: call target out of range: memset
CMakeFiles/cdc_msc_freertos.elf.dir/project/src/device/usbd_control.c.obj: in function `usbd_control_set_request':
usbd_control.c:(.text+0x231): dangerous relocation: call8: call target out of range: memcpy
```