### PR TITLE
Fix fifo memory overflow

### DIFF
--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -352,9 +352,10 @@ static uint16_t backward_pointer(tu_fifo_t* f, uint16_t p, uint16_t offset)
   return new_p;
 }
 
-// index to pointer, simply an modulo with minus
+// index to pointer, simply an modulo with minus.
 static inline uint16_t idx2ptr(uint16_t idx, uint16_t depth)
 {
+  // Only run at most 3 times since index is limit in the range of [0..2*depth)
   while ( idx >= depth ) idx -= depth;
   return idx;
 }
@@ -509,6 +510,7 @@ static uint16_t _tu_fifo_write_n(tu_fifo_t* f, const void * data, uint16_t n, tu
     else if (overflowable_count + n >= 2*f->depth)
     {
       // Double overflowed
+      // Index is bigger than the allowed range [0,2*depth)
       // re-position write index to have a full fifo after pushed
       wr_idx = advance_pointer(f, rd_idx, f->depth - n);
 
@@ -518,7 +520,9 @@ static uint16_t _tu_fifo_write_n(tu_fifo_t* f, const void * data, uint16_t n, tu
       // currently deliberately not implemented --> result in incorrect data read back
     }else
     {
-      // normal + single overflowed: just increase write index
+      // normal + single overflowed:
+      // Index is in the range of [0,2*depth) and thus detect and recoverable. Recovering is handled in read()
+      // Therefore we just increase write index
       // we will correct (re-position) read index later on in fifo_read() function
     }
   }

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -331,17 +331,6 @@ uint16_t _ff_count(uint16_t depth, uint16_t wr_idx, uint16_t rd_idx)
   }
 }
 
-// BE AWARE - THIS FUNCTION MIGHT NOT GIVE A CORRECT ANSWERE IN CASE WRITE POINTER "OVERFLOWS"
-// Only one overflow is allowed for this function to work e.g. if depth = 100, you must not
-// write more than 2*depth-1 items in one rush without updating write pointer. Otherwise
-// write pointer wraps and you pointer states are messed up. This can only happen if you
-// use DMAs, write functions do not allow such an error.
-TU_ATTR_ALWAYS_INLINE static inline
-bool _ff_overflowed(uint16_t depth, uint16_t wr_idx, uint16_t rd_idx)
-{
-  return _ff_count(depth, wr_idx, rd_idx) > depth;
-}
-
 // return remaining slot in fifo
 TU_ATTR_ALWAYS_INLINE static inline
 uint16_t _ff_remaining(uint16_t depth, uint16_t wr_idx, uint16_t rd_idx)
@@ -672,7 +661,7 @@ uint16_t tu_fifo_remaining(tu_fifo_t* f)
 /******************************************************************************/
 bool tu_fifo_overflowed(tu_fifo_t* f)
 {
-  return _ff_overflowed(f->depth, f->wr_idx, f->rd_idx);
+  return _ff_count(f->depth, f->wr_idx, f->rd_idx) > f->depth;
 }
 
 // Only use in case tu_fifo_overflow() returned true!

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -351,7 +351,8 @@ static uint16_t backward_index(uint16_t depth, uint16_t idx, uint16_t offset)
 }
 
 // index to pointer, simply an modulo with minus.
-static inline uint16_t idx2ptr(uint16_t idx, uint16_t depth)
+TU_ATTR_ALWAYS_INLINE static inline
+uint16_t idx2ptr(uint16_t depth, uint16_t idx)
 {
   // Only run at most 3 times since index is limit in the range of [0..2*depth)
   while ( idx >= depth ) idx -= depth;
@@ -415,7 +416,7 @@ static bool _tu_fifo_peek(tu_fifo_t* f, void * p_buffer, uint16_t wr_idx, uint16
   // Skip beginning of buffer
   if (cnt == 0) return false;
 
-  uint16_t rd_ptr = idx2ptr(rd_idx, f->depth);
+  uint16_t rd_ptr = idx2ptr(f->depth, rd_idx);
 
   // Peek data
   _ff_pull(f, p_buffer, rd_ptr);
@@ -443,7 +444,7 @@ static uint16_t _tu_fifo_peek_n(tu_fifo_t* f, void * p_buffer, uint16_t n, uint1
   // Check if we can read something at and after offset - if too less is available we read what remains
   if (cnt < n) n = cnt;
 
-  uint16_t rd_ptr = idx2ptr(rd_idx, f->depth);
+  uint16_t rd_ptr = idx2ptr(f->depth, rd_idx);
 
   // Peek data
   _ff_pull_n(f, p_buffer, n, rd_ptr, copy_mode);
@@ -520,7 +521,7 @@ static uint16_t _tu_fifo_write_n(tu_fifo_t* f, const void * data, uint16_t n, tu
 
   if (n)
   {
-    uint16_t wr_ptr = idx2ptr(wr_idx, f->depth);
+    uint16_t wr_ptr = idx2ptr(f->depth, wr_idx);
 
     TU_LOG(TU_FIFO_DBG, "actual_n = %u, wr_ptr = %u", n, wr_ptr);
 
@@ -794,7 +795,7 @@ bool tu_fifo_write(tu_fifo_t* f, const void * data)
     ret = false;
   }else
   {
-    uint16_t wr_ptr = idx2ptr(wr_idx, f->depth);
+    uint16_t wr_ptr = idx2ptr(f->depth, wr_idx);
 
     // Write data
     _ff_push(f, data, wr_ptr);
@@ -980,8 +981,8 @@ void tu_fifo_get_read_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info)
   }
 
   // Get relative pointers
-  uint16_t wr_ptr = idx2ptr(wr_idx, f->depth);
-  uint16_t rd_ptr = idx2ptr(rd_idx, f->depth);
+  uint16_t wr_ptr = idx2ptr(f->depth, wr_idx);
+  uint16_t rd_ptr = idx2ptr(f->depth, rd_idx);
 
   // Copy pointer to buffer to start reading from
   info->ptr_lin = &f->buffer[rd_ptr];
@@ -1034,8 +1035,8 @@ void tu_fifo_get_write_info(tu_fifo_t *f, tu_fifo_buffer_info_t *info)
   }
 
   // Get relative pointers
-  uint16_t wr_ptr = idx2ptr(wr_idx, f->depth);
-  uint16_t rd_ptr = idx2ptr(rd_idx, f->depth);
+  uint16_t wr_ptr = idx2ptr(f->depth, wr_idx);
+  uint16_t rd_ptr = idx2ptr(f->depth, rd_idx);
 
   // Copy pointer to buffer to start writing to
   info->ptr_lin = &f->buffer[wr_ptr];

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -82,7 +82,7 @@ bool tu_fifo_config(tu_fifo_t *f, void* buffer, uint16_t depth, uint16_t item_si
   // but limits the maximum depth to 2^16/2 = 2^15 and buffer overflows are detectable
   // only if overflow happens once (important for unsupervised DMA applications)
   //f->max_pointer_idx = (uint16_t) (2*depth - 1);
-  f->non_used_index_space = UINT16_MAX - (2*f->depth-1);
+  f->non_used_index_space = (uint16_t) (UINT16_MAX - (2*f->depth-1));
 
   f->rd_idx = f->wr_idx = 0;
 
@@ -867,7 +867,7 @@ bool tu_fifo_clear(tu_fifo_t *f)
 
   f->rd_idx = f->wr_idx = 0;
   //f->max_pointer_idx = (uint16_t) (2*f->depth-1);
-  f->non_used_index_space = UINT16_MAX - (2*f->depth-1);
+  f->non_used_index_space = (uint16_t) (UINT16_MAX - (2*f->depth-1));
 
   _ff_unlock(f->mutex_wr);
   _ff_unlock(f->mutex_rd);

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -178,7 +178,8 @@ static void _ff_push_n(tu_fifo_t* f, void const * app_buf, uint16_t n, uint16_t 
         // Write data to linear part of buffer
         memcpy(ff_buf, app_buf, nLin_bytes);
 
-        TU_ASSERT(nWrap_bytes <= f->depth, );
+        // Write data wrapped around
+        // TU_ASSERT(nWrap_bytes <= f->depth, );
         memcpy(f->buffer, ((uint8_t const*) app_buf) + nLin_bytes, nWrap_bytes);
       }
       break;
@@ -504,7 +505,8 @@ static uint16_t _tu_fifo_write_n(tu_fifo_t* f, const void * data, uint16_t n, tu
 
       // We start writing at the read pointer's position since we fill the whole buffer
       wr_idx = rd_idx;
-    }else if (overflowable_count + n >= 2*f->depth)
+    }
+    else if (overflowable_count + n >= 2*f->depth)
     {
       // Double overflowed
       // re-position write index to have a full fifo after pushed

--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -39,12 +39,12 @@
 // implement mutex lock and unlock
 #if CFG_FIFO_MUTEX
 
-static inline void _ff_lock(tu_fifo_mutex_t mutex)
+static inline void _ff_lock(osal_mutex_t mutex)
 {
   if (mutex) osal_mutex_lock(mutex, OSAL_TIMEOUT_WAIT_FOREVER);
 }
 
-static inline void _ff_unlock(tu_fifo_mutex_t mutex)
+static inline void _ff_unlock(osal_mutex_t mutex)
 {
   if (mutex) osal_mutex_unlock(mutex);
 }

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -54,7 +54,7 @@ extern "C" {
 
 /* Write/Read index is always in the range of:
  *      0 .. 2*depth-1
- * The extra window allow us to determine the fifo state of empty or full with only 2 indexes
+ * The extra window allow us to determine the fifo state of empty or full with only 2 indices
  * Following are examples with depth = 3
  *
  * - empty: W = R
@@ -86,7 +86,8 @@ extern "C" {
  *      -------------------------
  *      | R | 1 | 2 | 3 | W | 5 |
  *
- *  - Double Overflowed: write(3), write(1), write(2)
+ *  - Double Overflowed i.e index is out of allowed range [0,2*depth) e.g:
+ *      write(3), write(1), write(2)
  *    Continue to write after overflowed to 2nd overflowed.
  *    We must prevent 2nd overflowed since it will cause incorrect computed of count, in above example
  *    if not handled the fifo will be empty instead of continue-to-be full. Since we must not modify
@@ -94,7 +95,7 @@ extern "C" {
  *    after data is written it is a full fifo i.e W = depth - R
  *
  *      re-position W = 1 before write(2)
- *      Note: we should also move data from mem[4] to read index as well, but deliberately skipped here
+ *      Note: we should also move data from mem[3] to read index as well, but deliberately skipped here
  *      since it is an expensive operation !!!
  *                  |
  *      -------------------------

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -44,8 +44,6 @@ extern "C" {
 #include "common/tusb_common.h"
 #include "osal/osal.h"
 
-#define tu_fifo_mutex_t  osal_mutex_t
-
 // mutex is only needed for RTOS
 // for OS None, we don't get preempted
 #define CFG_FIFO_MUTEX      OSAL_MUTEX_REQUIRED
@@ -121,8 +119,8 @@ typedef struct
   volatile uint16_t rd_idx      ; ///< read index
 
 #if OSAL_MUTEX_REQUIRED
-  tu_fifo_mutex_t mutex_wr;
-  tu_fifo_mutex_t mutex_rd;
+  osal_mutex_t mutex_wr;
+  osal_mutex_t mutex_rd;
 #endif
 
 } tu_fifo_t;
@@ -155,7 +153,7 @@ bool tu_fifo_config(tu_fifo_t *f, void* buffer, uint16_t depth, uint16_t item_si
 
 #if OSAL_MUTEX_REQUIRED
 TU_ATTR_ALWAYS_INLINE static inline
-void tu_fifo_config_mutex(tu_fifo_t *f, tu_fifo_mutex_t wr_mutex, tu_fifo_mutex_t rd_mutex)
+void tu_fifo_config_mutex(tu_fifo_t *f, osal_mutex_t wr_mutex, osal_mutex_t rd_mutex)
 {
   f->mutex_wr = wr_mutex;
   f->mutex_rd = rd_mutex;

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -136,13 +136,13 @@ typedef struct
   void * ptr_wrap   ; ///< wrapped part start pointer
 } tu_fifo_buffer_info_t;
 
-#define TU_FIFO_INIT(_buffer, _depth, _type, _overwritable) \
-{                                                           \
-  .buffer               = _buffer,                          \
-  .depth                = _depth,                           \
-  .item_size            = sizeof(_type),                    \
-  .overwritable         = _overwritable,                    \
-  .non_used_index_space = UINT16_MAX - (2*(_depth)-1),      \
+#define TU_FIFO_INIT(_buffer, _depth, _type, _overwritable)        \
+{                                                                  \
+  .buffer               = _buffer,                                 \
+  .depth                = _depth,                                  \
+  .item_size            = sizeof(_type),                           \
+  .overwritable         = _overwritable,                           \
+  .non_used_index_space = (uint16_t)(UINT16_MAX - (2*(_depth)-1)), \
 }
 
 #define TU_FIFO_DEF(_name, _depth, _type, _overwritable)                      \

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -101,10 +101,10 @@ bool tu_fifo_config(tu_fifo_t *f, void* buffer, uint16_t depth, uint16_t item_si
 
 #if CFG_FIFO_MUTEX
 TU_ATTR_ALWAYS_INLINE static inline
-void tu_fifo_config_mutex(tu_fifo_t *f, tu_fifo_mutex_t write_mutex_hdl, tu_fifo_mutex_t read_mutex_hdl)
+void tu_fifo_config_mutex(tu_fifo_t *f, tu_fifo_mutex_t wr_mutex, tu_fifo_mutex_t rd_mutex)
 {
-  f->mutex_wr = write_mutex_hdl;
-  f->mutex_rd = read_mutex_hdl;
+  f->mutex_wr = wr_mutex;
+  f->mutex_rd = rd_mutex;
 }
 #endif
 

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -52,18 +52,74 @@ extern "C" {
 #define tu_fifo_mutex_t  osal_mutex_t
 #endif
 
+/* Write/Read index is always in the range of:
+ *      0 .. 2*depth-1
+ * The extra window allow us to determine the fifo state of empty or full with only 2 indexes
+ * Following are examples with depth = 3
+ *
+ * - empty: W = R
+ *                |
+ *    -------------------------
+ *    | 0 | RW| 2 | 3 | 4 | 5 |
+ *
+ * - full 1: W > R
+ *                |
+ *    -------------------------
+ *    | 0 | R | 2 | 3 | W | 5 |
+ *
+ * - full 2: W < R
+ *                |
+ *    -------------------------
+ *    | 0 | 1 | W | 3 | 4 | R |
+ *
+ * - Number of items in the fifo can be determined in either cases:
+ *    - case W > R: Count = W - R
+ *    - case W < R: Count = 2*depth - (R - W)
+ *
+ * In non-overwritable mode, computed Count (in above 2 cases) is at most equal to depth.
+ * However, in over-writable mode, write index can be repeatedly increased and count can be
+ * temporarily larger than depth (overflowed condition) e.g
+ *
+ *  - Overflowed 1: write(3), write(1)
+ *    In this case we will adjust Read index when read()/peek() is called so that count = depth.
+ *                  |
+ *      -------------------------
+ *      | R | 1 | 2 | 3 | W | 5 |
+ *
+ *  - Double Overflowed: write(3), write(1), write(2)
+ *    Continue to write after overflowed to 2nd overflowed.
+ *    We must prevent 2nd overflowed since it will cause incorrect computed of count, in above example
+ *    if not handled the fifo will be empty instead of continue-to-be full. Since we must not modify
+ *    read index in write() function, which cause race condition. We will re-position write index so that
+ *    after data is written it is a full fifo i.e W = depth - R
+ *
+ *      re-position W = 1 before write(2)
+ *      Note: we should also move data from mem[4] to read index as well, but deliberately skipped here
+ *      since it is an expensive operation !!!
+ *                  |
+ *      -------------------------
+ *      | R | W | 2 | 3 | 4 | 5 |
+ *
+ *      perform write(2), result is still a full fifo.
+ *
+ *                  |
+ *      -------------------------
+ *      | R | 1 | 2 | W | 4 | 5 |
+
+ */
 typedef struct
 {
   uint8_t* buffer               ; ///< buffer pointer
   uint16_t depth                ; ///< max items
   uint16_t item_size            ; ///< size of each item
+
   bool overwritable             ;
 
   uint16_t non_used_index_space ; ///< required for non-power-of-two buffer length
-  uint16_t max_pointer_idx      ; ///< maximum absolute pointer index
+  //uint16_t max_pointer_idx      ; ///< maximum absolute pointer index
 
-  volatile uint16_t wr_idx      ; ///< write pointer
-  volatile uint16_t rd_idx      ; ///< read pointer
+  volatile uint16_t wr_idx      ; ///< write index
+  volatile uint16_t rd_idx      ; ///< read index
 
 #if CFG_FIFO_MUTEX
   tu_fifo_mutex_t mutex_wr;
@@ -87,7 +143,6 @@ typedef struct
   .item_size            = sizeof(_type),                    \
   .overwritable         = _overwritable,                    \
   .non_used_index_space = UINT16_MAX - (2*(_depth)-1),      \
-  .max_pointer_idx      = 2*(_depth)-1,                     \
 }
 
 #define TU_FIFO_DEF(_name, _depth, _type, _overwritable)                      \

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -388,6 +388,8 @@ bool tud_init (uint8_t rhport)
 
   TU_LOG(USBD_DBG, "USBD init on controller %u\r\n", rhport);
   TU_LOG_INT(USBD_DBG, sizeof(usbd_device_t));
+  TU_LOG_INT(USBD_DBG, sizeof(tu_fifo_t));
+  TU_LOG_INT(USBD_DBG, sizeof(tu_edpt_stream_t));
 
   tu_varclr(&_usbd_dev);
 

--- a/test/unit-test/project.yml
+++ b/test/unit-test/project.yml
@@ -78,10 +78,24 @@
     :html_high_threshold: 90
     :xml_report: FALSE
 
-#:tools:
-# Ceedling defaults to using gcc for compiling, linking, etc.
-# As [:tools] is blank, gcc will be used (so long as it's in your system path)
-# See documentation to configure a given toolchain for use
+:tools:
+  :test_compiler:
+     :executable: clang
+     :name: 'clang compiler'
+     :arguments:
+        - -I"$": COLLECTION_PATHS_TEST_TOOLCHAIN_INCLUDE               #expands to -I search paths
+        - -I"$": COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR   #expands to -I search paths
+        - -D$: COLLECTION_DEFINES_TEST_AND_VENDOR  #expands to all -D defined symbols
+        - -fsanitize=address
+        - -c ${1}                       #source code input file (Ruby method call param list sub)
+        - -o ${2}                       #object file output (Ruby method call param list sub)
+  :test_linker:
+     :executable: clang
+     :name: 'clang linker'
+     :arguments:
+        - -fsanitize=address
+        - ${1}               #list of object files to link (Ruby method call param list sub)
+        - -o ${2}            #executable file output (Ruby method call param list sub)
 
 # LIBRARIES
 # These libraries are automatically injected into the build process. Those specified as

--- a/test/unit-test/test/test_fifo.c
+++ b/test/unit-test/test/test_fifo.c
@@ -28,15 +28,21 @@
 #include "unity.h"
 #include "tusb_fifo.h"
 
-#define FIFO_SIZE 10
+#define FIFO_SIZE 64
 TU_FIFO_DEF(tu_ff, FIFO_SIZE, uint8_t, false);
 tu_fifo_t* ff = &tu_ff;
 tu_fifo_buffer_info_t info;
+
+uint8_t test_data[4096];
+uint8_t rd_buf[FIFO_SIZE];
 
 void setUp(void)
 {
   tu_fifo_clear(ff);
   memset(&info, 0, sizeof(tu_fifo_buffer_info_t));
+
+  for(int i=0; i<sizeof(test_data); i++) test_data[i] = i;
+  memset(rd_buf, 0, sizeof(rd_buf));
 }
 
 void tearDown(void)
@@ -61,85 +67,106 @@ void test_normal(void)
 void test_item_size(void)
 {
   TU_FIFO_DEF(ff4, FIFO_SIZE, uint32_t, false);
-  tu_fifo_clear(&ff4);
 
-  uint32_t data[20];
-  for(uint32_t i=0; i<sizeof(data)/4; i++) data[i] = i;
+  uint32_t data4[2*FIFO_SIZE];
+  for(uint32_t i=0; i<sizeof(data4)/4; i++) data4[i] = i;
 
-  tu_fifo_write_n(&ff4, data, 10);
+  // fill up fifo
+  tu_fifo_write_n(&ff4, data4, FIFO_SIZE);
 
-  uint32_t rd[10];
+  uint32_t rd_buf4[FIFO_SIZE];
   uint16_t rd_count;
 
   // read 0 -> 4
-  rd_count = tu_fifo_read_n(&ff4, rd, 5);
+  rd_count = tu_fifo_read_n(&ff4, rd_buf4, 5);
   TEST_ASSERT_EQUAL( 5, rd_count );
-  TEST_ASSERT_EQUAL_UINT32_ARRAY( data, rd, rd_count ); // 0 -> 4
+  TEST_ASSERT_EQUAL_UINT32_ARRAY( data4, rd_buf4, rd_count ); // 0 -> 4
 
-  tu_fifo_write_n(&ff4, data+10, 5);
+  tu_fifo_write_n(&ff4, data4+FIFO_SIZE, 5);
 
-  // read 5 -> 14
-  rd_count = tu_fifo_read_n(&ff4, rd, 10);
-  TEST_ASSERT_EQUAL( 10, rd_count );
-  TEST_ASSERT_EQUAL_UINT32_ARRAY( data+5, rd, rd_count ); // 5 -> 14
+  // read all 5 -> 68
+  rd_count = tu_fifo_read_n(&ff4, rd_buf4, FIFO_SIZE);
+  TEST_ASSERT_EQUAL( FIFO_SIZE, rd_count );
+  TEST_ASSERT_EQUAL_UINT32_ARRAY( data4+5, rd_buf4, rd_count ); // 5 -> 68
 }
 
 void test_read_n(void)
 {
-  // prepare data
-  uint8_t data[20];
-  for(int i=0; i<sizeof(data); i++) data[i] = i;
-
-  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(ff, data+i);
-
-  uint8_t rd[10];
   uint16_t rd_count;
+
+  // fill up fifo
+  for(uint8_t i=0; i < FIFO_SIZE; i++) tu_fifo_write(ff, test_data+i);
 
   // case 1: Read index + count < depth
   // read 0 -> 4
-  rd_count = tu_fifo_read_n(ff, rd, 5);
+  rd_count = tu_fifo_read_n(ff, rd_buf, 5);
   TEST_ASSERT_EQUAL( 5, rd_count );
-  TEST_ASSERT_EQUAL_MEMORY( data, rd, rd_count ); // 0 -> 4
+  TEST_ASSERT_EQUAL_MEMORY( test_data, rd_buf, rd_count ); // 0 -> 4
 
   // case 2: Read index + count > depth
   // write 10, 11, 12
-  tu_fifo_write(ff, data+10);
-  tu_fifo_write(ff, data+11);
-  tu_fifo_write(ff, data+12);
+  tu_fifo_write(ff, test_data+FIFO_SIZE);
+  tu_fifo_write(ff, test_data+FIFO_SIZE+1);
+  tu_fifo_write(ff, test_data+FIFO_SIZE+2);
 
-  rd_count = tu_fifo_read_n(ff, rd, 7);
+  rd_count = tu_fifo_read_n(ff, rd_buf, 7);
   TEST_ASSERT_EQUAL( 7, rd_count );
 
-  TEST_ASSERT_EQUAL_MEMORY( data+5, rd, rd_count ); // 5 -> 11
+  TEST_ASSERT_EQUAL_MEMORY( test_data+5, rd_buf, rd_count ); // 5 -> 11
 
   // Should only read until empty
-  TEST_ASSERT_EQUAL( 1, tu_fifo_read_n(ff, rd, 100) );
+  TEST_ASSERT_EQUAL( FIFO_SIZE-5+3-7, tu_fifo_read_n(ff, rd_buf, 100) );
 }
 
 void test_write_n(void)
 {
-  // prepare data
-  uint8_t data[20];
-  for(int i=0; i<sizeof(data); i++) data[i] = i;
-
   // case 1: wr + count < depth
-  tu_fifo_write_n(ff, data, 8); // wr = 8, count = 8
+  tu_fifo_write_n(ff, test_data, 32); // wr = 32, count = 32
 
-  uint8_t rd[10];
   uint16_t rd_count;
 
-  rd_count = tu_fifo_read_n(ff, rd, 5); // wr = 8, count = 3
-  TEST_ASSERT_EQUAL( 5, rd_count );
-  TEST_ASSERT_EQUAL_MEMORY( data, rd, rd_count ); // 0 -> 4
+  rd_count = tu_fifo_read_n(ff, rd_buf, 16); // wr = 32, count = 16
+  TEST_ASSERT_EQUAL( 16, rd_count );
+  TEST_ASSERT_EQUAL_MEMORY( test_data, rd_buf, rd_count );
 
   // case 2: wr + count > depth
-  tu_fifo_write_n(ff, data+8, 6); // wr = 3, count = 9
+  tu_fifo_write_n(ff, test_data+32, 40); // wr = 72 -> 8, count = 56
 
-  for(rd_count=0; rd_count<7; rd_count++) tu_fifo_read(ff, rd+rd_count); // wr = 3, count = 2
+  tu_fifo_read_n(ff, rd_buf, 32); // count = 24
+  TEST_ASSERT_EQUAL_MEMORY( test_data+16, rd_buf, rd_count);
 
-  TEST_ASSERT_EQUAL_MEMORY( data+5, rd, rd_count); // 5 -> 11
+  TEST_ASSERT_EQUAL(24, tu_fifo_count(ff));
+}
 
-  TEST_ASSERT_EQUAL(2, tu_fifo_count(ff));
+static uint16_t help_write(uint16_t total, uint16_t n)
+{
+  tu_fifo_write_n(ff, test_data, n);
+  total = tu_min16(FIFO_SIZE, total + n);
+
+  TEST_ASSERT_EQUAL(total, tu_fifo_count(ff));
+  TEST_ASSERT_EQUAL(FIFO_SIZE - total, tu_fifo_remaining(ff));
+
+  return total;
+}
+
+void test_write_overwritable(void)
+{
+  tu_fifo_set_overwritable(ff, true);
+
+  // based on actual crash tests detected by fuzzing
+  uint16_t total = 0;
+
+  total = help_write(total, 12);
+  total = help_write(total, 55);
+  total = help_write(total, 73);
+  total = help_write(total, 55);
+  total = help_write(total, 75);
+  total = help_write(total, 84);
+  total = help_write(total, 1);
+  total = help_write(total, 10);
+  total = help_write(total, 12);
+  total = help_write(total, 25);
+  total = help_write(total, 192);
 }
 
 void test_peek(void)

--- a/test/unit-test/test/test_fifo.c
+++ b/test/unit-test/test/test_fifo.c
@@ -138,6 +138,34 @@ void test_write_n(void)
   TEST_ASSERT_EQUAL(24, tu_fifo_count(ff));
 }
 
+void test_write_double_overflowed(void)
+{
+  tu_fifo_set_overwritable(ff, true);
+
+  uint8_t rd_buf[FIFO_SIZE] = { 0 };
+  uint8_t* buf = test_data;
+
+  // full
+  buf += tu_fifo_write_n(ff, buf, FIFO_SIZE);
+  TEST_ASSERT_EQUAL(FIFO_SIZE, tu_fifo_count(ff));
+
+  // write more, should still full
+  buf += tu_fifo_write_n(ff, buf, FIFO_SIZE-8);
+  TEST_ASSERT_EQUAL(FIFO_SIZE, tu_fifo_count(ff));
+
+  // double overflowed: in total, write more than > 2*FIFO_SIZE
+  buf += tu_fifo_write_n(ff, buf, 16);
+  TEST_ASSERT_EQUAL(FIFO_SIZE, tu_fifo_count(ff));
+
+  // reading back should give back data from last FIFO_SIZE write
+  tu_fifo_read_n(ff, rd_buf, FIFO_SIZE);
+
+  TEST_ASSERT_EQUAL_MEMORY(buf-16, rd_buf+FIFO_SIZE-16, 16);
+
+  // TODO whole buffer should match, but we deliberately not implement it
+  // TEST_ASSERT_EQUAL_MEMORY(buf-FIFO_SIZE, rd_buf, FIFO_SIZE);
+}
+
 static uint16_t help_write(uint16_t total, uint16_t n)
 {
   tu_fifo_write_n(ff, test_data, n);
@@ -149,7 +177,7 @@ static uint16_t help_write(uint16_t total, uint16_t n)
   return total;
 }
 
-void test_write_overwritable(void)
+void test_write_overwritable2(void)
 {
   tu_fifo_set_overwritable(ff, true);
 

--- a/test/unit-test/test/test_fifo.c
+++ b/test/unit-test/test/test_fifo.c
@@ -30,8 +30,10 @@
 #include "osal/osal.h"
 #include "tusb_fifo.h"
 
-#define FIFO_SIZE 64
-TU_FIFO_DEF(tu_ff, FIFO_SIZE, uint8_t, false);
+#define FIFO_SIZE   64
+uint8_t tu_ff_buf[FIFO_SIZE * sizeof(uint8_t)];
+tu_fifo_t tu_ff = TU_FIFO_INIT(tu_ff_buf, FIFO_SIZE, uint8_t, false);
+
 tu_fifo_t* ff = &tu_ff;
 tu_fifo_buffer_info_t info;
 
@@ -68,7 +70,8 @@ void test_normal(void)
 
 void test_item_size(void)
 {
-  TU_FIFO_DEF(ff4, FIFO_SIZE, uint32_t, false);
+  uint8_t ff4_buf[FIFO_SIZE * sizeof(uint32_t)];
+  tu_fifo_t ff4 = TU_FIFO_INIT(ff4_buf, FIFO_SIZE, uint32_t, false);
 
   uint32_t data4[2*FIFO_SIZE];
   for(uint32_t i=0; i<sizeof(data4)/4; i++) data4[i] = i;


### PR DESCRIPTION
**Describe the PR**

While trying to fix an issue reported in https://github.com/hathach/tinyusb/issues/1729 (detected using fuzzing #1716). I am able to fix a couple of issues with current tusb_fifo when using with overwritable mode
- Prevent double overflowed to happen which make fifo count invalid. Though due to the cost of moving memory, the data at read index is not replaced by newer one.
- fix _tu_fifo_remaining() return incorrect value which cause memory overflowed, detected by fuzzing
- minimize tu_fifo size to 16
- simplify and remove _tu_fifo_empty, _tu_fifo_full. Also correct full condition check
- simplify _tu_fifo_count() and _tu_fifo_remaining(), also rename to _ff_count() and _ff_remaining()
- update advance_pointer/backward_pointer to use depth instead of fifo, also rename to advance/backward_index
- simplify _ff_correct_read_index()
- remove _ff_overflowed() due to lack of use
- using clang with ceedling unit-test with -fsanitize=address

Both of above cases can be reproduced/tested with 2 new unit tests. I also take the chance to add fifo implementation note (since I kind of forgot about it) to help future troubleshooting and rename absolute/relative naming to index/pointer and other minor changes. There is still room to improve fifo, thus submitted this as draft first for feedback.

ref reading: https://www.snellman.net/blog/archive/2016-12-13-ring-buffers/9 

probably fix #1039 , and also related to https://github.com/adafruit/circuitpython/pull/7041 since this could be the bug of cdc fifo instead of what we thought is Linux with echo mode.