### PR TITLE
add TU_ATTR_FAST_FUNC for audio sof isr call chain

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -2114,7 +2114,7 @@ uint32_t tud_audio_feedback_update(uint8_t func_id, uint32_t cycles)
 }
 #endif
 
-void audiod_sof_isr (uint8_t rhport, uint32_t frame_count)
+TU_ATTR_FAST_FUNC void audiod_sof_isr (uint8_t rhport, uint32_t frame_count)
 {
   (void) rhport;
   (void) frame_count;

--- a/src/class/audio/audio_device.h
+++ b/src/class/audio/audio_device.h
@@ -524,10 +524,10 @@ typedef struct {
 TU_ATTR_WEAK void tud_audio_feedback_params_cb(uint8_t func_id, uint8_t alt_itf, audio_feedback_params_t* feedback_param);
 
 // Callback in ISR context, invoked periodically according to feedback endpoint bInterval.
-// Could be used to compute and update feedback value
+// Could be used to compute and update feedback value, should be placed in RAM if possible
 // frame_number  : current SOF count
 // interval_shift: number of bit shift i.e log2(interval) from Feedback endpoint descriptor
-TU_ATTR_WEAK void tud_audio_feedback_interval_isr(uint8_t func_id, uint32_t frame_number, uint8_t interval_shift);
+TU_ATTR_WEAK TU_ATTR_FAST_FUNC void tud_audio_feedback_interval_isr(uint8_t func_id, uint32_t frame_number, uint8_t interval_shift);
 
 #endif // CFG_TUD_AUDIO_ENABLE_EP_OUT && CFG_TUD_AUDIO_ENABLE_FEEDBACK_EP
 


### PR DESCRIPTION
**Describe the PR**
- TU_ATTR_FAST_FUNC is equivalent to __not_in_flash() for rp2040
- add TU_ATTR_FAST_FUNC for sof isr call chain in audio