### PR TITLE
Fix warnings when compiling rp2040 with older version of gcc

### DIFF
--- a/examples/device/webusb_serial/src/main.c
+++ b/examples/device/webusb_serial/src/main.c
@@ -71,7 +71,7 @@ enum  {
 
 static uint32_t blink_interval_ms = BLINK_NOT_MOUNTED;
 
-#define URL  "example.tinyusb.org/webusb-serial/"
+#define URL  "example.tinyusb.org/webusb-serial/index.html"
 
 const tusb_desc_webusb_url_t desc_url =
 {
@@ -114,6 +114,7 @@ void echo_all(uint8_t buf[], uint32_t count)
   if ( web_serial_connected )
   {
     tud_vendor_write(buf, count);
+    tud_vendor_flush();
   }
 
   // echo to cdc
@@ -211,7 +212,8 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
           board_led_write(true);
           blink_interval_ms = BLINK_ALWAYS_ON;
 
-          tud_vendor_write_str("\r\nTinyUSB WebUSB device example\r\n");
+          tud_vendor_write_str("\r\nWebUSB interface connected\r\n");
+          tud_vendor_flush();
         }else
         {
           blink_interval_ms = BLINK_MOUNTED;

--- a/examples/example.cmake
+++ b/examples/example.cmake
@@ -4,28 +4,29 @@ target_compile_options(${PROJECT} PUBLIC
         -Werror
         -Wfatal-errors
         -Wdouble-promotion
-        #-Wstrict-prototypes
-        -Wstrict-overflow
-        #-Werror-implicit-function-declaration
         -Wfloat-equal
-        #-Wundef
         -Wshadow
         -Wwrite-strings
         -Wsign-compare
         -Wmissing-format-attribute
         -Wunreachable-code
         -Wcast-align
-        -Wcast-function-type
         -Wcast-qual
         -Wnull-dereference
         -Wuninitialized
         -Wunused
         -Wredundant-decls
+        #-Wstrict-prototypes
+        #-Werror-implicit-function-declaration
+        #-Wundef
         )
 
-# GCC version 9 or prior has a bug with incorrect Wconversion warnings
+# GCC 10
 if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
-  target_compile_options(${PROJECT} PUBLIC
-        -Wconversion
-        )
+  target_compile_options(${PROJECT} PUBLIC -Wconversion)
+endif()
+
+# GCC 8
+if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
+  target_compile_options(${PROJECT} PUBLIC -Wcast-function-type -Wstrict-overflow)
 endif()

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -123,7 +123,6 @@ typedef struct {
 
 // Invalid driver ID in itf2drv[] ep2drv[][] mapping
 enum { DRVID_INVALID = 0xFFu };
-enum { ADDR_INVALID  = 0xFFu };
 enum { CONTROLLER_INVALID = 0xFFu };
 
 #if CFG_TUSB_DEBUG >= 2
@@ -1434,7 +1433,8 @@ static uint8_t get_new_address(bool is_hub)
   {
     if (!_usbh_devices[idx].connected) return (idx+1);
   }
-  return ADDR_INVALID;
+
+  return 0; // invalid address
 }
 
 static bool enum_request_set_addr(void)
@@ -1443,7 +1443,7 @@ static bool enum_request_set_addr(void)
 
   // Get new address
   uint8_t const new_addr = get_new_address(desc_device->bDeviceClass == TUSB_CLASS_HUB);
-  TU_ASSERT(new_addr != ADDR_INVALID);
+  TU_ASSERT(new_addr != 0);
 
   TU_LOG2("Set Address = %d\r\n", new_addr);
 


### PR DESCRIPTION
**Describe the PR**
Fix warnings when compiling rp2040 with older version of gcc. pico-examples with across gcc version 7, 8, 9, 10, 11 
https://github.com/hathach/pico-examples/actions/runs/2651623363

PS: there is un-related cleanup to webusb example as well.