### PR TITLE
Rudimentary bulk endpoint support for RP2040 host mode.

### DIFF
--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -72,10 +72,19 @@ static struct hw_endpoint *get_dev_ep(uint8_t dev_addr, uint8_t ep_addr)
   for ( uint32_t i = 1; i < TU_ARRAY_SIZE(ep_pool); i++ )
   {
     struct hw_endpoint *ep = &ep_pool[i];
-    if ( ep->configured && (ep->dev_addr == dev_addr) && (ep->ep_addr == ep_addr) ) return ep;
+    if ( ep->configured && (ep->dev_addr == dev_addr) && (tu_edpt_number(ep->ep_addr) == num) ) return ep;
   }
 
   return NULL;
+}
+
+static struct hw_endpoint *get_epx_ep(void)
+{
+    uint8_t dev_addr = (usb_hw->dev_addr_ctrl & USB_ADDR_ENDP_ADDRESS_BITS) >> USB_ADDR_ENDP_ADDRESS_LSB;
+    uint8_t ep_addr = (usb_hw->dev_addr_ctrl & USB_ADDR_ENDP_ENDPOINT_BITS) >> USB_ADDR_ENDP_ENDPOINT_LSB;
+    pico_trace("  epx dev %d ep %d\n", dev_addr, ep_addr);
+
+    return get_dev_ep(dev_addr, ep_addr);
 }
 
 static inline uint8_t dev_speed(void)
@@ -120,7 +129,10 @@ static void hw_handle_buff_status(void)
     if (remaining_buffers & bit)
     {
         remaining_buffers &= ~bit;
-        struct hw_endpoint *ep = &epx;
+
+        struct hw_endpoint *ep = get_epx_ep();
+        assert(ep);
+        assert(ep->active);
 
         uint32_t ep_ctrl = *ep->endpoint_control;
         if (ep_ctrl & EP_CTRL_DOUBLE_BUFFERED_BITS)
@@ -163,8 +175,11 @@ static void hw_trans_complete(void)
   if (usb_hw->sie_ctrl & USB_SIE_CTRL_SEND_SETUP_BITS)
   {
     pico_trace("Sent setup packet\n");
-    struct hw_endpoint *ep = &epx;
+
+    struct hw_endpoint *ep = get_epx_ep();
+    assert(ep);
     assert(ep->active);
+
     hw_xfer_complete(ep, XFER_RESULT_SUCCESS);
   }
   else
@@ -178,6 +193,8 @@ static void hcd_rp2040_irq(void)
 {
     uint32_t status = usb_hw->ints;
     uint32_t handled = 0;
+
+    TU_LOG(2, "+IRQ %x\n", status);
 
     if (status & USB_INTS_HOST_CONN_DIS_BITS)
     {
@@ -237,33 +254,39 @@ static void hcd_rp2040_irq(void)
     {
         panic("Unhandled IRQ 0x%x\n", (uint) (status ^ handled));
     }
+
+    TU_LOG(2, "-IRQ\n");
 }
 
-static struct hw_endpoint *_next_free_interrupt_ep(void)
+static struct hw_endpoint *_next_free_ep(uint8_t transfer_type)
 {
-    struct hw_endpoint *ep = NULL;
+    if (transfer_type == TUSB_XFER_CONTROL)
+        return &epx;
+
     for (uint i = 1; i < TU_ARRAY_SIZE(ep_pool); i++)
     {
-        ep = &ep_pool[i];
+        struct hw_endpoint *ep = &ep_pool[i];
         if (!ep->configured)
         {
             // Will be configured by _hw_endpoint_init / _hw_endpoint_allocate
+            ep->transfer_type = transfer_type;
             ep->interrupt_num = i - 1;
             return ep;
         }
     }
-    return ep;
+    return NULL;
 }
 
 static struct hw_endpoint *_hw_endpoint_allocate(uint8_t transfer_type)
 {
     struct hw_endpoint *ep = NULL;
 
+    ep = _next_free_ep(transfer_type);
+    assert(ep);
+
     if (transfer_type == TUSB_XFER_INTERRUPT)
     {
-        ep = _next_free_interrupt_ep();
         pico_info("Allocate interrupt ep %d\n", ep->interrupt_num);
-        assert(ep);
         ep->buffer_control = &usbh_dpram->int_ep_buffer_ctrl[ep->interrupt_num].ctrl;
         ep->endpoint_control = &usbh_dpram->int_ep_ctrl[ep->interrupt_num].ctrl;
         // 0 for epx (double buffered): TODO increase to 1024 for ISO
@@ -274,7 +297,7 @@ static struct hw_endpoint *_hw_endpoint_allocate(uint8_t transfer_type)
     }
     else
     {
-        ep = &epx;
+        pico_info("Allocate ep %d\n", ep->interrupt_num);
         ep->buffer_control = &usbh_dpram->epx_buf_ctrl;
         ep->endpoint_control = &usbh_dpram->epx_ctrl;
         ep->hw_data_buf = &usbh_dpram->epx_data[0];
@@ -503,7 +526,7 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * 
     // If a normal transfer (non-interrupt) then initiate using
     // sie ctrl registers. Otherwise interrupt ep registers should
     // already be configured
-    if (ep == &epx) {
+    if (ep->transfer_type != TUSB_XFER_INTERRUPT) {
         hw_endpoint_xfer_start(ep, buffer, buflen);
 
         // That has set up buffer control, endpoint control etc
@@ -528,11 +551,13 @@ bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet
 {
     (void) rhport;
 
+    pico_trace("hcd_setup_send dev_addr %d\n", dev_addr);
+
     // Copy data into setup packet buffer
     memcpy((void*)&usbh_dpram->setup_packet[0], setup_packet, 8);
 
     // Configure EP0 struct with setup info for the trans complete
-    struct hw_endpoint *ep = _hw_endpoint_allocate(0);
+    struct hw_endpoint *ep = _hw_endpoint_allocate(TUSB_XFER_CONTROL);
 
     // EP0 out
     _hw_endpoint_init(ep, dev_addr, 0x00, ep->wMaxPacketSize, 0, 0);


### PR DESCRIPTION
Allows bulk endpoints to use entries in ep_pool, and forces only control endpoints to share ep_pool[0].

*THIS IS A HACK.*

It's only tested to the extent that the MSC example gets as far as invoking inquiry_complete_cb().
This exercises an input & an output bulk endpoints.
Coexistence of interrupt & bulk EPs is entirely untested and is sure to fail.