### PR TITLE
tusb_types: add edpt_dir and edpt_type strings

### DIFF
--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -513,6 +513,16 @@ static inline uint16_t tu_edpt_packet_size(tusb_desc_endpoint_t const* desc_ep)
   return tu_le16toh(desc_ep->wMaxPacketSize) & TU_GENMASK(10, 0);
 }
 
+static inline const char *tu_edpt_dir_str(tusb_dir_t dir) {
+  static const char *str[] = {"out", "in"};
+  return str[dir];
+}
+
+static inline const char *tu_edpt_type_str(tusb_xfer_type_t t) {
+  static const char *str[] = {"control", "isochronous", "bulk", "interrupt"};
+  return str[t];
+}
+
 //--------------------------------------------------------------------+
 // Descriptor helper
 //--------------------------------------------------------------------+


### PR DESCRIPTION
Added descriptive strings for edpt_dir and edpt_type for debug output use rather than ports having to define their own.
