### PR TITLE
olimex pic32 board fixes

### DIFF
--- a/hw/bsp/pic32mz/boards/olimex_emz64/olimex_emz64.c
+++ b/hw/bsp/pic32mz/boards/olimex_emz64/olimex_emz64.c
@@ -63,7 +63,7 @@ void led_init(void)
   // RB8 - LED
   // ANASELB RB8 not analog
   ANSELBCLR = TU_BIT(8);
-  // TRISH RH2 input
+  // TRISH RH2 output
   TRISBCLR = TU_BIT(8);
   // Initial value 0, LED off
   LATBCLR = TU_BIT(8);
@@ -128,7 +128,7 @@ void board_led_write(bool state)
 
 uint32_t board_button_read(void)
 {
-  return (PORTB >> 12) & 1;
+  return ((PORTB >> 12) & 1) == 0;
 }
 
 int board_uart_write(void const * buf, int len)

--- a/hw/bsp/pic32mz/boards/olimex_hmz144/olimex_hmz144.c
+++ b/hw/bsp/pic32mz/boards/olimex_hmz144/olimex_hmz144.c
@@ -60,7 +60,7 @@ void led_init(void)
 {
   // RH2 - LED
   // ANASELH no analog function on RH2
-  // TRISH RH2 input
+  // TRISH RH2 output
   TRISHCLR = TU_BIT(2);
   // Initial value 0, LED off
   LATHCLR = TU_BIT(2);
@@ -126,7 +126,7 @@ void board_led_write(bool state)
 
 uint32_t board_button_read(void)
 {
-  return (PORTB >> 12) & 1;
+  return ((PORTB >> 12) & 1) == 0;
 }
 
 int board_uart_write(void const * buf, int len)

--- a/src/portable/microchip/pic32mz/dcd_pic32mz.c
+++ b/src/portable/microchip/pic32mz/dcd_pic32mz.c
@@ -163,6 +163,10 @@ void dcd_remote_wakeup(uint8_t rhport)
   USB_REGS->POWERbits.RESUME = 1;
 #if CFG_TUSB_OS != OPT_OS_NONE
   osal_task_delay(10);
+#else
+  // TODO: Wait in non blocking mode
+  unsigned cnt = 2000;
+  while (cnt--) __asm__("nop");
 #endif
   USB_REGS->POWERbits.RESUME = 0;
 }


### PR DESCRIPTION
**Describe the PR**
Buttons for olimex_hmz144 and olimex_emz64 were incorrectly set to be active high.

Remote wakeup requires that RESUME bit be active for 10ms.
It was covered for OS build for non-OS build it is now handled by
utilizing board_millis() function.

**Additional context**
Changes needed for USB3V suite tests for remote wakeup functionality.
It was originally tested with Mynewt where remote wakeup was triggered
other way.
