### PR TITLE
Remove Hardcoded interface numbers from video descriptors

### DIFF
--- a/examples/device/video_capture/src/usb_descriptors.h
+++ b/examples/device/video_capture/src/usb_descriptors.h
@@ -38,7 +38,7 @@
 #define FRAME_RATE    10
 
 enum {
-  ITF_NUM_VIDEO_CONTROL = 0,
+  ITF_NUM_VIDEO_CONTROL,
   ITF_NUM_VIDEO_STREAMING,
   ITF_NUM_TOTAL
 };
@@ -74,19 +74,19 @@ enum {
   TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR(_fmtidx, _numfmtdesc, TUD_VIDEO_GUID_I420, 12, _frmidx, _asrx, _asry, _interlace, _cp)
 
 #define TUD_VIDEO_CAPTURE_DESCRIPTOR(_stridx, _epin, _width, _height, _fps, _epsize) \
-  TUD_VIDEO_DESC_IAD(ITF_NUM_VIDEO_CONTROL, ITF_NUM_TOTAL, _stridx), \
+  TUD_VIDEO_DESC_IAD(ITF_NUM_VIDEO_CONTROL, /* 2 Interfaces */ 0x02, _stridx), \
   /* Video control 0 */ \
   TUD_VIDEO_DESC_STD_VC(ITF_NUM_VIDEO_CONTROL, 0, _stridx), \
     TUD_VIDEO_DESC_CS_VC( /* UVC 1.5*/ 0x0150, \
          /* wTotalLength - bLength */ \
          TUD_VIDEO_DESC_CAMERA_TERM_LEN + TUD_VIDEO_DESC_OUTPUT_TERM_LEN, \
-         UVC_CLOCK_FREQUENCY, 1), \
+         UVC_CLOCK_FREQUENCY, ITF_NUM_VIDEO_STREAMING), \
       TUD_VIDEO_DESC_CAMERA_TERM(UVC_ENTITY_CAP_INPUT_TERMINAL, 0, 0,\
                                  /*wObjectiveFocalLengthMin*/0, /*wObjectiveFocalLengthMax*/0,\
                                  /*wObjectiveFocalLength*/0, /*bmControls*/0), \
       TUD_VIDEO_DESC_OUTPUT_TERM(UVC_ENTITY_CAP_OUTPUT_TERMINAL, VIDEO_TT_STREAMING, 0, 1, 0), \
   /* Video stream alt. 0 */ \
-  TUD_VIDEO_DESC_STD_VS( 1, 0, 0, 0), \
+  TUD_VIDEO_DESC_STD_VS(ITF_NUM_VIDEO_STREAMING, 0, 0, _stridx), \
     /* Video stream header for without still image capture */ \
     TUD_VIDEO_DESC_CS_VS_INPUT( /*bNumFormats*/1, \
         /*wTotalLength - bLength */\
@@ -106,7 +106,7 @@ enum {
             (10000000/_fps), (10000000/_fps), (10000000/_fps)*_fps, (10000000/_fps)), \
         TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING(VIDEO_COLOR_PRIMARIES_BT709, VIDEO_COLOR_XFER_CH_BT709, VIDEO_COLOR_COEF_SMPTE170M), \
   /* VS alt 1 */\
-  TUD_VIDEO_DESC_STD_VS(1, 1, 1, 0), \
+  TUD_VIDEO_DESC_STD_VS(ITF_NUM_VIDEO_STREAMING, 1, 1, _stridx), \
     /* EP */ \
     TUD_VIDEO_DESC_EP_ISO(_epin, _epsize, 1)
 


### PR DESCRIPTION
Removing the Hardcoded interface numbers from the video descriptors allow the user to add other interfaces before or after the Video Control Interface and Video Streaming Interface
