### PR TITLE
Correct interrupt polling interval in descriptor

### DIFF
--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -603,7 +603,7 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
 /* optional interrupt endpoint */ \
 // _int_pollingInterval : for LS/FS, expressed in frames (1ms each). 16 may be a good number?
 #define TUD_USBTMC_INT_DESCRIPTOR(_ep_interrupt, _ep_interrupt_size, _int_pollingInterval ) \
-  7, TUSB_DESC_ENDPOINT, _ep_interrupt, TUSB_XFER_INTERRUPT, U16_TO_U8S_LE(_ep_interrupt_size), 0x16
+  7, TUSB_DESC_ENDPOINT, _ep_interrupt, TUSB_XFER_INTERRUPT, U16_TO_U8S_LE(_ep_interrupt_size), _int_pollingInterval
 
 #define TUD_USBTMC_INT_DESCRIPTOR_LEN (7u)
 


### PR DESCRIPTION
Use macro argument instead of 0x16 constant value.
At least Linux kernel was complaining about this value, giving the following warning:
"config 1 interface 0 altsetting 0 endpoint 0x82 has an invalid bInterval 22, changing to 8"
(warning obtained using usbtmc device config)

