### PR TITLE
da1469x: fix resume

### DIFF
--- a/src/portable/dialog/da146xx/dcd_da146xx.c
+++ b/src/portable/dialog/da146xx/dcd_da146xx.c
@@ -935,13 +935,13 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
     if (dir == TUSB_DIR_OUT)
     {
       regs->epc_out = epnum | USB_USB_EPC1_REG_USB_EP_EN_Msk | iso_mask;
-      USB->USB_RXMSK_REG |= 0x101 << (epnum - 1);
+      USB->USB_RXMSK_REG |= 0x11 << (epnum - 1);
       REG_SET_BIT(USB_MAMSK_REG, USB_M_RX_EV);
     }
     else
     {
       regs->epc_in = epnum | USB_USB_EPC1_REG_USB_EP_EN_Msk | iso_mask;
-      USB->USB_TXMSK_REG |= 0x101 << (epnum - 1);
+      USB->USB_TXMSK_REG |= 0x11 << (epnum - 1);
       REG_SET_BIT(USB_MAMSK_REG, USB_M_TX_EV);
     }
   }
@@ -982,7 +982,7 @@ void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr)
     {
       regs->rxc = USB_USB_RXC1_REG_USB_FLUSH_Msk;
       regs->epc_out = 0;
-      USB->USB_RXMSK_REG &= ~(0x101 << (epnum - 1));
+      USB->USB_RXMSK_REG &= ~(0x11 << (epnum - 1));
       // Release DMA if needed
       if (_dcd.dma_ep[TUSB_DIR_OUT] == epnum)
       {
@@ -994,7 +994,7 @@ void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr)
     {
       regs->txc = USB_USB_TXC1_REG_USB_FLUSH_Msk;
       regs->epc_in = 0;
-      USB->USB_TXMSK_REG &= ~(0x101 << (epnum - 1));
+      USB->USB_TXMSK_REG &= ~(0x11 << (epnum - 1));
       // Release DMA if needed
       if (_dcd.dma_ep[TUSB_DIR_IN] == epnum)
       {

--- a/src/portable/dialog/da146xx/dcd_da146xx.c
+++ b/src/portable/dialog/da146xx/dcd_da146xx.c
@@ -733,6 +733,15 @@ static void handle_alt_ev(void)
       set_nfsr(NFSR_NODE_OPERATIONAL);
       USB->USB_ALTMSK_REG = USB_USB_ALTMSK_REG_USB_M_RESET_Msk |
                             USB_USB_ALTMSK_REG_USB_M_SD3_Msk;
+      // Re-enable reception of endpoint with pending transfer
+      for (int epnum = 1; epnum <= 3; ++epnum)
+      {
+        xfer_ctl_t * xfer = XFER_CTL_BASE(epnum, TUSB_DIR_OUT);
+        if (xfer->total_len > xfer->transferred)
+        {
+          start_rx_packet(xfer);
+        }
+      }
       dcd_event_bus_signal(0, DCD_EVENT_RESUME, true);
     }
   }


### PR DESCRIPTION
**Describe the PR**
Entering suspend mode clears bit USB_RX_EN in USB_RXCx_REG.
Resuming after suspend state did not enable reception on non-0 endpoints.
It resulted in incoming packets being NAK'ed after resume.

Now, on resume event, all OUT endpoints are checked for pending transfers
and when transfer is not completed USB_RX_EN bit is set by start_tx_packet.

Additionally over-run/under-run masks were off by 4 bits so those interrupts
would never be enabled.
