### PR TITLE
Update dwc2_stm32.h

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -61,6 +61,7 @@
     // USB_OTG_FS_PERIPH_BASE and OTG_FS_IRQn not defined
     #define USB_OTG_FS_PERIPH_BASE  USB1_OTG_HS_PERIPH_BASE
     #define OTG_FS_IRQn             OTG_HS_IRQn
+  #endif
 
 #elif CFG_TUSB_MCU == OPT_MCU_STM32F7
   #include "stm32f7xx.h"

--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -56,6 +56,11 @@
   #define EP_FIFO_SIZE_FS 4096
   #define EP_MAX_HS       9
   #define EP_FIFO_SIZE_HS 4096
+  #if (! defined USB2_OTG_FS)
+    // H7 with only 1 USB port: H72x / H73x / H7Ax / H7Bx
+    // USB_OTG_FS_PERIPH_BASE and OTG_FS_IRQn not defined
+    #define USB_OTG_FS_PERIPH_BASE  USB1_OTG_HS_PERIPH_BASE
+    #define OTG_FS_IRQn             OTG_HS_IRQn
 
 #elif CFG_TUSB_MCU == OPT_MCU_STM32F7
   #include "stm32f7xx.h"

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -27,6 +27,9 @@
 #ifndef _TUSB_OPTION_H_
 #define _TUSB_OPTION_H_
 
+// To avoid GCC compiler warnings when -pedantic option is used (strict ISO C)
+typedef int make_iso_compilers_happy ;
+
 #include "common/tusb_compiler.h"
 
 #define TUSB_VERSION_MAJOR     0


### PR DESCRIPTION
Support STM32H7 with only 1 USB port: H72x / H73x / H7Ax / H7Bx
Avoid GCC compiler warnings when -pedantic option is used (strict ISO C)

**Describe the PR**
The STM32H7 family have 2 sub families:

- H74x and H75x have 2 USB, and USB2 have an internal FS PHY. No problem with this sub family.
- H72x, H73x, H7Ax, H7Bx have only 1 USB named USB1 with an internal FS PHY (this USB1 is equivalent to the USB2 of the other sub family). And in the CMSIS files of this sub family the values USB_OTG_FS_PERIPH_BASE and OTG_FS_IRQn are not declared, so the file synopsys/dwc2/dwc2_stm32.h produce compile errors.

Add to tusb_options.h
`typedef int make_iso_compilers_happy ;`

**Additional context**
Successfully tested on NUCLEO-H723ZG (1 USB) and NUCLEO-H743ZI (2 USB).
fixes #1431