### PR TITLE
Minor cleanup of RP2040 code post addition of Pico-PIO-USB

### DIFF
--- a/examples/device/net_lwip_webserver/src/lwipopts.h
+++ b/examples/device/net_lwip_webserver/src/lwipopts.h
@@ -49,7 +49,9 @@
 
 #define TCP_MSS                         (1500 /*mtu*/ - 20 /*iphdr*/ - 20 /*tcphhr*/)
 #define TCP_SND_BUF                     (2 * TCP_MSS)
+#ifndef TCP_WND
 #define TCP_WND                         (TCP_MSS)
+#endif
 
 #define ETHARP_SUPPORT_STATIC_ENTRIES   1
 

--- a/examples/dual/CMakeLists.txt
+++ b/examples/dual/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../hw/bsp/family_support.cmake)
+
+project(tinyusb_dual_examples)
+family_initialize_project(tinyusb_dual_examples ${CMAKE_CURRENT_LIST_DIR})
+if (FAMILY STREQUAL "rp2040" AND NOT TARGET tinyusb_pico_pio_usb)
+    message("Skipping dual host/device mode examples as Pico-PIO-USB is not available")
+else()
+    # family_add_subdirectory will filter what to actually add based on selected FAMILY
+    family_add_subdirectory(host_hid_to_device_cdc)
+endif()

--- a/examples/dual/host_hid_to_device_cdc/CMakeLists.txt
+++ b/examples/dual/host_hid_to_device_cdc/CMakeLists.txt
@@ -25,6 +25,4 @@ target_include_directories(${PROJECT} PUBLIC
 
 # Configure compilation flags and libraries for the example... see the corresponding function
 # in hw/bsp/FAMILY/family.cmake for details.
-family_configure_device_example(${PROJECT})
-family_configure_host_example(${PROJECT})
-family_configure_pico_pio_usb_example(${PROJECT})
+family_configure_dual_usb_example(${PROJECT})

--- a/examples/host/bare_api/CMakeLists.txt
+++ b/examples/host/bare_api/CMakeLists.txt
@@ -27,4 +27,4 @@ target_include_directories(${PROJECT} PUBLIC
 family_configure_host_example(${PROJECT})
 
 # For rp2040, un-comment to enable pico-pio-usb
-# family_configure_pico_pio_usb_example(${PROJECT})
+# family_add_pico_pio_usb(${PROJECT})

--- a/examples/host/cdc_msc_hid/CMakeLists.txt
+++ b/examples/host/cdc_msc_hid/CMakeLists.txt
@@ -29,4 +29,4 @@ target_include_directories(${PROJECT} PUBLIC
 family_configure_host_example(${PROJECT})
 
 # For rp2040, un-comment to enable pico-pio-usb
-# family_configure_pico_pio_usb_example(${PROJECT})
+# family_add_pico_pio_usb(${PROJECT})

--- a/examples/host/hid_controller/CMakeLists.txt
+++ b/examples/host/hid_controller/CMakeLists.txt
@@ -28,4 +28,4 @@ target_include_directories(${PROJECT} PUBLIC
 family_configure_host_example(${PROJECT})
 
 # For rp2040, un-comment to enable pico-pio-usb
-# family_configure_pico_pio_usb_example(${PROJECT})
+# family_add_pico_pio_usb(${PROJECT})

--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -127,8 +127,10 @@ void board_init(void)
 #ifndef BUTTON_BOOTSEL
 #endif
 
+#if CFG_TUH_RPI_PIO_USB || CFG_TUD_RPI_PIO_USB
   // Set the system clock to a multiple of 120mhz for bitbanging USB with pico-usb
   set_sys_clock_khz(120000, true);
+#endif
 
 #if defined(UART_DEV) && defined(LIB_PICO_STDIO_UART)
   bi_decl(bi_2pins_with_func(UART_TX_PIN, UART_TX_PIN, GPIO_FUNC_UART));

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -537,7 +537,11 @@ bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet
     (void) rhport;
 
     // Copy data into setup packet buffer
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
     memcpy((void*)&usbh_dpram->setup_packet[0], setup_packet, 8);
+#pragma GCC diagnostic pop
 
     // Configure EP0 struct with setup info for the trans complete
     struct hw_endpoint *ep = _hw_endpoint_allocate(0);

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -58,9 +58,9 @@ void rp2040_usb_init(void)
   unreset_block_wait(RESETS_RESET_USBCTRL_BITS);
 
   // Clear any previous state just in case
-  // TODO Suppress warning array-bounds with gcc11
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
   memset(usb_hw, 0, sizeof(*usb_hw));
   memset(usb_dpram, 0, sizeof(*usb_dpram));
 #pragma GCC diagnostic pop


### PR DESCRIPTION
* Removed some compiler warnings, and cleaned out no-longer-necessary warning suppression from CMake `suppress_tinyusb_warnings()`
* Made explicit `family_configure_dual_usb_example()` for DUAL mode examples as `family_configure_target()` may not generally be called multiple times for the same target
* Renamed library `pico_pio_usb` to `tinyusb_pico_pio_usb` to be clearer and avoid conflict if someone already has a `pico_pio_usb` in their project
* Added `family_add_pico_pio_usb()` method for adding Pico-PIO-USB support to an existing example
* Added some explicit guards to check the Pico-PIO-USB submodule is initialized
* Removed explicit setting of a system clock for Pico-PIO-USB in the rp2040 board support unless using Pico-PIO-USB
* Allowed `tinyusb_pico_pio_usb` to be added as a dependency of regular apps using the Pico SDK