### PR TITLE
HID: Add FIDO U2F descriptors

### DIFF
--- a/src/class/hid/hid.h
+++ b/src/class/hid/hid.h
@@ -708,6 +708,7 @@ enum {
   HID_USAGE_PAGE_MSR             = 0x8e,
   HID_USAGE_PAGE_CAMERA          = 0x90,
   HID_USAGE_PAGE_ARCADE          = 0x91,
+  HID_USAGE_PAGE_FIDO_ALLIANCE   = 0xF1D0,
   HID_USAGE_PAGE_VENDOR          = 0xFF00 // 0xFF00 - 0xFFFF
 };
 
@@ -842,6 +843,14 @@ enum
 
   // Mouse Horizontal scroll
   HID_USAGE_CONSUMER_AC_PAN                            = 0x0238,
+};
+
+/// HID Usage Table: FIDO Alliance Page (0xF1D0)
+enum
+{
+  HID_USAGE_FIDO_U2F_AUTHENTICATOR_DEVICE  = 0x01,
+  HID_USAGE_FIDO_INPUT_REPORT_DATA         = 0x20,
+  HID_USAGE_FIDO_OUTPUT_REPORT_DATA        = 0x21
 };
 
 /*--------------------------------------------------------------------

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -352,6 +352,29 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
     HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
   HID_COLLECTION_END \
 
+// FIDO U2F Authenticator Descriptor Template
+#define TUD_HID_REPORT_DESC_FIDO_U2F(...) \
+  HID_USAGE_PAGE_N ( HID_USAGE_PAGE_FIDO_ALLIANCE, 2          ) ,\
+  HID_USAGE      ( HID_USAGE_FIDO_U2F_AUTHENTICATOR_DEVICE    ) ,\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION                 ) ,\
+    /* Report ID if any */ \
+    __VA_ARGS__ \
+    /* Usage Data In */ \
+    HID_USAGE         ( HID_USAGE_FIDO_INPUT_REPORT_DATA       ) ,\
+    HID_LOGICAL_MIN   ( 0                                      ) ,\
+    HID_LOGICAL_MAX_N ( 255, 2                                 ) ,\
+    HID_REPORT_SIZE   ( 8                                      ) ,\
+    HID_REPORT_COUNT  ( 64                                     ) ,\
+    HID_INPUT         ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* Usage Data Out */ \
+    HID_USAGE         ( HID_USAGE_FIDO_OUTPUT_REPORT_DATA      ) ,\
+    HID_LOGICAL_MIN   ( 0                                      ) ,\
+    HID_LOGICAL_MAX_N ( 255, 2                                 ) ,\
+    HID_REPORT_SIZE   ( 8                                      ) ,\
+    HID_REPORT_COUNT  ( 64                                     ) ,\
+    HID_OUTPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+  HID_COLLECTION_END \
+
 // HID Generic Input & Output
 // - 1st parameter is report size (mandatory)
 // - 2nd parameter is report id HID_REPORT_ID(n) (optional)

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -353,7 +353,9 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
   HID_COLLECTION_END \
 
 // FIDO U2F Authenticator Descriptor Template
-#define TUD_HID_REPORT_DESC_FIDO_U2F(...) \
+// - 1st parameter is report size, which is 64 bytes maximum in U2F
+// - 2nd parameter is HID_REPORT_ID(n) (optional)
+#define TUD_HID_REPORT_DESC_FIDO_U2F(report_size, ...) \
   HID_USAGE_PAGE_N ( HID_USAGE_PAGE_FIDO_ALLIANCE, 2          ) ,\
   HID_USAGE      ( HID_USAGE_FIDO_U2F_AUTHENTICATOR_DEVICE    ) ,\
   HID_COLLECTION ( HID_COLLECTION_APPLICATION                 ) ,\
@@ -362,16 +364,16 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
     /* Usage Data In */ \
     HID_USAGE         ( HID_USAGE_FIDO_INPUT_REPORT_DATA       ) ,\
     HID_LOGICAL_MIN   ( 0                                      ) ,\
-    HID_LOGICAL_MAX_N ( 255, 2                                 ) ,\
+    HID_LOGICAL_MAX_N ( 0xff, 2                                ) ,\
     HID_REPORT_SIZE   ( 8                                      ) ,\
-    HID_REPORT_COUNT  ( 64                                     ) ,\
+    HID_REPORT_COUNT  ( report_size                            ) ,\
     HID_INPUT         ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
     /* Usage Data Out */ \
     HID_USAGE         ( HID_USAGE_FIDO_OUTPUT_REPORT_DATA      ) ,\
     HID_LOGICAL_MIN   ( 0                                      ) ,\
-    HID_LOGICAL_MAX_N ( 255, 2                                 ) ,\
+    HID_LOGICAL_MAX_N ( 0xff, 2                                ) ,\
     HID_REPORT_SIZE   ( 8                                      ) ,\
-    HID_REPORT_COUNT  ( 64                                     ) ,\
+    HID_REPORT_COUNT  ( report_size                            ) ,\
     HID_OUTPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
   HID_COLLECTION_END \
 


### PR DESCRIPTION
**Describe the PR**
This PR adds FIDO U2F Authenticator usage page and descriptor template for HID class.

**Additional context**
This descriptor is based on [FIDO CTAP Protocol v2.1](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#usb-discovery) specification. And it's tested in Canokeys project.
