### PR TITLE
nrf5x: Fix endpoint internal state when closed

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -438,6 +438,7 @@ void dcd_edpt_close (uint8_t rhport, uint8_t ep_addr)
     // When both ISO endpoint are close there is no need for SOF any more.
     if (_dcd.xfer[EP_ISO_NUM][TUSB_DIR_IN].mps + _dcd.xfer[EP_ISO_NUM][TUSB_DIR_OUT].mps == 0) NRF_USBD->INTENCLR = USBD_INTENCLR_SOF_Msk;
   }
+  _dcd.xfer[epnum][dir].started = false;
   __ISB(); __DSB();
 }
 


### PR DESCRIPTION
**Describe the PR**
Field started (regarding transfer) was only cleared when transfer
was finished.
For audio devices set interface is called many times.
When there is no audio (silence) set interface requests zero
length bandwidth that in turn calls dcd_edpt_close().

When endpoint is closed due to set interface request transfer
should not longer be started since it will block next start transfer
with assert.

This just sets 'started' to false when endpoint is closed.

**Additional context**
This mostly affects audio where dcd_edpt_close() is called often but
maybe is could be observed on other classes.
