### PR TITLE
samd21: make uart_init() static

### DIFF
--- a/hw/bsp/samd21/family.c
+++ b/hw/bsp/samd21/family.c
@@ -47,7 +47,7 @@ void USB_Handler(void)
 //--------------------------------------------------------------------+
 // UART support
 //--------------------------------------------------------------------+
-void uart_init(void);
+static void uart_init(void);
 
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
@@ -152,7 +152,7 @@ uint32_t board_button_read(void)
 #define BOARD_SERCOM2(n)  SERCOM ## n
 #define BOARD_SERCOM(n) BOARD_SERCOM2(n)
 
-void uart_init(void)
+static void uart_init(void)
 {
 #if UART_SERCOM == 0
   gpio_set_pin_function(PIN_PA06, PINMUX_PA06D_SERCOM0_PAD2);
@@ -217,7 +217,7 @@ int board_uart_write(void const * buf, int len)
 }
 
 #else // ! defined(UART_SERCOM)
-void uart_init(void)
+static void uart_init(void)
 {
 
 }


### PR DESCRIPTION
Avoids a linker conflict if programs are using that same function name.

Otherwise building a samd21 fork of [apollo](https://github.com/greatscottgadgets/apollo) we get

```
/usr/lib/gcc/arm-none-eabi/9.2.1/../../../arm-none-eabi/bin/ld: _build/qtpy/obj/../../firmware/src/boards/qtpy/uart.o (symbol from plugin): in function `uart_configure_pinmux':
(.text+0x0): multiple definition of `uart_init'; _build/qtpy/obj/hw/bsp/samd21/family.o (symbol from plugin):(.text+0x0): first defined here
/home/matt/3rd/fpga/apollo/lib/tinyusb/../../firmware/src/uart.h:20:6: error: type of 'uart_init' does not match original declaration [-Werror=lto-type-mismatch]
   20 | void uart_init(bool configure_pinmux, unsigned long baudrate);
```