### PR TITLE
fix(ci): Switch pico-sdk from dev branch to stable release

### DIFF
--- a/.github/workflows/build_arm.yml
+++ b/.github/workflows/build_arm.yml
@@ -86,10 +86,12 @@ jobs:
          repository: hathach/linkermap
          path: linkermap
 
-    - name: Checkout pico-sdk for rp2040
+    - name: Fetch pico-sdk for rp2040
       if: matrix.family == 'rp2040'
       run: |
-        git clone --depth 1 -b develop https://github.com/raspberrypi/pico-sdk ~/pico-sdk
+        wget https://github.com/raspberrypi/pico-sdk/archive/refs/tags/1.4.0.tar.gz
+        mkdir ~/pico-sdk
+        tar xfz 1.4.0.tar.gz --strip-components=1 -C ~/pico-sdk
         echo >> $GITHUB_ENV PICO_SDK_PATH=~/pico-sdk
 
     - name: Get Dependencies


### PR DESCRIPTION
This change is intended to fix flakes in the CI for breaking downstream.

**Describe the PR**
Currently, when the pico-sdk is fetched it fetches the latest unstable commit from GitHub. This change switches this over to use the latest stable release instead. This solves flakes between CI runs, where an upstream breaking change will break the CI.

**Additional context**
This CI run failed https://github.com/hathach/tinyusb/actions/runs/3401326259/jobs/5662416900
Whereas this CI run (on my personal fork, but with the same commit) succeeded because it was operating on an older commit from the SDK. https://github.com/silvergasp/tinyusb/actions/runs/3373052253/jobs/5609688063