### PR TITLE
Open OUT endpoint for HID host

### DIFF
--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -328,9 +328,11 @@ static void _hw_endpoint_init(struct hw_endpoint *ep, uint8_t dev_addr, uint8_t 
         // endpoint number / direction
         // preamble
         uint32_t reg = dev_addr | (num << USB_ADDR_ENDP1_ENDPOINT_LSB);
-        // Assert the interrupt endpoint is IN_TO_HOST
-        // TODO Interrupt can also be OUT
-        assert(dir == TUSB_DIR_IN);
+
+        if (dir == TUSB_DIR_OUT)
+        {
+            reg |= USB_ADDR_ENDP1_INTEP_DIR_BITS;
+        }
 
         if (need_pre(dev_addr))
         {


### PR DESCRIPTION
**Describe the PR**
Updates the host HID code to open the OUT endpoint (if it exists). Also adds handling for interrupt OUT to the RP2040 host code. (at least, that seemed to be enough)

**Additional context**
I've been trying to connect a Wii U GameCube adapter, which requires some data to be sent to it before it starts sending reports. This PR doesn't add any code for actually doing that, but having the endpoint open helps.

(I've only tested this as far as sending the one byte I need for that)
