### PR TITLE
usbtmc: correct packet size bug

### DIFF
--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -364,7 +364,7 @@ bool tud_usbtmc_start_bus_read()
   default:
     TU_VERIFY(false);
   }
-  TU_VERIFY(usbd_edpt_xfer(usbtmc_state.rhport, usbtmc_state.ep_bulk_out, usbtmc_state.ep_bulk_out_buf, 64));
+  TU_VERIFY(usbd_edpt_xfer(usbtmc_state.rhport, usbtmc_state.ep_bulk_out, usbtmc_state.ep_bulk_out_buf, usbtmc_state.ep_bulk_out_wMaxPacketSize));
   return true;
 }
 

--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -364,7 +364,7 @@ bool tud_usbtmc_start_bus_read()
   default:
     TU_VERIFY(false);
   }
-  TU_VERIFY(usbd_edpt_xfer(usbtmc_state.rhport, usbtmc_state.ep_bulk_out, usbtmc_state.ep_bulk_out_buf, usbtmc_state.ep_bulk_out_wMaxPacketSize));
+  TU_VERIFY(usbd_edpt_xfer(usbtmc_state.rhport, usbtmc_state.ep_bulk_out, usbtmc_state.ep_bulk_out_buf, (uint16_t)usbtmc_state.ep_bulk_out_wMaxPacketSize));
   return true;
 }
 


### PR DESCRIPTION
Code was only reading the first 64 bytes of a 512 bytes packet.

For some reason, code was working if receiving a single packet strictly below 512 bytes. But when sending a USBTMC message which lead to a data stage longer than a single packet, only the first 64 bytes where read.
This seems to be only due to the "arming" of transfer which where obviously only asking for 64 bytes (constant).