### PR TITLE
feat(ci): Adds oss-fuzz integration on PRs

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,33 @@
+name: CIFuzz
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.c'
+      - '**.cc'
+      - '**.cpp'
+      - '**.cxx'
+      - '**.h'
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   steps:
+   - name: Build Fuzzers
+     id: build
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'tinyusb'
+       language: c++
+   - name: Run Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'tinyusb'
+       language: c++
+       fuzz-seconds: 600
+   - name: Upload Crash
+     uses: actions/upload-artifact@v3
+     if: failure() && steps.build.outcome == 'success'
+     with:
+       name: artifacts
+       path: ./out/artifacts


### PR DESCRIPTION
**Describe the PR**
This PR will trigger the fuzzer to run for 10min on every PR with the goal of catching bugs **before** they are merged.

This is intended as a more "surface level" fuzzing to catch obvious bugs before they are merged, the complete OSS-fuzz system will find deeper bugs that you can't find in 10min minutes or so of fuzzing. We can of course extend this time from the default of 10min if you want a "deeper" fuzzing analysis for the PR tests.

**Additional context**
Documentation: https://google.github.io/oss-fuzz/getting-started/continuous-integration/
Testing trigger of ci (on my local fork): https://github.com/silvergasp/tinyusb/actions/runs/3877844318/jobs/6613332627