### PR TITLE
Add _in and _out variants of tud_control_xfer for type cleanliness

### DIFF
--- a/examples/device/webusb_serial/src/main.c
+++ b/examples/device/webusb_serial/src/main.c
@@ -179,7 +179,7 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
         case VENDOR_REQUEST_WEBUSB:
           // match vendor request in BOS descriptor
           // Get landing page url
-          return tud_control_xfer(rhport, request, (void*)(uintptr_t) &desc_url, desc_url.bLength);
+          return tud_control_xfer_in(rhport, request, &desc_url, desc_url.bLength);
 
         case VENDOR_REQUEST_MICROSOFT:
           if ( request->wIndex == 7 )
@@ -188,7 +188,7 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
             uint16_t total_len;
             memcpy(&total_len, desc_ms_os_20+8, 2);
 
-            return tud_control_xfer(rhport, request, (void*)(uintptr_t) desc_ms_os_20, total_len);
+            return tud_control_xfer_in(rhport, request, desc_ms_os_20, total_len);
           }else
           {
             return false;

--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -255,12 +255,12 @@ bool hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t
       if (request->bRequest == TUSB_REQ_GET_DESCRIPTOR && desc_type == HID_DESC_TYPE_HID)
       {
         TU_VERIFY(p_hid->hid_descriptor);
-        TU_VERIFY(tud_control_xfer(rhport, request, (void*)(uintptr_t) p_hid->hid_descriptor, p_hid->hid_descriptor->bLength));
+        TU_VERIFY(tud_control_xfer_in(rhport, request, p_hid->hid_descriptor, p_hid->hid_descriptor->bLength));
       }
       else if (request->bRequest == TUSB_REQ_GET_DESCRIPTOR && desc_type == HID_DESC_TYPE_REPORT)
       {
         uint8_t const * desc_report = tud_hid_descriptor_report_cb(hid_itf);
-        tud_control_xfer(rhport, request, (void*)(uintptr_t) desc_report, p_hid->report_desc_len);
+        tud_control_xfer_in(rhport, request, desc_report, p_hid->report_desc_len);
       }
       else
       {

--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -392,7 +392,7 @@ bool netd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
 
       if (NCM_GET_NTB_PARAMETERS == request->bRequest)
       {
-        tud_control_xfer(rhport, request, (void*)(uintptr_t) &ntb_parameters, sizeof(ntb_parameters));
+        tud_control_xfer_in(rhport, request, &ntb_parameters, sizeof(ntb_parameters));
       }
 
       break;

--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -813,7 +813,7 @@ bool usbtmcd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request
     {
       TU_VERIFY(request->bmRequestType == 0xA1); // in,class,interface
       TU_VERIFY(request->wLength == sizeof(*(usbtmc_state.capabilities)));
-      TU_VERIFY(tud_control_xfer(rhport, request, (void*)(uintptr_t) usbtmc_state.capabilities, sizeof(*usbtmc_state.capabilities)));
+      TU_VERIFY(tud_control_xfer_in(rhport, request, usbtmc_state.capabilities, sizeof(*usbtmc_state.capabilities)));
       return true;
     }
   // USBTMC Optional Requests

--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -798,7 +798,7 @@ static int handle_video_ctl_cs_req(uint8_t rhport, uint8_t stage,
           if (stage == CONTROL_STAGE_SETUP)
           {
             TU_VERIFY(1 == request->wLength, VIDEO_ERROR_UNKNOWN);
-            TU_VERIFY(tud_control_xfer(rhport, request, (uint8_t*)(uintptr_t) &_cap_get_set, sizeof(_cap_get_set)), VIDEO_ERROR_UNKNOWN);
+            TU_VERIFY(tud_control_xfer_in(rhport, request, &_cap_get_set, sizeof(_cap_get_set)), VIDEO_ERROR_UNKNOWN);
           }
           return VIDEO_ERROR_NONE;
 
@@ -818,7 +818,7 @@ static int handle_video_ctl_cs_req(uint8_t rhport, uint8_t stage,
         case VIDEO_REQUEST_GET_INFO:
           if (stage == CONTROL_STAGE_SETUP)
           {
-            TU_VERIFY(tud_control_xfer(rhport, request, (uint8_t*)(uintptr_t) &_cap_get, sizeof(_cap_get)), VIDEO_ERROR_UNKNOWN);
+            TU_VERIFY(tud_control_xfer_in(rhport, request, &_cap_get, sizeof(_cap_get)), VIDEO_ERROR_UNKNOWN);
           }
           return VIDEO_ERROR_NONE;
 
@@ -911,7 +911,7 @@ static int handle_video_stm_cs_req(uint8_t rhport, uint8_t stage,
         case VIDEO_REQUEST_GET_INFO:
           if (stage == CONTROL_STAGE_SETUP)
           {
-            TU_VERIFY(tud_control_xfer(rhport, request, (uint8_t*)(uintptr_t) &_cap_get, sizeof(_cap_get)), VIDEO_ERROR_UNKNOWN);
+            TU_VERIFY(tud_control_xfer_in(rhport, request, &_cap_get, sizeof(_cap_get)), VIDEO_ERROR_UNKNOWN);
           }
           return VIDEO_ERROR_NONE;
 
@@ -967,7 +967,7 @@ static int handle_video_stm_cs_req(uint8_t rhport, uint8_t stage,
           if (stage == CONTROL_STAGE_SETUP)
           {
             TU_VERIFY(1 == request->wLength, VIDEO_ERROR_UNKNOWN);
-            TU_VERIFY(tud_control_xfer(rhport, request, (uint8_t*)(uintptr_t)&_cap_get_set, sizeof(_cap_get_set)), VIDEO_ERROR_UNKNOWN);
+            TU_VERIFY(tud_control_xfer_in(rhport, request, &_cap_get_set, sizeof(_cap_get_set)), VIDEO_ERROR_UNKNOWN);
           }
           return VIDEO_ERROR_NONE;
 
@@ -1010,7 +1010,7 @@ static int handle_video_stm_cs_req(uint8_t rhport, uint8_t stage,
           if (stage == CONTROL_STAGE_SETUP)
           {
             TU_VERIFY(1 == request->wLength, VIDEO_ERROR_UNKNOWN);
-            TU_VERIFY(tud_control_xfer(rhport, request, (uint8_t*)(uintptr_t) &_cap_get_set, sizeof(_cap_get_set)), VIDEO_ERROR_UNKNOWN);
+            TU_VERIFY(tud_control_xfer_in(rhport, request, &_cap_get_set, sizeof(_cap_get_set)), VIDEO_ERROR_UNKNOWN);
           }
           return VIDEO_ERROR_NONE;
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1047,7 +1047,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
       TU_VERIFY(desc_str);
 
       // first byte of descriptor is its size
-      return tud_control_xfer(rhport, p_request, (void*) (uintptr_t) desc_str, tu_desc_len(desc_str));
+      return tud_control_xfer_in(rhport, p_request, desc_str, tu_desc_len(desc_str));
     }
     // break; // unreachable
 
@@ -1061,7 +1061,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
       TU_VERIFY(desc_qualifier);
 
       // first byte of descriptor is its size
-      return tud_control_xfer(rhport, p_request, (void*) (uintptr_t) desc_qualifier, tu_desc_len(desc_qualifier));
+      return tud_control_xfer_in(rhport, p_request, desc_qualifier, tu_desc_len(desc_qualifier));
     }
     // break; // unreachable
 

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -101,6 +101,23 @@ bool tud_connect(void);
 // - If len > wLength : it will be truncated
 bool tud_control_xfer(uint8_t rhport, tusb_control_request_t const * request, void* buffer, uint16_t len);
 
+TU_ATTR_ALWAYS_INLINE static inline
+bool tud_control_xfer_in(uint8_t rhport, tusb_control_request_t const * request, const void* buffer, uint16_t len)
+{
+    TU_VERIFY(request->bmRequestType_bit.direction & TUSB_DIR_IN);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+    return tud_control_xfer(rhport, request, (void *)buffer, len);
+#pragma GCC diagnostic pop
+}
+
+TU_ATTR_ALWAYS_INLINE static inline
+bool tud_control_xfer_out(uint8_t rhport, tusb_control_request_t const * request, void* buffer, uint16_t len)
+{
+    TU_VERIFY(!(request->bmRequestType_bit.direction & TUSB_DIR_IN));
+    return tud_control_xfer(rhport, request, buffer, len);
+}
+
 // Send STATUS (zero length) packet
 bool tud_control_status(uint8_t rhport, tusb_control_request_t const * request);
 


### PR DESCRIPTION
This allows transferring data IN from a const buffer without compiler warnings.

Also changed several uses of `tud_control_xfer` on const data to use `tud_control_xfer_in` instead, eliminating ugly casts.  Did not change all uses - only the ones that were clearly acting on const data and had ugly casts that could be eliminated.

A more aggressive approach would be to modify all calls in the IN direction to use the new function.
An even more aggressive approach would be to modify all `tud_control_xfer` calls in either direction to use the new functions, and perhaps deprecate the old function as well.