### PR TITLE
Introduced declaration that supports STM32L4xx

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -98,6 +98,11 @@
   #undef USB_PMAADDR
   #define USB_PMAADDR USB1_PMAADDR
 
+// NOTE(lbayes): Added the following block for L4 support
+#elif CFG_TUSB_MCU == 309 // OPT_MCU_STM32L4
+  #include "stm32l4xx.h"
+  #define PMA_LENGTH (1024u)
+
 #else
   #error You are using an untested or unimplemented STM32 variant. Please update the driver.
   // This includes L1x0, L1x1, L1x2, L4x2 and L4x3, G1x1, G1x3, and G1x4


### PR DESCRIPTION
There are a number of compile errors for missing definitions when building against the library for an STM32L4 series IC.

It's possible there are other issues that need to be resolved to fully support this family of chips, but this did get us closer to being up and running.

While there are many compilation errors, here is one example:

```bash
tinyusb/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h:119:15: error: unknown type name '__IO'
  119 | static inline __IO uint16_t* pcd_ep_rx_cnt_ptr(USB_TypeDef * USBx, uint32_t bEpNum);
```