### PR TITLE
remove cmake compile macro for net example (use lwipopts.h instead)

### DIFF
--- a/examples/device/net_lwip_webserver/CMakeLists.txt
+++ b/examples/device/net_lwip_webserver/CMakeLists.txt
@@ -69,12 +69,6 @@ if (EXISTS ${TOP}/lib/lwip/src)
             ${TOP}/lib/networking/rndis_reports.c
             )
 
-    target_compile_definitions(${PROJECT} PUBLIC
-            PBUF_POOL_SIZE=2
-            TCP_WND=2*TCP_MSS
-            HTTPD_USE_CUSTOM_FSDATA=0
-            )
-
     # Configure compilation flags and libraries for the example... see the corresponding function
     # in hw/bsp/FAMILY/family.cmake for details.
     family_configure_device_example(${PROJECT})

--- a/examples/device/net_lwip_webserver/src/lwipopts.h
+++ b/examples/device/net_lwip_webserver/src/lwipopts.h
@@ -49,9 +49,7 @@
 
 #define TCP_MSS                         (1500 /*mtu*/ - 20 /*iphdr*/ - 20 /*tcphhr*/)
 #define TCP_SND_BUF                     (2 * TCP_MSS)
-#ifndef TCP_WND
 #define TCP_WND                         (TCP_MSS)
-#endif
 
 #define ETHARP_SUPPORT_STATIC_ENTRIES   1
 


### PR DESCRIPTION
**Describe the PR**
remove cmake compile macro for net example (use lwipopts.h instead). follow up to #1467 