### PR TITLE
nrf5x: Request HFXO via OS

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -38,6 +38,10 @@
 #include "device/usbd.h"
 #include "device/usbd_pvt.h" // to use defer function helper
 
+#if CFG_TUSB_OS == OPT_OS_MYNEWT
+#include "mcu/mcu.h"
+#endif
+
 /*------------------------------------------------------------------*/
 /* MACRO TYPEDEF CONSTANT ENUM
  *------------------------------------------------------------------*/
@@ -891,6 +895,11 @@ static bool hfclk_running(void)
 
 static void hfclk_enable(void)
 {
+#if CFG_TUSB_OS == OPT_OS_MYNEWT
+  usb_clock_request();
+  return;
+#else
+
   // already running, nothing to do
   if ( hfclk_running() ) return;
 
@@ -904,10 +913,16 @@ static void hfclk_enable(void)
 
   nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_HFCLKSTARTED);
   nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTART);
+#endif
 }
 
 static void hfclk_disable(void)
 {
+#if CFG_TUSB_OS == OPT_OS_MYNEWT
+  usb_clock_release();
+  return;
+#else
+
 #ifdef SOFTDEVICE_PRESENT
   if ( is_sd_enabled() )
   {
@@ -917,6 +932,7 @@ static void hfclk_disable(void)
 #endif
 
   nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTOP);
+#endif
 }
 
 // Power & Clock Peripheral on nRF5x to manage USB


### PR DESCRIPTION
**Describe the PR**
**Mynewt** (similar to Soft Device) has its own reference counting for
HFXO oscillator.
So far TinyUSB requested HFXO when VBUS was detected and stopped when
VBUS was removed.
But with Mynewt running HFXO can be stopped when other interested parties
don't require HFXO anymore. This results in very difficult to track
USB transmission errors when internal RC is used for USB clock source.

This change enables Mynewt specific HFXO management in Soft Device fashion.

**Additional context**
This PR should be merged AFTER matching mynewt PR is merged
https://github.com/apache/mynewt-core/pull/2748
