### PR TITLE
correct bulk size for highspeed endpoint in dynamic_configuration and usbtmc exmaples

### DIFF
--- a/examples/device/dynamic_configuration/src/usb_descriptors.c
+++ b/examples/device/dynamic_configuration/src/usb_descriptors.c
@@ -163,7 +163,7 @@ uint8_t const desc_configuration_0[] =
   TUD_CONFIG_DESCRIPTOR(1, ITF_0_NUM_TOTAL, 0, CONFIG_0_TOTAL_LEN, 0x00, 100),
 
   // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-  TUD_CDC_DESCRIPTOR(ITF_0_NUM_CDC, 0, EPNUM_0_CDC_NOTIF, 8, EPNUM_0_CDC_OUT, EPNUM_0_CDC_IN, 64),
+  TUD_CDC_DESCRIPTOR(ITF_0_NUM_CDC, 0, EPNUM_0_CDC_NOTIF, 8, EPNUM_0_CDC_OUT, EPNUM_0_CDC_IN, TUD_OPT_HIGH_SPEED ? 512 : 64),
 
   // Interface number, string index, EP Out & EP In address, EP size
   TUD_MIDI_DESCRIPTOR(ITF_0_NUM_MIDI, 0, EPNUM_0_MIDI_OUT, EPNUM_0_MIDI_IN, TUD_OPT_HIGH_SPEED ? 512 : 64),

--- a/src/class/usbtmc/usbtmc_device.h
+++ b/src/class/usbtmc/usbtmc_device.h
@@ -37,7 +37,7 @@
 
 // USB spec says that full-speed must be 8,16,32, or 64.
 // However, this driver implementation requires it to be >=32
-#define USBTMCD_MAX_PACKET_SIZE (64u)
+#define USBTMCD_MAX_PACKET_SIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
 
 /***********************************************
  *  Functions to be implemeted by the class implementation


### PR DESCRIPTION
**Describe the PR**
fix #1457, close #1459
bulk endpoint size must be 512 for highspeed and 64 for FS, dynamic_configuration and usbtmc examples hard coded to 64 and cause an assert in the stack

```
[ 4949.159993] usb 3-1: USB disconnect, device number 51
[ 4949.484276] usb 3-1: new high-speed USB device number 52 using xhci_hcd
[ 4949.633227] usb 3-1: config 1 interface 0 altsetting 0 bulk endpoint 0x1 has invalid maxpacket 64
[ 4949.633230] usb 3-1: config 1 interface 0 altsetting 0 bulk endpoint 0x81 has invalid maxpacket 64
```