### PR TITLE
Set the standard inquiry response additional length field.

### DIFF
--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -753,6 +753,7 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
           .is_removable         = 1,
           .version              = 2,
           .response_data_format = 2,
+          .additional_length    = sizeof(scsi_inquiry_resp_t) - 5,
       };
 
       // vendor_id, product_id, product_rev is space padded string


### PR DESCRIPTION
**Describe the PR**
The standard inquiry response additional length field needs to be set to the length in bytes of the remaining standard inquiry data (i.e. N - 5), otherwise the kernel driver issues a warning about short inquiry response.

**Additional context**
On Linux I see the following warning, it seems the driver assumes the response is the minimum 36 bytes:
```
[53564.998251] usb-storage 4-2:1.2: USB Mass Storage device detected
[53564.998424] scsi host0: usb-storage 4-2:1.2
[53566.008111] scsi host0: scsi scan: INQUIRY result too short (5), using 36
```
This warning is gone after setting the additional length field.

See section 3.6.2 Standard INQUIRY data in Seagate SCSI reference manual ([PDF link](https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf)). 

Tested using `sg_inq`, _without_ this patch (note the length=5):
```
> sudo sg_inq --only /dev/sda
standard INQUIRY:
  PQual=0  PDT=0  RMB=1  LU_CONG=0  hot_pluggable=0  version=0x02  [SCSI-2]
  [AERC=0]  [TrmTsk=0]  NormACA=0  HiSUP=0  Resp_data_format=2
  SCCS=0  ACC=0  TPGS=0  3PC=0  Protect=0  [BQue=0]
  EncServ=0  MultiP=0  [MChngr=0]  [ACKREQQ=0]  Addr16=0
  [RelAdr=0]  WBus16=0  Sync=0  [Linked=0]  [TranDis=0]  CmdQue=0
    length=5 (0x5)
  [for SCSI>=2, len>=36 is expected]   Peripheral device type: disk
Inquiry response length=5, no vendor, product or revision data
```

With this patch (the expected 36 bytes length):
```
> sudo sg_inq --only /dev/sda
standard INQUIRY:
  PQual=0  PDT=0  RMB=1  LU_CONG=0  hot_pluggable=0  version=0x02  [SCSI-2]
  [AERC=0]  [TrmTsk=0]  NormACA=0  HiSUP=0  Resp_data_format=2
  SCCS=0  ACC=0  TPGS=0  3PC=0  Protect=0  [BQue=0]
  EncServ=0  MultiP=0  [MChngr=0]  [ACKREQQ=0]  Addr16=0
  [RelAdr=0]  WBus16=0  Sync=0  [Linked=0]  [TranDis=0]  CmdQue=0
    length=36 (0x24)   Peripheral device type: disk
 Vendor identification: Micropy
 Product identification: Mass Storage
 Product revision level: 1.0
```