### PR TITLE
Fix typo in audio.h. Specifiy _ctrl_xfer struct in CFG_TUSB_MEM_SECTION in usbh.c

### DIFF
--- a/src/class/audio/audio.h
+++ b/src/class/audio/audio.h
@@ -721,11 +721,13 @@ typedef struct TU_ATTR_PACKED
   uint8_t bLength            ; ///< Size of this descriptor, in bytes: 17.
   uint8_t bDescriptorType    ; ///< Descriptor Type. Value: TUSB_DESC_CS_INTERFACE.
   uint8_t bDescriptorSubType ; ///< Descriptor SubType. Value: AUDIO_CS_AC_INTERFACE_INPUT_TERMINAL.
+  uint8_t bTerminalID        ; ///< Constant uniquely identifying the Terminal within the audio function. This value is used in all requests to address this terminal.
   uint16_t wTerminalType     ; ///< Constant characterizing the type of Terminal. See: audio_terminal_type_t for USB streaming and audio_terminal_input_type_t for other input types.
   uint8_t bAssocTerminal     ; ///< ID of the Output Terminal to which this Input Terminal is associated.
   uint8_t bCSourceID         ; ///< ID of the Clock Entity to which this Input Terminal is connected.
   uint8_t bNrChannels        ; ///< Number of logical output channels in the Terminal’s output audio channel cluster.
   uint32_t bmChannelConfig   ; ///< Describes the spatial location of the logical channels. See:audio_channel_config_t.
+  uint8_t iChannelNames      ; ///< Index of a string descriptor, describing the name of the first logical channel.
   uint16_t bmControls        ; ///< See: audio_terminal_input_control_pos_t.
   uint8_t iTerminal          ; ///< Index of a string descriptor, describing the Input Terminal.
 } audio_desc_input_terminal_t;

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -229,10 +229,10 @@ static osal_queue_t _usbh_q;
 CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN
 static uint8_t _usbh_ctrl_buf[CFG_TUH_ENUMERATION_BUFSIZE];
 
-// Control transfer: since most controller does not support multiple control transfer
-// on multiple devices concurrently. And control transfer is not used much except enumeration
-// We will only execute control transfer one at a time.
-struct
+// Control transfers: since most controllers do not support multiple control transfers
+// on multiple devices concurrently and control transfers are not used much except for
+// enumeration, we will only execute control transfers one at a time.
+CFG_TUSB_MEM_SECTION struct
 {
   tusb_control_request_t request TU_ATTR_ALIGNED(4);
   uint8_t* buffer;

--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -188,7 +188,7 @@ tusb_speed_t hcd_port_speed_get(uint8_t rhport)
 static void list_remove_qhd_by_addr(ehci_link_t* list_head, uint8_t dev_addr)
 {
   for(ehci_link_t* prev = list_head;
-      !prev->terminate && (tu_align32(prev->address) != (uint32_t) list_head);
+      !prev->terminate && (tu_align32(prev->address) != (uint32_t) list_head) && prev != NULL;
       prev = list_next(prev) )
   {
     // TODO check type for ISO iTD and siTD


### PR DESCRIPTION
Add NULL check to loop in list_remove_qhd_by_addr() function in ehci.c

See discussion [here](https://github.com/hathach/tinyusb/discussions/1769#discussioncomment-4377690) for some background about this PR