### PR TITLE
Fix ifdefs for disabled uart stdio in rp2040 family

### DIFF
--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -115,7 +115,7 @@ void stdio_rtt_init(void)
 
 #endif
 
-#ifdef UART_DEV
+#if defined(UART_DEV) && defined(LIB_PICO_STDIO_UART)
 static uart_inst_t *uart_inst;
 #endif
 
@@ -191,7 +191,7 @@ uint32_t board_button_read(void)
 
 int board_uart_read(uint8_t* buf, int len)
 {
-#ifdef UART_DEV
+#if defined(UART_DEV) && defined(LIB_PICO_STDIO_UART)
   int count = 0;
   while ( (count < len) && uart_is_readable(uart_inst) )
   {
@@ -207,7 +207,7 @@ int board_uart_read(uint8_t* buf, int len)
 
 int board_uart_write(void const * buf, int len)
 {
-#ifdef UART_DEV
+#if defined(UART_DEV) && defined(LIB_PICO_STDIO_UART)
   char const* bufch = (char const*) buf;
   for(int i=0;i<len;i++) {
     uart_putc(uart_inst, bufch[i]);


### PR DESCRIPTION
Fix ifdefs such that uart is not used for stdio by tinyusb when it is disabled via pico_enable_stdio_uart in CMakeLists.txt.

Without the extra guards, the compiler infers that a null pointer deref will take place when the pico stdio uart object is accessed in tinyusb and aborts compilation.
