### PR TITLE
Fix bug #1628 by preventing shared irq slots for filling up

### DIFF
--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -380,6 +380,9 @@ bool hcd_init(uint8_t rhport)
   // Force VBUS detect to always present, for now we assume vbus is always provided (without using VBUS En)
   usb_hw->pwr = USB_USB_PWR_VBUS_DETECT_BITS | USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN_BITS;
 
+  // Remove shared irq if it was previously added so as not to fill up shared irq slots
+  irq_remove_handler(USBCTRL_IRQ, hcd_rp2040_irq);
+
   irq_add_shared_handler(USBCTRL_IRQ, hcd_rp2040_irq, PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY);
 
   // clear epx and interrupt eps


### PR DESCRIPTION
This pull request is to fix bug #1628.  After adding this code I can call hcd_init(0) multiple times without causing a hard_assert on rp2040.




