### PR TITLE
Host: Add support for multi-level usb hubs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Host Stack
 
 - Human Interface Device (HID): Keyboard, Mouse, Generic
 - Mass Storage Class (MSC)
-- Hub currently only supports 1 level of hub (due to my laziness)
+- Hub with multiple-level support
 
 OS Abstraction layer
 ====================

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -81,7 +81,7 @@
 // Size of buffer to hold descriptors and other data used for enumeration
 #define CFG_TUH_ENUMERATION_BUFSIZE 256
 
-#define CFG_TUH_HUB                 1
+#define CFG_TUH_HUB                 1 // number of supported hubs
 #define CFG_TUH_CDC                 1
 #define CFG_TUH_HID                 4 // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 1

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -204,13 +204,11 @@ void hcd_event_xfer_complete(uint8_t dev_addr, uint8_t ep_addr, uint32_t xferred
     .rhport   = 0, // TODO correct rhport
     .event_id = HCD_EVENT_XFER_COMPLETE,
     .dev_addr = dev_addr,
-    .xfer_complete =
-    {
-      .ep_addr = ep_addr,
-      .result  = result,
-      .len     = xferred_bytes
-    }
   };
+  event.xfer_complete.ep_addr = ep_addr;
+  event.xfer_complete.result = result;
+  event.xfer_complete.len = xferred_bytes;
+
 
   hcd_event_handler(&event, in_isr);
 }

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -169,7 +169,7 @@ bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void* resp,
   };
 
   TU_LOG2("HUB Get Port Status: addr = %u port = %u\r\n", hub_addr, hub_port);
-  TU_ASSERT( tuh_control_xfer(&xfer) );
+  TU_VERIFY( tuh_control_xfer(&xfer) );
   return true;
 }
 
@@ -332,7 +332,11 @@ bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32
   {
     if ( tu_bit_test(p_hub->status_change, port) )
     {
-      hub_port_get_status(dev_addr, port, &p_hub->port_status, connection_get_status_complete, 0);
+      if (hub_port_get_status(dev_addr, port, &p_hub->port_status, connection_get_status_complete, 0) == false)
+      {
+        //Hub status control transfer failed, retry
+        hub_edpt_status_xfer(dev_addr);
+      }
       break;
     }
   }

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1107,6 +1107,12 @@ static void process_device_unplugged(uint8_t rhport, uint8_t hub_addr, uint8_t h
     {
       TU_LOG2("  Address = %u\r\n", dev_addr);
 
+      // If the device itself is a usb hub, unplug downstream devices.
+      if (dev_addr > CFG_TUH_DEVICE_MAX)
+      {
+        process_device_unplugged(rhport, dev_addr, 0);
+      }
+
       // Invoke callback before close driver
       if (tuh_umount_cb) tuh_umount_cb(dev_addr);
 


### PR DESCRIPTION
**Describe the PR**
* Add support for multiple levels of USB hubs in the usb host stack. For your consideration Hathach 😄 

To get this working reliably I had to relax the assert on failed port_status control transfer. Currently with multiple hubs it may perform a control xfer if the ctrl buffer is busy. 

**Additional context**
1. Developed on imxrt (Teensy41) with EHCI.
2. Tested with 3 USB hubs levels, combination of low speed and full speed devices. (HID devices) Not tested with Bulk or Iso but this is not expected to be different from upstream.
3. Quite susceptible to 5V rail supply issues. So an externally powered usb hub is recommended.

**Known issues**
1. If you unplug a downstream hub, it will hit this assert which makes sense and can easily be fixed by relaxing this assert to a TU_VERIFY, but not included in this PR. I think this assert is quite strict as is, but will leave for feedback.
https://github.com/hathach/tinyusb/blob/f4efb51fe2b7f4fee38c28ff80d03904d0b5b73e/src/host/hub.c#L324 

May help to review on a per commit basis.

Below is a working log of 2 daisy chained usb hubs, with 3 usb drives connected. One drive in the first hub, 2 in the 2nd hub.
After enumeration of all 5 devices, I unplug the root hub so you can see all downstream devices disconnected successfully.
[multihub-log.txt](https://github.com/hathach/tinyusb/files/8792675/multihub-log.txt)

Thanks for this great USB stack 🚀 


