### PR TITLE
Removed RP2040 from skip.txt in FreeRTOS examples.

### DIFF
--- a/examples/device/cdc_msc_freertos/skip.txt
+++ b/examples/device/cdc_msc_freertos/skip.txt
@@ -3,7 +3,6 @@ mcu:MSP430x5xx
 mcu:SAMD11
 mcu:VALENTYUSB_EPTRI
 mcu:MKL25ZXX
-mcu:RP2040
 mcu:SAMX7X
 mcu:GD32VF103
 family:broadcom_64bit

--- a/examples/device/hid_composite_freertos/skip.txt
+++ b/examples/device/hid_composite_freertos/skip.txt
@@ -2,7 +2,6 @@ mcu:CXD56
 mcu:MSP430x5xx
 mcu:SAMD11
 mcu:VALENTYUSB_EPTRI
-mcu:RP2040
 mcu:SAMX7X
 mcu:GD32VF103
 family:broadcom_64bit


### PR DESCRIPTION
A port of FreeRTOS is available for the RP2040 now.

**Describe the PR**
Removed RP2040 from skip.txt in FreeRTOS examples.

**Additional context**
https://github.com/hathach/tinyusb/discussions/1348#discussioncomment-2250901
