### PR TITLE
Update osal_freertos.h to fix FreeRTOS wrong task switch

### DIFF
--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -115,7 +115,7 @@ TU_ATTR_ALWAYS_INLINE static inline bool osal_semaphore_post(osal_semaphore_t se
   }
   else
   {
-    BaseType_t xHigherPriorityTaskWoken;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
     BaseType_t res = xSemaphoreGiveFromISR(sem_hdl, &xHigherPriorityTaskWoken);
 
 #if CFG_TUSB_MCU == OPT_MCU_ESP32S2 || CFG_TUSB_MCU == OPT_MCU_ESP32S3
@@ -189,7 +189,7 @@ TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_send(osal_queue_t qhdl, void
   }
   else
   {
-    BaseType_t xHigherPriorityTaskWoken;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
     BaseType_t res = xQueueSendToBackFromISR(qhdl, data, &xHigherPriorityTaskWoken);
 
 #if CFG_TUSB_MCU == OPT_MCU_ESP32S2 || CFG_TUSB_MCU == OPT_MCU_ESP32S3


### PR DESCRIPTION
Fix FreeRTOS task switch even if not required (unitialized variable usage)

**Describe the PR**
See https://github.com/hathach/tinyusb/issues/1798

**Additional context**
If applicable, add any other context about the PR and/or screenshots here.
