### PR TITLE
rp2040: make moving 1K of code into RAM optional - and off by default

### DIFF
--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -185,7 +185,7 @@ static void hw_endpoint_xfer(uint8_t ep_addr, uint8_t *buffer, uint16_t total_by
     hw_endpoint_xfer_start(ep, buffer, total_bytes);
 }
 
-static void __no_inline_not_in_flash_func(hw_handle_buff_status)(void)
+static void __tusb_irq_path_func(hw_handle_buff_status)(void)
 {
     uint32_t remaining_buffers = usb_hw->buf_status;
     pico_trace("buf_status = 0x%08x\n", remaining_buffers);
@@ -226,7 +226,7 @@ TU_ATTR_ALWAYS_INLINE static inline void reset_ep0_pid(void)
     }
 }
 
-static void __no_inline_not_in_flash_func(reset_non_control_endpoints)(void)
+static void __tusb_irq_path_func(reset_non_control_endpoints)(void)
 {
   // Disable all non-control
   for ( uint8_t i = 0; i < USB_MAX_ENDPOINTS-1; i++ )
@@ -242,7 +242,7 @@ static void __no_inline_not_in_flash_func(reset_non_control_endpoints)(void)
   next_buffer_ptr = &usb_dpram->epx_data[0];
 }
 
-static void __no_inline_not_in_flash_func(dcd_rp2040_irq)(void)
+static void __tusb_irq_path_func(dcd_rp2040_irq)(void)
 {
     uint32_t const status = usb_hw->ints;
     uint32_t handled = 0;
@@ -524,7 +524,7 @@ void dcd_edpt_close (uint8_t rhport, uint8_t ep_addr)
     hw_endpoint_close(ep_addr);
 }
 
-void __no_inline_not_in_flash_func(dcd_int_handler)(uint8_t rhport)
+void __tusb_irq_path_func(dcd_int_handler)(uint8_t rhport)
 {
   (void) rhport;
   dcd_rp2040_irq();

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -91,7 +91,7 @@ static bool need_pre(uint8_t dev_addr)
     return hcd_port_speed_get(0) != tuh_speed_get(dev_addr);
 }
 
-static void __no_inline_not_in_flash_func(hw_xfer_complete)(struct hw_endpoint *ep, xfer_result_t xfer_result)
+static void __tusb_irq_path_func(hw_xfer_complete)(struct hw_endpoint *ep, xfer_result_t xfer_result)
 {
     // Mark transfer as done before we tell the tinyusb stack
     uint8_t dev_addr = ep->dev_addr;
@@ -101,7 +101,7 @@ static void __no_inline_not_in_flash_func(hw_xfer_complete)(struct hw_endpoint *
     hcd_event_xfer_complete(dev_addr, ep_addr, xferred_len, xfer_result, true);
 }
 
-static void __no_inline_not_in_flash_func(_handle_buff_status_bit)(uint bit, struct hw_endpoint *ep)
+static void __tusb_irq_path_func(_handle_buff_status_bit)(uint bit, struct hw_endpoint *ep)
 {
     usb_hw_clear->buf_status = bit;
     bool done = hw_endpoint_xfer_continue(ep);
@@ -111,7 +111,7 @@ static void __no_inline_not_in_flash_func(_handle_buff_status_bit)(uint bit, str
     }
 }
 
-static void __no_inline_not_in_flash_func(hw_handle_buff_status)(void)
+static void __tusb_irq_path_func(hw_handle_buff_status)(void)
 {
     uint32_t remaining_buffers = usb_hw->buf_status;
     pico_trace("buf_status 0x%08x\n", remaining_buffers);
@@ -159,7 +159,7 @@ static void __no_inline_not_in_flash_func(hw_handle_buff_status)(void)
     }
 }
 
-static void __no_inline_not_in_flash_func(hw_trans_complete)(void)
+static void __tusb_irq_path_func(hw_trans_complete)(void)
 {
   if (usb_hw->sie_ctrl & USB_SIE_CTRL_SEND_SETUP_BITS)
   {
@@ -175,7 +175,7 @@ static void __no_inline_not_in_flash_func(hw_trans_complete)(void)
   }
 }
 
-static void __no_inline_not_in_flash_func(hcd_rp2040_irq)(void)
+static void __tusb_irq_path_func(hcd_rp2040_irq)(void)
 {
     uint32_t status = usb_hw->ints;
     uint32_t handled = 0;
@@ -240,7 +240,7 @@ static void __no_inline_not_in_flash_func(hcd_rp2040_irq)(void)
     }
 }
 
-void __no_inline_not_in_flash_func(hcd_int_handler)(uint8_t rhport)
+void __tusb_irq_path_func(hcd_int_handler)(uint8_t rhport)
 {
   (void) rhport;
   hcd_rp2040_irq();

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -69,7 +69,7 @@ void rp2040_usb_init(void)
   usb_hw->muxing = USB_USB_MUXING_TO_PHY_BITS | USB_USB_MUXING_SOFTCON_BITS;
 }
 
-void __no_inline_not_in_flash_func(hw_endpoint_reset_transfer)(struct hw_endpoint *ep)
+void __tusb_irq_path_func(hw_endpoint_reset_transfer)(struct hw_endpoint *ep)
 {
   ep->active = false;
   ep->remaining_len = 0;
@@ -77,7 +77,7 @@ void __no_inline_not_in_flash_func(hw_endpoint_reset_transfer)(struct hw_endpoin
   ep->user_buf = 0;
 }
 
-void __no_inline_not_in_flash_func(_hw_endpoint_buffer_control_update32)(struct hw_endpoint *ep, uint32_t and_mask, uint32_t or_mask) {
+void __tusb_irq_path_func(_hw_endpoint_buffer_control_update32)(struct hw_endpoint *ep, uint32_t and_mask, uint32_t or_mask) {
     uint32_t value = 0;
     if (and_mask) {
         value = *ep->buffer_control & and_mask;
@@ -108,7 +108,7 @@ void __no_inline_not_in_flash_func(_hw_endpoint_buffer_control_update32)(struct 
 }
 
 // prepare buffer, return buffer control
-static uint32_t __no_inline_not_in_flash_func(prepare_ep_buffer)(struct hw_endpoint *ep, uint8_t buf_id)
+static uint32_t __tusb_irq_path_func(prepare_ep_buffer)(struct hw_endpoint *ep, uint8_t buf_id)
 {
   uint16_t const buflen = tu_min16(ep->remaining_len, ep->wMaxPacketSize);
   ep->remaining_len = (uint16_t)(ep->remaining_len - buflen);
@@ -143,7 +143,7 @@ static uint32_t __no_inline_not_in_flash_func(prepare_ep_buffer)(struct hw_endpo
 }
 
 // Prepare buffer control register value
-static void __no_inline_not_in_flash_func(_hw_endpoint_start_next_buffer)(struct hw_endpoint *ep)
+static void __tusb_irq_path_func(_hw_endpoint_start_next_buffer)(struct hw_endpoint *ep)
 {
   uint32_t ep_ctrl = *ep->endpoint_control;
 
@@ -205,7 +205,7 @@ void hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, uint16_t to
 }
 
 // sync endpoint buffer and return transferred bytes
-static uint16_t __no_inline_not_in_flash_func(sync_ep_buffer)(struct hw_endpoint *ep, uint8_t buf_id)
+static uint16_t __tusb_irq_path_func(sync_ep_buffer)(struct hw_endpoint *ep, uint8_t buf_id)
 {
   uint32_t buf_ctrl = _hw_endpoint_buffer_control_get_value32(ep);
   if (buf_id)  buf_ctrl = buf_ctrl >> 16;
@@ -241,7 +241,7 @@ static uint16_t __no_inline_not_in_flash_func(sync_ep_buffer)(struct hw_endpoint
   return xferred_bytes;
 }
 
-static void __no_inline_not_in_flash_func(_hw_endpoint_xfer_sync) (struct hw_endpoint *ep)
+static void __tusb_irq_path_func(_hw_endpoint_xfer_sync) (struct hw_endpoint *ep)
 {
   // Update hw endpoint struct with info from hardware
   // after a buff status interrupt
@@ -292,7 +292,7 @@ static void __no_inline_not_in_flash_func(_hw_endpoint_xfer_sync) (struct hw_end
 }
 
 // Returns true if transfer is complete
-bool __no_inline_not_in_flash_func(hw_endpoint_xfer_continue)(struct hw_endpoint *ep)
+bool __tusb_irq_path_func(hw_endpoint_xfer_continue)(struct hw_endpoint *ep)
 {
   _hw_endpoint_lock_update(ep, 1);
   // Part way through a transfer

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -16,6 +16,15 @@
 #define TUD_OPT_RP2040_USB_DEVICE_ENUMERATION_FIX PICO_RP2040_USB_DEVICE_ENUMERATION_FIX
 #endif
 
+#ifndef PICO_RP2040_USB_FAST_IRQ
+#define PICO_RP2040_USB_FAST_IRQ 0
+#endif
+
+#if PICO_RP2040_USB_FAST_IRQ
+#define __tusb_irq_path_func(x) __no_inline_not_in_flash_func(x)
+#else
+#define __tusb_irq_path_func(x) x
+#endif
 
 #define pico_info(...)  TU_LOG(2, __VA_ARGS__)
 #define pico_trace(...) TU_LOG(3, __VA_ARGS__)


### PR DESCRIPTION
Made the changes in commit dd035b0eb optional because stealing 1K of RAM by default seems undesirable.

It is now controlled by PICO_RP2040_USB_FAST_IRQ which is 0 by default.

It is probably worth documenting what use cases the faster IRQ helps/is-required-for.
