### PR TITLE
Fix RP2040 Issue 1721

### DIFF
--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -155,7 +155,9 @@ static void __tusb_irq_path_func(_hw_endpoint_start_next_buffer)(struct hw_endpo
   // For now: skip double buffered for Device mode, OUT endpoint since
   // host could send < 64 bytes and cause short packet on buffer0
   // NOTE this could happen to Host mode IN endpoint
-  bool const force_single = !(usb_hw->main_ctrl & USB_MAIN_CTRL_HOST_NDEVICE_BITS) && !tu_edpt_dir(ep->ep_addr);
+  // Also, Host mode interrupt endpoint hardware is only single buffered
+  bool const force_single = (!(usb_hw->main_ctrl & USB_MAIN_CTRL_HOST_NDEVICE_BITS) && !tu_edpt_dir(ep->ep_addr)) ||
+    ((usb_hw->main_ctrl & USB_MAIN_CTRL_HOST_NDEVICE_BITS) && tu_edpt_number(ep->ep_addr) != 0);
 
   if(ep->remaining_len && !force_single)
   {


### PR DESCRIPTION
**Describe the PR**
Fix issue #1721 by disabling double-buffering for RP2040 host mode non-control endpoints.

**Additional context**
Issue #1721 discusses this issue and @hathach proposed the solution. I have tested this locally and it works for me.
