### PR TITLE
dwc2: fix iar warnings

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -529,8 +529,10 @@ void dcd_init (uint8_t rhport)
   dwc2->dcfg |= DCFG_NZLSOHSK;
 
   // Clear all interrupts
-  dwc2->gintsts |= dwc2->gintsts;
-  dwc2->gotgint |= dwc2->gotgint;
+  uint32_t int_mask = dwc2->gintsts;
+  dwc2->gintsts |= int_mask;
+  int_mask = dwc2->gotgint;
+  dwc2->gotgint |= int_mask;
 
   // Required as part of core initialization.
   // TODO: How should mode mismatch be handled? It will cause
@@ -1219,7 +1221,8 @@ void dcd_int_handler(uint8_t rhport)
 {
   dwc2_regs_t *dwc2 = DWC2_REG(rhport);
 
-  uint32_t const int_status = dwc2->gintsts & dwc2->gintmsk;
+  uint32_t const int_mask = dwc2->gintmsk;
+  uint32_t const int_status = dwc2->gintsts & int_mask;
 
   if(int_status & GINTSTS_USBRST)
   {

--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -122,13 +122,13 @@ static const dwc2_controller_t _dwc2_controller[] =
 TU_ATTR_ALWAYS_INLINE
 static inline void dwc2_dcd_int_enable(uint8_t rhport)
 {
-  NVIC_EnableIRQ(_dwc2_controller[rhport].irqnum);
+  NVIC_EnableIRQ((IRQn_Type)_dwc2_controller[rhport].irqnum);
 }
 
 TU_ATTR_ALWAYS_INLINE
 static inline void dwc2_dcd_int_disable (uint8_t rhport)
 {
-  NVIC_DisableIRQ(_dwc2_controller[rhport].irqnum);
+  NVIC_DisableIRQ((IRQn_Type)_dwc2_controller[rhport].irqnum);
 }
 
 TU_ATTR_ALWAYS_INLINE


### PR DESCRIPTION
**Describe the PR**
Fix:
Warning[Pe188]: enumerated type mixed with another type	dwc2_stm32.h	125	
Warning[Pa082]: undefined behavior: the order of volatile accesses is undefined in this statement	dcd_dwc2.c	532	
Warning[Pa082]: undefined behavior: the order of volatile accesses is undefined in this statement	dcd_dwc2.c	1221