### PR TITLE
usb host: Add support for multi-level USB Hubs

### DIFF
--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -287,6 +287,15 @@ bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32
 
   TU_LOG2("  Port Status Change = 0x%02X\r\n", p_hub->status_change);
 
+  if (tuh_control_xfer_busy())
+  {
+    TU_LOG2("  Control buffer busy, requeue hub status check\n");
+    //The usb stack is busy other control transfers, just requeue the transfer
+    //and we can try again later
+    hub_status_pipe_queue(dev_addr);
+    return true;
+  }
+
   // Hub ignore bit0 in status change
   for (uint8_t port=1; port <= p_hub->port_count; port++)
   {

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -281,15 +281,16 @@ bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32
 {
   (void) xferred_bytes; // TODO can be more than 1 for hub with lots of ports
   (void) ep_addr;
-  TU_ASSERT(result == XFER_RESULT_SUCCESS);
+  //Might stall if unplugged
+  TU_ASSERT(result != XFER_RESULT_FAILED);
 
   hub_interface_t* p_hub = get_itf(dev_addr);
 
   TU_LOG2("  Port Status Change = 0x%02X\r\n", p_hub->status_change);
 
-  if (tuh_control_xfer_busy())
+  if (tuh_control_xfer_busy() || tuh_is_enumerating())
   {
-    TU_LOG2("  Control buffer busy, requeue hub status check\n");
+    TU_LOG2("  Control buffer busy or stack enumerating, requeue hub status check\n");
     //The usb stack is busy other control transfers, just requeue the transfer
     //and we can try again later
     hub_status_pipe_queue(dev_addr);

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -774,10 +774,11 @@ static bool enum_get_addr0_device_desc_complete(uint8_t dev_addr, tusb_control_r
   {
     // after RESET_DELAY the hub_port_reset() already complete
     TU_ASSERT( hub_port_reset(_dev0.hub_addr, _dev0.hub_port, NULL) );
+    while(tuh_control_xfer_busy())
+    {
+      tuh_task(); //FIXME. Should be non blocking.
+    }
     osal_task_delay(RESET_DELAY);
-
-    tuh_task(); // FIXME temporarily to clean up port_reset control transfer
-
     TU_ASSERT( hub_port_get_status(_dev0.hub_addr, _dev0.hub_port, _usbh_ctrl_buf, enum_hub_get_status1_complete) );
   }
 #endif

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -80,6 +80,7 @@ static inline bool tuh_ready(uint8_t dev_addr)
 
 // Carry out control transfer
 bool tuh_control_xfer (uint8_t dev_addr, tusb_control_request_t const* request, void* buffer, tuh_control_complete_cb_t complete_cb);
+bool tuh_control_xfer_busy();
 
 //--------------------------------------------------------------------+
 // APPLICATION CALLBACK

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -63,6 +63,9 @@ tusb_speed_t tuh_speed_get(uint8_t dev_addr);
 // Check if device is connected and configured
 bool tuh_mounted(uint8_t dev_addr);
 
+// Check if tusb is currently enumerating a usb device
+bool tuh_is_enumerating(void);
+
 // Check if device is suspended
 static inline bool tuh_suspended(uint8_t dev_addr)
 {

--- a/src/host/usbh_control.c
+++ b/src/host/usbh_control.c
@@ -47,6 +47,7 @@ typedef struct
   tuh_control_complete_cb_t complete_cb;
 } usbh_control_xfer_t;
 
+static bool ctrl_xfer_busy = false;
 static usbh_control_xfer_t _ctrl_xfer;
 
 //CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN
@@ -56,8 +57,16 @@ static usbh_control_xfer_t _ctrl_xfer;
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
 //--------------------------------------------------------------------+
 
+bool tuh_control_xfer_busy()
+{
+  return ctrl_xfer_busy;
+}
+
 bool tuh_control_xfer (uint8_t dev_addr, tusb_control_request_t const* request, void* buffer, tuh_control_complete_cb_t complete_cb)
 {
+  TU_ASSERT(ctrl_xfer_busy == false);
+  ctrl_xfer_busy = true;
+
   // TODO need to claim the endpoint first
   const uint8_t rhport = usbh_get_rhport(dev_addr);
 
@@ -79,6 +88,7 @@ bool tuh_control_xfer (uint8_t dev_addr, tusb_control_request_t const* request, 
 static void _xfer_complete(uint8_t dev_addr, xfer_result_t result)
 {
   TU_LOG2("\r\n");
+  ctrl_xfer_busy = false;
   if (_ctrl_xfer.complete_cb) _ctrl_xfer.complete_cb(dev_addr, &_ctrl_xfer.request, result);
 }
 


### PR DESCRIPTION
**Describe the PR**
* Add support for multiple levels of USB hubs. For your consideration Hathach 😄 

To get this working reliably I also added a few additonal changes/fixes:
1. Check if the shared control buffer is busy and assert if it is. This happened alot on hub status checks, it is aleast visible now if we mess up and conflict multiple control transfers.
2. Prevent another device from enumerating if another device is currently being enumerated.
3. These tweaks also seems to improve the reliability of a single level hub with multiple USB devices in my testing.

**Additional context**
1. Developed on imxrt (Teensy41) with EHCI. ~~Have not been able to test on Pico host yet~~. Tested it on my Pico and appears to work fine!
2. Tested with 3 USB hubs levels, combination of low speed and full speed devices. (HID devices) Not tested with Bulk or Iso but this is not expected to be different from upstream.
3. Quite susceptible to 5V rail supply issues. So an externally powered usb hub is recommended.
4. My dev/test repo is https://github.com/Ryzee119/tinyusb_host_test.git
5. No retry mechanism in enumeration (yet), so it can just fail on picky devices.

May help to review on a per commit basis.

Thanks for this great USB stack 🚀 
