### PR TITLE
Some platforms require SDKs and use of cmake

### DIFF
--- a/docs/reference/getting_started.rst
+++ b/docs/reference/getting_started.rst
@@ -52,6 +52,8 @@ Some TinyUSB examples also requires external submodule libraries in ``/lib`` suc
 
 In addition, MCU driver submodule is also needed to provide low-level MCU peripheral's driver. Luckily, it will be fetched if needed when you run the ``make`` to build your board.
 
+Some modules will also require a module-specific SDK (e.g. RP2040) or binary (e.g. Sony Spresense) to build examples.
+
 Note: some examples especially those that uses Vendor class (e.g webUSB) may requires udev permission on Linux (and/or macOS) to access usb device. It depends on your OS distro, typically copy ``/examples/device/99-tinyusb.rules`` file to /etc/udev/rules.d/ then run ``sudo udevadm control --reload-rules && sudo udevadm trigger`` is good enough.
 
 Build
@@ -62,6 +64,8 @@ To build example, first change directory to an example folder.
 .. code-block::
 
    $ cd examples/device/cdc_msc
+
+Some modules (e.g. RP2040 and ESP32s2) require the project makefiles to be customized using CMake. If necessary apply any setup steps for the platform's SDK.
 
 Then compile with ``make BOARD=[board_name] all``\ , for example
 


### PR DESCRIPTION
**Describe the PR**
Add information on the assumption that module-specific setup steps may be needed to build. See issue #1297 

