### PR TITLE
Check for event queue overflow in usbd / dcd_event_handler

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -296,9 +296,9 @@ tu_static osal_queue_t _usbd_q;
 #endif
 
 TU_ATTR_ALWAYS_INLINE static inline bool queue_event(dcd_event_t const * event, bool in_isr) {
-  bool ret = osal_queue_send(_usbd_q, event, in_isr);
+  TU_ASSERT(osal_queue_send(_usbd_q, event, in_isr));
   tud_event_hook_cb(event->rhport, event->event_id, in_isr);
-  return ret;
+  return true;
 }
 
 //--------------------------------------------------------------------+

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -288,9 +288,9 @@ TU_ATTR_WEAK void osal_task_delay(uint32_t msec) {
 #endif
 
 TU_ATTR_ALWAYS_INLINE static inline bool queue_event(hcd_event_t const * event, bool in_isr) {
-  bool ret = osal_queue_send(_usbh_q, event, in_isr);
+  TU_ASSERT(osal_queue_send(_usbh_q, event, in_isr));
   tuh_event_hook_cb(event->rhport, event->event_id, in_isr);
-  return ret;
+  return true;
 }
 
 //--------------------------------------------------------------------+

--- a/src/osal/osal_none.h
+++ b/src/osal/osal_none.h
@@ -180,7 +180,6 @@ TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void
     _osal_q_unlock(qhdl);
   }
 
-  TU_ASSERT(success);
   return success;
 }
 

--- a/src/osal/osal_pico.h
+++ b/src/osal/osal_pico.h
@@ -145,7 +145,6 @@ TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void
   bool success = tu_fifo_write(&qhdl->ff, data);
   critical_section_exit(&qhdl->critsec);
 
-  TU_ASSERT(success);
   return success;
 }
 


### PR DESCRIPTION
When using `osal_queue_send` to send events to the queue `_usbd_q` in `udbd.c`'s `dcd_event_handler`, the queue may overflow (particularly if the application calls `usbd_defer_func` too often). In that case, events will be missed, leading to spurious and hard-to-debug errors (for example, IN data is sent, ISR is called, but nothing else happens).

Therefore I'd like to suggest adding `TU_ASSERT` around the calls to `osal_queue_send` in order to make finding these bugs easier.