### PR TITLE
Fix UVC probe and commit on MacOS

### DIFF
--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -917,7 +917,7 @@ static int handle_video_stm_cs_req(uint8_t rhport, uint8_t stage,
       switch (request->bRequest) {
         case VIDEO_REQUEST_SET_CUR:
           if (stage == CONTROL_STAGE_SETUP) {
-            TU_VERIFY(sizeof(video_probe_and_commit_control_t) == request->wLength, VIDEO_ERROR_UNKNOWN);
+            TU_VERIFY(sizeof(video_probe_and_commit_control_t) >= request->wLength, VIDEO_ERROR_UNKNOWN);
             TU_VERIFY(tud_control_xfer(rhport, request, self->ep_buf, sizeof(video_probe_and_commit_control_t)),
                       VIDEO_ERROR_UNKNOWN);
           } else if (stage == CONTROL_STAGE_DATA) {
@@ -973,7 +973,7 @@ static int handle_video_stm_cs_req(uint8_t rhport, uint8_t stage,
       switch (request->bRequest) {
         case VIDEO_REQUEST_SET_CUR:
           if (stage == CONTROL_STAGE_SETUP) {
-            TU_VERIFY(sizeof(video_probe_and_commit_control_t) == request->wLength, VIDEO_ERROR_UNKNOWN);
+            TU_VERIFY(sizeof(video_probe_and_commit_control_t) >= request->wLength, VIDEO_ERROR_UNKNOWN);
             TU_VERIFY(tud_control_xfer(rhport, request, self->ep_buf, sizeof(video_probe_and_commit_control_t)), VIDEO_ERROR_UNKNOWN);
           } else if (stage == CONTROL_STAGE_DATA) {
             TU_VERIFY(_update_streaming_parameters(self, (video_probe_and_commit_control_t*)self->ep_buf), VIDEO_ERROR_INVALID_VALUE_WITHIN_RANGE);


### PR DESCRIPTION
**Describe the PR**
This is a minor change to the USB Video class implementation to accept a too small wLength during probe and commit requests in order to fix MacOS compatibility.

**Additional context**
My (UVC project)[https://github.com/Staacks/gbinterceptor] as well as a minimal example on a Raspberry Pi Pico based on the examples here fails on MacOS during SET CUR Probe because wLength is set to 0x22 instead of the expected 0x30. This behavior can actually be observed with WireShark on MacOS for any commercial webcam that I plugged in and it is marked by Wireshark as a malformed package.

However, if I understand section 4.1 of the UVC 1.5 definition correctly, this behavior is allowed:

> If the parameter block is longer than is indicated in the wLength field, only the initial bytes of the
parameter block are returned. If the parameter block is shorter than is indicated in the wLength
field, the device indicates the end of the control transfer by sending a short packet when further
data is requested.

But even if I misinterpret this (this is the first time I really look into these specs) and it is a bug by Apple, I still recommend to accept too small wLength values here as I do not see any relevant downside to doing so.
