### PR TITLE
RP2040: track DPRAM buffer for each endpoint

### DIFF
--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -256,7 +256,7 @@ static void __tusb_irq_path_func(reset_non_control_endpoints)(void)
   tu_memclr(hw_endpoints[1], sizeof(hw_endpoints) - 2*sizeof(hw_endpoint_t));
 
   // reclaim buffer space
-  dpram_state = (1 << (hw_data_offset(&usb_dpram->epx_data[0]) / DPRAM_BLOCK_SIZE)) - 1;
+  dpram_state = (1ull<< (hw_data_offset(&usb_dpram->epx_data[0]) / DPRAM_BLOCK_SIZE)) - 1;
 }
 
 static void __tusb_irq_path_func(dcd_rp2040_irq)(void)

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -142,6 +142,9 @@ static void hw_endpoint_close(uint8_t ep_addr)
     _hw_endpoint_close(ep);
 }
 
+#pragma GCC push_options
+// prevent inlining of this function (__noinline is ignored on -O3)
+#pragma GCC optimize("-Os")
 static void hw_endpoint_init(uint8_t ep_addr, uint16_t wMaxPacketSize, uint8_t transfer_type)
 {
   struct hw_endpoint *ep = hw_endpoint_get_by_addr(ep_addr);
@@ -195,6 +198,7 @@ static void hw_endpoint_init(uint8_t ep_addr, uint16_t wMaxPacketSize, uint8_t t
     _hw_endpoint_alloc(ep);
   }
 }
+#pragma GCC pop_options
 
 static void hw_endpoint_xfer(uint8_t ep_addr, uint8_t *buffer, uint16_t total_bytes)
 {

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -121,7 +121,7 @@ static void _hw_endpoint_close(struct hw_endpoint *ep)
 {
   uint size = _hw_endpoint_data_size(ep);
   uint block_count = size / DPRAM_BLOCK_SIZE;
-  uint start_block = (ep->hw_data_buf - &usb_dpram->epx_data[0]) / DPRAM_BLOCK_SIZE + hw_data_offset(&usb_dpram->epx_data[0]) / DPRAM_BLOCK_SIZE;
+  uint start_block = (uint)(ep->hw_data_buf - &usb_dpram->epx_data[0]) / DPRAM_BLOCK_SIZE + hw_data_offset(&usb_dpram->epx_data[0]) / DPRAM_BLOCK_SIZE;
   uint64_t block_mask = ((1ull << block_count) - 1) << start_block;
 
   // Clear hardware registers and then zero the struct


### PR DESCRIPTION
**Describe the PR**
Running audio example on pico, I am still hitting the following assert:
hard_assert(hw_data_offset(next_buffer_ptr) <= USB_DPRAM_MAX);

**Additional context**
The issue is that pico implementation only reclaim the memory when all the endpoints are closed. In audio example, speaker and mic may not share the same lifecycle. This end up the crash.

I fixed this to implement a poor man allocation algorithm to track 64 of the blocks with 64 bytes. Since there are only 64 blocks, the simple algorithm works well.

Tested on Pico with UAC2 example
