### PR TITLE
make all hcd/dcd function used in isr into ram 

### DIFF
--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -492,23 +492,23 @@ TU_ATTR_BIT_FIELD_ORDER_END
 //--------------------------------------------------------------------+
 
 // Get direction from Endpoint address
-static inline tusb_dir_t tu_edpt_dir(uint8_t addr)
+TU_ATTR_ALWAYS_INLINE static inline tusb_dir_t tu_edpt_dir(uint8_t addr)
 {
   return (addr & TUSB_DIR_IN_MASK) ? TUSB_DIR_IN : TUSB_DIR_OUT;
 }
 
 // Get Endpoint number from address
-static inline uint8_t tu_edpt_number(uint8_t addr)
+TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_edpt_number(uint8_t addr)
 {
   return (uint8_t)(addr & (~TUSB_DIR_IN_MASK));
 }
 
-static inline uint8_t tu_edpt_addr(uint8_t num, uint8_t dir)
+TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_edpt_addr(uint8_t num, uint8_t dir)
 {
   return (uint8_t)(num | (dir ? TUSB_DIR_IN_MASK : 0));
 }
 
-static inline uint16_t tu_edpt_packet_size(tusb_desc_endpoint_t const* desc_ep)
+TU_ATTR_ALWAYS_INLINE static inline uint16_t tu_edpt_packet_size(tusb_desc_endpoint_t const* desc_ep)
 {
   return tu_le16toh(desc_ep->wMaxPacketSize) & TU_GENMASK(10, 0);
 }
@@ -516,18 +516,18 @@ static inline uint16_t tu_edpt_packet_size(tusb_desc_endpoint_t const* desc_ep)
 //--------------------------------------------------------------------+
 // Descriptor helper
 //--------------------------------------------------------------------+
-static inline uint8_t const * tu_desc_next(void const* desc)
+TU_ATTR_ALWAYS_INLINE static inline uint8_t const * tu_desc_next(void const* desc)
 {
   uint8_t const* desc8 = (uint8_t const*) desc;
   return desc8 + desc8[DESC_OFFSET_LEN];
 }
 
-static inline uint8_t tu_desc_type(void const* desc)
+TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_desc_type(void const* desc)
 {
   return ((uint8_t const*) desc)[DESC_OFFSET_TYPE];
 }
 
-static inline uint8_t tu_desc_len(void const* desc)
+TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_desc_len(void const* desc)
 {
   return ((uint8_t const*) desc)[DESC_OFFSET_LEN];
 }

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -55,7 +55,7 @@ static uint8_t *next_buffer_ptr;
 // USB_MAX_ENDPOINTS Endpoints, direction TUSB_DIR_OUT for out and TUSB_DIR_IN for in.
 static struct hw_endpoint hw_endpoints[USB_MAX_ENDPOINTS][2];
 
-static inline struct hw_endpoint *hw_endpoint_get_by_num(uint8_t num, tusb_dir_t dir)
+TU_ATTR_ALWAYS_INLINE static inline struct hw_endpoint *hw_endpoint_get_by_num(uint8_t num, tusb_dir_t dir)
 {
   return &hw_endpoints[num][dir];
 }
@@ -185,7 +185,7 @@ static void hw_endpoint_xfer(uint8_t ep_addr, uint8_t *buffer, uint16_t total_by
     hw_endpoint_xfer_start(ep, buffer, total_bytes);
 }
 
-static void hw_handle_buff_status(void)
+static void __no_inline_not_in_flash_func(hw_handle_buff_status)(void)
 {
     uint32_t remaining_buffers = usb_hw->buf_status;
     pico_trace("buf_status = 0x%08x\n", remaining_buffers);
@@ -214,7 +214,7 @@ static void hw_handle_buff_status(void)
     }
 }
 
-static void reset_ep0_pid(void)
+TU_ATTR_ALWAYS_INLINE static inline void reset_ep0_pid(void)
 {
     // If we have finished this transfer on EP0 set pid back to 1 for next
     // setup transfer. Also clear a stall in case
@@ -226,7 +226,7 @@ static void reset_ep0_pid(void)
     }
 }
 
-static void reset_non_control_endpoints(void)
+static void __no_inline_not_in_flash_func(reset_non_control_endpoints)(void)
 {
   // Disable all non-control
   for ( uint8_t i = 0; i < USB_MAX_ENDPOINTS-1; i++ )
@@ -242,7 +242,7 @@ static void reset_non_control_endpoints(void)
   next_buffer_ptr = &usb_dpram->epx_data[0];
 }
 
-static void dcd_rp2040_irq(void)
+static void __no_inline_not_in_flash_func(dcd_rp2040_irq)(void)
 {
     uint32_t const status = usb_hw->ints;
     uint32_t handled = 0;
@@ -524,7 +524,7 @@ void dcd_edpt_close (uint8_t rhport, uint8_t ep_addr)
     hw_endpoint_close(ep_addr);
 }
 
-void dcd_int_handler(uint8_t rhport)
+void __no_inline_not_in_flash_func(dcd_int_handler)(uint8_t rhport)
 {
   (void) rhport;
   dcd_rp2040_irq();

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -79,7 +79,7 @@ static struct hw_endpoint *get_dev_ep(uint8_t dev_addr, uint8_t ep_addr)
   return NULL;
 }
 
-static inline uint8_t dev_speed(void)
+TU_ATTR_ALWAYS_INLINE static inline uint8_t dev_speed(void)
 {
     return (usb_hw->sie_status & USB_SIE_STATUS_SPEED_BITS) >> USB_SIE_STATUS_SPEED_LSB;
 }
@@ -91,7 +91,7 @@ static bool need_pre(uint8_t dev_addr)
     return hcd_port_speed_get(0) != tuh_speed_get(dev_addr);
 }
 
-static void hw_xfer_complete(struct hw_endpoint *ep, xfer_result_t xfer_result)
+static void __no_inline_not_in_flash_func(hw_xfer_complete)(struct hw_endpoint *ep, xfer_result_t xfer_result)
 {
     // Mark transfer as done before we tell the tinyusb stack
     uint8_t dev_addr = ep->dev_addr;
@@ -101,7 +101,7 @@ static void hw_xfer_complete(struct hw_endpoint *ep, xfer_result_t xfer_result)
     hcd_event_xfer_complete(dev_addr, ep_addr, xferred_len, xfer_result, true);
 }
 
-static void _handle_buff_status_bit(uint bit, struct hw_endpoint *ep)
+static void __no_inline_not_in_flash_func(_handle_buff_status_bit)(uint bit, struct hw_endpoint *ep)
 {
     usb_hw_clear->buf_status = bit;
     bool done = hw_endpoint_xfer_continue(ep);
@@ -111,7 +111,7 @@ static void _handle_buff_status_bit(uint bit, struct hw_endpoint *ep)
     }
 }
 
-static void hw_handle_buff_status(void)
+static void __no_inline_not_in_flash_func(hw_handle_buff_status)(void)
 {
     uint32_t remaining_buffers = usb_hw->buf_status;
     pico_trace("buf_status 0x%08x\n", remaining_buffers);
@@ -159,7 +159,7 @@ static void hw_handle_buff_status(void)
     }
 }
 
-static void hw_trans_complete(void)
+static void __no_inline_not_in_flash_func(hw_trans_complete)(void)
 {
   if (usb_hw->sie_ctrl & USB_SIE_CTRL_SEND_SETUP_BITS)
   {
@@ -175,7 +175,7 @@ static void hw_trans_complete(void)
   }
 }
 
-static void hcd_rp2040_irq(void)
+static void __no_inline_not_in_flash_func(hcd_rp2040_irq)(void)
 {
     uint32_t status = usb_hw->ints;
     uint32_t handled = 0;
@@ -238,6 +238,12 @@ static void hcd_rp2040_irq(void)
     {
         panic("Unhandled IRQ 0x%x\n", (uint) (status ^ handled));
     }
+}
+
+void __no_inline_not_in_flash_func(hcd_int_handler)(uint8_t rhport)
+{
+  (void) rhport;
+  hcd_rp2040_irq();
 }
 
 static struct hw_endpoint *_next_free_interrupt_ep(void)

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -38,7 +38,7 @@ const char *ep_dir_string[] = {
         "in",
 };
 
-static inline void _hw_endpoint_lock_update(__unused struct hw_endpoint * ep, __unused int delta) {
+TU_ATTR_ALWAYS_INLINE static inline void _hw_endpoint_lock_update(__unused struct hw_endpoint * ep, __unused int delta) {
     // todo add critsec as necessary to prevent issues between worker and IRQ...
     //  note that this is perhaps as simple as disabling IRQs because it would make
     //  sense to have worker and IRQ on same core, however I think using critsec is about equivalent.
@@ -69,7 +69,7 @@ void rp2040_usb_init(void)
   usb_hw->muxing = USB_USB_MUXING_TO_PHY_BITS | USB_USB_MUXING_SOFTCON_BITS;
 }
 
-void hw_endpoint_reset_transfer(struct hw_endpoint *ep)
+void __no_inline_not_in_flash_func(hw_endpoint_reset_transfer)(struct hw_endpoint *ep)
 {
   ep->active = false;
   ep->remaining_len = 0;
@@ -77,7 +77,7 @@ void hw_endpoint_reset_transfer(struct hw_endpoint *ep)
   ep->user_buf = 0;
 }
 
-void _hw_endpoint_buffer_control_update32(struct hw_endpoint *ep, uint32_t and_mask, uint32_t or_mask) {
+void __no_inline_not_in_flash_func(_hw_endpoint_buffer_control_update32)(struct hw_endpoint *ep, uint32_t and_mask, uint32_t or_mask) {
     uint32_t value = 0;
     if (and_mask) {
         value = *ep->buffer_control & and_mask;
@@ -108,7 +108,7 @@ void _hw_endpoint_buffer_control_update32(struct hw_endpoint *ep, uint32_t and_m
 }
 
 // prepare buffer, return buffer control
-static uint32_t prepare_ep_buffer(struct hw_endpoint *ep, uint8_t buf_id)
+static uint32_t __no_inline_not_in_flash_func(prepare_ep_buffer)(struct hw_endpoint *ep, uint8_t buf_id)
 {
   uint16_t const buflen = tu_min16(ep->remaining_len, ep->wMaxPacketSize);
   ep->remaining_len = (uint16_t)(ep->remaining_len - buflen);
@@ -143,7 +143,7 @@ static uint32_t prepare_ep_buffer(struct hw_endpoint *ep, uint8_t buf_id)
 }
 
 // Prepare buffer control register value
-static void _hw_endpoint_start_next_buffer(struct hw_endpoint *ep)
+static void __no_inline_not_in_flash_func(_hw_endpoint_start_next_buffer)(struct hw_endpoint *ep)
 {
   uint32_t ep_ctrl = *ep->endpoint_control;
 
@@ -205,7 +205,7 @@ void hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t to
 }
 
 // sync endpoint buffer and return transferred bytes
-static uint16_t sync_ep_buffer(struct hw_endpoint *ep, uint8_t buf_id)
+static uint16_t __no_inline_not_in_flash_func(sync_ep_buffer)(struct hw_endpoint *ep, uint8_t buf_id)
 {
   uint32_t buf_ctrl = _hw_endpoint_buffer_control_get_value32(ep);
   if (buf_id)  buf_ctrl = buf_ctrl >> 16;
@@ -241,7 +241,7 @@ static uint16_t sync_ep_buffer(struct hw_endpoint *ep, uint8_t buf_id)
   return xferred_bytes;
 }
 
-static void _hw_endpoint_xfer_sync (struct hw_endpoint *ep)
+static void __no_inline_not_in_flash_func(_hw_endpoint_xfer_sync) (struct hw_endpoint *ep)
 {
   // Update hw endpoint struct with info from hardware
   // after a buff status interrupt
@@ -292,7 +292,7 @@ static void _hw_endpoint_xfer_sync (struct hw_endpoint *ep)
 }
 
 // Returns true if transfer is complete
-bool hw_endpoint_xfer_continue(struct hw_endpoint *ep)
+bool __no_inline_not_in_flash_func(hw_endpoint_xfer_continue)(struct hw_endpoint *ep)
 {
   _hw_endpoint_lock_update(ep, 1);
   // Part way through a transfer

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -72,16 +72,20 @@ bool hw_endpoint_xfer_continue(struct hw_endpoint *ep);
 void hw_endpoint_reset_transfer(struct hw_endpoint *ep);
 
 void _hw_endpoint_buffer_control_update32(struct hw_endpoint *ep, uint32_t and_mask, uint32_t or_mask);
-static inline uint32_t _hw_endpoint_buffer_control_get_value32(struct hw_endpoint *ep) {
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t _hw_endpoint_buffer_control_get_value32(struct hw_endpoint *ep) {
     return *ep->buffer_control;
 }
-static inline void _hw_endpoint_buffer_control_set_value32(struct hw_endpoint *ep, uint32_t value) {
+
+TU_ATTR_ALWAYS_INLINE static inline void _hw_endpoint_buffer_control_set_value32(struct hw_endpoint *ep, uint32_t value) {
     return _hw_endpoint_buffer_control_update32(ep, 0, value);
 }
-static inline void _hw_endpoint_buffer_control_set_mask32(struct hw_endpoint *ep, uint32_t value) {
+
+TU_ATTR_ALWAYS_INLINE static inline void _hw_endpoint_buffer_control_set_mask32(struct hw_endpoint *ep, uint32_t value) {
     return _hw_endpoint_buffer_control_update32(ep, ~value, value);
 }
-static inline void _hw_endpoint_buffer_control_clear_mask32(struct hw_endpoint *ep, uint32_t value) {
+
+TU_ATTR_ALWAYS_INLINE static inline void _hw_endpoint_buffer_control_clear_mask32(struct hw_endpoint *ep, uint32_t value) {
     return _hw_endpoint_buffer_control_update32(ep, ~value, 0);
 }
 


### PR DESCRIPTION
**Describe the PR**
- either force inline or use __no_inline_not_in_flash_func() for faster irq handling
- result is 1KB of code moved from rom -> ram