### PR TITLE
add tud_queue_send_cb

### DIFF
--- a/src/osal/osal_pico.h
+++ b/src/osal/osal_pico.h
@@ -155,19 +155,24 @@ TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_receive(osal_queue_t qhdl, v
   return success;
 }
 
+#define TUD_QUEUE_SEND_CB_SUPPORTED 1
+
+TU_ATTR_WEAK void tud_queue_send_cb(bool in_isr);
+
 TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr)
 {
   // TODO: revisit... docs say that mutexes are never used from IRQ context,
   //  however osal_queue_recieve may be. therefore my assumption is that
   //  the fifo mutex is not populated for queues used from an IRQ context
   //assert(!qhdl->ff.mutex);
-  (void) in_isr;
 
   _osal_q_lock(qhdl);
   bool success = tu_fifo_write(&qhdl->ff, data);
   _osal_q_unlock(qhdl);
 
   TU_ASSERT(success);
+
+  if (tud_queue_send_cb) tud_queue_send_cb(in_isr);
 
   return success;
 }


### PR DESCRIPTION
In the Pico SDK for stdio over USB, (by default) we call TinyUSB in a low priority IRQ (so the user does not have to have a polling loop).

Currently this IRQ is called every 1ms which is pretty wasteful. This change adds a callback which can be hooked to know when there is something in the queue that needs processing.

Note, i don't know if:

1) i called this the right thing
2) whether it should be defined somewhere else (if other ports might find it useful)
3) it performs the callback for all queues. This was just to avoid having to put a call after every queue_write (and based on the fact that no other use of osal_queue is made in the code base!
