### PR TITLE
Fix buffer overrun in dcd_musb driver

### DIFF
--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -250,12 +250,12 @@ static void pipe_read_packet(void *buf, volatile void *fifo, unsigned len)
     len  -= 4;
   }
   if (len >= 2) {
-    *(uint32_t *)addr = reg->u16;
+    *(uint16_t *)addr = reg->u16;
     addr += 2;
     len  -= 2;
   }
   if (len) {
-    *(uint32_t *)addr = reg->u8;
+    *(uint8_t *)addr = reg->u8;
   }
 }
 


### PR DESCRIPTION
**Describe the PR**
Fix the bug of buffer overrun at pipe_read_packet() in dcd_musb.c.

**Additional context**
Cast operations for the left side symbols were wrong. So, when packet length is not 4 bytes unit, it occurs buffer overrun and corrupts some buffers.