### PR TITLE
Fixed wrong FreeRTOS port for EFM32GG12

### DIFF
--- a/hw/bsp/sltb009a/board.mk
+++ b/hw/bsp/sltb009a/board.mk
@@ -35,7 +35,7 @@ INC += \
   $(TOP)/hw/bsp/$(BOARD)
 
 # For freeRTOS port source
-FREERTOS_PORT = ARM_CM3
+FREERTOS_PORT = ARM_CM4F
 
 # For flash-jlink target
 JLINK_DEVICE = EFM32GG12B810F1024


### PR DESCRIPTION
Changed Freertos port for EFM32GG12 to ARM_CM4F as EFM32GG12 is not an M3, but rather an M4F based MCU
Fixes hid_composite_freertos example for SLTB009a