### PR TITLE
Stub out dcd_edpt_close for samd

### DIFF
--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -250,6 +250,13 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
   return true;
 }
 
+void dcd_edpt_close (uint8_t rhport, uint8_t ep_addr) {
+  (void) rhport;
+  (void) ep_addr;
+
+  // TODO: implement if necessary?
+}
+
 void dcd_edpt_close_all (uint8_t rhport)
 {
   (void) rhport;


### PR DESCRIPTION
Not having this prevents the device from finishing the mounting process.

Tested on a SAMD51 and didn't seem to need to actually do anything in the close function. Did repeated close/opens of an audio streaming endpoint.