### PR TITLE
The IAR compilier does not resolve references to fields in the anonym…

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -62,12 +62,12 @@ typedef struct
   uint8_t hub_port;
   uint8_t speed;
 
-  volatile struct TU_ATTR_PACKED
+  struct TU_ATTR_PACKED
   {
-    uint8_t connected    : 1;
-    uint8_t addressed    : 1;
-    uint8_t configured   : 1;
-    uint8_t suspended    : 1;
+    volatile uint8_t connected    : 1;
+    volatile uint8_t addressed    : 1;
+    volatile uint8_t configured   : 1;
+    volatile uint8_t suspended    : 1;
   };
 } usbh_dev0_t;
 
@@ -78,12 +78,12 @@ typedef struct {
   uint8_t hub_port;
   uint8_t speed;
 
-  volatile struct TU_ATTR_PACKED
+  struct TU_ATTR_PACKED
   {
-    uint8_t connected    : 1;
-    uint8_t addressed    : 1;
-    uint8_t configured   : 1;
-    uint8_t suspended    : 1;
+    volatile uint8_t connected    : 1;
+    volatile uint8_t addressed    : 1;
+    volatile uint8_t configured   : 1;
+    volatile uint8_t suspended    : 1;
   };
 
   //------------- device descriptor -------------//


### PR DESCRIPTION
…ous structs defined within the usbh_dev0_t and usbh_device_t structs as they are defined.  The problem seems to relate to the placement of the 'volatile' keyword at the struct level.  I fixed the problem by removing the 'volatile' from the struct level, and instead placing it on each of the field declarations within the structs.

**Describe the PR**
IAR compile-time errors on src/host/usbh.c are removed by reassigning 'volatile' keyword from the struct level in two anonymous structs within outer structs to the individual field names within the anonymous structs.  The original placement results in the field names appearing undefined when they are referenced later in the file.

**Additional context**
![IAR compiler error on TinyUSB volatile-anonymous in usbh c](https://user-images.githubusercontent.com/60118419/155814021-5c74310a-d985-4efe-838a-542b4c96ca45.png)

