### PR TITLE
When clearing an endpoint stall, reset DTOG

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -636,7 +636,7 @@ static bool invoke_class_control(uint8_t rhport, usbd_class_driver_t const * dri
 }
 
 // This handles the actual request and its response.
-// return false will cause its caller to stall control endpoint
+// Returns false if unable to complete the request, causing caller to stall control endpoints.
 static bool process_control_request(uint8_t rhport, tusb_control_request_t const * p_request) {
   usbd_control_set_complete_callback(NULL);
   TU_ASSERT(p_request->bmRequestType_bit.type < TUSB_REQ_TYPE_INVALID);

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1306,12 +1306,10 @@ void usbd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
   uint8_t const dir = tu_edpt_dir(ep_addr);
 
   // only stalled if currently cleared
-  if (!_usbd_dev.ep_status[epnum][dir].stalled) {
-    TU_LOG_USBD("    Stall EP %02X\r\n", ep_addr);
-    dcd_edpt_stall(rhport, ep_addr);
-    _usbd_dev.ep_status[epnum][dir].stalled = 1;
-    _usbd_dev.ep_status[epnum][dir].busy = 1;
-  }
+  TU_LOG_USBD("    Stall EP %02X\r\n", ep_addr);
+  dcd_edpt_stall(rhport, ep_addr);
+  _usbd_dev.ep_status[epnum][dir].stalled = 1;
+  _usbd_dev.ep_status[epnum][dir].busy = 1;
 }
 
 void usbd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr) {
@@ -1321,12 +1319,10 @@ void usbd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr) {
   uint8_t const dir = tu_edpt_dir(ep_addr);
 
   // only clear if currently stalled
-  if (_usbd_dev.ep_status[epnum][dir].stalled) {
-    TU_LOG_USBD("    Clear Stall EP %02X\r\n", ep_addr);
-    dcd_edpt_clear_stall(rhport, ep_addr);
-    _usbd_dev.ep_status[epnum][dir].stalled = 0;
-    _usbd_dev.ep_status[epnum][dir].busy = 0;
-  }
+  TU_LOG_USBD("    Clear Stall EP %02X\r\n", ep_addr);
+  dcd_edpt_clear_stall(rhport, ep_addr);
+  _usbd_dev.ep_status[epnum][dir].stalled = 0;
+  _usbd_dev.ep_status[epnum][dir].busy = 0;
 }
 
 bool usbd_edpt_stalled(uint8_t rhport, uint8_t ep_addr) {


### PR DESCRIPTION
According to the USB spec, the DTOG of an endpoint should always be reset to DATA0 when receiving CLEAR_FEATURE(ENDPOINT_HALT), regardless of if the endpoint had been stalled (See citations in #1529).

I believe the attached changes should be made to USBD to facilitate this requirement.

However, some issues to discuss are:

1. When stalling endpoints (even when not in response to a control request), do we need to purge the event queue from transfers on that endpoint?
2. When SET_CONFIGURATION() is received with the active configuration, does DTOG need to be reset? Does the class driver need to be reset? (Currently the code treats SET_CONFIG(active config) as a NOOP.)
3. Is there a better way to tell if an EP is a control endpoint, besides checking its address? (USB devices may have multiple control endpoints) Or perhaps we can remove the address check and unconditionally call usbd_edpt_stall?
4. Will these changes cause deadlocks or extra bugs in existing class drivers? (e.g., class initiates OUT transfer, host clear(halt) on the EP, class doesn't react to the transaction being cancelled)? Though perhaps the class drivers would already not have properly handled these situations, so it wouldn't be any more broken than it is now?
5. Or do we need to push this logic into class drivers?
6. Are there error cases when a class driver should be able to force the endpoint to stay stalled, even when the host requests that it be cleared? (I don't need this at the moment, but this was mentioned in the USBTMC spec).
7. Perhaps a simpler solution would be to make the `usbd_edpt_clear_stall` unconditionally clear the stall... but does that run into race conditions?

(If this is merged, then the workaround in #1531 can be removed from the USBTMC driver)