### PR TITLE
examples/uac2: Fix mute and volume array lengths

### DIFF
--- a/examples/device/uac2_headset/src/main.c
+++ b/examples/device/uac2_headset/src/main.c
@@ -79,8 +79,8 @@ static uint32_t blink_interval_ms = BLINK_NOT_MOUNTED;
 
 // Audio controls
 // Current states
-int8_t mute[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1];       // +1 for master channel 0
-int16_t volume[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1];    // +1 for master channel 0
+int8_t mute[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1];       // +1 for master channel 0
+int16_t volume[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1];    // +1 for master channel 0
 
 // Buffer for microphone data
 int32_t mic_buf[CFG_TUD_AUDIO_FUNC_1_EP_IN_SW_BUF_SZ / 4];


### PR DESCRIPTION
**Describe the PR**
mute and volume arrays in main.c have wrong number of elements (2 instead of 3) because CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX was used to calculate array lengths. CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX changed to CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX.

**Additional context**
Changing the volume of second channel ends up soft brick of device in my case because OS will remember last volume control.