### PR TITLE
set irq priority for freertos

### DIFF
--- a/hw/bsp/imxrt/family.c
+++ b/hw/bsp/imxrt/family.c
@@ -51,7 +51,10 @@ void board_init(void)
   SysTick_Config(SystemCoreClock / 1000);
 #elif CFG_TUSB_OS == OPT_OS_FREERTOS
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
-//  NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
+  NVIC_SetPriority(USB_OTG1_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
+#ifdef USB_OTG2_IRQn
+  NVIC_SetPriority(USB_OTG2_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
+#endif
 #endif
 
   // LED


### PR DESCRIPTION
**Describe the PR**
For FreeRTOS, This PR sets the USB interrupt priority to configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, which is where it should be in order to not cause problems for freeRTOS.  it was initially there, then commented out for some reason.  Not sure exactly why it was removed.  

This sets the interrupt priority for both USB ports, if they exist.

