### PR TITLE
Solve problems with CCRX toolchain

### DIFF
--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -75,7 +75,11 @@
  * Nth position is the same as the number of arguments
  * - ##__VA_ARGS__ is used to deal with 0 paramerter (swallows comma)
  *------------------------------------------------------------------*/
-#define TU_ARGS_NUM(...) 	 _TU_NARG(_0, ##__VA_ARGS__,_RSEQ_N())
+#if !defined(__CCRX__)
+#define TU_ARGS_NUM(...)   _TU_NARG(_0, ##__VA_ARGS__,_RSEQ_N())
+#else
+#define TU_ARGS_NUM(...)   _TU_NARG(_0, __VA_ARGS__,_RSEQ_N())
+#endif
 
 #define _TU_NARG(...)      _GET_NTH_ARG(__VA_ARGS__)
 #define _GET_NTH_ARG( \

--- a/src/portable/renesas/usba/dcd_usba.c
+++ b/src/portable/renesas/usba/dcd_usba.c
@@ -494,7 +494,11 @@ static bool process_pipe_xfer(int buffer_type, uint8_t ep_addr, void* buffer, ui
       while (USB0.D0FIFOSEL.BIT.CURPIPE) ; /* if CURPIPE bits changes, check written value */
     }
   } else {
+#if defined(__CCRX__)
+    __evenaccess volatile reg_pipetre_t *pt = get_pipetre(num);
+#else
     volatile reg_pipetre_t *pt = get_pipetre(num);
+#endif
     if (pt) {
       const unsigned     mps = edpt_max_packet_size(num);
       volatile uint16_t *ctr = get_pipectr(num);
@@ -715,11 +719,11 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * ep_desc)
   *ctr = 0;
   unsigned cfg = (dir << 4) | epn;
   if (xfer == TUSB_XFER_BULK) {
-    cfg |= USB_PIPECFG_BULK | USB_PIPECFG_SHTNAK | USB_PIPECFG_DBLB;
+    cfg |= (USB_PIPECFG_BULK | USB_PIPECFG_SHTNAK | USB_PIPECFG_DBLB);
   } else if (xfer == TUSB_XFER_INTERRUPT) {
     cfg |= USB_PIPECFG_INT;
   } else {
-    cfg |= USB_PIPECFG_ISO | USB_PIPECFG_DBLB;
+    cfg |= (USB_PIPECFG_ISO | USB_PIPECFG_DBLB);
   }
   USB0.PIPECFG.WORD  = cfg;
   USB0.BRDYSTS.WORD  = 0x1FFu ^ TU_BIT(num);


### PR DESCRIPTION
This PR solves two issues that happens with the CCRX toolchain.

The first issue was found in the `TU_ARGS_NUM` macro. Without this modification it is not possible to build the tinyUSB successfully. 

The second issue belong to local pointer variable definition of the type `reg_pipetre_t`, which is mapped over the `PIPExTRE` register of the RX USB hardware. To ensure access in the correct size the keyword `__evenaccess` needs to be used. 
Note: Without this modifier, it seems that receiving of data from a host is working, but only as long as the number of bytes is less then 65 bytes.

The modification was successful tested with the CCRX toolchain in little and big endian mode and also with the GCC toolchain in little endian mode.
