### PR TITLE
cdc: Fix autoflush for FIFO < MPS

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -171,7 +171,7 @@ uint32_t tud_cdc_n_write(uint8_t itf, void const* buffer, uint32_t bufsize)
   uint16_t ret = tu_fifo_write_n(&p_cdc->tx_ff, buffer, (uint16_t) bufsize);
 
   // flush if queue more than packet size
-  if ( tu_fifo_count(&p_cdc->tx_ff) >= BULK_PACKET_SIZE )
+  if ( (tu_fifo_count(&p_cdc->tx_ff) >= BULK_PACKET_SIZE) || ((CFG_TUD_CDC_TX_BUFSIZE < BULK_PACKET_SIZE) && tu_fifo_full(&p_cdc->tx_ff)) )
   {
     tud_cdc_n_write_flush(itf);
   }


### PR DESCRIPTION
**Describe the PR**
If CDC TX buffer size is configured to be less than bulk packet size, the autoflushing condition is never reached.

Changes:
1. TX buff is automatically flushed when TX FIFO is full

**Additional context**
Found out during https://github.com/espressif/esp-idf/issues/9040
