### PR TITLE
Osal queue timeout

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,8 @@
+blank_issues_enabled: false
 contact_links:
   - name: TinyUSB Discussion
     url: https://github.com/hathach/tinyusb/discussions
     about: If you have other questions or need help, post it here.
+  - name: TinyUSB Docs
+    url: https://docs.tinyusb.org/
+    about: Online documentation

--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -130,10 +130,10 @@ void usb_device_task(void* param)
   // RTOS forever loop
   while (1)
   {
-    // tinyusb device task
+    // put this thread to waiting state until there is new events
     tud_task();
 
-    tud_cdc_write_flush();
+    // following code only run if tud_task() process at least 1 event
   }
 }
 
@@ -196,6 +196,7 @@ void cdc_task(void* params)
         // for throughput test e.g
         //    $ dd if=/dev/zero of=/dev/ttyACM0 count=10000
         tud_cdc_write(buf, count);
+        tud_cdc_write_flush();
       }
     }
 

--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -198,6 +198,9 @@ void cdc_task(void* params)
         tud_cdc_write(buf, count);
       }
     }
+
+    // For ESP32-Sx this delay is essential to allow idle how to run and reset watchdog
+    vTaskDelay(1);
   }
 }
 

--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -132,6 +132,8 @@ void usb_device_task(void* param)
   {
     // tinyusb device task
     tud_task();
+
+    tud_cdc_write_flush();
   }
 }
 
@@ -194,12 +196,8 @@ void cdc_task(void* params)
         // for throughput test e.g
         //    $ dd if=/dev/zero of=/dev/ttyACM0 count=10000
         tud_cdc_write(buf, count);
-        tud_cdc_write_flush();
       }
     }
-
-    // For ESP32-S2 this delay is essential to allow idle how to run and reset wdt
-    vTaskDelay(pdMS_TO_TICKS(10));
   }
 }
 

--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -134,6 +134,7 @@ void usb_device_task(void* param)
     tud_task();
 
     // following code only run if tud_task() process at least 1 event
+    tud_cdc_write_flush();
   }
 }
 
@@ -183,7 +184,7 @@ void cdc_task(void* params)
     // if ( tud_cdc_connected() )
     {
       // There are data available
-      if ( tud_cdc_available() )
+      while ( tud_cdc_available() )
       {
         uint8_t buf[64];
 
@@ -196,8 +197,9 @@ void cdc_task(void* params)
         // for throughput test e.g
         //    $ dd if=/dev/zero of=/dev/ttyACM0 count=10000
         tud_cdc_write(buf, count);
-        tud_cdc_write_flush();
       }
+
+      tud_cdc_write_flush();
     }
 
     // For ESP32-Sx this delay is essential to allow idle how to run and reset watchdog

--- a/examples/device/hid_composite_freertos/src/main.c
+++ b/examples/device/hid_composite_freertos/src/main.c
@@ -132,8 +132,10 @@ void usb_device_task(void* param)
   // RTOS forever loop
   while (1)
   {
-    // tinyusb device task
+    // put this thread to waiting state until there is new events
     tud_task();
+
+    // following code only run if tud_task() process at least 1 event
   }
 }
 

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -99,8 +99,8 @@
  *------------------------------------------------------------------*/
 
 // Helper to implement optional parameter for TU_VERIFY Macro family
-#define GET_3RD_ARG(arg1, arg2, arg3, ...)        arg3
-#define GET_4TH_ARG(arg1, arg2, arg3, arg4, ...)  arg4
+#define _GET_3RD_ARG(arg1, arg2, arg3, ...)        arg3
+#define _GET_4TH_ARG(arg1, arg2, arg3, arg4, ...)  arg4
 
 /*------------- Generator for TU_VERIFY and TU_VERIFY_HDLR -------------*/
 #define TU_VERIFY_DEFINE(_cond, _handler, _ret)  do            \
@@ -116,7 +116,7 @@
 #define TU_VERIFY_1ARGS(_cond)                         TU_VERIFY_DEFINE(_cond, , false)
 #define TU_VERIFY_2ARGS(_cond, _ret)                   TU_VERIFY_DEFINE(_cond, , _ret)
 
-#define TU_VERIFY(...)                   GET_3RD_ARG(__VA_ARGS__, TU_VERIFY_2ARGS, TU_VERIFY_1ARGS, UNUSED)(__VA_ARGS__)
+#define TU_VERIFY(...)                   _GET_3RD_ARG(__VA_ARGS__, TU_VERIFY_2ARGS, TU_VERIFY_1ARGS, UNUSED)(__VA_ARGS__)
 
 
 /*------------------------------------------------------------------*/
@@ -127,7 +127,7 @@
 #define TU_VERIFY_HDLR_2ARGS(_cond, _handler)           TU_VERIFY_DEFINE(_cond, _handler, false)
 #define TU_VERIFY_HDLR_3ARGS(_cond, _handler, _ret)     TU_VERIFY_DEFINE(_cond, _handler, _ret)
 
-#define TU_VERIFY_HDLR(...)              GET_4TH_ARG(__VA_ARGS__, TU_VERIFY_HDLR_3ARGS, TU_VERIFY_HDLR_2ARGS,UNUSED)(__VA_ARGS__)
+#define TU_VERIFY_HDLR(...)              _GET_4TH_ARG(__VA_ARGS__, TU_VERIFY_HDLR_3ARGS, TU_VERIFY_HDLR_2ARGS,UNUSED)(__VA_ARGS__)
 
 /*------------------------------------------------------------------*/
 /* ASSERT
@@ -139,7 +139,7 @@
 #define ASSERT_2ARGS(_cond, _ret)      TU_VERIFY_DEFINE(_cond, _MESS_FAILED(); TU_BREAKPOINT(), _ret)
 
 #ifndef TU_ASSERT
-#define TU_ASSERT(...)             GET_3RD_ARG(__VA_ARGS__, ASSERT_2ARGS, ASSERT_1ARGS,UNUSED)(__VA_ARGS__)
+#define TU_ASSERT(...)             _GET_3RD_ARG(__VA_ARGS__, ASSERT_2ARGS, ASSERT_1ARGS,UNUSED)(__VA_ARGS__)
 #endif
 
 /*------------------------------------------------------------------*/

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -475,8 +475,7 @@ void tud_task (void)
   while (1)
   {
     dcd_event_t event;
-
-    if ( !osal_queue_receive(_usbd_q, &event) ) return;
+    if ( !osal_queue_receive(_usbd_q, &event, 1) ) return;
 
 #if CFG_TUSB_DEBUG >= 2
     if (event.event_id == DCD_EVENT_SETUP_RECEIVED) TU_LOG2("\r\n"); // extra line for setup

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -466,8 +466,10 @@ bool tud_task_event_ready(void)
     }
     @endcode
  */
-void tud_task (void)
+void tud_task_ext(uint32_t timeout_ms, bool in_isr)
 {
+  (void) in_isr; // not implemented yet
+
   // Skip if stack is not initialized
   if ( !tusb_inited() ) return;
 
@@ -475,7 +477,7 @@ void tud_task (void)
   while (1)
   {
     dcd_event_t event;
-    if ( !osal_queue_receive(_usbd_q, &event, 1) ) return;
+    if ( !osal_queue_receive(_usbd_q, &event, timeout_ms) ) return;
 
 #if CFG_TUSB_DEBUG >= 2
     if (event.event_id == DCD_EVENT_SETUP_RECEIVED) TU_LOG2("\r\n"); // extra line for setup
@@ -592,6 +594,11 @@ void tud_task (void)
         TU_BREAKPOINT();
       break;
     }
+
+#if CFG_TUSB_OS != OPT_OS_NONE && CFG_TUSB_OS != OPT_OS_PICO
+    // return if there is no more events, for application to run other background
+    if (osal_queue_empty(_usbd_q)) return;
+#endif
   }
 }
 

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -52,7 +52,7 @@ void tud_task_ext(uint32_t timeout_ms, bool in_isr);
 TU_ATTR_ALWAYS_INLINE static inline
 void tud_task (void)
 {
-  tud_task_ext(OSAL_TIMEOUT_WAIT_FOREVER, false);
+  tud_task_ext(UINT32_MAX, false);
 }
 
 // Check if there is pending events need proccessing by tud_task()

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -43,8 +43,17 @@ bool tud_init (uint8_t rhport);
 // Check if device stack is already initialized
 bool tud_inited(void);
 
+// Task function should be called in main/rtos loop, extended version of tud_task()
+// - timeout_ms: millisecond to wait, zero = no wait, 0xFFFFFFFF = wait forever
+// - in_isr: if function is called in ISR
+void tud_task_ext(uint32_t timeout_ms, bool in_isr);
+
 // Task function should be called in main/rtos loop
-void tud_task (void);
+TU_ATTR_ALWAYS_INLINE static inline
+void tud_task (void)
+{
+  tud_task_ext(OSAL_TIMEOUT_WAIT_FOREVER, false);
+}
 
 // Check if there is pending events need proccessing by tud_task()
 bool tud_task_event_ready(void);

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -401,7 +401,7 @@ void tuh_task(void)
   while (1)
   {
     hcd_event_t event;
-    if ( !osal_queue_receive(_usbh_q, &event) ) return;
+    if ( !osal_queue_receive(_usbh_q, &event, 1) ) return;
 
     switch (event.event_id)
     {

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -392,8 +392,10 @@ bool tuh_init(uint8_t rhport)
     }
     @endcode
  */
-void tuh_task(void)
+void tuh_task_ext(uint32_t timeout_ms, bool in_isr)
 {
+  (void) in_isr; // not implemented yet
+
   // Skip if stack is not initialized
   if ( !tusb_inited() ) return;
 
@@ -401,7 +403,7 @@ void tuh_task(void)
   while (1)
   {
     hcd_event_t event;
-    if ( !osal_queue_receive(_usbh_q, &event, 1) ) return;
+    if ( !osal_queue_receive(_usbh_q, &event, timeout_ms) ) return;
 
     switch (event.event_id)
     {
@@ -497,6 +499,11 @@ void tuh_task(void)
 
       default: break;
     }
+
+#if CFG_TUSB_OS != OPT_OS_NONE && CFG_TUSB_OS != OPT_OS_PICO
+    // return if there is no more events, for application to run other background
+    if (osal_queue_empty(_usbh_q)) return;
+#endif
   }
 }
 

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -91,8 +91,17 @@ bool tuh_init(uint8_t rhport);
 // Check if host stack is already initialized
 bool tuh_inited(void);
 
+// Task function should be called in main/rtos loop, extended version of tuh_task()
+// - timeout_ms: millisecond to wait, zero = no wait, 0xFFFFFFFF = wait forever
+// - in_isr: if function is called in ISR
+void tuh_task_ext(uint32_t timeout_ms, bool in_isr);
+
 // Task function should be called in main/rtos loop
-void tuh_task(void);
+TU_ATTR_ALWAYS_INLINE static inline
+void tuh_task(void)
+{
+  tuh_task_ext(OSAL_TIMEOUT_WAIT_FOREVER, false);
+}
 
 // Interrupt handler, name alias to HCD
 extern void hcd_int_handler(uint8_t rhport);
@@ -106,8 +115,8 @@ tusb_speed_t tuh_speed_get(uint8_t daddr);
 bool tuh_mounted(uint8_t daddr);
 
 // Check if device is suspended
-TU_ATTR_ALWAYS_INLINE
-static inline bool tuh_suspended(uint8_t daddr)
+TU_ATTR_ALWAYS_INLINE static inline
+bool tuh_suspended(uint8_t daddr)
 {
   // TODO implement suspend & resume on host
   (void) daddr;
@@ -115,8 +124,8 @@ static inline bool tuh_suspended(uint8_t daddr)
 }
 
 // Check if device is ready to communicate with
-TU_ATTR_ALWAYS_INLINE
-static inline bool tuh_ready(uint8_t daddr)
+TU_ATTR_ALWAYS_INLINE static inline
+bool tuh_ready(uint8_t daddr)
 {
   return tuh_mounted(daddr) && !tuh_suspended(daddr);
 }

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -100,7 +100,7 @@ void tuh_task_ext(uint32_t timeout_ms, bool in_isr);
 TU_ATTR_ALWAYS_INLINE static inline
 void tuh_task(void)
 {
-  tuh_task_ext(OSAL_TIMEOUT_WAIT_FOREVER, false);
+  tuh_task_ext(UINT32_MAX, false);
 }
 
 // Interrupt handler, name alias to HCD

--- a/src/osal/osal.h
+++ b/src/osal/osal.h
@@ -66,19 +66,19 @@ typedef void (*osal_task_func_t)( void * );
 // OSAL Porting API
 // Should be implemented as static inline function in osal_port.h header
 /*
-    static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef);
-    static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr);
-    static inline bool osal_semaphore_wait(osal_semaphore_t sem_hdl, uint32_t msec);
-    static inline void osal_semaphore_reset(osal_semaphore_t sem_hdl); // TODO removed
+   osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef);
+   bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr);
+   bool osal_semaphore_wait(osal_semaphore_t sem_hdl, uint32_t msec);
+   void osal_semaphore_reset(osal_semaphore_t sem_hdl); // TODO removed
 
-    static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef);
-    static inline bool osal_mutex_lock (osal_mutex_t sem_hdl, uint32_t msec);
-    static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl);
+   osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef);
+   bool osal_mutex_lock (osal_mutex_t sem_hdl, uint32_t msec);
+   bool osal_mutex_unlock(osal_mutex_t mutex_hdl);
 
-    static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef);
-    static inline bool osal_queue_receive(osal_queue_t qhdl, void* data);
-    static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr);
-    static inline bool osal_queue_empty(osal_queue_t qhdl);
+   osal_queue_t osal_queue_create(osal_queue_def_t* qdef);
+   bool osal_queue_receive(osal_queue_t qhdl, void* data, uint32_t msec);
+   bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr);
+   bool osal_queue_empty(osal_queue_t qhdl);
 */
 //--------------------------------------------------------------------+
 

--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -40,7 +40,7 @@ extern "C" {
 //--------------------------------------------------------------------+
 // TASK API
 //--------------------------------------------------------------------+
-static inline void osal_task_delay(uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline void osal_task_delay(uint32_t msec)
 {
   vTaskDelay( pdMS_TO_TICKS(msec) );
 }
@@ -51,12 +51,12 @@ static inline void osal_task_delay(uint32_t msec)
 typedef StaticSemaphore_t osal_semaphore_def_t;
 typedef SemaphoreHandle_t osal_semaphore_t;
 
-static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef)
 {
   return xSemaphoreCreateBinaryStatic(semdef);
 }
 
-static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
 {
   if ( !in_isr )
   {
@@ -78,13 +78,13 @@ static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
   }
 }
 
-static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec)
 {
   uint32_t const ticks = (msec == OSAL_TIMEOUT_WAIT_FOREVER) ? portMAX_DELAY : pdMS_TO_TICKS(msec);
   return xSemaphoreTake(sem_hdl, ticks);
 }
 
-static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl)
+TU_ATTR_ALWAYS_INLINE static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl)
 {
   xQueueReset(sem_hdl);
 }
@@ -95,17 +95,17 @@ static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl)
 typedef StaticSemaphore_t osal_mutex_def_t;
 typedef SemaphoreHandle_t osal_mutex_t;
 
-static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
 {
   return xSemaphoreCreateMutexStatic(mdef);
 }
 
-static inline bool osal_mutex_lock (osal_mutex_t mutex_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_lock (osal_mutex_t mutex_hdl, uint32_t msec)
 {
   return osal_semaphore_wait(mutex_hdl, msec);
 }
 
-static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
 {
   return xSemaphoreGive(mutex_hdl);
 }
@@ -114,7 +114,7 @@ static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
 // QUEUE API
 //--------------------------------------------------------------------+
 
-// role device/host is used by OS NONE for mutex (disable usb isr) only
+// _int_set is not used with an RTOS
 #define OSAL_QUEUE_DEF(_int_set, _name, _depth, _type) \
   static _type _name##_##buf[_depth];\
   osal_queue_def_t _name = { .depth = _depth, .item_sz = sizeof(_type), .buf = _name##_##buf };
@@ -130,17 +130,18 @@ typedef struct
 
 typedef QueueHandle_t osal_queue_t;
 
-static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
 {
   return xQueueCreateStatic(qdef->depth, qdef->item_sz, (uint8_t*) qdef->buf, &qdef->sq);
 }
 
-static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_receive(osal_queue_t qhdl, void* data, uint32_t msec)
 {
-  return xQueueReceive(qhdl, data, portMAX_DELAY);
+  uint32_t const ticks = (msec == OSAL_TIMEOUT_WAIT_FOREVER) ? portMAX_DELAY : pdMS_TO_TICKS(msec);
+  return xQueueReceive(qhdl, data, ticks);
 }
 
-static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
   if ( !in_isr )
   {
@@ -162,7 +163,7 @@ static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in
   }
 }
 
-static inline bool osal_queue_empty(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
   return uxQueueMessagesWaiting(qhdl) == 0;
 }

--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -37,6 +37,20 @@
 extern "C" {
 #endif
 
+TU_ATTR_ALWAYS_INLINE static inline uint32_t _osal_ms2tick(uint32_t msec)
+{
+  if (msec == OSAL_TIMEOUT_WAIT_FOREVER) return portMAX_DELAY;
+  if (msec == 0) return 0;
+
+  uint32_t ticks = pdMS_TO_TICKS(msec);
+
+  // configTICK_RATE_HZ is less than 1000 and 1 tick > 1 ms
+  // we still need to delay at least 1 tick
+  if (ticks == 0) ticks =1 ;
+
+  return ticks;
+}
+
 //--------------------------------------------------------------------+
 // TASK API
 //--------------------------------------------------------------------+
@@ -80,8 +94,7 @@ TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_post(osal_semaphore_t se
 
 TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec)
 {
-  uint32_t const ticks = (msec == OSAL_TIMEOUT_WAIT_FOREVER) ? portMAX_DELAY : pdMS_TO_TICKS(msec);
-  return xSemaphoreTake(sem_hdl, ticks);
+  return xSemaphoreTake(sem_hdl, _osal_ms2tick(msec));
 }
 
 TU_ATTR_ALWAYS_INLINE static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl)
@@ -137,8 +150,7 @@ TU_ATTR_ALWAYS_INLINE static inline osal_queue_t osal_queue_create(osal_queue_de
 
 TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_receive(osal_queue_t qhdl, void* data, uint32_t msec)
 {
-  uint32_t const ticks = (msec == OSAL_TIMEOUT_WAIT_FOREVER) ? portMAX_DELAY : pdMS_TO_TICKS(msec);
-  return xQueueReceive(qhdl, data, ticks);
+  return xQueueReceive(qhdl, data, _osal_ms2tick(msec));
 }
 
 TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)

--- a/src/osal/osal_mynewt.h
+++ b/src/osal/osal_mynewt.h
@@ -36,7 +36,7 @@
 //--------------------------------------------------------------------+
 // TASK API
 //--------------------------------------------------------------------+
-static inline void osal_task_delay(uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline void osal_task_delay(uint32_t msec)
 {
   os_time_delay( os_time_ms_to_ticks32(msec) );
 }
@@ -47,18 +47,18 @@ static inline void osal_task_delay(uint32_t msec)
 typedef struct os_sem  osal_semaphore_def_t;
 typedef struct os_sem* osal_semaphore_t;
 
-static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef)
 {
   return (os_sem_init(semdef, 0) == OS_OK) ? (osal_semaphore_t) semdef : NULL;
 }
 
-static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
 {
   (void) in_isr;
   return os_sem_release(sem_hdl) == OS_OK;
 }
 
-static inline bool osal_semaphore_wait(osal_semaphore_t sem_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_wait(osal_semaphore_t sem_hdl, uint32_t msec)
 {
   uint32_t const ticks = (msec == OSAL_TIMEOUT_WAIT_FOREVER) ? OS_TIMEOUT_NEVER : os_time_ms_to_ticks32(msec);
   return os_sem_pend(sem_hdl, ticks) == OS_OK;
@@ -75,18 +75,18 @@ static inline void osal_semaphore_reset(osal_semaphore_t sem_hdl)
 typedef struct os_mutex osal_mutex_def_t;
 typedef struct os_mutex* osal_mutex_t;
 
-static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
 {
   return (os_mutex_init(mdef) == OS_OK) ? (osal_mutex_t) mdef : NULL;
 }
 
-static inline bool osal_mutex_lock(osal_mutex_t mutex_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_lock(osal_mutex_t mutex_hdl, uint32_t msec)
 {
   uint32_t const ticks = (msec == OSAL_TIMEOUT_WAIT_FOREVER) ? OS_TIMEOUT_NEVER : os_time_ms_to_ticks32(msec);
   return os_mutex_pend(mutex_hdl, ticks) == OS_OK;
 }
 
-static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
 {
   return os_mutex_release(mutex_hdl) == OS_OK;
 }
@@ -116,7 +116,7 @@ typedef struct
 
 typedef osal_queue_def_t* osal_queue_t;
 
-static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
 {
   if ( OS_OK != os_mempool_init(&qdef->mpool, qdef->depth, qdef->item_sz, qdef->buf, "usbd queue") ) return NULL;
   if ( OS_OK != os_mempool_init(&qdef->epool, qdef->depth, sizeof(struct os_event), qdef->evbuf, "usbd evqueue") ) return NULL;
@@ -125,8 +125,10 @@ static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
   return (osal_queue_t) qdef;
 }
 
-static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_receive(osal_queue_t qhdl, void* data, uint32_t msec)
 {
+  (void) msec; // os_eventq_get() does not take timeout, always behave as msec = WAIT_FOREVER
+
   struct os_event* ev;
   ev = os_eventq_get(&qhdl->evq);
 
@@ -161,7 +163,7 @@ static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in
   return true;
 }
 
-static inline bool osal_queue_empty(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
   return STAILQ_EMPTY(&qhdl->evq.evq_list);
 }

--- a/src/osal/osal_none.h
+++ b/src/osal/osal_none.h
@@ -46,13 +46,13 @@ typedef struct
 
 typedef osal_semaphore_def_t* osal_semaphore_t;
 
-static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef)
 {
   semdef->count = 0;
   return semdef;
 }
 
-static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
 {
   (void) in_isr;
   sem_hdl->count++;
@@ -60,7 +60,7 @@ static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
 }
 
 // TODO blocking for now
-static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec)
 {
   (void) msec;
 
@@ -70,7 +70,7 @@ static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec)
   return true;
 }
 
-static inline void osal_semaphore_reset(osal_semaphore_t sem_hdl)
+TU_ATTR_ALWAYS_INLINE static inline void osal_semaphore_reset(osal_semaphore_t sem_hdl)
 {
   sem_hdl->count = 0;
 }
@@ -82,18 +82,18 @@ static inline void osal_semaphore_reset(osal_semaphore_t sem_hdl)
 typedef osal_semaphore_def_t osal_mutex_def_t;
 typedef osal_semaphore_t osal_mutex_t;
 
-static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
 {
   mdef->count = 1;
   return mdef;
 }
 
-static inline bool osal_mutex_lock (osal_mutex_t mutex_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_lock (osal_mutex_t mutex_hdl, uint32_t msec)
 {
   return osal_semaphore_wait(mutex_hdl, msec);
 }
 
-static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
 {
   return osal_semaphore_post(mutex_hdl, false);
 }
@@ -120,27 +120,29 @@ typedef osal_queue_def_t* osal_queue_t;
   }
 
 // lock queue by disable USB interrupt
-static inline void _osal_q_lock(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline void _osal_q_lock(osal_queue_t qhdl)
 {
   // disable dcd/hcd interrupt
   qhdl->interrupt_set(false);
 }
 
 // unlock queue
-static inline void _osal_q_unlock(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline void _osal_q_unlock(osal_queue_t qhdl)
 {
   // enable dcd/hcd interrupt
   qhdl->interrupt_set(true);
 }
 
-static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
 {
   tu_fifo_clear(&qdef->ff);
   return (osal_queue_t) qdef;
 }
 
-static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_receive(osal_queue_t qhdl, void* data, uint32_t msec)
 {
+  (void) msec; // not used, always behave as msec = 0
+
   _osal_q_lock(qhdl);
   bool success = tu_fifo_read(&qhdl->ff, data);
   _osal_q_unlock(qhdl);
@@ -148,7 +150,7 @@ static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
   return success;
 }
 
-static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
   if (!in_isr) {
     _osal_q_lock(qhdl);
@@ -165,7 +167,7 @@ static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in
   return success;
 }
 
-static inline bool osal_queue_empty(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
   // Skip queue lock/unlock since this function is primarily called
   // with interrupt disabled before going into low power mode

--- a/src/osal/osal_pico.h
+++ b/src/osal/osal_pico.h
@@ -39,7 +39,7 @@
 //--------------------------------------------------------------------+
 // TASK API
 //--------------------------------------------------------------------+
-static inline void osal_task_delay(uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline void osal_task_delay(uint32_t msec)
 {
   sleep_ms(msec);
 }
@@ -49,25 +49,25 @@ static inline void osal_task_delay(uint32_t msec)
 //--------------------------------------------------------------------+
 typedef struct semaphore osal_semaphore_def_t, *osal_semaphore_t;
 
-static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_semaphore_t osal_semaphore_create(osal_semaphore_def_t* semdef)
 {
   sem_init(semdef, 0, 255);
   return semdef;
 }
 
-static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr)
 {
   (void) in_isr;
   sem_release(sem_hdl);
   return true;
 }
 
-static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec)
 {
   return sem_acquire_timeout_ms(sem_hdl, msec);
 }
 
-static inline void osal_semaphore_reset(osal_semaphore_t sem_hdl)
+TU_ATTR_ALWAYS_INLINE static inline void osal_semaphore_reset(osal_semaphore_t sem_hdl)
 {
   sem_reset(sem_hdl, 0);
 }
@@ -78,21 +78,21 @@ static inline void osal_semaphore_reset(osal_semaphore_t sem_hdl)
 //--------------------------------------------------------------------+
 typedef struct mutex osal_mutex_def_t, *osal_mutex_t;
 
-static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
 {
-    mutex_init(mdef);
-    return mdef;
+  mutex_init(mdef);
+  return mdef;
 }
 
-static inline bool osal_mutex_lock (osal_mutex_t mutex_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_lock (osal_mutex_t mutex_hdl, uint32_t msec)
 {
-    return mutex_enter_timeout_ms(mutex_hdl, msec);
+  return mutex_enter_timeout_ms(mutex_hdl, msec);
 }
 
-static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
 {
-    mutex_exit(mutex_hdl);
-    return true;
+  mutex_exit(mutex_hdl);
+  return true;
 }
 
 //--------------------------------------------------------------------+
@@ -121,26 +121,28 @@ typedef osal_queue_def_t* osal_queue_t;
   }
 
 // lock queue by disable USB interrupt
-static inline void _osal_q_lock(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline void _osal_q_lock(osal_queue_t qhdl)
 {
-    critical_section_enter_blocking(&qhdl->critsec);
+  critical_section_enter_blocking(&qhdl->critsec);
 }
 
 // unlock queue
-static inline void _osal_q_unlock(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline void _osal_q_unlock(osal_queue_t qhdl)
 {
-    critical_section_exit(&qhdl->critsec);
+  critical_section_exit(&qhdl->critsec);
 }
 
-static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
 {
   critical_section_init(&qdef->critsec);
   tu_fifo_clear(&qdef->ff);
   return (osal_queue_t) qdef;
 }
 
-static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_receive(osal_queue_t qhdl, void* data, uint32_t msec)
 {
+  (void) msec; // not used, always behave as msec = 0
+
   // TODO: revisit... docs say that mutexes are never used from IRQ context,
   //  however osal_queue_recieve may be. therefore my assumption is that
   //  the fifo mutex is not populated for queues used from an IRQ context
@@ -153,7 +155,7 @@ static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
   return success;
 }
 
-static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
   // TODO: revisit... docs say that mutexes are never used from IRQ context,
   //  however osal_queue_recieve may be. therefore my assumption is that
@@ -170,7 +172,7 @@ static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in
   return success;
 }
 
-static inline bool osal_queue_empty(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
   // TODO: revisit; whether this is true or not currently, tu_fifo_empty is a single
   //  volatile read.

--- a/src/osal/osal_rtthread.h
+++ b/src/osal/osal_rtthread.h
@@ -37,7 +37,7 @@ extern "C" {
 //--------------------------------------------------------------------+
 // TASK API
 //--------------------------------------------------------------------+
-static inline void osal_task_delay(uint32_t msec) {
+TU_ATTR_ALWAYS_INLINE static inline void osal_task_delay(uint32_t msec) {
   rt_thread_mdelay(msec);
 }
 
@@ -47,22 +47,22 @@ static inline void osal_task_delay(uint32_t msec) {
 typedef struct rt_semaphore osal_semaphore_def_t;
 typedef rt_sem_t osal_semaphore_t;
 
-static inline osal_semaphore_t
+TU_ATTR_ALWAYS_INLINE static inline osal_semaphore_t
 osal_semaphore_create(osal_semaphore_def_t *semdef) {
     rt_sem_init(semdef, "tusb", 0, RT_IPC_FLAG_FIFO);
     return semdef;
 }
 
-static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr) {
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr) {
     (void) in_isr;
     return rt_sem_release(sem_hdl) == RT_EOK;
 }
 
-static inline bool osal_semaphore_wait(osal_semaphore_t sem_hdl, uint32_t msec) {
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_wait(osal_semaphore_t sem_hdl, uint32_t msec) {
     return rt_sem_take(sem_hdl, rt_tick_from_millisecond(msec)) == RT_EOK;
 }
 
-static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl) {
+TU_ATTR_ALWAYS_INLINE static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl) {
     // TODO: implement
 }
 
@@ -72,16 +72,16 @@ static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl) {
 typedef struct rt_mutex osal_mutex_def_t;
 typedef rt_mutex_t osal_mutex_t;
 
-static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t *mdef) {
+TU_ATTR_ALWAYS_INLINE static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t *mdef) {
     rt_mutex_init(mdef, "tusb", RT_IPC_FLAG_FIFO);
     return mdef;
 }
 
-static inline bool osal_mutex_lock(osal_mutex_t mutex_hdl, uint32_t msec) {
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_lock(osal_mutex_t mutex_hdl, uint32_t msec) {
     return rt_mutex_take(mutex_hdl, rt_tick_from_millisecond(msec)) == RT_EOK;
 }
 
-static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl) {
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl) {
     return rt_mutex_release(mutex_hdl) == RT_EOK;
 }
 
@@ -104,22 +104,24 @@ typedef struct {
 
 typedef rt_mq_t osal_queue_t;
 
-static inline osal_queue_t osal_queue_create(osal_queue_def_t *qdef) {
+TU_ATTR_ALWAYS_INLINE static inline osal_queue_t osal_queue_create(osal_queue_def_t *qdef) {
     rt_mq_init(&(qdef->sq), "tusb", qdef->buf, qdef->item_sz,
                qdef->item_sz * qdef->depth, RT_IPC_FLAG_FIFO);
     return &(qdef->sq);
 }
 
-static inline bool osal_queue_receive(osal_queue_t qhdl, void *data) {
-    return rt_mq_recv(qhdl, data, qhdl->msg_size, RT_WAITING_FOREVER) == RT_EOK;
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_receive(osal_queue_t qhdl, void *data, uint32_t msec) {
+
+    rt_tick_t tick = rt_tick_from_millisecond((rt_int32_t) msec));
+    return rt_mq_recv(qhdl, data, qhdl->msg_size, tick) == RT_EOK;
 }
 
-static inline bool osal_queue_send(osal_queue_t qhdl, void const *data, bool in_isr) {
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void const *data, bool in_isr) {
     (void) in_isr;
     return rt_mq_send(qhdl, (void *)data, qhdl->msg_size) == RT_EOK;
 }
 
-static inline bool osal_queue_empty(osal_queue_t qhdl) {
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_empty(osal_queue_t qhdl) {
     return (qhdl->entry) == 0;
 }
 

--- a/src/osal/osal_rtx4.h
+++ b/src/osal/osal_rtx4.h
@@ -37,7 +37,7 @@ extern "C" {
 //--------------------------------------------------------------------+
 // TASK API
 //--------------------------------------------------------------------+
-static inline void osal_task_delay(uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline void osal_task_delay(uint32_t msec)
 {
   uint16_t hi = msec >> 16;
   uint16_t lo = msec;
@@ -47,7 +47,7 @@ static inline void osal_task_delay(uint32_t msec)
   os_dly_wait(lo);
 }
 
-static inline uint16_t msec2wait(uint32_t msec) {
+TU_ATTR_ALWAYS_INLINE static inline uint16_t msec2wait(uint32_t msec) {
   if (msec == OSAL_TIMEOUT_WAIT_FOREVER)
     return 0xFFFF;
   else if (msec >= 0xFFFE)
@@ -62,12 +62,12 @@ static inline uint16_t msec2wait(uint32_t msec) {
 typedef OS_SEM osal_semaphore_def_t;
 typedef OS_ID osal_semaphore_t;
 
-static inline OS_ID osal_semaphore_create(osal_semaphore_def_t* semdef) {
+TU_ATTR_ALWAYS_INLINE static inline OS_ID osal_semaphore_create(osal_semaphore_def_t* semdef) {
   os_sem_init(semdef, 0);
   return semdef;
 }
 
-static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr) {
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr) {
   if ( !in_isr ) {
     os_sem_send(sem_hdl);
   } else {
@@ -76,11 +76,11 @@ static inline bool osal_semaphore_post(osal_semaphore_t sem_hdl, bool in_isr) {
 	return true;
 }
 
-static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec) {
+TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_wait (osal_semaphore_t sem_hdl, uint32_t msec) {
   return os_sem_wait(sem_hdl, msec2wait(msec)) != OS_R_TMO;
 }
 
-static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl) {
+TU_ATTR_ALWAYS_INLINE static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl) {
   // TODO: implement
 }
 
@@ -90,18 +90,18 @@ static inline void osal_semaphore_reset(osal_semaphore_t const sem_hdl) {
 typedef OS_MUT osal_mutex_def_t;
 typedef OS_ID osal_mutex_t;
 
-static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_mutex_t osal_mutex_create(osal_mutex_def_t* mdef)
 {
   os_mut_init(mdef);
   return mdef;
 }
 
-static inline bool osal_mutex_lock (osal_mutex_t mutex_hdl, uint32_t msec)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_lock (osal_mutex_t mutex_hdl, uint32_t msec)
 {
   return os_mut_wait(mutex_hdl, msec2wait(msec)) != OS_R_TMO;
 }
 
-static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_mutex_unlock(osal_mutex_t mutex_hdl)
 {
   return os_mut_release(mutex_hdl) == OS_R_OK;
 }
@@ -127,23 +127,23 @@ typedef struct
 
 typedef osal_queue_def_t* osal_queue_t;
 
-static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
+TU_ATTR_ALWAYS_INLINE static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef)
 {
   os_mbx_init(qdef->mbox, (qdef->depth + 4) * 4);
   _init_box(qdef->pool, ((qdef->item_sz+3)/4)*(qdef->depth) + 3, qdef->item_sz);
   return qdef;
 }
 
-static inline bool osal_queue_receive(osal_queue_t qhdl, void* data)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_receive(osal_queue_t qhdl, void* data, uint32_t msec)
 {
   void* buf;
-  os_mbx_wait(qhdl->mbox, &buf, 0xFFFF);
+  os_mbx_wait(qhdl->mbox, &buf, msec2wait(msec));
   memcpy(data, buf, qhdl->item_sz);
   _free_box(qhdl->pool, buf);
   return true;
 }
 
-static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
   void* buf = _alloc_box(qhdl->pool);
   memcpy(buf, data, qhdl->item_sz);
@@ -158,7 +158,7 @@ static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in
   return true;
 }
 
-static inline bool osal_queue_empty(osal_queue_t qhdl)
+TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_empty(osal_queue_t qhdl)
 {
   return os_mbx_check(qhdl->mbox) == qhdl->depth;
 }

--- a/src/portable/sony/cxd56/dcd_cxd56.c
+++ b/src/portable/sony/cxd56/dcd_cxd56.c
@@ -363,7 +363,7 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t to
 
     if (usbdcd_driver.setup_processed)
     {
-      if (osal_queue_receive(usbdcd_driver.setup_queue, &ctrl))
+      if (osal_queue_receive(usbdcd_driver.setup_queue, &ctrl, 100))
       {
         usbdcd_driver.setup_processed = false;
         dcd_event_setup_received(0, (uint8_t *)&ctrl, false);

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -286,7 +286,7 @@
 #endif
 
 // mutex is only needed for RTOS TODO also required with multiple core MCUs
-#define TUSB_OPT_MUTEX    (CFG_TUSB_OS != OPT_OS_NONE)
+#define TUSB_OPT_MUTEX      (CFG_TUSB_OS != OPT_OS_NONE)
 
 //--------------------------------------------------------------------
 // DEVICE OPTIONS


### PR DESCRIPTION
**Describe the PR**
- add mili-second timeout to osal_queue_receive (mynewt does not support this).
- tud_task() and tuh_task() ~timeout in 1 ms~ wait forever on event queue, but will exit once processed all events to allow RTOS thread to be shared with other background work e.g cdc flush().
- tud_task_ext() and tuh_task_ext() are added to take `timeout_ms` and `in_isr` (not yet supported)
- In case where 1 tick > 1ms (e.g 1 tick = 10ms), at least 1 tick will be used.
- add TU_ATTR_ALWAYS_INLINE to most of osal function.
- add tinyusb docs and disable blank issue 

@dhalbert