### PR TITLE
add tuh_configure() for port/dynamic host behavior config

### DIFF
--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -35,6 +35,13 @@
 #include "bsp/board.h"
 #include "board.h"
 
+#if CFG_TUH_RPI_PIO_USB || CFG_TUD_RPI_PIO_USB
+#include "pio_usb.h"
+#endif
+
+// PIO_USB_DP_PIN_DEFAULT is 0, which conflict with UART, change to 2
+#define PICO_PIO_USB_PIN_DP   2
+
 #ifdef BUTTON_BOOTSEL
 // This example blinks the Picoboard LED when the BOOTSEL button is pressed.
 //
@@ -130,6 +137,12 @@ void board_init(void)
 #if CFG_TUH_RPI_PIO_USB || CFG_TUD_RPI_PIO_USB
   // Set the system clock to a multiple of 120mhz for bitbanging USB with pico-usb
   set_sys_clock_khz(120000, true);
+
+  // rp2040 use pico-pio-usb for host tuh_configure() can be used to passed pio configuration to the host stack
+  // Note: tuh_configure() must be called before tuh_init()
+  pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
+  pio_cfg.pin_dp = PICO_PIO_USB_PIN_DP;
+  tuh_configure(BOARD_TUH_RHPORT, TUH_CFGID_RPI_PIO_USB_CONFIGURATION, &pio_cfg);
 #endif
 
 #if defined(UART_DEV) && defined(LIB_PICO_STDIO_UART)
@@ -142,9 +155,8 @@ void board_init(void)
   stdio_rtt_init();
 #endif
 
-  // todo probably set up device mode?
 #if CFG_TUD_ENABLED
-
+  // TODO probably set up device mode?
 #endif
 
 #if CFG_TUH_ENABLED

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -392,7 +392,7 @@ bool tud_init (uint8_t rhport)
   // skip if already initialized
   if ( tud_inited() ) return true;
 
-  TU_LOG2("USBD init\r\n");
+  TU_LOG2("USBD init rhport %u\r\n", rhport);
   TU_LOG2_INT(sizeof(usbd_device_t));
 
   tu_varclr(&_usbd_dev);

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -48,7 +48,7 @@
 //  #endif
 #endif
 
- //--------------------------------------------------------------------+
+//--------------------------------------------------------------------+
 // MACRO CONSTANT TYPEDEF
 //--------------------------------------------------------------------+
 typedef enum
@@ -105,6 +105,9 @@ typedef struct
 //--------------------------------------------------------------------+
 // Controller API
 //--------------------------------------------------------------------+
+
+// optional hcd configuration, called by tuh_config()
+bool hcd_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param) TU_ATTR_WEAK;
 
 // Initialize controller to host mode
 bool hcd_init(uint8_t rhport);

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -46,8 +46,8 @@ typedef void (*tuh_xfer_cb_t)(tuh_xfer_t* xfer);
 
 // Note1: layout and order of this will be changed in near future
 // it is advised to initialize it using member name
-// Note2: not all field is available/meaningful in callback, some info is not saved by
-// usbh to save SRAM
+// Note2: not all field is available/meaningful in callback,
+// some info is not saved by usbh to save SRAM
 struct tuh_xfer_s
 {
   uint8_t daddr;
@@ -69,6 +69,12 @@ struct tuh_xfer_s
   // uint32_t timeout_ms;    // place holder, not supported yet
 };
 
+// ConfigID for tuh_config()
+enum
+{
+  TUH_CFGID_RPI_PIO_USB_CONFIGURATION = OPT_MCU_RP2040 // cfg_param: pio_usb_configuration_t
+};
+
 //--------------------------------------------------------------------+
 // APPLICATION CALLBACK
 //--------------------------------------------------------------------+
@@ -84,6 +90,12 @@ TU_ATTR_WEAK void tuh_umount_cb(uint8_t daddr);
 //--------------------------------------------------------------------+
 // APPLICATION API
 //--------------------------------------------------------------------+
+
+// Configure host stack behavior with dynamic or port-specific parameters.
+// Should be called before tuh_init()
+// - cfg_id   : configure ID (TBD)
+// - cfg_param: configure data, structure depends on the ID
+bool tuh_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param);
 
 // Init host stack
 bool tuh_init(uint8_t rhport);

--- a/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
+++ b/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
@@ -43,17 +43,25 @@
 #define RHPORT_OFFSET     1
 #define RHPORT_PIO(_x)    ((_x)-RHPORT_OFFSET)
 
-static pio_usb_configuration_t pio_host_config = PIO_USB_DEFAULT_CONFIG;
+static pio_usb_configuration_t pio_host_cfg = PIO_USB_DEFAULT_CONFIG;
 
 //--------------------------------------------------------------------+
 // HCD API
 //--------------------------------------------------------------------+
+bool hcd_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param)
+{
+  (void) rhport;
+  TU_VERIFY(cfg_id == TUH_CFGID_RPI_PIO_USB_CONFIGURATION);
+  memcpy(&pio_host_cfg, cfg_param, sizeof(pio_usb_configuration_t));
+  return true;
+}
+
 bool hcd_init(uint8_t rhport)
 {
   (void) rhport;
 
   // To run USB SOF interrupt in core1, call this init in core1
-  pio_usb_host_init(&pio_host_config);
+  pio_usb_host_init(&pio_host_cfg);
 
   return true;
 }


### PR DESCRIPTION
**Describe the PR**

Add new API to allow configure host behavior dynamically and/or port specific params e.g use to configure pico_pio_usb configuration

```C
bool tuh_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param)
```
