### PR TITLE
nrf5x: Fix reception of large ISO packets

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -765,7 +765,7 @@ void dcd_int_handler(uint8_t rhport)
     if ( tu_bit_test(int_status, USBD_INTEN_ENDEPOUT0_Pos+epnum))
     {
       xfer_td_t* xfer = get_td(epnum, TUSB_DIR_OUT);
-      uint8_t const xact_len = NRF_USBD->EPOUT[epnum].AMOUNT;
+      uint16_t const xact_len = NRF_USBD->EPOUT[epnum].AMOUNT;
 
       xfer->buffer     += xact_len;
       xfer->actual_len += xact_len;


### PR DESCRIPTION
**Describe the PR**
ISO packet size is up to 1023 for full speed device. Upon completion of ISO reception, reported length of incoming packet was truncated to one byte only.
This results in incorrect data stream for higher bit rates 48 samples * 4 bytes per sample * 2 channels = 384 bytes of data and 128 was reported.

There is no change in logic extending xact_len to uint16_t fixes the issue.
