### PR TITLE
build system: Changes for xc32 compiler

### DIFF
--- a/examples/make.mk
+++ b/examples/make.mk
@@ -54,6 +54,8 @@ endif
 #-------------- Cross Compiler  ------------
 # Can be set by board, default to ARM GCC
 CROSS_COMPILE ?= arm-none-eabi-
+# Allow for -Os to be changed by board makefiles in case -Os is not allowed
+CFLAGS_OPTIMIZED ?= -Os
 
 CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)g++
@@ -112,7 +114,7 @@ CFLAGS += \
 ifeq ($(DEBUG), 1)
   CFLAGS += -Og
 else
-  CFLAGS += -Os
+  CFLAGS += $(CFLAGS_OPTIMIZED)
 endif
 
 # Log level is mapped to TUSB DEBUG option

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -12,8 +12,10 @@ ifeq (,$(findstring $(FAMILY),esp32s2 esp32s3 rp2040))
 # Compiler Flags
 # ---------------------------------------
 
+LIBS_GCC ?= -lgcc -lm -lnosys
+
 # libc
-LIBS += -lgcc -lm -lnosys
+LIBS += $(LIBS_GCC)
 
 ifneq ($(BOARD), spresense)
 LIBS += -lc
@@ -49,7 +51,11 @@ ifeq ($(NO_LTO),1)
 CFLAGS := $(filter-out -flto,$(CFLAGS))
 endif
 
-LDFLAGS += $(CFLAGS) -Wl,-T,$(TOP)/$(LD_FILE) -Wl,-Map=$@.map -Wl,-cref -Wl,-gc-sections
+ifneq ($(LD_FILE),)
+LDFLAGS_LD_FILE ?= -Wl,-T,$(TOP)/$(LD_FILE)
+endif
+
+LDFLAGS += $(CFLAGS) $(LDFLAGS_LD_FILE) -Wl,-Map=$@.map -Wl,-cref -Wl,-gc-sections
 ifneq ($(SKIP_NANOLIB), 1)
 LDFLAGS += -specs=nosys.specs -specs=nano.specs
 endif


### PR DESCRIPTION
**Describe the PR**
Three changes are needed to accommodate **xc32** compiler build:
- optimized build flag other than -Os
   added **CFLAGS_OPTIMIZED** that defaults to `-Os` but can be overridden in boards
- build without `-lnosys`
   added **LIBS_GCC** with default libraries that can be changed in boards
- build without **LD_FILE** specification
   if **LD_FILE** is empty `-Wl,-T` options is not added to **LDFLAGS**

**Additional context**
xc32 compiler for Microchip mips chips in free edition have some functional limitations like
lack of `-Os` and `-flto`.
It also provides linker script automatically so it does not have to be specified on command line.
It does not have **nosys** library that is not needed for bulild.
