### PR TITLE
Fix Mynewt build for Microchip PIC32MZ devices.

### DIFF
--- a/src/portable/valentyusb/eptri/dcd_eptri.c
+++ b/src/portable/valentyusb/eptri/dcd_eptri.c
@@ -24,6 +24,10 @@
  * This file is part of the TinyUSB stack.
  */
 
+#include "tusb_option.h"
+
+#if TUSB_OPT_DEVICE_ENABLED && (CFG_TUSB_MCU == OPT_MCU_VALENTYUSB_EPTRI)
+
 #ifndef DEBUG
 #define DEBUG 0
 #endif
@@ -31,10 +35,6 @@
 #ifndef LOG_USB
 #define LOG_USB 0
 #endif
-
-#include "tusb_option.h"
-
-#if TUSB_OPT_DEVICE_ENABLED && (CFG_TUSB_MCU == OPT_MCU_VALENTYUSB_EPTRI)
 
 #include "device/dcd.h"
 #include "dcd_eptri.h"


### PR DESCRIPTION
**Describe the PR**
Mynewt build fails when xc32 compiler is used.

definition of DEBUG breaks Microchip pic32 builds for Mynewt.
When MCU is not VALENTYUSB_EPTRI there is no need to have any
preprocessor definitions.
It may not look like a big deal but for xc32 builds, compiler
automatically force-includes some file that have structure with field name
DEBUG that result in build error in dcd_eptri.c when this file
is not really needed.

Moving DEBUG and LOG_USB few lines down should not break eptri builds.

**Additional context**
This is prerequisite to have Microchip mips-arhitecture support for pic32 family
for Mynewt.
