### PR TITLE
Fix video_capture example fails enumeration when 8FPS

### DIFF
--- a/examples/device/video_capture/src/usb_descriptors.h
+++ b/examples/device/video_capture/src/usb_descriptors.h
@@ -103,7 +103,7 @@ enum {
         TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT(/*bFrameIndex */1, 0, _width, _height, \
             _width * _height * 16, _width * _height * 16 * _fps, \
             _width * _height * 16, \
-            (10000000/_fps), (10000000/_fps), 10000000, 100000), \
+            (10000000/_fps), (10000000/_fps), (10000000/_fps)*_fps, (10000000/_fps)), \
         TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING(VIDEO_COLOR_PRIMARIES_BT709, VIDEO_COLOR_XFER_CH_BT709, VIDEO_COLOR_COEF_SMPTE170M), \
   /* VS alt 1 */\
   TUD_VIDEO_DESC_STD_VS(1, 1, 1, 0), \


### PR DESCRIPTION
**Describe the PR**
If `FRAME_RATE` was changed to 8, enumeration process had been failed. `FRAME_RATE` is defined followings.
https://github.com/hathach/tinyusb/blob/3b09b82123a50bef6b18cf90c2734ae7581da4a3/examples/device/video_capture/src/usb_descriptors.h#L38

See also: https://github.com/hathach/tinyusb/pull/1118#issuecomment-1010401051

**Additional context**
I had confirmed this patch on Raspberry Pi Pico.