### PR TITLE
Fix docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx~=3.0
 furo>=2020.12.30.b24
 sphinx-autodoc-typehints>=1.10
+jinja2==3.0.3


### PR DESCRIPTION
`jinja2` updated to `3.1.0` / `3.1.1` which broke the docs, fix it to a known working version

Fixes #1411 

~~Testing, do not merge.~~