### PR TITLE
rp2040: use shared IRQ handlers, so user can also hook the USB IRQ

### DIFF
--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -363,7 +363,7 @@ void dcd_init (uint8_t rhport)
   usb_hw->pwr = USB_USB_PWR_VBUS_DETECT_BITS | USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN_BITS;
 #endif
 
-  irq_set_exclusive_handler(USBCTRL_IRQ, dcd_rp2040_irq);
+  irq_add_shared_handler(USBCTRL_IRQ, dcd_rp2040_irq, PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY);
 
   // Init control endpoints
   tu_memclr(hw_endpoints[0], 2*sizeof(hw_endpoint_t));

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -369,7 +369,7 @@ bool hcd_init(uint8_t rhport)
     // Force VBUS detect to always present, for now we assume vbus is always provided (without using VBUS En)
     usb_hw->pwr = USB_USB_PWR_VBUS_DETECT_BITS | USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN_BITS;
 
-    irq_set_exclusive_handler(USBCTRL_IRQ, hcd_rp2040_irq);
+    irq_add_shared_handler(USBCTRL_IRQ, hcd_rp2040_irq, PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY);
 
     // clear epx and interrupt eps
     memset(&ep_pool, 0, sizeof(ep_pool));


### PR DESCRIPTION
By using shared IRQ handlers, the user can add a lower priority handler, and therefore be aware when they might need to poll TinyUSB
