### PR TITLE
Updated the clearing of the status register bits to use a straight '=…

### DIFF
--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -657,7 +657,7 @@ void hcd_int_handler(uint8_t rhport)
   uint32_t int_status = regs->status;
   int_status &= regs->inten;
   
-  regs->status |= int_status; // Acknowledge handled interrupt
+  regs->status = int_status; // Acknowledge handled interrupt
 
   if (int_status == 0) return;
 


### PR DESCRIPTION
…', rather than an '|='.  Use of the latter caused an extra, unwanted read of the status register before the write-to-clear operation, which, in some cases, allowed new status bits to assert (relative to the initial read of the status register two statements earlier), and then be cleared blindly and unconditionally during the write-back.  This had the potential (and, in my case, observed) effect of dropping the handling of an enabled interrupt.  Ultimately, the system would lock up in a busy state, with no hope of clearing the condition.  See Issue #1339 for more information.

**Describe the PR**
A clear and concise description of what this PR solve.

**Additional context**
If applicable, add any other context about the PR and/or screenshots here.
