### PR TITLE
fix idfgh-6508: return type in tu_fifo_peek_n()

### DIFF
--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -716,7 +716,7 @@ bool tu_fifo_peek(tu_fifo_t* f, void * p_buffer)
 uint16_t tu_fifo_peek_n(tu_fifo_t* f, void * p_buffer, uint16_t n)
 {
   _ff_lock(f->mutex_rd);
-  bool ret = _tu_fifo_peek_n(f, p_buffer, n, f->wr_idx, f->rd_idx, TU_FIFO_COPY_INC);
+  uint16_t ret = _tu_fifo_peek_n(f, p_buffer, n, f->wr_idx, f->rd_idx, TU_FIFO_COPY_INC);
   _ff_unlock(f->mutex_rd);
   return ret;
 }


### PR DESCRIPTION
**Describe the PR**
This simple PR is submitted to fix the IDFGH-6508 issue as described here: https://github.com/espressif/esp-idf/issues/8161
The return type in the line /src/common/tusb_fifo.c:719 should be changed to `uint16_t` instead of bool.
The [esp-idf fork](https://github.com/espressif/tinyusb/blob/master/src/common/tusb_fifo.c#L488) then can be rebased on upstream master.
