### PR TITLE
audio_device: prototype added for function referenced before use

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -447,6 +447,10 @@ static inline uint8_t tu_desc_subtype(void const* desc)
 }
 #endif
 
+#if CFG_TUD_AUDIO_ENABLE_EP_OUT && CFG_TUD_AUDIO_ENABLE_FEEDBACK_EP
+static bool set_fb_params_freq(audiod_function_t* audio, uint32_t sample_freq, uint32_t mclk_freq);
+#endif
+
 bool tud_audio_n_mounted(uint8_t func_id)
 {
   TU_VERIFY(func_id < CFG_TUD_AUDIO);


### PR DESCRIPTION
**Describe the PR**
Fixes the following compiler error when compiling an audio device with feedback enabled (no rtos, st/synopsys port).

```
lib/tinyusb/src/class/audio/audio_device.c:2051:13: error: conflicting types for 'set_fb_params_freq'; have '_Bool(audiod_function_t *, uint32_t,  uint32_t)' {aka '_Bool(audiod_function_t *, long unsigned int,  long unsigned int)'}
 2051 | static bool set_fb_params_freq(audiod_function_t* audio, uint32_t sample_freq, uint32_t mclk_freq)
      |             ^~~~~~~~~~~~~~~~~~
lib/tinyusb/src/class/audio/audio_device.c:1718:13: note: previous implicit declaration of 'set_fb_params_freq' with type 'int()'
 1718 |             set_fb_params_freq(audio, fb_param.sample_freq, fb_param.frequency.mclk_freq);
      |             ^~~~~~~~~~~~~~~~~~
```

Ås the line-numbers there indicate, the first definition of the function is ~300 lines after the call site referencing it.

**Additional context**
I'm not sure what the best solution would be for the style of the library - to add a prototype at top-level, add one at the call-site, or move the function upwards.

I suspect one of the first two options from what I've seen so far, so I put this together quickly to get feedback on where exactly the prototype should be placed.