### PR TITLE
dhserver: Support DHCP clients that don't send the MESSAGETYPE as first option

### DIFF
--- a/lib/networking/dhserver.c
+++ b/lib/networking/dhserver.c
@@ -240,7 +240,11 @@ static void udp_recv_proc(void *arg, struct udp_pcb *upcb, struct pbuf *p, const
 	unsigned n = p->len;
 	if (n > sizeof(dhcp_data)) n = sizeof(dhcp_data);
 	memcpy(&dhcp_data, p->payload, n);
-	switch (dhcp_data.dp_options[2])
+
+	ptr = find_dhcp_option(dhcp_data.dp_options, sizeof(dhcp_data.dp_options), DHCP_MESSAGETYPE);
+	if (ptr == NULL) return;
+
+	switch (ptr[2])
 	{
 		case DHCP_DISCOVER:
 			entry = entry_by_mac(dhcp_data.dp_chaddr);


### PR DESCRIPTION
The included DHCP server fails to process DHCP DISCOVER or REQUEST packages that don't contain the "DHCP MESSAGE TYPE" option as the first option in the package.
The initial report that triggered me was in https://github.com/OpenLightingProject/rp2040-dmxsun/issues/53 and after some investigation, I found that the "dhcpcd" client (maybe others, too) don't send the MESSAGE TYPE as the first option (see Wireshark dump attached in the linked issue). This seems to be valid since the order of the options contained in the package shouldn't matter. However, tinyUSB's DHCP server expects the MESSAGE TYPE to be the first option.

This change uses the already existing function to extract the MESSAGE TYPE option from the options properly. It will also fail now, if the MESSAGE TYPE option doesn't exist at all, making the code safer than the current approach.