### PR TITLE
dfu: Allow DFU coexistence with other interfaces (BTH, RNDIS, future one)

### DIFF
--- a/src/class/dfu/dfu_device.c
+++ b/src/class/dfu/dfu_device.c
@@ -167,6 +167,8 @@ uint16_t dfu_moded_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, 
   uint8_t alt_count = 0;
 
   uint16_t drv_len = 0;
+  TU_VERIFY(itf_desc->bInterfaceSubClass == TUD_DFU_APP_SUBCLASS && itf_desc->bInterfaceProtocol == DFU_PROTOCOL_DFU, 0);
+
   while(itf_desc->bInterfaceSubClass == TUD_DFU_APP_SUBCLASS && itf_desc->bInterfaceProtocol == DFU_PROTOCOL_DFU)
   {
     TU_ASSERT(max_len > drv_len, 0);


### PR DESCRIPTION
**Describe the PR**
dfu_moded_open() only works correct when its called on DFU interface
descriptor. It means that DFU is the only one interface in configuration
or driver is called after all others interface drivers were tried and
gave up.

If other interface is supported and but driver for DFU is called first
(this is the case for BTH and RNDIS).
Code after while loop (that was not entered) has an TU_ASSERT that will
make set_configuration to fail.

Now TU_VERIFY is called first to make sure open code is called for DFU
only and not other interface descriptors like in other drivers.


**Additional context**

