### PR TITLE
pic32 sanity fixes

### DIFF
--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -90,6 +90,9 @@
 #elif defined(__riscv)
   #define TU_BREAKPOINT() do { __asm("ebreak\n"); } while(0)
 
+#elif defined(_mips)
+  #define TU_BREAKPOINT() do { __asm("sdbbp 0"); } while (0)
+
 #else
   #define TU_BREAKPOINT() do {} while (0)
 #endif

--- a/src/portable/microchip/pic32mz/dcd_pic32mz.c
+++ b/src/portable/microchip/pic32mz/dcd_pic32mz.c
@@ -564,6 +564,7 @@ static void epn_handle_rx_int(uint8_t epnum)
     TU_ASSERT(xfer->transferred <= xfer->total_len,);
     if (transferred < xfer->max_packet_size || xfer->transferred == xfer->total_len)
     {
+      USB_REGS->INTRRXEbits.w &= ~(1u << epnum);
       xfer_complete(xfer, XFER_RESULT_SUCCESS, true);
     }
   }
@@ -692,7 +693,7 @@ void dcd_int_handler(uint8_t rhport)
   int i;
   uint8_t mask;
   __USBCSR2bits_t csr2_bits;
-  uint16_t rxints = USB_REGS->INTRRX;
+  uint16_t rxints = USB_REGS->INTRRX & USB_REGS->INTRRXEbits.w;
   uint16_t txints = USB_REGS->INTRTX;
   csr2_bits = USBCSR2bits;
   (void) rhport;

--- a/src/portable/microchip/pic32mz/dcd_pic32mz.c
+++ b/src/portable/microchip/pic32mz/dcd_pic32mz.c
@@ -530,6 +530,7 @@ static void ep0_handle_rx(void)
 
   transferred = rx_fifo_read(0, xfer->buffer + xfer->transferred);
   xfer->transferred += transferred;
+  TU_ASSERT(xfer->transferred <= xfer->total_len,);
   if (transferred < xfer->max_packet_size || xfer->transferred == xfer->total_len)
   {
     ep0_set_stage(EP0_STAGE_DATA_OUT_COMPLETE);
@@ -560,6 +561,7 @@ static void epn_handle_rx_int(uint8_t epnum)
     transferred = rx_fifo_read(epnum, xfer->buffer + xfer->transferred);
     USB_REGS->EPCSR[epnum].RXCSRL_HOSTbits.RXPKTRDY = 0;
     xfer->transferred += transferred;
+    TU_ASSERT(xfer->transferred <= xfer->total_len,);
     if (transferred < xfer->max_packet_size || xfer->transferred == xfer->total_len)
     {
       xfer_complete(xfer, XFER_RESULT_SUCCESS, true);
@@ -579,6 +581,7 @@ static void epn_handle_tx_int(uint8_t epnum)
   else
   {
     xfer->transferred += xfer->last_packet_size;
+    TU_ASSERT(xfer->transferred <= xfer->total_len,);
     if (xfer->last_packet_size < xfer->max_packet_size || xfer->transferred == xfer->total_len)
     {
       xfer->last_packet_size = 0;


### PR DESCRIPTION
**Describe the PR**
For PIC32 OUT packets that were sent from host and not handled
fast enough could lead to memory corruption.
When transfer was complete OUT endpoint was left open for
host to send more data (which is fine and allow for faster transfer).
however if data packet arrived before new transfer was scheduled
code was reading endpoint and writing past buffer that was filled
with previous transfer data.
To prevent such scenario RX interrupt is disabled when transfer is
finished (data can still arrived at endpoint).
Interrupt handler now handles only enabled RX transfers.
When new transfer starts it will enable interrupt (as it was doing
so far).

Two first commits are just to improve error detection.
Third fixes overwrite problem.
**Additional context**
This was detected when MSC device was used.
