### PR TITLE
fix(fuzz): Make sanitizer flags optional

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,6 +38,8 @@ jobs:
 
     - name: Build Fuzzer
       run: |
+        export CC=clang
+        export CXX=clang++
         fuzz_harness=$(ls -d test/fuzz/device/*/)
         for h in $fuzz_harness
         do

--- a/test/fuzz/make.mk
+++ b/test/fuzz/make.mk
@@ -16,9 +16,9 @@ __check_defined = \
 
 #-------------- Fuzz harness compiler  ------------
 
-CC = clang
-CXX = clang++
-GDB = gdb
+CC ?= clang
+CXX ?= clang++
+GDB ?= gdb
 OBJCOPY = objcopy
 SIZE = size
 MKDIR = mkdir
@@ -34,6 +34,13 @@ else
   PYTHON = python3
 endif
 
+#-------------- Fuzz harness flags ------------
+COVERAGE_FLAGS ?= -fsanitize-coverage=trace-pc-guard
+SANITIZER_FLAGS ?= -fsanitize=fuzzer \
+                   -fsanitize=address
+
+CFLAGS += $(COVERAGE_FLAGS) $(SANITIZER_FLAGS)
+
 #-------------- Source files and compiler flags --------------
 
 
@@ -42,9 +49,6 @@ INC += $(TOP)/test
 # Compiler Flags
 CFLAGS += \
   -ggdb \
-  -fsanitize=fuzzer \
-  -fsanitize=address \
-  -fsanitize=undefined \
   -fdata-sections \
   -ffunction-sections \
   -fno-strict-aliasing \


### PR DESCRIPTION
**Describe the PR**
Currently OSS fuzz expects to have complete control over the sanitizer flags. As we currently have these set it's causing problems with the OSS fuzz build. Instead we should use the provided variables from the OSS fuzz build environment. For local testing we'll create a set a well defined defaults.

**Additional context**
https://github.com/google/oss-fuzz/actions/runs/3761908047