### PR TITLE
Host edpt xfer

### DIFF
--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -136,11 +136,10 @@ void print_device_descriptor(uint8_t daddr, tuh_xfer_t* xfer)
   printf("  idProduct           0x%04x\r\n" , desc_device.idProduct);
   printf("  bcdDevice           %04x\r\n"   , desc_device.bcdDevice);
 
-  uint32_t timeout_ms = 10;
   uint16_t temp_buf[128];
 
   printf("  iManufacturer       %u     "     , desc_device.iManufacturer);
-  if (XFER_RESULT_SUCCESS == tuh_descriptor_get_manufacturer_string_sync(daddr, LANGUAGE_ID, temp_buf, TU_ARRAY_SIZE(temp_buf), timeout_ms) )
+  if (XFER_RESULT_SUCCESS == tuh_descriptor_get_manufacturer_string_sync(daddr, LANGUAGE_ID, temp_buf, TU_ARRAY_SIZE(temp_buf)) )
   {
     utf16_to_utf8(temp_buf, TU_ARRAY_SIZE(temp_buf));
     printf((const char*) temp_buf);
@@ -148,7 +147,7 @@ void print_device_descriptor(uint8_t daddr, tuh_xfer_t* xfer)
   printf("\r\n");
 
   printf("  iProduct            %u     "     , desc_device.iProduct);
-  if (XFER_RESULT_SUCCESS == tuh_descriptor_get_product_string_sync(daddr, LANGUAGE_ID, temp_buf, TU_ARRAY_SIZE(temp_buf), timeout_ms))
+  if (XFER_RESULT_SUCCESS == tuh_descriptor_get_product_string_sync(daddr, LANGUAGE_ID, temp_buf, TU_ARRAY_SIZE(temp_buf)))
   {
     utf16_to_utf8(temp_buf, TU_ARRAY_SIZE(temp_buf));
     printf((const char*) temp_buf);
@@ -156,7 +155,7 @@ void print_device_descriptor(uint8_t daddr, tuh_xfer_t* xfer)
   printf("\r\n");
 
   printf("  iSerialNumber       %u     "     , desc_device.iSerialNumber);
-  if (XFER_RESULT_SUCCESS == tuh_descriptor_get_serial_string_sync(daddr, LANGUAGE_ID, temp_buf, TU_ARRAY_SIZE(temp_buf), timeout_ms))
+  if (XFER_RESULT_SUCCESS == tuh_descriptor_get_serial_string_sync(daddr, LANGUAGE_ID, temp_buf, TU_ARRAY_SIZE(temp_buf)))
   {
     utf16_to_utf8(temp_buf, TU_ARRAY_SIZE(temp_buf));
     printf((const char*) temp_buf);

--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -37,6 +37,13 @@
 
 // English
 #define LANGUAGE_ID 0x0409
+#define BUF_COUNT   4
+
+
+tusb_desc_device_t desc_device;
+
+uint8_t buf_pool[BUF_COUNT][64];
+uint8_t buf_owner[BUF_COUNT] = { 0 }; // device address that owns buffer
 
 //--------------------------------------------------------------------+
 // MACRO CONSTANT TYPEDEF PROTYPES
@@ -47,12 +54,8 @@ static void print_utf16(uint16_t *temp_buf, size_t buf_len);
 void print_device_descriptor(tuh_xfer_t* xfer);
 void parse_config_descriptor(uint8_t dev_addr, tusb_desc_configuration_t const* desc_cfg);
 
-tusb_desc_device_t desc_device;
-
-#define BUF_COUNT   4
-
-uint8_t buf_pool[BUF_COUNT][64];
-uint8_t buf_owner[BUF_COUNT] = { 0 }; // device address that owns buffer
+uint8_t* get_hid_buf(uint8_t daddr);
+void free_hid_buf(uint8_t daddr);
 
 /*------------- MAIN -------------*/
 int main(void)
@@ -88,6 +91,7 @@ void tuh_mount_cb (uint8_t daddr)
 void tuh_umount_cb(uint8_t daddr)
 {
   printf("Device removed, address = %d\r\n", daddr);
+  free_hid_buf(daddr);
 }
 
 //--------------------------------------------------------------------+
@@ -150,115 +154,14 @@ void print_device_descriptor(tuh_xfer_t* xfer)
   }
 }
 
-
 //--------------------------------------------------------------------+
 // Configuration Descriptor
 //--------------------------------------------------------------------+
 
-// get an buffer from pool
-uint8_t* get_hid_buf(uint8_t daddr)
-{
-  for(size_t i=0; i<BUF_COUNT; i++)
-  {
-    if (buf_owner[i] == 0)
-    {
-      buf_owner[i] = daddr;
-      return buf_pool[i];
-    }
-  }
-
-  // out of memory, increase BUF_COUNT
-  return NULL;
-}
-
-// free all buffer owned by device
-void free_hid_buf(uint8_t daddr)
-{
-  for(size_t i=0; i<BUF_COUNT; i++)
-  {
-    if (buf_owner[i] == daddr) buf_owner[i] = 0;
-  }
-}
-
-void hid_report_received(tuh_xfer_t* xfer)
-{
-  // Note: not all field in xfer is available for use (i.e filled by tinyusb stack) in callback to save sram
-  // For instance, xfer->buffer is NULL. We have used user_data to store buffer when submitted callback
-  uint8_t* buf = (uint8_t*) xfer->user_data;
-
-  if (xfer->result == XFER_RESULT_SUCCESS)
-  {
-    printf("[dev %u: ep %02x] HID Report:", xfer->daddr, xfer->ep_addr);
-    for(uint32_t i=0; i<xfer->actual_len; i++)
-    {
-      if (i%16 == 0) printf("\r\n  ");
-      printf("%02X ", buf[i]);
-    }
-    printf("\r\n");
-  }
-
-  // continue to submit transfer, with updated buffer
-  // other field remain the same
-  xfer->buflen = 64;
-  xfer->buffer = buf;
-
-  tuh_edpt_xfer(xfer);
-}
-
 // count total length of an interface
 uint16_t count_interface_total_len(tusb_desc_interface_t const* desc_itf, uint8_t itf_count, uint16_t max_len);
 
-void open_hid_interface(uint8_t daddr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
-{
-  // len = interface + hid + n*endpoints
-  uint16_t const drv_len = sizeof(tusb_desc_interface_t) + sizeof(tusb_hid_descriptor_hid_t) + desc_itf->bNumEndpoints*sizeof(tusb_desc_endpoint_t);
-
-  // corrupted descriptor
-  if (max_len < drv_len) return;
-
-  uint8_t const *p_desc = (uint8_t const *) desc_itf;
-
-  // HID descriptor
-  p_desc = tu_desc_next(p_desc);
-  tusb_hid_descriptor_hid_t const *desc_hid = (tusb_hid_descriptor_hid_t const *) p_desc;
-  if(HID_DESC_TYPE_HID != desc_hid->bDescriptorType) return;
-
-  // Endpoint descriptor
-  p_desc = tu_desc_next(p_desc);
-  tusb_desc_endpoint_t const * desc_ep = (tusb_desc_endpoint_t const *) p_desc;
-
-  for(int i = 0; i < desc_itf->bNumEndpoints; i++)
-  {
-    if (TUSB_DESC_ENDPOINT != desc_ep->bDescriptorType) return;
-
-    if(tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN)
-    {
-      // skip if failed to open endpoint
-      if ( ! tuh_edpt_open(daddr, desc_ep) ) return;
-
-      uint8_t* buf = get_hid_buf(daddr);
-      if (!buf) return; // out of memory
-
-      tuh_xfer_t xfer =
-      {
-        .daddr       = daddr,
-        .ep_addr     = desc_ep->bEndpointAddress,
-        .buflen      = 64,
-        .buffer      = buf,
-        .complete_cb = hid_report_received,
-        .user_data   = (uintptr_t) buf, // since buffer is not available in callback, use user data to store the buffer
-      };
-
-      // submit transfer for this EP
-      tuh_edpt_xfer(&xfer);
-
-      printf("Listen to [dev %u: ep %02x]\r\n", daddr, desc_ep->bEndpointAddress);
-    }
-
-    p_desc = tu_desc_next(p_desc);
-    desc_ep = (tusb_desc_endpoint_t const *) p_desc;
-  }
-}
+void open_hid_interface(uint8_t daddr, tusb_desc_interface_t const *desc_itf, uint16_t max_len);
 
 // simple configuration parser to open and listen to HID Endpoint IN
 void parse_config_descriptor(uint8_t dev_addr, tusb_desc_configuration_t const* desc_cfg)
@@ -330,6 +233,117 @@ uint16_t count_interface_total_len(tusb_desc_interface_t const* desc_itf, uint8_
   return len;
 }
 
+//--------------------------------------------------------------------+
+// HID Interface
+//--------------------------------------------------------------------+
+
+void hid_report_received(tuh_xfer_t* xfer);
+
+void open_hid_interface(uint8_t daddr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
+{
+  // len = interface + hid + n*endpoints
+  uint16_t const drv_len = sizeof(tusb_desc_interface_t) + sizeof(tusb_hid_descriptor_hid_t) + desc_itf->bNumEndpoints*sizeof(tusb_desc_endpoint_t);
+
+  // corrupted descriptor
+  if (max_len < drv_len) return;
+
+  uint8_t const *p_desc = (uint8_t const *) desc_itf;
+
+  // HID descriptor
+  p_desc = tu_desc_next(p_desc);
+  tusb_hid_descriptor_hid_t const *desc_hid = (tusb_hid_descriptor_hid_t const *) p_desc;
+  if(HID_DESC_TYPE_HID != desc_hid->bDescriptorType) return;
+
+  // Endpoint descriptor
+  p_desc = tu_desc_next(p_desc);
+  tusb_desc_endpoint_t const * desc_ep = (tusb_desc_endpoint_t const *) p_desc;
+
+  for(int i = 0; i < desc_itf->bNumEndpoints; i++)
+  {
+    if (TUSB_DESC_ENDPOINT != desc_ep->bDescriptorType) return;
+
+    if(tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN)
+    {
+      // skip if failed to open endpoint
+      if ( ! tuh_edpt_open(daddr, desc_ep) ) return;
+
+      uint8_t* buf = get_hid_buf(daddr);
+      if (!buf) return; // out of memory
+
+      tuh_xfer_t xfer =
+      {
+        .daddr       = daddr,
+        .ep_addr     = desc_ep->bEndpointAddress,
+        .buflen      = 64,
+        .buffer      = buf,
+        .complete_cb = hid_report_received,
+        .user_data   = (uintptr_t) buf, // since buffer is not available in callback, use user data to store the buffer
+      };
+
+      // submit transfer for this EP
+      tuh_edpt_xfer(&xfer);
+
+      printf("Listen to [dev %u: ep %02x]\r\n", daddr, desc_ep->bEndpointAddress);
+    }
+
+    p_desc = tu_desc_next(p_desc);
+    desc_ep = (tusb_desc_endpoint_t const *) p_desc;
+  }
+}
+
+void hid_report_received(tuh_xfer_t* xfer)
+{
+  // Note: not all field in xfer is available for use (i.e filled by tinyusb stack) in callback to save sram
+  // For instance, xfer->buffer is NULL. We have used user_data to store buffer when submitted callback
+  uint8_t* buf = (uint8_t*) xfer->user_data;
+
+  if (xfer->result == XFER_RESULT_SUCCESS)
+  {
+    printf("[dev %u: ep %02x] HID Report:", xfer->daddr, xfer->ep_addr);
+    for(uint32_t i=0; i<xfer->actual_len; i++)
+    {
+      if (i%16 == 0) printf("\r\n  ");
+      printf("%02X ", buf[i]);
+    }
+    printf("\r\n");
+  }
+
+  // continue to submit transfer, with updated buffer
+  // other field remain the same
+  xfer->buflen = 64;
+  xfer->buffer = buf;
+
+  tuh_edpt_xfer(xfer);
+}
+
+//--------------------------------------------------------------------+
+// Buffer helper
+//--------------------------------------------------------------------+
+
+// get an buffer from pool
+uint8_t* get_hid_buf(uint8_t daddr)
+{
+  for(size_t i=0; i<BUF_COUNT; i++)
+  {
+    if (buf_owner[i] == 0)
+    {
+      buf_owner[i] = daddr;
+      return buf_pool[i];
+    }
+  }
+
+  // out of memory, increase BUF_COUNT
+  return NULL;
+}
+
+// free all buffer owned by device
+void free_hid_buf(uint8_t daddr)
+{
+  for(size_t i=0; i<BUF_COUNT; i++)
+  {
+    if (buf_owner[i] == daddr) buf_owner[i] = 0;
+  }
+}
 
 //--------------------------------------------------------------------+
 // Blinking Task
@@ -350,7 +364,7 @@ void led_blinking_task(void)
 }
 
 //--------------------------------------------------------------------+
-// Helper
+// String Descriptor Helper
 //--------------------------------------------------------------------+
 
 static void _convert_utf16le_to_utf8(const uint16_t *utf16, size_t utf16_len, uint8_t *utf8, size_t utf8_len) {

--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -115,13 +115,15 @@ static void utf16_to_utf8(uint16_t *temp_buf, size_t buf_len) {
     ((uint8_t*) temp_buf)[utf8_len] = '\0';
 }
 
-void print_device_descriptor(uint8_t daddr, tuh_xfer_t* xfer)
+void print_device_descriptor(tuh_xfer_t* xfer)
 {
   if ( XFER_RESULT_SUCCESS != xfer->result )
   {
     printf("Failed to get device descriptor\r\n");
     return;
   }
+
+  uint8_t const daddr = xfer->daddr;
 
   printf("Device %u: ID %04x:%04x\r\n", daddr, desc_device.idVendor, desc_device.idProduct);
   printf("Device Descriptor:\r\n");

--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -115,7 +115,7 @@ static void utf16_to_utf8(uint16_t *temp_buf, size_t buf_len) {
     ((uint8_t*) temp_buf)[utf8_len] = '\0';
 }
 
-void print_device_descriptor(uint8_t daddr, tuh_control_xfer_t* xfer)
+void print_device_descriptor(uint8_t daddr, tuh_xfer_t* xfer)
 {
   if ( XFER_RESULT_SUCCESS != xfer->result )
   {

--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -115,12 +115,12 @@ static void utf16_to_utf8(uint16_t *temp_buf, size_t buf_len) {
     ((uint8_t*) temp_buf)[utf8_len] = '\0';
 }
 
-bool print_device_descriptor(uint8_t daddr, tuh_control_xfer_t const * xfer)
+void print_device_descriptor(uint8_t daddr, tuh_control_xfer_t* xfer)
 {
   if ( XFER_RESULT_SUCCESS != xfer->result )
   {
     printf("Failed to get device descriptor\r\n");
-    return false;
+    return;
   }
 
   printf("Device %u: ID %04x:%04x\r\n", daddr, desc_device.idVendor, desc_device.idProduct);
@@ -164,8 +164,6 @@ bool print_device_descriptor(uint8_t daddr, tuh_control_xfer_t const * xfer)
   printf("\r\n");
 
   printf("  bNumConfigurations  %u\r\n"     , desc_device.bNumConfigurations);
-
-  return true;
 }
 
 // Invoked when device is mounted (configured)

--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -234,7 +234,7 @@ void open_hid_interface(uint8_t daddr, tusb_desc_interface_t const *desc_itf, ui
     if(tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN)
     {
       // skip if failed to open endpoint
-      if ( ! usbh_edpt_open(daddr, desc_ep) ) return;
+      if ( ! tuh_edpt_open(daddr, desc_ep) ) return;
 
       uint8_t* buf = get_hid_buf(daddr);
       if (!buf) return; // out of memory

--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -115,11 +115,9 @@ static void utf16_to_utf8(uint16_t *temp_buf, size_t buf_len) {
     ((uint8_t*) temp_buf)[utf8_len] = '\0';
 }
 
-bool print_device_descriptor(uint8_t daddr, tuh_control_xfer_t const * xfer, xfer_result_t result)
+bool print_device_descriptor(uint8_t daddr, tuh_control_xfer_t const * xfer)
 {
-  (void) xfer;
-
-  if ( XFER_RESULT_SUCCESS != result )
+  if ( XFER_RESULT_SUCCESS != xfer->result )
   {
     printf("Failed to get device descriptor\r\n");
     return false;

--- a/examples/host/bare_api/src/tusb_config.h
+++ b/examples/host/bare_api/src/tusb_config.h
@@ -81,11 +81,11 @@
 // 1 hub typically has 4 ports
 #define CFG_TUH_DEVICE_MAX          (CFG_TUH_HUB ? 4 : 1)
 
-#define CFG_TUH_ENDPOINT_MAX       8
+// Max endpoint per device
+#define CFG_TUH_ENDPOINT_MAX        8
 
-//------------- HID -------------//
-
-#define CFG_TUH_HID_EP_BUFSIZE      64
+// Enable tuh_edpt_xfer() API
+#define CFG_TUH_API_EDPT_XFER       1
 
 #ifdef __cplusplus
  }

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -161,6 +161,7 @@ void cdch_init(void)
 
 bool cdch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *itf_desc, uint16_t max_len)
 {
+  (void) rhport;
   (void) max_len;
 
   // Only support ACM subclass
@@ -196,7 +197,7 @@ bool cdch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *it
     // notification endpoint
     tusb_desc_endpoint_t const * desc_ep = (tusb_desc_endpoint_t const *) p_desc;
 
-    TU_ASSERT( usbh_edpt_open(rhport, dev_addr, desc_ep) );
+    TU_ASSERT( usbh_edpt_open(dev_addr, desc_ep) );
     p_cdc->ep_notif = desc_ep->bEndpointAddress;
 
     drv_len += tu_desc_len(p_desc);
@@ -217,7 +218,7 @@ bool cdch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *it
       tusb_desc_endpoint_t const *desc_ep = (tusb_desc_endpoint_t const *) p_desc;
       TU_ASSERT(TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType && TUSB_XFER_BULK == desc_ep->bmAttributes.xfer);
 
-      TU_ASSERT(usbh_edpt_open(rhport, dev_addr, desc_ep));
+      TU_ASSERT(usbh_edpt_open(dev_addr, desc_ep));
 
       if ( tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN )
       {

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -124,22 +124,24 @@ bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_co
 {
   cdch_data_t const * p_cdc = get_itf(dev_addr);
 
+  tusb_control_request_t const request =
+  {
+    .bmRequestType_bit =
+    {
+      .recipient = TUSB_REQ_RCPT_INTERFACE,
+      .type      = TUSB_REQ_TYPE_CLASS,
+      .direction = TUSB_DIR_OUT
+    },
+    .bRequest = CDC_REQUEST_SET_CONTROL_LINE_STATE,
+    .wValue   = (rts ? 2 : 0) | (dtr ? 1 : 0),
+    .wIndex   = p_cdc->itf_num,
+    .wLength  = 0
+  };
+
   tuh_control_xfer_t const xfer =
   {
-    .request =
-    {
-      .bmRequestType_bit =
-      {
-        .recipient = TUSB_REQ_RCPT_INTERFACE,
-        .type      = TUSB_REQ_TYPE_CLASS,
-        .direction = TUSB_DIR_OUT
-      },
-      .bRequest = CDC_REQUEST_SET_CONTROL_LINE_STATE,
-      .wValue   = (rts ? 2 : 0) | (dtr ? 1 : 0),
-      .wIndex   = p_cdc->itf_num,
-      .wLength  = 0
-    },
-
+    .ep_addr     = 0,
+    .setup       = &request,
     .buffer      = NULL,
     .complete_cb = complete_cb,
     .user_arg    = 0

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -197,7 +197,7 @@ bool cdch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *it
     // notification endpoint
     tusb_desc_endpoint_t const * desc_ep = (tusb_desc_endpoint_t const *) p_desc;
 
-    TU_ASSERT( usbh_edpt_open(dev_addr, desc_ep) );
+    TU_ASSERT( tuh_edpt_open(dev_addr, desc_ep) );
     p_cdc->ep_notif = desc_ep->bEndpointAddress;
 
     drv_len += tu_desc_len(p_desc);
@@ -218,7 +218,7 @@ bool cdch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *it
       tusb_desc_endpoint_t const *desc_ep = (tusb_desc_endpoint_t const *) p_desc;
       TU_ASSERT(TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType && TUSB_XFER_BULK == desc_ep->bmAttributes.xfer);
 
-      TU_ASSERT(usbh_edpt_open(dev_addr, desc_ep));
+      TU_ASSERT(tuh_edpt_open(dev_addr, desc_ep));
 
       if ( tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN )
       {

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -120,7 +120,7 @@ bool tuh_cdc_receive(uint8_t dev_addr, void * p_buffer, uint32_t length, bool is
   return usbh_edpt_xfer(dev_addr, ep_in, p_buffer, length);
 }
 
-bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_control_xfer_cb_t complete_cb)
+bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_xfer_cb_t complete_cb)
 {
   cdch_data_t const * p_cdc = get_itf(dev_addr);
 
@@ -138,7 +138,7 @@ bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_co
     .wLength  = 0
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -144,7 +144,7 @@ bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_xf
     .setup       = &request,
     .buffer      = NULL,
     .complete_cb = complete_cb,
-    .user_arg    = 0
+    .user_data    = 0
   };
 
   return tuh_control_xfer(dev_addr, &xfer);

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -140,6 +140,7 @@ bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_xf
 
   tuh_xfer_t xfer =
   {
+    .daddr       = dev_addr,
     .ep_addr     = 0,
     .setup       = &request,
     .buffer      = NULL,
@@ -147,7 +148,7 @@ bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_xf
     .user_data    = 0
   };
 
-  return tuh_control_xfer(dev_addr, &xfer);
+  return tuh_control_xfer(&xfer);
 }
 
 //--------------------------------------------------------------------+

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -138,7 +138,7 @@ bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_co
     .wLength  = 0
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,

--- a/src/class/cdc/cdc_host.h
+++ b/src/class/cdc/cdc_host.h
@@ -42,14 +42,14 @@
  * \defgroup   CDC_Serial_Host Host
  * @{ */
 
-bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_control_xfer_cb_t complete_cb);
+bool tuh_cdc_set_control_line_state(uint8_t dev_addr, bool dtr, bool rts, tuh_xfer_cb_t complete_cb);
 
-static inline bool tuh_cdc_connect(uint8_t dev_addr, tuh_control_xfer_cb_t complete_cb)
+static inline bool tuh_cdc_connect(uint8_t dev_addr, tuh_xfer_cb_t complete_cb)
 {
   return tuh_cdc_set_control_line_state(dev_addr, true, true, complete_cb);
 }
 
-static inline bool tuh_cdc_disconnect(uint8_t dev_addr, tuh_control_xfer_cb_t complete_cb)
+static inline bool tuh_cdc_disconnect(uint8_t dev_addr, tuh_xfer_cb_t complete_cb)
 {
   return tuh_cdc_set_control_line_state(dev_addr, false, false, complete_cb);
 }

--- a/src/class/hid/hid.h
+++ b/src/class/hid/hid.h
@@ -43,7 +43,7 @@
 /** \defgroup ClassDriver_HID_Common Common Definitions
  *  @{ */
 
- /// USB HID Descriptor
+/// USB HID Descriptor
 typedef struct TU_ATTR_PACKED
 {
   uint8_t  bLength;         /**< Numeric expression that is the total size of the HID descriptor */

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -103,7 +103,7 @@ uint8_t tuh_hid_get_protocol(uint8_t dev_addr, uint8_t instance)
   return hid_itf->protocol_mode;
 }
 
-static bool set_protocol_complete(uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool set_protocol_complete(uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   uint8_t const itf_num     = (uint8_t) xfer->setup->wIndex;
   uint8_t const instance    = get_instance_id_by_itfnum(dev_addr, itf_num);
@@ -159,7 +159,7 @@ bool tuh_hid_set_protocol(uint8_t dev_addr, uint8_t instance, uint8_t protocol)
   return _hidh_set_protocol(dev_addr, hid_itf->itf_num, protocol, set_protocol_complete, 0);
 }
 
-static bool set_report_complete(uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool set_report_complete(uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   TU_LOG2("HID Set Report complete\r\n");
 
@@ -390,7 +390,7 @@ enum {
 };
 
 static void config_driver_mount_complete(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len);
-static bool process_set_config(uint8_t dev_addr, tuh_control_xfer_t const * xfer);
+static bool process_set_config(uint8_t dev_addr, tuh_control_xfer_t* xfer);
 
 bool hidh_set_config(uint8_t dev_addr, uint8_t itf_num)
 {
@@ -406,7 +406,7 @@ bool hidh_set_config(uint8_t dev_addr, uint8_t itf_num)
   return process_set_config(dev_addr, &xfer);
 }
 
-static bool process_set_config(uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool process_set_config(uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   // Stall is a valid response for SET_IDLE, therefore we could ignore its result
   if ( xfer->setup->bRequest != HID_REQ_CONTROL_SET_IDLE )

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -121,7 +121,7 @@ static void set_protocol_complete(uint8_t dev_addr, tuh_xfer_t* xfer)
 }
 
 
-static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protocol, tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
+static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protocol, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   TU_LOG2("HID Set Protocol = %d\r\n", protocol);
 
@@ -145,7 +145,7 @@ static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protoc
     .setup       = &request,
     .buffer      = NULL,
     .complete_cb = complete_cb,
-    .user_arg    = user_arg
+    .user_data   = user_data
   };
 
   TU_ASSERT( tuh_control_xfer(dev_addr, &xfer) );
@@ -202,14 +202,14 @@ bool tuh_hid_set_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, u
     .setup       = &request,
     .buffer      = report,
     .complete_cb = set_report_complete,
-    .user_arg    = 0
+    .user_data   = 0
   };
 
   TU_ASSERT( tuh_control_xfer(dev_addr, &xfer) );
   return true;
 }
 
-static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate, tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
+static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   // SET IDLE request, device can stall if not support this request
   TU_LOG2("HID Set Idle \r\n");
@@ -233,7 +233,7 @@ static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate
     .setup       = &request,
     .buffer      = NULL,
     .complete_cb = complete_cb,
-    .user_arg    = user_arg
+    .user_data   = user_data
   };
 
   TU_ASSERT( tuh_control_xfer(dev_addr, &xfer) );
@@ -397,9 +397,9 @@ bool hidh_set_config(uint8_t dev_addr, uint8_t itf_num)
   request.wIndex = tu_htole16((uint16_t) itf_num);
 
   tuh_xfer_t xfer;
-  xfer.result = XFER_RESULT_SUCCESS;
-  xfer.setup = &request;
-  xfer.user_arg = CONFG_SET_IDLE;
+  xfer.result    = XFER_RESULT_SUCCESS;
+  xfer.setup     = &request;
+  xfer.user_data = CONFG_SET_IDLE;
 
   // fake request to kick-off the set config process
   process_set_config(dev_addr, &xfer);
@@ -415,7 +415,7 @@ static void process_set_config(uint8_t dev_addr, tuh_xfer_t* xfer)
     TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS, );
   }
 
-  uintptr_t const state     = xfer->user_arg;
+  uintptr_t const state     = xfer->user_data;
   uint8_t const itf_num     = (uint8_t) tu_le16toh(xfer->setup->wIndex);
   uint8_t const instance    = get_instance_id_by_itfnum(dev_addr, itf_num);
   hidh_interface_t* hid_itf = get_instance(dev_addr, instance);

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -256,7 +256,13 @@ bool tuh_hid_receive_report(uint8_t dev_addr, uint8_t instance)
   // claim endpoint
   TU_VERIFY( usbh_edpt_claim(dev_addr, hid_itf->ep_in) );
 
-  return usbh_edpt_xfer(dev_addr, hid_itf->ep_in, hid_itf->epin_buf, hid_itf->epin_size);
+  if ( !usbh_edpt_xfer(dev_addr, hid_itf->ep_in, hid_itf->epin_buf, hid_itf->epin_size) )
+  {
+    usbh_edpt_claim(dev_addr, hid_itf->ep_in);
+    return false;
+  }
+
+  return true;
 }
 
 //bool tuh_n_hid_n_ready(uint8_t dev_addr, uint8_t instance)

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -103,7 +103,7 @@ uint8_t tuh_hid_get_protocol(uint8_t dev_addr, uint8_t instance)
   return hid_itf->protocol_mode;
 }
 
-static void set_protocol_complete(uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void set_protocol_complete(uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   uint8_t const itf_num     = (uint8_t) tu_le16toh(xfer->setup->wIndex);
   uint8_t const instance    = get_instance_id_by_itfnum(dev_addr, itf_num);
@@ -121,7 +121,7 @@ static void set_protocol_complete(uint8_t dev_addr, tuh_control_xfer_t* xfer)
 }
 
 
-static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protocol, tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protocol, tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   TU_LOG2("HID Set Protocol = %d\r\n", protocol);
 
@@ -139,7 +139,7 @@ static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protoc
     .wLength  = 0
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -160,7 +160,7 @@ bool tuh_hid_set_protocol(uint8_t dev_addr, uint8_t instance, uint8_t protocol)
   return _hidh_set_protocol(dev_addr, hid_itf->itf_num, protocol, set_protocol_complete, 0);
 }
 
-static void set_report_complete(uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void set_report_complete(uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   TU_LOG2("HID Set Report complete\r\n");
 
@@ -196,7 +196,7 @@ bool tuh_hid_set_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, u
     .wLength  = len
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -209,7 +209,7 @@ bool tuh_hid_set_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, u
   return true;
 }
 
-static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate, tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate, tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   // SET IDLE request, device can stall if not support this request
   TU_LOG2("HID Set Idle \r\n");
@@ -227,7 +227,7 @@ static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate
     .wLength  = 0
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -389,14 +389,14 @@ enum {
 };
 
 static void config_driver_mount_complete(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len);
-static void process_set_config(uint8_t dev_addr, tuh_control_xfer_t* xfer);
+static void process_set_config(uint8_t dev_addr, tuh_xfer_t* xfer);
 
 bool hidh_set_config(uint8_t dev_addr, uint8_t itf_num)
 {
   tusb_control_request_t request;
   request.wIndex = tu_htole16((uint16_t) itf_num);
 
-  tuh_control_xfer_t xfer;
+  tuh_xfer_t xfer;
   xfer.result = XFER_RESULT_SUCCESS;
   xfer.setup = &request;
   xfer.user_arg = CONFG_SET_IDLE;
@@ -407,7 +407,7 @@ bool hidh_set_config(uint8_t dev_addr, uint8_t itf_num)
   return true;
 }
 
-static void process_set_config(uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void process_set_config(uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   // Stall is a valid response for SET_IDLE, therefore we could ignore its result
   if ( xfer->setup->bRequest != HID_REQ_CONTROL_SET_IDLE )

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -324,6 +324,7 @@ void hidh_close(uint8_t dev_addr)
 
 bool hidh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
 {
+  (void) rhport;
   (void) max_len;
 
   TU_VERIFY(TUSB_CLASS_HID == desc_itf->bInterfaceClass);
@@ -355,7 +356,7 @@ bool hidh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *de
   for(int i = 0; i < desc_itf->bNumEndpoints; i++)
   {
     TU_ASSERT(TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType);
-    TU_ASSERT( usbh_edpt_open(rhport, dev_addr, desc_ep) );
+    TU_ASSERT( usbh_edpt_open(dev_addr, desc_ep) );
 
     if(tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN)
     {

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -139,7 +139,7 @@ static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protoc
     .wLength  = 0
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -196,7 +196,7 @@ bool tuh_hid_set_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, u
     .wLength  = len
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -227,7 +227,7 @@ static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate
     .wLength  = 0
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -356,7 +356,7 @@ bool hidh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *de
   for(int i = 0; i < desc_itf->bNumEndpoints; i++)
   {
     TU_ASSERT(TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType);
-    TU_ASSERT( usbh_edpt_open(dev_addr, desc_ep) );
+    TU_ASSERT( tuh_edpt_open(dev_addr, desc_ep) );
 
     if(tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN)
     {

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -425,7 +425,7 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
     .setup       = &request,
     .buffer      = &p_msc->max_lun,
     .complete_cb = config_get_maxlun_complete,
-    .user_arg    = 0
+    .user_data    = 0
   };
   TU_ASSERT(tuh_control_xfer(dev_addr, &xfer));
 

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -419,7 +419,7 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
     .wLength  = 1
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -358,7 +358,7 @@ bool msch_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t event, uint32
 // MSC Enumeration
 //--------------------------------------------------------------------+
 
-static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
+static void config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
 static bool config_test_unit_ready_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
 static bool config_request_sense_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
 static bool config_read_capacity_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
@@ -432,7 +432,7 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
   return true;
 }
 
-static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   msch_interface_t* p_msc = get_itf(dev_addr);
 
@@ -444,8 +444,6 @@ static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xf
   TU_LOG2("SCSI Test Unit Ready\r\n");
   uint8_t const lun = 0;
   tuh_msc_test_unit_ready(dev_addr, lun, config_test_unit_ready_complete);
-
-  return true;
 }
 
 static bool config_test_unit_ready_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw)

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -365,6 +365,7 @@ static bool config_read_capacity_complete(uint8_t dev_addr, msc_cbw_t const* cbw
 
 bool msch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
 {
+  (void) rhport;
   TU_VERIFY (MSC_SUBCLASS_SCSI == desc_itf->bInterfaceSubClass &&
              MSC_PROTOCOL_BOT  == desc_itf->bInterfaceProtocol);
 
@@ -378,7 +379,7 @@ bool msch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *de
   for(uint32_t i=0; i<2; i++)
   {
     TU_ASSERT(TUSB_DESC_ENDPOINT == ep_desc->bDescriptorType && TUSB_XFER_BULK == ep_desc->bmAttributes.xfer);
-    TU_ASSERT(usbh_edpt_open(rhport, dev_addr, ep_desc));
+    TU_ASSERT(usbh_edpt_open(dev_addr, ep_desc));
 
     if ( tu_edpt_dir(ep_desc->bEndpointAddress) == TUSB_DIR_IN )
     {

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -358,7 +358,7 @@ bool msch_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t event, uint32
 // MSC Enumeration
 //--------------------------------------------------------------------+
 
-static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
+static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
 static bool config_test_unit_ready_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
 static bool config_request_sense_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
 static bool config_read_capacity_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
@@ -432,7 +432,7 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
   return true;
 }
 
-static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   msch_interface_t* p_msc = get_itf(dev_addr);
 

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -379,7 +379,7 @@ bool msch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *de
   for(uint32_t i=0; i<2; i++)
   {
     TU_ASSERT(TUSB_DESC_ENDPOINT == ep_desc->bDescriptorType && TUSB_XFER_BULK == ep_desc->bmAttributes.xfer);
-    TU_ASSERT(usbh_edpt_open(dev_addr, ep_desc));
+    TU_ASSERT(tuh_edpt_open(dev_addr, ep_desc));
 
     if ( tu_edpt_dir(ep_desc->bEndpointAddress) == TUSB_DIR_IN )
     {

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -405,22 +405,24 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
 
   //------------- Get Max Lun -------------//
   TU_LOG2("MSC Get Max Lun\r\n");
+  tusb_control_request_t const request =
+  {
+    .bmRequestType_bit =
+    {
+      .recipient = TUSB_REQ_RCPT_INTERFACE,
+      .type      = TUSB_REQ_TYPE_CLASS,
+      .direction = TUSB_DIR_IN
+    },
+    .bRequest = MSC_REQ_GET_MAX_LUN,
+    .wValue   = 0,
+    .wIndex   = itf_num,
+    .wLength  = 1
+  };
+
   tuh_control_xfer_t const xfer =
   {
-    .request =
-    {
-      .bmRequestType_bit =
-      {
-        .recipient = TUSB_REQ_RCPT_INTERFACE,
-        .type      = TUSB_REQ_TYPE_CLASS,
-        .direction = TUSB_DIR_IN
-      },
-      .bRequest = MSC_REQ_GET_MAX_LUN,
-      .wValue   = 0,
-      .wIndex   = itf_num,
-      .wLength  = 1
-    },
-
+    .ep_addr     = 0,
+    .setup       = &request,
     .buffer      = &p_msc->max_lun,
     .complete_cb = config_get_maxlun_complete,
     .user_arg    = 0

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -358,7 +358,7 @@ bool msch_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t event, uint32
 // MSC Enumeration
 //--------------------------------------------------------------------+
 
-static void config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
+static void config_get_maxlun_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
 static bool config_test_unit_ready_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
 static bool config_request_sense_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
 static bool config_read_capacity_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
@@ -419,7 +419,7 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
     .wLength  = 1
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -432,7 +432,7 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
   return true;
 }
 
-static void config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void config_get_maxlun_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   msch_interface_t* p_msc = get_itf(dev_addr);
 

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -358,7 +358,7 @@ bool msch_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t event, uint32
 // MSC Enumeration
 //--------------------------------------------------------------------+
 
-static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer,  xfer_result_t result);
+static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
 static bool config_test_unit_ready_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
 static bool config_request_sense_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
 static bool config_read_capacity_complete(uint8_t dev_addr, msc_cbw_t const* cbw, msc_csw_t const* csw);
@@ -432,14 +432,12 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
   return true;
 }
 
-static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer,  xfer_result_t result)
+static bool config_get_maxlun_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
 {
-  (void) xfer;
-
   msch_interface_t* p_msc = get_itf(dev_addr);
 
   // STALL means zero
-  p_msc->max_lun = (XFER_RESULT_SUCCESS == result) ? _msch_buffer[0] : 0;
+  p_msc->max_lun = (XFER_RESULT_SUCCESS == xfer->result) ? _msch_buffer[0] : 0;
   p_msc->max_lun++; // MAX LUN is minus 1 by specs
 
   // TODO multiple LUN support

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -483,7 +483,7 @@ static bool config_read_capacity_complete(uint8_t dev_addr, msc_cbw_t const* cbw
   // Capacity response field: Block size and Last LBA are both Big-Endian
   scsi_read_capacity10_resp_t* resp = (scsi_read_capacity10_resp_t*) ((void*) _msch_buffer);
   p_msc->capacity[cbw->lun].block_count = tu_ntohl(resp->last_lba) + 1;
-  p_msc->capacity[cbw->lun].block_size = tu_ntohl(resp->block_size);
+  p_msc->capacity[cbw->lun].block_size  = tu_ntohl(resp->block_size);
 
   // Mark enumeration is complete
   p_msc->mounted = true;

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -201,7 +201,7 @@ bool hub_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *itf
   TU_ASSERT(TUSB_DESC_ENDPOINT  == desc_ep->bDescriptorType &&
             TUSB_XFER_INTERRUPT == desc_ep->bmAttributes.xfer, 0);
   
-  TU_ASSERT(usbh_edpt_open(dev_addr, desc_ep));
+  TU_ASSERT(tuh_edpt_open(dev_addr, desc_ep));
 
   hub_interface_t* p_hub = get_itf(dev_addr);
 

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -78,7 +78,7 @@ static char const* const _hub_feature_str[] =
 // HUB
 //--------------------------------------------------------------------+
 bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
-                            tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                            tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   tusb_control_request_t const request =
   {
@@ -94,7 +94,7 @@ bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
     .wLength  = 0
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -109,7 +109,7 @@ bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
 }
 
 bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
-                          tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                          tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   tusb_control_request_t const request =
   {
@@ -125,7 +125,7 @@ bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
     .wLength  = 0
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -140,7 +140,7 @@ bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
 }
 
 bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp,
-                         tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                         tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   tusb_control_request_t const request =
   {
@@ -156,7 +156,7 @@ bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp,
     .wLength  = 4
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -225,8 +225,8 @@ bool hub_edpt_status_xfer(uint8_t dev_addr)
 // Set Configure
 //--------------------------------------------------------------------+
 
-static void config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t* xfer);
-static void config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
+static void config_set_port_power (uint8_t dev_addr, tuh_xfer_t* xfer);
+static void config_port_power_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
 
 bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
 {
@@ -248,7 +248,7 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
     .wLength  = sizeof(descriptor_hub_desc_t)
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -262,7 +262,7 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
   return true;
 }
 
-static void config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void config_set_port_power (uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   TU_ASSERT(XFER_RESULT_SUCCESS == xfer->result, );
 
@@ -279,7 +279,7 @@ static void config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t* xfer)
   hub_port_set_feature(dev_addr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete, 0);
 }
 
-static void config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void config_port_power_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   TU_ASSERT(XFER_RESULT_SUCCESS == xfer->result, );
    hub_interface_t* p_hub = get_itf(dev_addr);
@@ -303,9 +303,9 @@ static void config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t* xf
 // Connection Changes
 //--------------------------------------------------------------------+
 
-static void connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
-static void connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
-static void connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
+static void connection_get_status_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
+static void connection_clear_conn_change_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
+static void connection_port_reset_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
 
 // callback as response of interrupt endpoint polling
 bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
@@ -333,7 +333,7 @@ bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32
   return true;
 }
 
-static void connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void connection_get_status_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS, );
 
@@ -359,7 +359,7 @@ static void connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t
   }
 }
 
-static void connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void connection_clear_conn_change_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS, );
 
@@ -388,7 +388,7 @@ static void connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control
   }
 }
 
-static void connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void connection_port_reset_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS, );
 

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -225,8 +225,8 @@ bool hub_edpt_status_xfer(uint8_t dev_addr)
 // Set Configure
 //--------------------------------------------------------------------+
 
-static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result);
-static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result);
+static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
+static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
 
 bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
 {
@@ -262,10 +262,9 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
   return true;
 }
 
-static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result)
+static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
 {
-  (void) xfer;
-  TU_ASSERT(XFER_RESULT_SUCCESS == result);
+  TU_ASSERT(XFER_RESULT_SUCCESS == xfer->result);
 
   hub_interface_t* p_hub = get_itf(dev_addr);
 
@@ -280,9 +279,9 @@ static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t const * 
   return hub_port_set_feature(dev_addr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete, 0);
 }
 
-static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result)
+static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
 {
-  TU_ASSERT(XFER_RESULT_SUCCESS == result);
+  TU_ASSERT(XFER_RESULT_SUCCESS == xfer->result);
    hub_interface_t* p_hub = get_itf(dev_addr);
 
   if (xfer->setup->wIndex == p_hub->port_count)
@@ -306,9 +305,9 @@ static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t con
 // Connection Changes
 //--------------------------------------------------------------------+
 
-static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result);
-static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result);
-static bool connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result);
+static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
+static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
+static bool connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
 
 // callback as response of interrupt endpoint polling
 bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
@@ -336,9 +335,9 @@ bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32
   return true;
 }
 
-static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result)
+static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
 {
-  TU_ASSERT(result == XFER_RESULT_SUCCESS);
+  TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS);
 
   hub_interface_t* p_hub = get_itf(dev_addr);
   uint8_t const port_num = (uint8_t) xfer->setup->wIndex;
@@ -364,9 +363,9 @@ static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t
   return true;
 }
 
-static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result)
+static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
 {
-  TU_ASSERT(result == XFER_RESULT_SUCCESS);
+  TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS);
 
   hub_interface_t* p_hub = get_itf(dev_addr);
   uint8_t const port_num = (uint8_t) xfer->setup->wIndex;
@@ -395,9 +394,9 @@ static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control
   return true;
 }
 
-static bool connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer, xfer_result_t result)
+static bool connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
 {
-  TU_ASSERT(result == XFER_RESULT_SUCCESS);
+  TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS);
 
   // hub_interface_t* p_hub = get_itf(dev_addr);
   uint8_t const port_num = (uint8_t) xfer->setup->wIndex;

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -183,6 +183,8 @@ void hub_init(void)
 
 bool hub_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *itf_desc, uint16_t max_len)
 {
+  (void) rhport;
+
   TU_VERIFY(TUSB_CLASS_HUB == itf_desc->bInterfaceClass &&
             0              == itf_desc->bInterfaceSubClass);
 
@@ -199,7 +201,7 @@ bool hub_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *itf
   TU_ASSERT(TUSB_DESC_ENDPOINT  == desc_ep->bDescriptorType &&
             TUSB_XFER_INTERRUPT == desc_ep->bmAttributes.xfer, 0);
   
-  TU_ASSERT(usbh_edpt_open(rhport, dev_addr, desc_ep));
+  TU_ASSERT(usbh_edpt_open(dev_addr, desc_ep));
 
   hub_interface_t* p_hub = get_itf(dev_addr);
 

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -96,6 +96,7 @@ bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
 
   tuh_xfer_t xfer =
   {
+    .daddr       = hub_addr,
     .ep_addr     = 0,
     .setup       = &request,
     .buffer      = NULL,
@@ -104,7 +105,7 @@ bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
   };
 
   TU_LOG2("HUB Clear Feature: %s, addr = %u port = %u\r\n", _hub_feature_str[feature], hub_addr, hub_port);
-  TU_ASSERT( tuh_control_xfer(hub_addr, &xfer) );
+  TU_ASSERT( tuh_control_xfer(&xfer) );
   return true;
 }
 
@@ -127,6 +128,7 @@ bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
 
   tuh_xfer_t xfer =
   {
+    .daddr       = hub_addr,
     .ep_addr     = 0,
     .setup       = &request,
     .buffer      = NULL,
@@ -135,7 +137,7 @@ bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
   };
 
   TU_LOG2("HUB Set Feature: %s, addr = %u port = %u\r\n", _hub_feature_str[feature], hub_addr, hub_port);
-  TU_ASSERT( tuh_control_xfer(hub_addr, &xfer) );
+  TU_ASSERT( tuh_control_xfer(&xfer) );
   return true;
 }
 
@@ -158,6 +160,7 @@ bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp,
 
   tuh_xfer_t xfer =
   {
+    .daddr       = hub_addr,
     .ep_addr     = 0,
     .setup       = &request,
     .buffer      = resp,
@@ -166,7 +169,7 @@ bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp,
   };
 
   TU_LOG2("HUB Get Port Status: addr = %u port = %u\r\n", hub_addr, hub_port);
-  TU_ASSERT( tuh_control_xfer( hub_addr, &xfer) );
+  TU_ASSERT( tuh_control_xfer(&xfer) );
   return true;
 }
 
@@ -225,8 +228,8 @@ bool hub_edpt_status_xfer(uint8_t dev_addr)
 // Set Configure
 //--------------------------------------------------------------------+
 
-static void config_set_port_power (uint8_t dev_addr, tuh_xfer_t* xfer);
-static void config_port_power_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
+static void config_set_port_power (tuh_xfer_t* xfer);
+static void config_port_power_complete (tuh_xfer_t* xfer);
 
 bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
 {
@@ -250,6 +253,7 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
 
   tuh_xfer_t xfer =
   {
+    .daddr       = dev_addr,
     .ep_addr     = 0,
     .setup       = &request,
     .buffer      = _hub_buffer,
@@ -257,16 +261,17 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
     .user_data    = 0
   };
 
-  TU_ASSERT( tuh_control_xfer(dev_addr, &xfer) );
+  TU_ASSERT( tuh_control_xfer(&xfer) );
 
   return true;
 }
 
-static void config_set_port_power (uint8_t dev_addr, tuh_xfer_t* xfer)
+static void config_set_port_power (tuh_xfer_t* xfer)
 {
   TU_ASSERT(XFER_RESULT_SUCCESS == xfer->result, );
 
-  hub_interface_t* p_hub = get_itf(dev_addr);
+  uint8_t const daddr = xfer->daddr;
+  hub_interface_t* p_hub = get_itf(daddr);
 
   // only use number of ports in hub descriptor
   descriptor_hub_desc_t const* desc_hub = (descriptor_hub_desc_t const*) _hub_buffer;
@@ -276,26 +281,28 @@ static void config_set_port_power (uint8_t dev_addr, tuh_xfer_t* xfer)
 
   // Set Port Power to be able to detect connection, starting with port 1
   uint8_t const hub_port = 1;
-  hub_port_set_feature(dev_addr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete, 0);
+  hub_port_set_feature(daddr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete, 0);
 }
 
-static void config_port_power_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
+static void config_port_power_complete (tuh_xfer_t* xfer)
 {
   TU_ASSERT(XFER_RESULT_SUCCESS == xfer->result, );
-   hub_interface_t* p_hub = get_itf(dev_addr);
+
+  uint8_t const daddr = xfer->daddr;
+  hub_interface_t* p_hub = get_itf(daddr);
 
   if (xfer->setup->wIndex == p_hub->port_count)
   {
     // All ports are power -> queue notification status endpoint and
     // complete the SET CONFIGURATION
-    TU_ASSERT( usbh_edpt_xfer(dev_addr, p_hub->ep_in, &p_hub->status_change, 1), );
+    TU_ASSERT( usbh_edpt_xfer(daddr, p_hub->ep_in, &p_hub->status_change, 1), );
 
-    usbh_driver_set_config_complete(dev_addr, p_hub->itf_num);
+    usbh_driver_set_config_complete(daddr, p_hub->itf_num);
   }else
   {
     // power next port
     uint8_t const hub_port = (uint8_t) (xfer->setup->wIndex + 1);
-    hub_port_set_feature(dev_addr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete, 0);
+    hub_port_set_feature(daddr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete, 0);
   }
 }
 
@@ -303,9 +310,9 @@ static void config_port_power_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
 // Connection Changes
 //--------------------------------------------------------------------+
 
-static void connection_get_status_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
-static void connection_clear_conn_change_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
-static void connection_port_reset_complete (uint8_t dev_addr, tuh_xfer_t* xfer);
+static void connection_get_status_complete (tuh_xfer_t* xfer);
+static void connection_clear_conn_change_complete (tuh_xfer_t* xfer);
+static void connection_port_reset_complete (tuh_xfer_t* xfer);
 
 // callback as response of interrupt endpoint polling
 bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
@@ -333,11 +340,12 @@ bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32
   return true;
 }
 
-static void connection_get_status_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
+static void connection_get_status_complete (tuh_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS, );
 
-  hub_interface_t* p_hub = get_itf(dev_addr);
+  uint8_t const daddr = xfer->daddr;
+  hub_interface_t* p_hub = get_itf(daddr);
   uint8_t const port_num = (uint8_t) tu_le16toh(xfer->setup->wIndex);
 
   // Connection change
@@ -347,7 +355,7 @@ static void connection_get_status_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
     //TU_VERIFY(port_status.status_current.port_power && port_status.status_current.port_enable, );
 
     // Acknowledge Port Connection Change
-    hub_port_clear_feature(dev_addr, port_num, HUB_FEATURE_PORT_CONNECTION_CHANGE, connection_clear_conn_change_complete, 0);
+    hub_port_clear_feature(daddr, port_num, HUB_FEATURE_PORT_CONNECTION_CHANGE, connection_clear_conn_change_complete, 0);
   }else
   {
     // Other changes are: Enable, Suspend, Over Current, Reset, L1 state
@@ -355,31 +363,32 @@ static void connection_get_status_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
 
     // prepare for next hub status
     // TODO continue with status_change, or maybe we can do it again with status
-    hub_edpt_status_xfer(dev_addr);
+    hub_edpt_status_xfer(daddr);
   }
 }
 
-static void connection_clear_conn_change_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
+static void connection_clear_conn_change_complete (tuh_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS, );
 
-  hub_interface_t* p_hub = get_itf(dev_addr);
+  uint8_t const daddr = xfer->daddr;
+  hub_interface_t* p_hub = get_itf(daddr);
   uint8_t const port_num = (uint8_t) tu_le16toh(xfer->setup->wIndex);
 
   if ( p_hub->port_status.status.connection )
   {
     // Reset port if attach event
-    hub_port_reset(dev_addr, port_num, connection_port_reset_complete, 0);
+    hub_port_reset(daddr, port_num, connection_port_reset_complete, 0);
   }else
   {
     // submit detach event
     hcd_event_t event =
     {
-      .rhport     = usbh_get_rhport(dev_addr),
+      .rhport     = usbh_get_rhport(daddr),
       .event_id   = HCD_EVENT_DEVICE_REMOVE,
       .connection =
        {
-         .hub_addr = dev_addr,
+         .hub_addr = daddr,
          .hub_port = port_num
        }
     };
@@ -388,21 +397,22 @@ static void connection_clear_conn_change_complete (uint8_t dev_addr, tuh_xfer_t*
   }
 }
 
-static void connection_port_reset_complete (uint8_t dev_addr, tuh_xfer_t* xfer)
+static void connection_port_reset_complete (tuh_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS, );
 
-  // hub_interface_t* p_hub = get_itf(dev_addr);
+  uint8_t const daddr = xfer->daddr;
+  // hub_interface_t* p_hub = get_itf(daddr);
   uint8_t const port_num = (uint8_t) tu_le16toh(xfer->setup->wIndex);
 
   // submit attach event
   hcd_event_t event =
   {
-    .rhport     = usbh_get_rhport(dev_addr),
+    .rhport     = usbh_get_rhport(daddr),
     .event_id   = HCD_EVENT_DEVICE_ATTACH,
     .connection =
     {
-      .hub_addr = dev_addr,
+      .hub_addr = daddr,
       .hub_port = port_num
     }
   };

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -94,7 +94,7 @@ bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
     .wLength  = 0
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -125,7 +125,7 @@ bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
     .wLength  = 0
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -156,7 +156,7 @@ bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp,
     .wLength  = 4
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -248,7 +248,7 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
     .wLength  = sizeof(descriptor_hub_desc_t)
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -225,8 +225,8 @@ bool hub_edpt_status_xfer(uint8_t dev_addr)
 // Set Configure
 //--------------------------------------------------------------------+
 
-static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
-static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
+static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t* xfer);
+static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
 
 bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
 {
@@ -262,7 +262,7 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
   return true;
 }
 
-static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   TU_ASSERT(XFER_RESULT_SUCCESS == xfer->result);
 
@@ -279,7 +279,7 @@ static bool config_set_port_power (uint8_t dev_addr, tuh_control_xfer_t const * 
   return hub_port_set_feature(dev_addr, hub_port, HUB_FEATURE_PORT_POWER, config_port_power_complete, 0);
 }
 
-static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   TU_ASSERT(XFER_RESULT_SUCCESS == xfer->result);
    hub_interface_t* p_hub = get_itf(dev_addr);
@@ -305,9 +305,9 @@ static bool config_port_power_complete (uint8_t dev_addr, tuh_control_xfer_t con
 // Connection Changes
 //--------------------------------------------------------------------+
 
-static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
-static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
-static bool connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer);
+static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
+static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
+static bool connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer);
 
 // callback as response of interrupt endpoint polling
 bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
@@ -335,7 +335,7 @@ bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32
   return true;
 }
 
-static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS);
 
@@ -363,7 +363,7 @@ static bool connection_get_status_complete (uint8_t dev_addr, tuh_control_xfer_t
   return true;
 }
 
-static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS);
 
@@ -394,7 +394,7 @@ static bool connection_clear_conn_change_complete (uint8_t dev_addr, tuh_control
   return true;
 }
 
-static bool connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool connection_port_reset_complete (uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS);
 

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -78,7 +78,7 @@ static char const* const _hub_feature_str[] =
 // HUB
 //--------------------------------------------------------------------+
 bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
-                            tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
+                            tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   tusb_control_request_t const request =
   {
@@ -100,7 +100,7 @@ bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
     .setup       = &request,
     .buffer      = NULL,
     .complete_cb = complete_cb,
-    .user_arg    = user_arg
+    .user_data   = user_data
   };
 
   TU_LOG2("HUB Clear Feature: %s, addr = %u port = %u\r\n", _hub_feature_str[feature], hub_addr, hub_port);
@@ -109,7 +109,7 @@ bool hub_port_clear_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
 }
 
 bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
-                          tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
+                          tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   tusb_control_request_t const request =
   {
@@ -131,7 +131,7 @@ bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
     .setup       = &request,
     .buffer      = NULL,
     .complete_cb = complete_cb,
-    .user_arg    = user_arg
+    .user_data   = user_data
   };
 
   TU_LOG2("HUB Set Feature: %s, addr = %u port = %u\r\n", _hub_feature_str[feature], hub_addr, hub_port);
@@ -140,7 +140,7 @@ bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
 }
 
 bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp,
-                         tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
+                         tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   tusb_control_request_t const request =
   {
@@ -162,7 +162,7 @@ bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp,
     .setup       = &request,
     .buffer      = resp,
     .complete_cb = complete_cb,
-    .user_arg    = user_arg
+    .user_data   = user_data
   };
 
   TU_LOG2("HUB Get Port Status: addr = %u port = %u\r\n", hub_addr, hub_port);
@@ -254,7 +254,7 @@ bool hub_set_config(uint8_t dev_addr, uint8_t itf_num)
     .setup       = &request,
     .buffer      = _hub_buffer,
     .complete_cb = config_set_port_power,
-    .user_arg    = 0
+    .user_data    = 0
   };
 
   TU_ASSERT( tuh_control_xfer(dev_addr, &xfer) );

--- a/src/host/hub.h
+++ b/src/host/hub.h
@@ -173,31 +173,31 @@ TU_VERIFY_STATIC( sizeof(hub_port_status_response_t) == 4, "size is not correct"
 
 // Clear feature
 bool hub_port_clear_feature (uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
-                             tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                             tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Set feature
 bool hub_port_set_feature   (uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
-                             tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                             tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get port status
 bool hub_port_get_status    (uint8_t hub_addr, uint8_t hub_port, void* resp,
-                             tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                             tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get status from Interrupt endpoint
 bool hub_edpt_status_xfer(uint8_t dev_addr);
 
 // Reset a port
 static inline bool hub_port_reset(uint8_t hub_addr, uint8_t hub_port,
-                                  tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                  tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
-  return hub_port_set_feature(hub_addr, hub_port, HUB_FEATURE_PORT_RESET, complete_cb, user_arg);
+  return hub_port_set_feature(hub_addr, hub_port, HUB_FEATURE_PORT_RESET, complete_cb, user_data);
 }
 
 // Clear Reset Change
 static inline bool hub_port_clear_reset_change(uint8_t hub_addr, uint8_t hub_port,
-                                               tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                               tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
-  return hub_port_clear_feature(hub_addr, hub_port, HUB_FEATURE_PORT_RESET_CHANGE, complete_cb, user_arg);
+  return hub_port_clear_feature(hub_addr, hub_port, HUB_FEATURE_PORT_RESET_CHANGE, complete_cb, user_data);
 }
 
 

--- a/src/host/hub.h
+++ b/src/host/hub.h
@@ -173,29 +173,29 @@ TU_VERIFY_STATIC( sizeof(hub_port_status_response_t) == 4, "size is not correct"
 
 // Clear feature
 bool hub_port_clear_feature (uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
-                             tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                             tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Set feature
 bool hub_port_set_feature   (uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
-                             tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                             tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get port status
 bool hub_port_get_status    (uint8_t hub_addr, uint8_t hub_port, void* resp,
-                             tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                             tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get status from Interrupt endpoint
 bool hub_edpt_status_xfer(uint8_t dev_addr);
 
 // Reset a port
 static inline bool hub_port_reset(uint8_t hub_addr, uint8_t hub_port,
-                                  tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                  tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   return hub_port_set_feature(hub_addr, hub_port, HUB_FEATURE_PORT_RESET, complete_cb, user_arg);
 }
 
 // Clear Reset Change
 static inline bool hub_port_clear_reset_change(uint8_t hub_addr, uint8_t hub_port,
-                                               tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                               tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   return hub_port_clear_feature(hub_addr, hub_port, HUB_FEATURE_PORT_RESET_CHANGE, complete_cb, user_arg);
 }

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -268,7 +268,7 @@ struct
   uintptr_t user_data;
 
   volatile uint16_t actual_len;
-  uint8_t daddr;  // device address that is transferring
+  uint8_t daddr;  // transferring device
   volatile uint8_t stage;
 }_ctrl_xfer;
 
@@ -548,7 +548,7 @@ bool tuh_init(uint8_t rhport)
   TU_LOG2("USBH init\r\n");
   TU_LOG2_INT(sizeof(usbh_device_t));
   TU_LOG2_INT(sizeof(hcd_event_t));
-  TU_LOG2_INT(sizeof(tuh_xfer_t));
+  TU_LOG2_INT(sizeof(_ctrl_xfer));
 
   // Event queue
   _usbh_q = osal_queue_create( &_usbh_qdef );
@@ -1077,6 +1077,8 @@ static bool usbh_control_xfer_cb (uint8_t dev_addr, uint8_t ep_addr, xfer_result
 
 bool tuh_edpt_xfer(uint8_t daddr, tuh_xfer_t* xfer)
 {
+  (void) daddr;
+  (void) xfer;
   return true;
 }
 

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1297,12 +1297,10 @@ static bool enum_new_device(hcd_event_t* event)
     _dev0.speed = hcd_port_speed_get(_dev0.rhport );
     TU_LOG2("%s Speed\r\n", tu_str_speed[_dev0.speed]);
 
-    //enum_request_addr0_device_desc();
-    tuh_control_xfer_t const xfer =
-    {
-      .complete_cb = process_enumeration,
-      .user_arg    = ENUM_ADDR0_DEVICE_DESC
-    };
+    // start the enumeration process
+    tuh_control_xfer_t xfer;
+    xfer.user_arg = ENUM_ADDR0_DEVICE_DESC;
+
     process_enumeration(0, &xfer, XFER_RESULT_SUCCESS);
 
   }

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -487,52 +487,49 @@ bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
 // Descriptor Sync
 //--------------------------------------------------------------------+
 
-#define _CONTROL_SYNC_API(_async_func, _timeout, ...) \
-  (void) _timeout; \
+#define _CONTROL_SYNC_API(_async_func, ...) \
   xfer_result_t result = XFER_RESULT_INVALID;\
-  /* TODO use timeout to wait */ \
   TU_VERIFY(_async_func(__VA_ARGS__, NULL, (uintptr_t) &result), XFER_RESULT_TIMEOUT); \
   return (uint8_t) result
 
-uint8_t tuh_descriptor_get_sync(uint8_t daddr, uint8_t type, uint8_t index, void* buffer, uint16_t len, uint8_t timeout_ms)
+uint8_t tuh_descriptor_get_sync(uint8_t daddr, uint8_t type, uint8_t index, void* buffer, uint16_t len)
 {
-  _CONTROL_SYNC_API(tuh_descriptor_get, timeout_ms, daddr, type, index, buffer, len);
+  _CONTROL_SYNC_API(tuh_descriptor_get, daddr, type, index, buffer, len);
 }
 
-uint8_t tuh_descriptor_get_device_sync(uint8_t daddr, void* buffer, uint16_t len, uint8_t timeout_ms)
+uint8_t tuh_descriptor_get_device_sync(uint8_t daddr, void* buffer, uint16_t len)
 {
-  len = tu_min16(len, sizeof(tusb_desc_device_t));
-  return tuh_descriptor_get_sync(daddr, TUSB_DESC_DEVICE, 0, buffer, len, timeout_ms);
+  _CONTROL_SYNC_API(tuh_descriptor_get_device, daddr, buffer, len);
 }
 
-uint8_t tuh_descriptor_get_configuration_sync(uint8_t daddr, uint8_t index, void* buffer, uint16_t len, uint8_t timeout_ms)
+uint8_t tuh_descriptor_get_configuration_sync(uint8_t daddr, uint8_t index, void* buffer, uint16_t len)
 {
-  return tuh_descriptor_get_sync(daddr, TUSB_DESC_CONFIGURATION, index, buffer, len, timeout_ms);
+  _CONTROL_SYNC_API(tuh_descriptor_get_configuration, daddr, index, buffer, len);
 }
 
-uint8_t tuh_descriptor_get_hid_report_sync(uint8_t daddr, uint8_t itf_num, uint8_t desc_type, uint8_t index, void* buffer, uint16_t len, uint8_t timeout_ms)
+uint8_t tuh_descriptor_get_hid_report_sync(uint8_t daddr, uint8_t itf_num, uint8_t desc_type, uint8_t index, void* buffer, uint16_t len)
 {
-  _CONTROL_SYNC_API(tuh_descriptor_get_hid_report, timeout_ms, daddr, itf_num, desc_type, index, buffer, len);
+  _CONTROL_SYNC_API(tuh_descriptor_get_hid_report, daddr, itf_num, desc_type, index, buffer, len);
 }
 
-uint8_t tuh_descriptor_get_string_sync(uint8_t daddr, uint8_t index, uint16_t language_id, void* buffer, uint16_t len, uint8_t timeout_ms)
+uint8_t tuh_descriptor_get_string_sync(uint8_t daddr, uint8_t index, uint16_t language_id, void* buffer, uint16_t len)
 {
-  _CONTROL_SYNC_API(tuh_descriptor_get_string, timeout_ms, daddr, index, language_id, buffer, len);
+  _CONTROL_SYNC_API(tuh_descriptor_get_string, daddr, index, language_id, buffer, len);
 }
 
-uint8_t tuh_descriptor_get_manufacturer_string_sync(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len, uint8_t timeout_ms)
+uint8_t tuh_descriptor_get_manufacturer_string_sync(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len)
 {
-  _CONTROL_SYNC_API(tuh_descriptor_get_manufacturer_string, timeout_ms, daddr, language_id, buffer, len);
+  _CONTROL_SYNC_API(tuh_descriptor_get_manufacturer_string, daddr, language_id, buffer, len);
 }
 
-uint8_t tuh_descriptor_get_product_string_sync(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len, uint8_t timeout_ms)
+uint8_t tuh_descriptor_get_product_string_sync(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len)
 {
-  _CONTROL_SYNC_API(tuh_descriptor_get_product_string, timeout_ms, daddr, language_id, buffer, len);
+  _CONTROL_SYNC_API(tuh_descriptor_get_product_string, daddr, language_id, buffer, len);
 }
 
-uint8_t tuh_descriptor_get_serial_string_sync(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len, uint8_t timeout_ms)
+uint8_t tuh_descriptor_get_serial_string_sync(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len)
 {
-  _CONTROL_SYNC_API(tuh_descriptor_get_serial_string, timeout_ms, daddr, language_id, buffer, len);
+  _CONTROL_SYNC_API(tuh_descriptor_get_serial_string, daddr, language_id, buffer, len);
 }
 
 //--------------------------------------------------------------------+
@@ -919,19 +916,7 @@ static void _control_blocking_complete_cb(uint8_t daddr, tuh_xfer_t* xfer)
   *((xfer_result_t*) xfer->user_data) = xfer->result;
 }
 
-bool tuh_control_xfer_sync(uint8_t daddr, tuh_xfer_t* xfer, uint32_t timeout_ms)
-{
-  (void) timeout_ms;
-
-  // clear callback for sync
-  xfer->complete_cb = NULL;
-
-  // TODO use timeout to wait
-  TU_VERIFY(tuh_control_xfer(daddr, xfer));
-
-  return true;
-}
-
+// TODO timeout_ms is not supported yet
 bool tuh_control_xfer (uint8_t daddr, tuh_xfer_t* xfer)
 {
   // pre-check to help reducing mutex lock

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -882,7 +882,7 @@ bool usbh_edpt_busy(uint8_t dev_addr, uint8_t ep_addr)
 // Control transfer
 //--------------------------------------------------------------------+
 
-static bool _control_blocking_complete_cb(uint8_t daddr, tuh_control_xfer_t const * xfer)
+static bool _control_blocking_complete_cb(uint8_t daddr, tuh_control_xfer_t* xfer)
 {
   (void) daddr;
 
@@ -943,12 +943,15 @@ bool tuh_control_xfer (uint8_t daddr, tuh_control_xfer_t const* xfer)
 
       // TODO probably some timeout to prevent hanged
     }
+
+    // update result
+    //xfer->result = result;
   }
 
   return true;
 }
 
-uint8_t tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t const* xfer, uint32_t timeout_ms)
+bool tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t* xfer, uint32_t timeout_ms)
 {
   (void) timeout_ms;
 
@@ -977,7 +980,7 @@ static void _xfer_complete(uint8_t dev_addr, xfer_result_t result)
 
   // duplicate xfer since user can execute control transfer within callback
   tusb_control_request_t const request = _ctrl_xfer.request;
-  tuh_control_xfer_t const xfer_temp =
+  tuh_control_xfer_t xfer_temp =
   {
     .ep_addr     = 0,
     .result      = result,
@@ -1119,7 +1122,7 @@ static bool parse_configuration_descriptor (uint8_t dev_addr, tusb_desc_configur
 static void enum_full_complete(void);
 
 // process device enumeration
-static bool process_enumeration(uint8_t dev_addr, tuh_control_xfer_t const * xfer)
+static bool process_enumeration(uint8_t dev_addr, tuh_control_xfer_t* xfer)
 {
   if (XFER_RESULT_SUCCESS != xfer->result)
   {

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -326,7 +326,7 @@ static bool _get_descriptor(uint8_t daddr, uint8_t type, uint8_t index, uint16_t
     .wLength  = tu_htole16(len)
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -411,7 +411,7 @@ bool tuh_descriptor_get_hid_report(uint8_t daddr, uint8_t itf_num, uint8_t desc_
     .wLength  = len
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -442,7 +442,7 @@ bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
     .wLength  = 0
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -889,7 +889,7 @@ static void _control_blocking_complete_cb(uint8_t daddr, tuh_control_xfer_t* xfe
   *((xfer_result_t*) xfer->user_arg) = xfer->result;
 }
 
-bool tuh_control_xfer (uint8_t daddr, tuh_control_xfer_t const* xfer)
+bool tuh_control_xfer (uint8_t daddr, tuh_control_xfer_t* xfer)
 {
   // pre-check to help reducing mutex lock
   TU_VERIFY(_ctrl_xfer.stage == CONTROL_STAGE_IDLE);
@@ -1404,7 +1404,7 @@ static bool enum_request_set_addr(void)
     .wLength  = 0
   };
 
-  tuh_control_xfer_t const xfer =
+  tuh_control_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -806,10 +806,11 @@ static bool usbh_edpt_control_open(uint8_t dev_addr, uint8_t max_packet_size)
   return hcd_edpt_open(usbh_get_rhport(dev_addr), dev_addr, &ep0_desc);
 }
 
-bool usbh_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep)
+bool usbh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep)
 {
   TU_ASSERT( tu_edpt_validate(desc_ep, tuh_speed_get(dev_addr)) );
-  return hcd_edpt_open(rhport, dev_addr, desc_ep);
+
+  return hcd_edpt_open(usbh_get_rhport(dev_addr), dev_addr, desc_ep);
 }
 
 bool usbh_edpt_busy(uint8_t dev_addr, uint8_t ep_addr)
@@ -1189,7 +1190,7 @@ enum {
 };
 
 static bool enum_request_set_addr(void);
-static bool parse_configuration_descriptor (uint8_t dev_addr, tusb_desc_configuration_t const* desc_cfg);
+static bool _parse_configuration_descriptor (uint8_t dev_addr, tusb_desc_configuration_t const* desc_cfg);
 static void enum_full_complete(void);
 
 // process device enumeration
@@ -1350,7 +1351,7 @@ static void process_enumeration(tuh_xfer_t* xfer)
     case ENUM_SET_CONFIG:
       // Parse configuration & set up drivers
       // Driver open aren't allowed to make any usb transfer yet
-      TU_ASSERT( parse_configuration_descriptor(daddr, (tusb_desc_configuration_t*) _usbh_ctrl_buf), );
+      TU_ASSERT( _parse_configuration_descriptor(daddr, (tusb_desc_configuration_t*) _usbh_ctrl_buf), );
 
       TU_ASSERT( tuh_configuration_set(daddr, CONFIG_NUM, process_enumeration, ENUM_CONFIG_DRIVER), );
     break;
@@ -1496,7 +1497,7 @@ static bool enum_request_set_addr(void)
   return true;
 }
 
-static bool parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configuration_t const* desc_cfg)
+static bool _parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configuration_t const* desc_cfg)
 {
   usbh_device_t* dev = get_device(dev_addr);
 

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -247,7 +247,7 @@ struct
 {
   tusb_control_request_t request TU_ATTR_ALIGNED(4);
   uint8_t* buffer;
-  tuh_control_xfer_cb_t complete_cb;
+  tuh_xfer_cb_t complete_cb;
   uintptr_t user_arg;
 
   volatile uint16_t actual_len;
@@ -311,7 +311,7 @@ void osal_task_delay(uint32_t msec)
 //--------------------------------------------------------------------+
 
 static bool _get_descriptor(uint8_t daddr, uint8_t type, uint8_t index, uint16_t language_id, void* buffer, uint16_t len,
-                            tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                            tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   tusb_control_request_t const request =
   {
@@ -327,7 +327,7 @@ static bool _get_descriptor(uint8_t daddr, uint8_t type, uint8_t index, uint16_t
     .wLength  = tu_htole16(len)
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -340,20 +340,20 @@ static bool _get_descriptor(uint8_t daddr, uint8_t type, uint8_t index, uint16_t
 }
 
 bool tuh_descriptor_get(uint8_t daddr, uint8_t type, uint8_t index, void* buffer, uint16_t len,
-                        tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                        tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   return _get_descriptor(daddr, type, index, 0x0000, buffer, len, complete_cb, user_arg);
 }
 
 bool tuh_descriptor_get_device(uint8_t daddr, void* buffer, uint16_t len,
-                               tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                               tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   len = tu_min16(len, sizeof(tusb_desc_device_t));
   return tuh_descriptor_get(daddr, TUSB_DESC_DEVICE, 0, buffer, len, complete_cb, user_arg);
 }
 
 bool tuh_descriptor_get_configuration(uint8_t daddr, uint8_t index, void* buffer, uint16_t len,
-                                      tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                      tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   return tuh_descriptor_get(daddr, TUSB_DESC_CONFIGURATION, index, buffer, len, complete_cb, user_arg);
 }
@@ -361,14 +361,14 @@ bool tuh_descriptor_get_configuration(uint8_t daddr, uint8_t index, void* buffer
 //------------- String Descriptor -------------//
 
 bool tuh_descriptor_get_string(uint8_t daddr, uint8_t index, uint16_t language_id, void* buffer, uint16_t len,
-                               tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                               tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   return _get_descriptor(daddr, TUSB_DESC_STRING, index, language_id, buffer, len, complete_cb, user_arg);
 }
 
 // Get manufacturer string descriptor
 bool tuh_descriptor_get_manufacturer_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                            tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                            tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   usbh_device_t const* dev = get_device(daddr);
   TU_VERIFY(dev && dev->i_manufacturer);
@@ -377,7 +377,7 @@ bool tuh_descriptor_get_manufacturer_string(uint8_t daddr, uint16_t language_id,
 
 // Get product string descriptor
 bool tuh_descriptor_get_product_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                       tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                       tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   usbh_device_t const* dev = get_device(daddr);
   TU_VERIFY(dev && dev->i_product);
@@ -386,7 +386,7 @@ bool tuh_descriptor_get_product_string(uint8_t daddr, uint16_t language_id, void
 
 // Get serial string descriptor
 bool tuh_descriptor_get_serial_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                      tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                      tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   usbh_device_t const* dev = get_device(daddr);
   TU_VERIFY(dev && dev->i_serial);
@@ -395,7 +395,7 @@ bool tuh_descriptor_get_serial_string(uint8_t daddr, uint16_t language_id, void*
 
 // Get HID report descriptor
 bool tuh_descriptor_get_hid_report(uint8_t daddr, uint8_t itf_num, uint8_t desc_type, uint8_t index, void* buffer, uint16_t len,
-                                   tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                                   tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   TU_LOG2("HID Get Report Descriptor\r\n");
   tusb_control_request_t const request =
@@ -412,7 +412,7 @@ bool tuh_descriptor_get_hid_report(uint8_t daddr, uint8_t itf_num, uint8_t desc_
     .wLength  = len
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -425,7 +425,7 @@ bool tuh_descriptor_get_hid_report(uint8_t daddr, uint8_t itf_num, uint8_t desc_
 }
 
 bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
-                           tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg)
+                           tuh_xfer_cb_t complete_cb, uintptr_t user_arg)
 {
   TU_LOG2("Set Configuration = %d\r\n", config_num);
 
@@ -443,7 +443,7 @@ bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
     .wLength  = 0
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,
@@ -531,7 +531,7 @@ bool tuh_init(uint8_t rhport)
   TU_LOG2("USBH init\r\n");
   TU_LOG2_INT(sizeof(usbh_device_t));
   TU_LOG2_INT(sizeof(hcd_event_t));
-  TU_LOG2_INT(sizeof(tuh_control_xfer_t));
+  TU_LOG2_INT(sizeof(tuh_xfer_t));
 
   // Event queue
   _usbh_q = osal_queue_create( &_usbh_qdef );
@@ -883,14 +883,14 @@ bool usbh_edpt_busy(uint8_t dev_addr, uint8_t ep_addr)
 // Control transfer
 //--------------------------------------------------------------------+
 
-static void _control_blocking_complete_cb(uint8_t daddr, tuh_control_xfer_t* xfer)
+static void _control_blocking_complete_cb(uint8_t daddr, tuh_xfer_t* xfer)
 {
   (void) daddr;
   // update result
   *((xfer_result_t*) xfer->user_arg) = xfer->result;
 }
 
-bool tuh_control_xfer (uint8_t daddr, tuh_control_xfer_t* xfer)
+bool tuh_control_xfer (uint8_t daddr, tuh_xfer_t* xfer)
 {
   // pre-check to help reducing mutex lock
   TU_VERIFY(_ctrl_xfer.stage == CONTROL_STAGE_IDLE);
@@ -956,7 +956,7 @@ bool tuh_control_xfer (uint8_t daddr, tuh_control_xfer_t* xfer)
   return true;
 }
 
-bool tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t* xfer, uint32_t timeout_ms)
+bool tuh_control_xfer_sync(uint8_t daddr, tuh_xfer_t* xfer, uint32_t timeout_ms)
 {
   (void) timeout_ms;
 
@@ -982,7 +982,7 @@ static void _xfer_complete(uint8_t dev_addr, xfer_result_t result)
 
   // duplicate xfer since user can execute control transfer within callback
   tusb_control_request_t const request = _ctrl_xfer.request;
-  tuh_control_xfer_t xfer_temp =
+  tuh_xfer_t xfer_temp =
   {
     .ep_addr     = 0,
     .result      = result,
@@ -1125,7 +1125,7 @@ static bool parse_configuration_descriptor (uint8_t dev_addr, tusb_desc_configur
 static void enum_full_complete(void);
 
 // process device enumeration
-static void process_enumeration(uint8_t dev_addr, tuh_control_xfer_t* xfer)
+static void process_enumeration(uint8_t dev_addr, tuh_xfer_t* xfer)
 {
   if (XFER_RESULT_SUCCESS != xfer->result)
   {
@@ -1327,7 +1327,7 @@ static bool enum_new_device(hcd_event_t* event)
     TU_LOG2("%s Speed\r\n", tu_str_speed[_dev0.speed]);
 
     // fake transfer to kick-off the enumeration process
-    tuh_control_xfer_t xfer;
+    tuh_xfer_t xfer;
     xfer.result   = XFER_RESULT_SUCCESS;
     xfer.user_arg = ENUM_ADDR0_DEVICE_DESC;
 
@@ -1410,7 +1410,7 @@ static bool enum_request_set_addr(void)
     .wLength  = 0
   };
 
-  tuh_control_xfer_t xfer =
+  tuh_xfer_t xfer =
   {
     .ep_addr     = 0,
     .setup       = &request,

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -806,7 +806,7 @@ static bool usbh_edpt_control_open(uint8_t dev_addr, uint8_t max_packet_size)
   return hcd_edpt_open(usbh_get_rhport(dev_addr), dev_addr, &ep0_desc);
 }
 
-bool usbh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep)
+bool tuh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep)
 {
   TU_ASSERT( tu_edpt_validate(desc_ep, tuh_speed_get(dev_addr)) );
 

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -135,8 +135,8 @@ bool tuh_control_xfer(tuh_xfer_t* xfer);
 //  - sync : blocking if complete callback is NULL.
 bool tuh_edpt_xfer(tuh_xfer_t* xfer);
 
-// Open an endpoint
-bool usbh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep);
+// Open an non-control endpoint
+bool tuh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep);
 
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -39,12 +39,12 @@
 //--------------------------------------------------------------------+
 
 // forward declaration
-struct tuh_control_xfer_s;
-typedef struct tuh_control_xfer_s tuh_control_xfer_t;
+struct tuh_xfer_s;
+typedef struct tuh_xfer_s tuh_xfer_t;
 
-typedef void (*tuh_control_xfer_cb_t)(uint8_t daddr, tuh_control_xfer_t* xfer);
+typedef void (*tuh_xfer_cb_t)(uint8_t daddr, tuh_xfer_t* xfer);
 
-struct tuh_control_xfer_s
+struct tuh_xfer_s
 {
   uint8_t ep_addr;
   xfer_result_t result;
@@ -53,7 +53,7 @@ struct tuh_control_xfer_s
   uint32_t actual_len; // excluding setup packet
 
   uint8_t* buffer;
-  tuh_control_xfer_cb_t complete_cb;
+  tuh_xfer_cb_t complete_cb;
   uintptr_t user_arg;
 };
 
@@ -117,7 +117,7 @@ static inline bool tuh_ready(uint8_t daddr)
 // true on success, false if there is on-going control transfer or incorrect parameters
 // Note: blocking if complete callback is NULL. In this case 'xfer->result' will be updated
 //       and if 'user_arg' point to a xfer_result_t variable, it will be updated as well.
-bool tuh_control_xfer(uint8_t daddr, tuh_control_xfer_t* xfer);
+bool tuh_control_xfer(uint8_t daddr, tuh_xfer_t* xfer);
 
 //bool tuh_edpt_xfer(uint8_t daddr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes);
 
@@ -125,7 +125,7 @@ bool tuh_control_xfer(uint8_t daddr, tuh_control_xfer_t* xfer);
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
-                           tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                           tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 //--------------------------------------------------------------------+
 // Endpoint Synchronous (blocking)
@@ -133,7 +133,7 @@ bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
 
 // Sync (blocking) version of tuh_control_xfer()
 // xfer contents will be updated to reflect the transfer
-bool tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t * xfer, uint32_t timeout_ms);
+bool tuh_control_xfer_sync(uint8_t daddr, tuh_xfer_t * xfer, uint32_t timeout_ms);
 
 //--------------------------------------------------------------------+
 // Descriptors Asynchronous (non-blocking)
@@ -142,43 +142,43 @@ bool tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t * xfer, uint32_t ti
 // Get an descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get(uint8_t daddr, uint8_t type, uint8_t index, void* buffer, uint16_t len,
-                        tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                        tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get device descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_device(uint8_t daddr, void* buffer, uint16_t len,
-                               tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                               tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get configuration descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_configuration(uint8_t daddr, uint8_t index, void* buffer, uint16_t len,
-                                      tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                      tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get HID report descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_hid_report(uint8_t daddr, uint8_t itf_num, uint8_t desc_type, uint8_t index, void* buffer, uint16_t len,
-                                   tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                   tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 // Blocking if complete callback is NULL, in this case 'user_arg' must contain xfer_result_t variable
 bool tuh_descriptor_get_string(uint8_t daddr, uint8_t index, uint16_t language_id, void* buffer, uint16_t len,
-                               tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                               tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get manufacturer string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_manufacturer_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                            tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                            tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get product string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_product_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                       tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                       tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 // Get serial string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_serial_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                      tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                      tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
 
 //--------------------------------------------------------------------+
 // Descriptors Synchronous (blocking)

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -53,8 +53,6 @@ struct tuh_control_xfer_s
   uint32_t actual_len;
 
   uint8_t* buffer;
-
-
   tuh_control_xfer_cb_t complete_cb;
   uintptr_t user_arg;
 };
@@ -118,7 +116,7 @@ static inline bool tuh_ready(uint8_t daddr)
 // Carry out a control transfer
 // true on success, false if there is on-going control transfer or incorrect parameters
 // Blocking if complete callback is NULL, in this case 'user_arg' must contain xfer_result_t variable
-bool tuh_control_xfer(uint8_t daddr, tuh_control_xfer_t const* xfer);
+bool tuh_control_xfer(uint8_t daddr, tuh_control_xfer_t* xfer);
 
 //bool tuh_edpt_xfer(uint8_t daddr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes);
 

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -42,7 +42,7 @@
 struct tuh_control_xfer_s;
 typedef struct tuh_control_xfer_s tuh_control_xfer_t;
 
-typedef bool (*tuh_control_xfer_cb_t)(uint8_t daddr, tuh_control_xfer_t const * xfer);
+typedef bool (*tuh_control_xfer_cb_t)(uint8_t daddr, tuh_control_xfer_t* xfer);
 
 struct tuh_control_xfer_s
 {
@@ -135,7 +135,7 @@ bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
 
 // Sync (blocking) version of tuh_control_xfer()
 // return transfer result
-uint8_t tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t const* xfer, uint32_t timeout_ms);
+bool tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t * xfer, uint32_t timeout_ms);
 
 //--------------------------------------------------------------------+
 // Descriptors Asynchronous (non-blocking)

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -44,8 +44,10 @@ typedef struct tuh_xfer_s tuh_xfer_t;
 
 typedef void (*tuh_xfer_cb_t)(tuh_xfer_t* xfer);
 
-// Note: layout and order of this will be changed in near future
+// Note1: layout and order of this will be changed in near future
 // it is advised to initialize it using member name
+// Note2: not all field is available/meaningful in callback, some info is not saved by
+// usbh to save SRAM
 struct tuh_xfer_s
 {
   uint8_t daddr;
@@ -124,13 +126,17 @@ static inline bool tuh_ready(uint8_t daddr)
 //--------------------------------------------------------------------+
 
 // Submit a control transfer
-// Note: blocking if complete callback is NULL, in this case xfer contents will be updated to reflect the result
+//  - async: complete callback invoked when finished.
+//  - sync : blocking if complete callback is NULL.
 bool tuh_control_xfer(tuh_xfer_t* xfer);
 
 // Submit a bulk/interrupt transfer
-// xfer memory must exist until transfer is complete.
-// Note: blocking if complete callback is NULL.
+//  - async: complete callback invoked when finished.
+//  - sync : blocking if complete callback is NULL.
 bool tuh_edpt_xfer(tuh_xfer_t* xfer);
+
+// Open an endpoint
+bool usbh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep);
 
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -201,6 +201,10 @@ uint8_t tuh_descriptor_get_product_string_sync(uint8_t daddr, uint16_t language_
 // return transfer result
 uint8_t tuh_descriptor_get_serial_string_sync(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len, uint8_t timeout_ms);
 
+//--------------------------------------------------------------------+
+//
+//--------------------------------------------------------------------+
+
 #ifdef __cplusplus
  }
 #endif

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -42,7 +42,7 @@
 struct tuh_control_xfer_s;
 typedef struct tuh_control_xfer_s tuh_control_xfer_t;
 
-typedef bool (*tuh_control_xfer_cb_t)(uint8_t daddr, tuh_control_xfer_t* xfer);
+typedef void (*tuh_control_xfer_cb_t)(uint8_t daddr, tuh_control_xfer_t* xfer);
 
 struct tuh_control_xfer_s
 {

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -113,13 +113,17 @@ static inline bool tuh_ready(uint8_t daddr)
 // Endpoint Asynchronous (non-blocking)
 //--------------------------------------------------------------------+
 
-// Carry out a control transfer
+// Submit a control transfer
 // true on success, false if there is on-going control transfer or incorrect parameters
 // Note: blocking if complete callback is NULL. In this case 'xfer->result' will be updated
 //       and if 'user_arg' point to a xfer_result_t variable, it will be updated as well.
 bool tuh_control_xfer(uint8_t daddr, tuh_xfer_t* xfer);
 
-//bool tuh_edpt_xfer(uint8_t daddr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes);
+// Submit a bulk/interrupt transfer
+// true on success, false if there is on-going control transfer or incorrect parameters
+// Note: blocking if complete callback is NULL. In this case 'xfer->result' will be updated
+//       and if 'user_arg' point to a xfer_result_t variable, it will be updated as well.
+bool tuh_edpt_xfer(uint8_t daddr, tuh_xfer_t* xfer);
 
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -47,14 +47,15 @@ typedef void (*tuh_xfer_cb_t)(uint8_t daddr, tuh_xfer_t* xfer);
 struct tuh_xfer_s
 {
   uint8_t ep_addr;
-  xfer_result_t result;
-
-  tusb_control_request_t const* setup;
-  uint32_t actual_len; // excluding setup packet
-
+  tusb_control_request_t const* setup; // pointer to setup packet if control transfer
+  uint32_t buflen;
   uint8_t* buffer;
   tuh_xfer_cb_t complete_cb;
-  uintptr_t user_arg;
+  uintptr_t user_data;
+
+  // will be updated when transfer is complete
+  xfer_result_t result;
+  uint32_t actual_len; // excluding setup packet
 };
 
 //--------------------------------------------------------------------+
@@ -116,20 +117,20 @@ static inline bool tuh_ready(uint8_t daddr)
 // Submit a control transfer
 // true on success, false if there is on-going control transfer or incorrect parameters
 // Note: blocking if complete callback is NULL. In this case 'xfer->result' will be updated
-//       and if 'user_arg' point to a xfer_result_t variable, it will be updated as well.
+//       and if 'user_data' point to a xfer_result_t variable, it will be updated as well.
 bool tuh_control_xfer(uint8_t daddr, tuh_xfer_t* xfer);
 
 // Submit a bulk/interrupt transfer
 // true on success, false if there is on-going control transfer or incorrect parameters
 // Note: blocking if complete callback is NULL. In this case 'xfer->result' will be updated
-//       and if 'user_arg' point to a xfer_result_t variable, it will be updated as well.
+//       and if 'user_data' point to a xfer_result_t variable, it will be updated as well.
 bool tuh_edpt_xfer(uint8_t daddr, tuh_xfer_t* xfer);
 
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
-                           tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                           tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 //--------------------------------------------------------------------+
 // Endpoint Synchronous (blocking)
@@ -146,43 +147,43 @@ bool tuh_control_xfer_sync(uint8_t daddr, tuh_xfer_t * xfer, uint32_t timeout_ms
 // Get an descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get(uint8_t daddr, uint8_t type, uint8_t index, void* buffer, uint16_t len,
-                        tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                        tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get device descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_device(uint8_t daddr, void* buffer, uint16_t len,
-                               tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                               tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get configuration descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_configuration(uint8_t daddr, uint8_t index, void* buffer, uint16_t len,
-                                      tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                      tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get HID report descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_hid_report(uint8_t daddr, uint8_t itf_num, uint8_t desc_type, uint8_t index, void* buffer, uint16_t len,
-                                   tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                   tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
-// Blocking if complete callback is NULL, in this case 'user_arg' must contain xfer_result_t variable
+// Blocking if complete callback is NULL, in this case 'user_data' must contain xfer_result_t variable
 bool tuh_descriptor_get_string(uint8_t daddr, uint8_t index, uint16_t language_id, void* buffer, uint16_t len,
-                               tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                               tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get manufacturer string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_manufacturer_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                            tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                            tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get product string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_product_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                       tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                       tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get serial string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_serial_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
-                                      tuh_xfer_cb_t complete_cb, uintptr_t user_arg);
+                                      tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 //--------------------------------------------------------------------+
 // Descriptors Synchronous (blocking)

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -46,7 +46,10 @@ typedef bool (*tuh_control_xfer_cb_t)(uint8_t daddr, tuh_control_xfer_t const * 
 
 struct tuh_control_xfer_s
 {
-  tusb_control_request_t request TU_ATTR_ALIGNED(4);
+  uint8_t ep_addr;
+  tusb_control_request_t const* setup;
+  uint32_t actual_len;
+
   uint8_t* buffer;
   tuh_control_xfer_cb_t complete_cb;
   uintptr_t user_arg;
@@ -104,14 +107,16 @@ static inline bool tuh_ready(uint8_t daddr)
   return tuh_mounted(daddr) && !tuh_suspended(daddr);
 }
 
+//--------------------------------------------------------------------+
+// Endpoint Asynchronous (non-blocking)
+//--------------------------------------------------------------------+
+
 // Carry out a control transfer
 // true on success, false if there is on-going control transfer or incorrect parameters
 // Blocking if complete callback is NULL, in this case 'user_arg' must contain xfer_result_t variable
-bool tuh_control_xfer (uint8_t daddr, tuh_control_xfer_t const* xfer);
+bool tuh_control_xfer(uint8_t daddr, tuh_control_xfer_t const* xfer);
 
-// Sync (blocking) version of tuh_control_xfer()
-// return transfer result
-uint8_t tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t const* xfer, uint32_t timeout_ms);
+//bool tuh_edpt_xfer(uint8_t daddr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes);
 
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1
@@ -119,6 +124,14 @@ uint8_t tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t const* xfer, uin
 // Blocking if complete callback is NULL, in this case 'user_arg' must contain xfer_result_t variable
 bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
                            tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
+
+//--------------------------------------------------------------------+
+// Endpoint Synchronous (blocking)
+//--------------------------------------------------------------------+
+
+// Sync (blocking) version of tuh_control_xfer()
+// return transfer result
+uint8_t tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t const* xfer, uint32_t timeout_ms);
 
 //--------------------------------------------------------------------+
 // Descriptors Asynchronous (non-blocking)
@@ -200,10 +213,6 @@ uint8_t tuh_descriptor_get_product_string_sync(uint8_t daddr, uint16_t language_
 // Sync (blocking) version of tuh_descriptor_get_serial_string()
 // return transfer result
 uint8_t tuh_descriptor_get_serial_string_sync(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len, uint8_t timeout_ms);
-
-//--------------------------------------------------------------------+
-//
-//--------------------------------------------------------------------+
 
 #ifdef __cplusplus
  }

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -42,15 +42,19 @@
 struct tuh_control_xfer_s;
 typedef struct tuh_control_xfer_s tuh_control_xfer_t;
 
-typedef bool (*tuh_control_xfer_cb_t)(uint8_t daddr, tuh_control_xfer_t const * xfer, xfer_result_t result);
+typedef bool (*tuh_control_xfer_cb_t)(uint8_t daddr, tuh_control_xfer_t const * xfer);
 
 struct tuh_control_xfer_s
 {
   uint8_t ep_addr;
+  xfer_result_t result;
+
   tusb_control_request_t const* setup;
   uint32_t actual_len;
 
   uint8_t* buffer;
+
+
   tuh_control_xfer_cb_t complete_cb;
   uintptr_t user_arg;
 };

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -42,7 +42,7 @@
 struct tuh_xfer_s;
 typedef struct tuh_xfer_s tuh_xfer_t;
 
-typedef void (*tuh_xfer_cb_t)(uint8_t daddr, tuh_xfer_t* xfer);
+typedef void (*tuh_xfer_cb_t)(tuh_xfer_t* xfer);
 
 struct tuh_xfer_s
 {
@@ -54,7 +54,7 @@ struct tuh_xfer_s
 
   union
   {
-    tusb_control_request_t const* setup; // setup packet if control transfer
+    tusb_control_request_t const* setup; // setup packet pointer if control transfer
     uint32_t buflen;                     // length if not control transfer
   };
 
@@ -62,7 +62,7 @@ struct tuh_xfer_s
   tuh_xfer_cb_t complete_cb;
   uintptr_t user_data;
 
-  uint32_t timeout_ms;
+  uint32_t timeout_ms; // place holder, not supported yet
 };
 
 //--------------------------------------------------------------------+
@@ -118,19 +118,17 @@ static inline bool tuh_ready(uint8_t daddr)
 }
 
 //--------------------------------------------------------------------+
-// Endpoint Asynchronous (non-blocking)
+// Transfer API
 //--------------------------------------------------------------------+
 
 // Submit a control transfer
-// true on success, false if there is on-going control transfer or incorrect parameters
-// Note: blocking if complete callback is NULL.
-//       xfer contents will be updated to reflect the result
-bool tuh_control_xfer(uint8_t daddr, tuh_xfer_t* xfer);
+// Note: blocking if complete callback is NULL, in this case xfer contents will be updated to reflect the result
+bool tuh_control_xfer(tuh_xfer_t* xfer);
 
 // Submit a bulk/interrupt transfer
-// true on success, false if there is on-going control transfer or incorrect parameters
+// xfer memory must exist until transfer is complete.
 // Note: blocking if complete callback is NULL.
-bool tuh_edpt_xfer(uint8_t daddr, tuh_xfer_t* xfer);
+bool tuh_edpt_xfer(tuh_xfer_t* xfer);
 
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -50,7 +50,7 @@ struct tuh_control_xfer_s
   xfer_result_t result;
 
   tusb_control_request_t const* setup;
-  uint32_t actual_len;
+  uint32_t actual_len; // excluding setup packet
 
   uint8_t* buffer;
   tuh_control_xfer_cb_t complete_cb;
@@ -115,7 +115,8 @@ static inline bool tuh_ready(uint8_t daddr)
 
 // Carry out a control transfer
 // true on success, false if there is on-going control transfer or incorrect parameters
-// Blocking if complete callback is NULL, in this case 'user_arg' must contain xfer_result_t variable
+// Note: blocking if complete callback is NULL. In this case 'xfer->result' will be updated
+//       and if 'user_arg' point to a xfer_result_t variable, it will be updated as well.
 bool tuh_control_xfer(uint8_t daddr, tuh_control_xfer_t* xfer);
 
 //bool tuh_edpt_xfer(uint8_t daddr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes);
@@ -123,7 +124,6 @@ bool tuh_control_xfer(uint8_t daddr, tuh_control_xfer_t* xfer);
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1
 // true on success, false if there is on-going control transfer or incorrect parameters
-// Blocking if complete callback is NULL, in this case 'user_arg' must contain xfer_result_t variable
 bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
                            tuh_control_xfer_cb_t complete_cb, uintptr_t user_arg);
 
@@ -132,7 +132,7 @@ bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
 //--------------------------------------------------------------------+
 
 // Sync (blocking) version of tuh_control_xfer()
-// return transfer result
+// xfer contents will be updated to reflect the transfer
 bool tuh_control_xfer_sync(uint8_t daddr, tuh_control_xfer_t * xfer, uint32_t timeout_ms);
 
 //--------------------------------------------------------------------+

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -44,25 +44,27 @@ typedef struct tuh_xfer_s tuh_xfer_t;
 
 typedef void (*tuh_xfer_cb_t)(tuh_xfer_t* xfer);
 
+// Note: layout and order of this will be changed in near future
+// it is advised to initialize it using member name
 struct tuh_xfer_s
 {
   uint8_t daddr;
   uint8_t ep_addr;
 
   xfer_result_t result;
-  uint32_t actual_len; // excluding setup packet
+  uint32_t actual_len;      // excluding setup packet
 
   union
   {
     tusb_control_request_t const* setup; // setup packet pointer if control transfer
-    uint32_t buflen;                     // length if not control transfer
+    uint32_t buflen;        // expected length if not control transfer (not available in callback)
   };
 
-  uint8_t* buffer;
+  uint8_t* buffer;           // not available in callback if not control transfer
   tuh_xfer_cb_t complete_cb;
   uintptr_t user_data;
 
-  uint32_t timeout_ms; // place holder, not supported yet
+  // uint32_t timeout_ms;    // place holder, not supported yet
 };
 
 //--------------------------------------------------------------------+

--- a/src/host/usbh_classdriver.h
+++ b/src/host/usbh_classdriver.h
@@ -63,9 +63,6 @@ void usbh_int_set(bool enabled);
 // USBH Endpoint API
 //--------------------------------------------------------------------+
 
-// Open an endpoint
-bool usbh_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep);
-
 // Submit a usb transfer with callback support, require CFG_TUH_API_EDPT_XFER
 bool usbh_edpt_xfer_with_callback(uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes,
                                   tuh_xfer_cb_t complete_cb, uintptr_t user_data);

--- a/src/host/usbh_classdriver.h
+++ b/src/host/usbh_classdriver.h
@@ -66,8 +66,16 @@ void usbh_int_set(bool enabled);
 // Open an endpoint
 bool usbh_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep);
 
-// Submit a usb transfer
-bool usbh_edpt_xfer(uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes);
+// Submit a usb transfer with callback support, require CFG_TUH_API_EDPT_XFER
+bool usbh_edpt_xfer_with_callback(uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes,
+                                  tuh_xfer_cb_t complete_cb, uintptr_t user_data);
+
+TU_ATTR_ALWAYS_INLINE
+static inline bool usbh_edpt_xfer(uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes)
+{
+  return usbh_edpt_xfer_with_callback(dev_addr, ep_addr, buffer, total_bytes, NULL, 0);
+}
+
 
 // Claim an endpoint before submitting a transfer.
 // If caller does not make any transfer, it must release endpoint for others.

--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -656,6 +656,26 @@ static void xfer_error_isr(uint8_t hostid)
   }
 }
 
+#if CFG_TUSB_DEBUG >= EHCI_DBG
+
+static inline void print_portsc(ehci_registers_t* regs)
+{
+  TU_LOG_HEX(EHCI_DBG, regs->portsc);
+  TU_LOG(EHCI_DBG, "  Current Connect Status: %u\r\n", regs->portsc_bm.current_connect_status);
+  TU_LOG(EHCI_DBG, "  Connect Status Change : %u\r\n", regs->portsc_bm.connect_status_change);
+  TU_LOG(EHCI_DBG, "  Port Enabled          : %u\r\n", regs->portsc_bm.port_enabled);
+  TU_LOG(EHCI_DBG, "  Port Enabled Change   : %u\r\n", regs->portsc_bm.port_enable_change);
+
+  TU_LOG(EHCI_DBG, "  Port Reset            : %u\r\n", regs->portsc_bm.port_reset);
+  TU_LOG(EHCI_DBG, "  Port Power            : %u\r\n", regs->portsc_bm.port_power);
+}
+
+#else
+
+#define print_portsc(_reg)
+
+#endif
+
 //------------- Host Controller Driver's Interrupt Handler -------------//
 void hcd_int_handler(uint8_t rhport)
 {
@@ -675,9 +695,8 @@ void hcd_int_handler(uint8_t rhport)
 
   if (int_status & EHCI_INT_MASK_PORT_CHANGE)
   {
-    uint32_t port_status = regs->portsc & EHCI_PORTSC_MASK_ALL;
-
-    TU_LOG_HEX(EHCI_DBG, regs->portsc);
+    uint32_t const port_status = regs->portsc & EHCI_PORTSC_MASK_ALL;
+    print_portsc(regs);
 
     if (regs->portsc_bm.connect_status_change)
     {

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -38,6 +38,8 @@
 #include "osal/osal.h"
 #include "common/tusb_fifo.h"
 
+#include "class/hid/hid.h"
+
 //------------- HOST -------------//
 #if CFG_TUH_ENABLED
   #include "host/usbh.h"

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -392,6 +392,10 @@
 #define CFG_TUH_VENDOR 0
 #endif
 
+#ifndef CFG_TUH_API_EDPT_XFER
+#define CFG_TUH_API_EDPT_XFER 0
+#endif
+
 //------------------------------------------------------------------
 // Configuration Validation
 //------------------------------------------------------------------


### PR DESCRIPTION
**Describe the PR**
- More major changes for host stack transfer, include support for generic endpoint transfer.
- tuh_control_xfer(), tuh_edpt_xfer() and callback follow similar API with 1 unique tuh_xfer_t following the libusb convention https://libusb.sourceforge.io/api-1.0/group__libusb__syncio.html
  - required `CFG_TUH_API_EDPT_XFER=1` since it requires 8 more bytes per endpoint
  - does not requires to alloc or keep the xfer struct memory lasting for transfer to complete (usbh will keep a copy of required fields).  
  - to save sram, not all xfer struct is available for use in callback
  - timeout not supported yet (maybe later).