### PR TITLE
fix: Change all static variables to thread when fuzzing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -76,7 +76,7 @@ typedef struct
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
-CFG_TUSB_MEM_SECTION static cdcd_interface_t _cdcd_itf[CFG_TUD_CDC];
+CFG_TUSB_MEM_SECTION TU_STATIC cdcd_interface_t _cdcd_itf[CFG_TUD_CDC];
 
 static bool _prep_out_transaction (cdcd_interface_t* p_cdc)
 {

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -76,7 +76,7 @@ typedef struct
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
-CFG_TUSB_MEM_SECTION TU_STATIC cdcd_interface_t _cdcd_itf[CFG_TUD_CDC];
+CFG_TUSB_MEM_SECTION static _fuzz_thread cdcd_interface_t _cdcd_itf[CFG_TUD_CDC];
 
 static bool _prep_out_transaction (cdcd_interface_t* p_cdc)
 {

--- a/src/class/dfu/dfu_device.c
+++ b/src/class/dfu/dfu_device.c
@@ -56,7 +56,7 @@ typedef struct
 } dfu_state_ctx_t;
 
 // Only a single dfu state is allowed
-CFG_TUSB_MEM_SECTION static dfu_state_ctx_t _dfu_ctx;
+CFG_TUSB_MEM_SECTION TU_STATIC dfu_state_ctx_t _dfu_ctx;
 
 static void reset_state(void)
 {
@@ -74,7 +74,7 @@ static bool process_manifest_get_status(uint8_t rhport, uint8_t stage, tusb_cont
 //--------------------------------------------------------------------+
 #if CFG_TUSB_DEBUG >= 2
 
-static tu_lookup_entry_t const _dfu_request_lookup[] =
+TU_STATIC tu_lookup_entry_t const _dfu_request_lookup[] =
 {
   { .key = DFU_REQUEST_DETACH         , .data = "DETACH"    },
   { .key = DFU_REQUEST_DNLOAD         , .data = "DNLOAD"    },
@@ -85,13 +85,13 @@ static tu_lookup_entry_t const _dfu_request_lookup[] =
   { .key = DFU_REQUEST_ABORT          , .data = "ABORT"     },
 };
 
-static tu_lookup_table_t const _dfu_request_table =
+TU_STATIC tu_lookup_table_t const _dfu_request_table =
 {
   .count = TU_ARRAY_SIZE(_dfu_request_lookup),
   .items = _dfu_request_lookup
 };
 
-static tu_lookup_entry_t const _dfu_state_lookup[] =
+TU_STATIC tu_lookup_entry_t const _dfu_state_lookup[] =
 {
   { .key = APP_IDLE                   , .data = "APP_IDLE"                },
   { .key = APP_DETACH                 , .data = "APP_DETACH"              },
@@ -106,13 +106,13 @@ static tu_lookup_entry_t const _dfu_state_lookup[] =
   { .key = DFU_ERROR                  , .data = "ERROR"               },
 };
 
-static tu_lookup_table_t const _dfu_state_table =
+TU_STATIC tu_lookup_table_t const _dfu_state_table =
 {
   .count = TU_ARRAY_SIZE(_dfu_state_lookup),
   .items = _dfu_state_lookup
 };
 
-static tu_lookup_entry_t const _dfu_status_lookup[] =
+TU_STATIC tu_lookup_entry_t const _dfu_status_lookup[] =
 {
   { .key = DFU_STATUS_OK               , .data = "OK"              },
   { .key = DFU_STATUS_ERR_TARGET       , .data = "errTARGET"       },
@@ -132,7 +132,7 @@ static tu_lookup_entry_t const _dfu_status_lookup[] =
   { .key = DFU_STATUS_ERR_STALLEDPKT   , .data = "errSTALLEDPKT"   },
 };
 
-static tu_lookup_table_t const _dfu_status_table =
+TU_STATIC tu_lookup_table_t const _dfu_status_table =
 {
   .count = TU_ARRAY_SIZE(_dfu_status_lookup),
   .items = _dfu_status_lookup

--- a/src/class/dfu/dfu_device.c
+++ b/src/class/dfu/dfu_device.c
@@ -56,7 +56,7 @@ typedef struct
 } dfu_state_ctx_t;
 
 // Only a single dfu state is allowed
-CFG_TUSB_MEM_SECTION TU_STATIC dfu_state_ctx_t _dfu_ctx;
+CFG_TUSB_MEM_SECTION static _fuzz_thread dfu_state_ctx_t _dfu_ctx;
 
 static void reset_state(void)
 {
@@ -74,7 +74,7 @@ static bool process_manifest_get_status(uint8_t rhport, uint8_t stage, tusb_cont
 //--------------------------------------------------------------------+
 #if CFG_TUSB_DEBUG >= 2
 
-TU_STATIC tu_lookup_entry_t const _dfu_request_lookup[] =
+static _fuzz_thread tu_lookup_entry_t const _dfu_request_lookup[] =
 {
   { .key = DFU_REQUEST_DETACH         , .data = "DETACH"    },
   { .key = DFU_REQUEST_DNLOAD         , .data = "DNLOAD"    },
@@ -85,13 +85,13 @@ TU_STATIC tu_lookup_entry_t const _dfu_request_lookup[] =
   { .key = DFU_REQUEST_ABORT          , .data = "ABORT"     },
 };
 
-TU_STATIC tu_lookup_table_t const _dfu_request_table =
+static _fuzz_thread tu_lookup_table_t const _dfu_request_table =
 {
   .count = TU_ARRAY_SIZE(_dfu_request_lookup),
   .items = _dfu_request_lookup
 };
 
-TU_STATIC tu_lookup_entry_t const _dfu_state_lookup[] =
+static _fuzz_thread tu_lookup_entry_t const _dfu_state_lookup[] =
 {
   { .key = APP_IDLE                   , .data = "APP_IDLE"                },
   { .key = APP_DETACH                 , .data = "APP_DETACH"              },
@@ -106,13 +106,13 @@ TU_STATIC tu_lookup_entry_t const _dfu_state_lookup[] =
   { .key = DFU_ERROR                  , .data = "ERROR"               },
 };
 
-TU_STATIC tu_lookup_table_t const _dfu_state_table =
+static _fuzz_thread tu_lookup_table_t const _dfu_state_table =
 {
   .count = TU_ARRAY_SIZE(_dfu_state_lookup),
   .items = _dfu_state_lookup
 };
 
-TU_STATIC tu_lookup_entry_t const _dfu_status_lookup[] =
+static _fuzz_thread tu_lookup_entry_t const _dfu_status_lookup[] =
 {
   { .key = DFU_STATUS_OK               , .data = "OK"              },
   { .key = DFU_STATUS_ERR_TARGET       , .data = "errTARGET"       },
@@ -132,7 +132,7 @@ TU_STATIC tu_lookup_entry_t const _dfu_status_lookup[] =
   { .key = DFU_STATUS_ERR_STALLEDPKT   , .data = "errSTALLEDPKT"   },
 };
 
-TU_STATIC tu_lookup_table_t const _dfu_status_table =
+static _fuzz_thread tu_lookup_table_t const _dfu_status_table =
 {
   .count = TU_ARRAY_SIZE(_dfu_status_lookup),
   .items = _dfu_status_lookup

--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -58,7 +58,7 @@ typedef struct
   tusb_hid_descriptor_hid_t const * hid_descriptor;
 } hidd_interface_t;
 
-CFG_TUSB_MEM_SECTION TU_STATIC hidd_interface_t _hidd_itf[CFG_TUD_HID];
+CFG_TUSB_MEM_SECTION static _fuzz_thread hidd_interface_t _hidd_itf[CFG_TUD_HID];
 
 /*------------- Helpers -------------*/
 static inline uint8_t get_index_by_itfnum(uint8_t itf_num)

--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -58,7 +58,7 @@ typedef struct
   tusb_hid_descriptor_hid_t const * hid_descriptor;
 } hidd_interface_t;
 
-CFG_TUSB_MEM_SECTION static hidd_interface_t _hidd_itf[CFG_TUD_HID];
+CFG_TUSB_MEM_SECTION TU_STATIC hidd_interface_t _hidd_itf[CFG_TUD_HID];
 
 /*------------- Helpers -------------*/
 static inline uint8_t get_index_by_itfnum(uint8_t itf_num)

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -71,8 +71,8 @@ typedef struct
   uint8_t add_sense_qualifier;
 }mscd_interface_t;
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC mscd_interface_t _mscd_itf;
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC uint8_t _mscd_buf[CFG_TUD_MSC_EP_BUFSIZE];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static _fuzz_thread mscd_interface_t _mscd_itf;
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static _fuzz_thread uint8_t _mscd_buf[CFG_TUD_MSC_EP_BUFSIZE];
 
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
@@ -202,7 +202,7 @@ uint8_t rdwr10_validate_cmd(msc_cbw_t const* cbw)
 //--------------------------------------------------------------------+
 #if CFG_TUSB_DEBUG >= 2
 
-TU_ATTR_UNUSED TU_STATIC tu_lookup_entry_t const _msc_scsi_cmd_lookup[] =
+TU_ATTR_UNUSED static _fuzz_thread tu_lookup_entry_t const _msc_scsi_cmd_lookup[] =
 {
   { .key = SCSI_CMD_TEST_UNIT_READY              , .data = "Test Unit Ready" },
   { .key = SCSI_CMD_INQUIRY                      , .data = "Inquiry" },
@@ -217,7 +217,7 @@ TU_ATTR_UNUSED TU_STATIC tu_lookup_entry_t const _msc_scsi_cmd_lookup[] =
   { .key = SCSI_CMD_WRITE_10                     , .data = "Write10" }
 };
 
-TU_ATTR_UNUSED TU_STATIC tu_lookup_table_t const _msc_scsi_cmd_table =
+TU_ATTR_UNUSED static _fuzz_thread tu_lookup_table_t const _msc_scsi_cmd_table =
 {
   .count = TU_ARRAY_SIZE(_msc_scsi_cmd_lookup),
   .items = _msc_scsi_cmd_lookup

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -71,8 +71,8 @@ typedef struct
   uint8_t add_sense_qualifier;
 }mscd_interface_t;
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static mscd_interface_t _mscd_itf;
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t _mscd_buf[CFG_TUD_MSC_EP_BUFSIZE];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC mscd_interface_t _mscd_itf;
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC uint8_t _mscd_buf[CFG_TUD_MSC_EP_BUFSIZE];
 
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
@@ -202,7 +202,7 @@ uint8_t rdwr10_validate_cmd(msc_cbw_t const* cbw)
 //--------------------------------------------------------------------+
 #if CFG_TUSB_DEBUG >= 2
 
-TU_ATTR_UNUSED static tu_lookup_entry_t const _msc_scsi_cmd_lookup[] =
+TU_ATTR_UNUSED TU_STATIC tu_lookup_entry_t const _msc_scsi_cmd_lookup[] =
 {
   { .key = SCSI_CMD_TEST_UNIT_READY              , .data = "Test Unit Ready" },
   { .key = SCSI_CMD_INQUIRY                      , .data = "Inquiry" },
@@ -217,7 +217,7 @@ TU_ATTR_UNUSED static tu_lookup_entry_t const _msc_scsi_cmd_lookup[] =
   { .key = SCSI_CMD_WRITE_10                     , .data = "Write10" }
 };
 
-TU_ATTR_UNUSED static tu_lookup_table_t const _msc_scsi_cmd_table =
+TU_ATTR_UNUSED TU_STATIC tu_lookup_table_t const _msc_scsi_cmd_table =
 {
   .count = TU_ARRAY_SIZE(_msc_scsi_cmd_lookup),
   .items = _msc_scsi_cmd_lookup

--- a/src/class/net/ecm_rndis_device.c
+++ b/src/class/net/ecm_rndis_device.c
@@ -61,8 +61,8 @@ typedef struct
 #define CFG_TUD_NET_PACKET_PREFIX_LEN sizeof(rndis_data_packet_t)
 #define CFG_TUD_NET_PACKET_SUFFIX_LEN 0
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t received[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t transmitted[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC uint8_t received[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC uint8_t transmitted[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
 
 struct ecm_notify_struct
 {
@@ -70,7 +70,7 @@ struct ecm_notify_struct
   uint32_t downlink, uplink;
 };
 
-static const struct ecm_notify_struct ecm_notify_nc =
+TU_STATIC const struct ecm_notify_struct ecm_notify_nc =
 {
   .header = {
     .bmRequestType = 0xA1,
@@ -80,7 +80,7 @@ static const struct ecm_notify_struct ecm_notify_nc =
   },
 };
 
-static const struct ecm_notify_struct ecm_notify_csc =
+TU_STATIC const struct ecm_notify_struct ecm_notify_csc =
 {
   .header = {
     .bmRequestType = 0xA1,
@@ -92,7 +92,7 @@ static const struct ecm_notify_struct ecm_notify_csc =
 };
 
 // TODO remove CFG_TUSB_MEM_SECTION, control internal buffer is already in this special section
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static union
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC union
 {
   uint8_t rndis_buf[120];
   struct ecm_notify_struct ecm_buf;
@@ -102,9 +102,9 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static union
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 // TODO remove CFG_TUSB_MEM_SECTION
-CFG_TUSB_MEM_SECTION static netd_interface_t _netd_itf;
+CFG_TUSB_MEM_SECTION TU_STATIC netd_interface_t _netd_itf;
 
-static bool can_xmit;
+TU_STATIC bool can_xmit;
 
 void tud_network_recv_renew(void)
 {

--- a/src/class/net/ecm_rndis_device.c
+++ b/src/class/net/ecm_rndis_device.c
@@ -61,8 +61,11 @@ typedef struct
 #define CFG_TUD_NET_PACKET_PREFIX_LEN sizeof(rndis_data_packet_t)
 #define CFG_TUD_NET_PACKET_SUFFIX_LEN 0
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC uint8_t received[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC uint8_t transmitted[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static _fuzz_thread 
+uint8_t received[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
+
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static _fuzz_thread 
+uint8_t transmitted[CFG_TUD_NET_PACKET_PREFIX_LEN + CFG_TUD_NET_MTU + CFG_TUD_NET_PACKET_PREFIX_LEN];
 
 struct ecm_notify_struct
 {
@@ -70,7 +73,7 @@ struct ecm_notify_struct
   uint32_t downlink, uplink;
 };
 
-TU_STATIC const struct ecm_notify_struct ecm_notify_nc =
+static _fuzz_thread const struct ecm_notify_struct ecm_notify_nc =
 {
   .header = {
     .bmRequestType = 0xA1,
@@ -80,7 +83,7 @@ TU_STATIC const struct ecm_notify_struct ecm_notify_nc =
   },
 };
 
-TU_STATIC const struct ecm_notify_struct ecm_notify_csc =
+static _fuzz_thread const struct ecm_notify_struct ecm_notify_csc =
 {
   .header = {
     .bmRequestType = 0xA1,
@@ -92,7 +95,7 @@ TU_STATIC const struct ecm_notify_struct ecm_notify_csc =
 };
 
 // TODO remove CFG_TUSB_MEM_SECTION, control internal buffer is already in this special section
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC union
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static _fuzz_thread union
 {
   uint8_t rndis_buf[120];
   struct ecm_notify_struct ecm_buf;
@@ -102,9 +105,9 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC union
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 // TODO remove CFG_TUSB_MEM_SECTION
-CFG_TUSB_MEM_SECTION TU_STATIC netd_interface_t _netd_itf;
+CFG_TUSB_MEM_SECTION static _fuzz_thread netd_interface_t _netd_itf;
 
-TU_STATIC bool can_xmit;
+static _fuzz_thread bool can_xmit;
 
 void tud_network_recv_renew(void)
 {

--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -130,7 +130,7 @@ typedef struct
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC const ntb_parameters_t ntb_parameters = {
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static _fuzz_thread const ntb_parameters_t ntb_parameters = {
     .wLength                 = sizeof(ntb_parameters_t),
     .bmNtbFormatsSupported   = 0x01,
     .dwNtbInMaxSize          = CFG_TUD_NCM_IN_NTB_MAX_SIZE,
@@ -145,11 +145,11 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC const ntb_parameters_t ntb_par
     .wNtbOutMaxDatagrams     = 0
 };
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC transmit_ntb_t transmit_ntb[2];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static _fuzz_thread transmit_ntb_t transmit_ntb[2];
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC uint8_t receive_ntb[CFG_TUD_NCM_OUT_NTB_MAX_SIZE];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static _fuzz_thread uint8_t receive_ntb[CFG_TUD_NCM_OUT_NTB_MAX_SIZE];
 
-TU_STATIC ncm_interface_t ncm_interface;
+static _fuzz_thread ncm_interface_t ncm_interface;
 
 /*
  * Set up the NTB state in ncm_interface to be ready to add datagrams.
@@ -196,7 +196,7 @@ static void ncm_start_tx(void) {
   ncm_prepare_for_tx();
 }
 
-TU_STATIC struct ecm_notify_struct ncm_notify_connected =
+static _fuzz_thread struct ecm_notify_struct ncm_notify_connected =
 {
     .header = {
         .bmRequestType_bit = {
@@ -210,7 +210,7 @@ TU_STATIC struct ecm_notify_struct ncm_notify_connected =
     },
 };
 
-TU_STATIC struct ecm_notify_struct ncm_notify_speed_change =
+static _fuzz_thread struct ecm_notify_struct ncm_notify_speed_change =
 {
     .header = {
         .bmRequestType_bit = {

--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -130,7 +130,7 @@ typedef struct
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static const ntb_parameters_t ntb_parameters = {
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC const ntb_parameters_t ntb_parameters = {
     .wLength                 = sizeof(ntb_parameters_t),
     .bmNtbFormatsSupported   = 0x01,
     .dwNtbInMaxSize          = CFG_TUD_NCM_IN_NTB_MAX_SIZE,
@@ -145,11 +145,11 @@ CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static const ntb_parameters_t ntb_parame
     .wNtbOutMaxDatagrams     = 0
 };
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static transmit_ntb_t transmit_ntb[2];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC transmit_ntb_t transmit_ntb[2];
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN static uint8_t receive_ntb[CFG_TUD_NCM_OUT_NTB_MAX_SIZE];
+CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN TU_STATIC uint8_t receive_ntb[CFG_TUD_NCM_OUT_NTB_MAX_SIZE];
 
-static ncm_interface_t ncm_interface;
+TU_STATIC ncm_interface_t ncm_interface;
 
 /*
  * Set up the NTB state in ncm_interface to be ready to add datagrams.
@@ -196,7 +196,7 @@ static void ncm_start_tx(void) {
   ncm_prepare_for_tx();
 }
 
-static struct ecm_notify_struct ncm_notify_connected =
+TU_STATIC struct ecm_notify_struct ncm_notify_connected =
 {
     .header = {
         .bmRequestType_bit = {
@@ -210,7 +210,7 @@ static struct ecm_notify_struct ncm_notify_connected =
     },
 };
 
-static struct ecm_notify_struct ncm_notify_speed_change =
+TU_STATIC struct ecm_notify_struct ncm_notify_speed_change =
 {
     .header = {
         .bmRequestType_bit = {

--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -78,7 +78,7 @@
 
 #ifdef xDEBUG
 #include "uart_util.h"
-TU_STATIC char logMsg[150];
+static _fuzz_thread char logMsg[150];
 #endif
 
 // Buffer size must be an exact multiple of the max packet size for both
@@ -143,7 +143,7 @@ typedef struct
   usbtmc_capabilities_specific_t const * capabilities;
 } usbtmc_interface_state_t;
 
-CFG_TUSB_MEM_SECTION TU_STATIC usbtmc_interface_state_t usbtmc_state =
+CFG_TUSB_MEM_SECTION static _fuzz_thread usbtmc_interface_state_t usbtmc_state =
 {
     .itf_id = 0xFF,
 };
@@ -154,8 +154,8 @@ TU_VERIFY_STATIC(USBTMCD_BUFFER_SIZE >= 32u,"USBTMC dev buffer size too small");
 static bool handle_devMsgOutStart(uint8_t rhport, void *data, size_t len);
 static bool handle_devMsgOut(uint8_t rhport, void *data, size_t len, size_t packetLen);
 
-TU_STATIC uint8_t termChar;
-TU_STATIC uint8_t termCharRequested = false;
+static _fuzz_thread uint8_t termChar;
+static _fuzz_thread uint8_t termCharRequested = false;
 
 #if OSAL_MUTEX_REQUIRED
 static OSAL_MUTEX_DEF(usbtmcLockBuffer);

--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -78,7 +78,7 @@
 
 #ifdef xDEBUG
 #include "uart_util.h"
-static char logMsg[150];
+TU_STATIC char logMsg[150];
 #endif
 
 // Buffer size must be an exact multiple of the max packet size for both
@@ -143,7 +143,7 @@ typedef struct
   usbtmc_capabilities_specific_t const * capabilities;
 } usbtmc_interface_state_t;
 
-CFG_TUSB_MEM_SECTION static usbtmc_interface_state_t usbtmc_state =
+CFG_TUSB_MEM_SECTION TU_STATIC usbtmc_interface_state_t usbtmc_state =
 {
     .itf_id = 0xFF,
 };
@@ -154,8 +154,8 @@ TU_VERIFY_STATIC(USBTMCD_BUFFER_SIZE >= 32u,"USBTMC dev buffer size too small");
 static bool handle_devMsgOutStart(uint8_t rhport, void *data, size_t len);
 static bool handle_devMsgOut(uint8_t rhport, void *data, size_t len, size_t packetLen);
 
-static uint8_t termChar;
-static uint8_t termCharRequested = false;
+TU_STATIC uint8_t termChar;
+TU_STATIC uint8_t termCharRequested = false;
 
 #if OSAL_MUTEX_REQUIRED
 static OSAL_MUTEX_DEF(usbtmcLockBuffer);

--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -59,7 +59,7 @@ typedef struct
   CFG_TUSB_MEM_ALIGN uint8_t epin_buf[CFG_TUD_VENDOR_EPSIZE];
 } vendord_interface_t;
 
-CFG_TUSB_MEM_SECTION TU_STATIC vendord_interface_t _vendord_itf[CFG_TUD_VENDOR];
+CFG_TUSB_MEM_SECTION static _fuzz_thread vendord_interface_t _vendord_itf[CFG_TUD_VENDOR];
 
 #define ITF_MEM_RESET_SIZE   offsetof(vendord_interface_t, rx_ff)
 

--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -59,7 +59,7 @@ typedef struct
   CFG_TUSB_MEM_ALIGN uint8_t epin_buf[CFG_TUD_VENDOR_EPSIZE];
 } vendord_interface_t;
 
-CFG_TUSB_MEM_SECTION static vendord_interface_t _vendord_itf[CFG_TUD_VENDOR];
+CFG_TUSB_MEM_SECTION TU_STATIC vendord_interface_t _vendord_itf[CFG_TUD_VENDOR];
 
 #define ITF_MEM_RESET_SIZE   offsetof(vendord_interface_t, rx_ff)
 

--- a/src/class/vendor/vendor_device.h
+++ b/src/class/vendor/vendor_device.h
@@ -50,7 +50,7 @@ void     tud_vendor_n_read_flush      (uint8_t itf);
 uint32_t tud_vendor_n_write           (uint8_t itf, void const* buffer, uint32_t bufsize);
 uint32_t tud_vendor_n_write_available (uint8_t itf);
 
-static inline
+TU_STATIC inline
 uint32_t tud_vendor_n_write_str       (uint8_t itf, char const* str);
 uint32_t tud_vendor_n_flush           (uint8_t itf);
 

--- a/src/class/vendor/vendor_device.h
+++ b/src/class/vendor/vendor_device.h
@@ -50,8 +50,7 @@ void     tud_vendor_n_read_flush      (uint8_t itf);
 uint32_t tud_vendor_n_write           (uint8_t itf, void const* buffer, uint32_t bufsize);
 uint32_t tud_vendor_n_write_available (uint8_t itf);
 
-TU_STATIC inline
-uint32_t tud_vendor_n_write_str       (uint8_t itf, char const* str);
+static inline uint32_t tud_vendor_n_write_str (uint8_t itf, char const* str);
 uint32_t tud_vendor_n_flush           (uint8_t itf);
 
 //--------------------------------------------------------------------+

--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -125,11 +125,11 @@ typedef struct TU_ATTR_PACKED {
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
-CFG_TUSB_MEM_SECTION static videod_interface_t _videod_itf[CFG_TUD_VIDEO];
-CFG_TUSB_MEM_SECTION static videod_streaming_interface_t _videod_streaming_itf[CFG_TUD_VIDEO_STREAMING];
+CFG_TUSB_MEM_SECTION TU_STATIC videod_interface_t _videod_itf[CFG_TUD_VIDEO];
+CFG_TUSB_MEM_SECTION TU_STATIC videod_streaming_interface_t _videod_streaming_itf[CFG_TUD_VIDEO_STREAMING];
 
-static uint8_t const _cap_get     = 0x1u; /* support for GET */
-static uint8_t const _cap_get_set = 0x3u; /* support for GET and SET */
+TU_STATIC uint8_t const _cap_get     = 0x1u; /* support for GET */
+TU_STATIC uint8_t const _cap_get_set = 0x3u; /* support for GET and SET */
 
 /** Get interface number from the interface descriptor
  *

--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -125,11 +125,11 @@ typedef struct TU_ATTR_PACKED {
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
-CFG_TUSB_MEM_SECTION TU_STATIC videod_interface_t _videod_itf[CFG_TUD_VIDEO];
-CFG_TUSB_MEM_SECTION TU_STATIC videod_streaming_interface_t _videod_streaming_itf[CFG_TUD_VIDEO_STREAMING];
+CFG_TUSB_MEM_SECTION static _fuzz_thread videod_interface_t _videod_itf[CFG_TUD_VIDEO];
+CFG_TUSB_MEM_SECTION static _fuzz_thread videod_streaming_interface_t _videod_streaming_itf[CFG_TUD_VIDEO_STREAMING];
 
-TU_STATIC uint8_t const _cap_get     = 0x1u; /* support for GET */
-TU_STATIC uint8_t const _cap_get_set = 0x3u; /* support for GET and SET */
+static _fuzz_thread uint8_t const _cap_get     = 0x1u; /* support for GET */
+static _fuzz_thread uint8_t const _cap_get_set = 0x3u; /* support for GET and SET */
 
 /** Get interface number from the interface descriptor
  *

--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -61,6 +61,13 @@
   #define TU_VERIFY_STATIC(const_expr, _mess) enum { TU_XSTRCAT(_verify_static_, _TU_COUNTER_) = 1/(!!(const_expr)) }
 #endif
 
+/* --------------------- Fuzzing types -------------------------------------- */
+#ifdef FUZZ
+  #define TU_STATIC __thread static
+#else
+  #define TU_STATIC static
+#endif
+
 // for declaration of reserved field, make use of _TU_COUNTER_
 #define TU_RESERVED           TU_XSTRCAT(reserved, _TU_COUNTER_)
 

--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -62,10 +62,10 @@
 #endif
 
 /* --------------------- Fuzzing types -------------------------------------- */
-#ifdef FUZZ
-  #define TU_STATIC __thread static
+#ifdef _FUZZ
+  #define _fuzz_thread __thread
 #else
-  #define TU_STATIC static
+  #define _fuzz_thread
 #endif
 
 // for declaration of reserved field, make use of _TU_COUNTER_

--- a/src/common/tusb_debug.h
+++ b/src/common/tusb_debug.h
@@ -114,7 +114,7 @@ typedef struct
 
 static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint32_t key)
 {
-  static char not_found[11];
+  TU_STATIC char not_found[11];
 
   for(uint16_t i=0; i<p_table->count; i++)
   {

--- a/src/common/tusb_debug.h
+++ b/src/common/tusb_debug.h
@@ -114,7 +114,7 @@ typedef struct
 
 static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint32_t key)
 {
-  TU_STATIC char not_found[11];
+  static _fuzz_thread char not_found[11];
 
   for(uint16_t i=0; i<p_table->count; i++)
   {

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -529,13 +529,13 @@ TU_ATTR_ALWAYS_INLINE static inline uint16_t tu_edpt_packet_size(tusb_desc_endpo
 #if CFG_TUSB_DEBUG
 TU_ATTR_ALWAYS_INLINE static inline const char *tu_edpt_dir_str(tusb_dir_t dir)
 {
-  TU_STATIC const char *str[] = {"out", "in"};
+  static _fuzz_thread const char *str[] = {"out", "in"};
   return str[dir];
 }
 
 TU_ATTR_ALWAYS_INLINE static inline const char *tu_edpt_type_str(tusb_xfer_type_t t)
 {
-  TU_STATIC const char *str[] = {"control", "isochronous", "bulk", "interrupt"};
+  static _fuzz_thread const char *str[] = {"control", "isochronous", "bulk", "interrupt"};
   return str[t];
 }
 #endif

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -529,13 +529,13 @@ TU_ATTR_ALWAYS_INLINE static inline uint16_t tu_edpt_packet_size(tusb_desc_endpo
 #if CFG_TUSB_DEBUG
 TU_ATTR_ALWAYS_INLINE static inline const char *tu_edpt_dir_str(tusb_dir_t dir)
 {
-  static const char *str[] = {"out", "in"};
+  TU_STATIC const char *str[] = {"out", "in"};
   return str[dir];
 }
 
 TU_ATTR_ALWAYS_INLINE static inline const char *tu_edpt_type_str(tusb_xfer_type_t t)
 {
-  static const char *str[] = {"control", "isochronous", "bulk", "interrupt"};
+  TU_STATIC const char *str[] = {"control", "isochronous", "bulk", "interrupt"};
   return str[t];
 }
 #endif

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -76,7 +76,7 @@ typedef struct
 
 }usbd_device_t;
 
-TU_STATIC usbd_device_t _usbd_dev;
+static _fuzz_thread usbd_device_t _usbd_dev;
 
 //--------------------------------------------------------------------+
 // Class Driver
@@ -88,7 +88,7 @@ TU_STATIC usbd_device_t _usbd_dev;
 #endif
 
 // Built-in class drivers
-TU_STATIC usbd_class_driver_t const _usbd_driver[] =
+static _fuzz_thread usbd_class_driver_t const _usbd_driver[] =
 {
   #if CFG_TUD_CDC
   {
@@ -238,8 +238,8 @@ TU_STATIC usbd_class_driver_t const _usbd_driver[] =
 enum { BUILTIN_DRIVER_COUNT = TU_ARRAY_SIZE(_usbd_driver) };
 
 // Additional class drivers implemented by application
-TU_STATIC usbd_class_driver_t const * _app_driver = NULL;
-TU_STATIC uint8_t _app_driver_count = 0;
+static _fuzz_thread usbd_class_driver_t const * _app_driver = NULL;
+static _fuzz_thread uint8_t _app_driver_count = 0;
 
 // virtually joins built-in and application drivers together.
 // Application is positioned first to allow overwriting built-in ones.
@@ -265,17 +265,17 @@ static inline usbd_class_driver_t const * get_driver(uint8_t drvid)
 //--------------------------------------------------------------------+
 
 enum { RHPORT_INVALID = 0xFFu };
-TU_STATIC uint8_t _usbd_rhport = RHPORT_INVALID;
+static _fuzz_thread uint8_t _usbd_rhport = RHPORT_INVALID;
 
 // Event queue
 // usbd_int_set() is used as mutex in OS NONE config
 OSAL_QUEUE_DEF(usbd_int_set, _usbd_qdef, CFG_TUD_TASK_QUEUE_SZ, dcd_event_t);
-TU_STATIC osal_queue_t _usbd_q;
+static _fuzz_thread osal_queue_t _usbd_q;
 
 // Mutex for claiming endpoint
 #if OSAL_MUTEX_REQUIRED
-  TU_STATIC osal_mutex_def_t _ubsd_mutexdef;
-  TU_STATIC osal_mutex_t _usbd_mutex;
+  static _fuzz_thread osal_mutex_def_t _ubsd_mutexdef;
+  static _fuzz_thread osal_mutex_t _usbd_mutex;
 #else
   #define _usbd_mutex   NULL
 #endif
@@ -299,7 +299,7 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t event,
 // Debug
 //--------------------------------------------------------------------+
 #if CFG_TUSB_DEBUG >= 2
-TU_STATIC char const* const _usbd_event_str[DCD_EVENT_COUNT] =
+static _fuzz_thread char const* const _usbd_event_str[DCD_EVENT_COUNT] =
 {
   "Invalid"        ,
   "Bus Reset"      ,

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -76,7 +76,7 @@ typedef struct
 
 }usbd_device_t;
 
-static usbd_device_t _usbd_dev;
+TU_STATIC usbd_device_t _usbd_dev;
 
 //--------------------------------------------------------------------+
 // Class Driver
@@ -88,7 +88,7 @@ static usbd_device_t _usbd_dev;
 #endif
 
 // Built-in class drivers
-static usbd_class_driver_t const _usbd_driver[] =
+TU_STATIC usbd_class_driver_t const _usbd_driver[] =
 {
   #if CFG_TUD_CDC
   {
@@ -238,8 +238,8 @@ static usbd_class_driver_t const _usbd_driver[] =
 enum { BUILTIN_DRIVER_COUNT = TU_ARRAY_SIZE(_usbd_driver) };
 
 // Additional class drivers implemented by application
-static usbd_class_driver_t const * _app_driver = NULL;
-static uint8_t _app_driver_count = 0;
+TU_STATIC usbd_class_driver_t const * _app_driver = NULL;
+TU_STATIC uint8_t _app_driver_count = 0;
 
 // virtually joins built-in and application drivers together.
 // Application is positioned first to allow overwriting built-in ones.
@@ -265,17 +265,17 @@ static inline usbd_class_driver_t const * get_driver(uint8_t drvid)
 //--------------------------------------------------------------------+
 
 enum { RHPORT_INVALID = 0xFFu };
-static uint8_t _usbd_rhport = RHPORT_INVALID;
+TU_STATIC uint8_t _usbd_rhport = RHPORT_INVALID;
 
 // Event queue
 // usbd_int_set() is used as mutex in OS NONE config
 OSAL_QUEUE_DEF(usbd_int_set, _usbd_qdef, CFG_TUD_TASK_QUEUE_SZ, dcd_event_t);
-static osal_queue_t _usbd_q;
+TU_STATIC osal_queue_t _usbd_q;
 
 // Mutex for claiming endpoint
 #if OSAL_MUTEX_REQUIRED
-  static osal_mutex_def_t _ubsd_mutexdef;
-  static osal_mutex_t _usbd_mutex;
+  TU_STATIC osal_mutex_def_t _ubsd_mutexdef;
+  TU_STATIC osal_mutex_t _usbd_mutex;
 #else
   #define _usbd_mutex   NULL
 #endif
@@ -299,7 +299,7 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t event,
 // Debug
 //--------------------------------------------------------------------+
 #if CFG_TUSB_DEBUG >= 2
-static char const* const _usbd_event_str[DCD_EVENT_COUNT] =
+TU_STATIC char const* const _usbd_event_str[DCD_EVENT_COUNT] =
 {
   "Invalid"        ,
   "Bus Reset"      ,

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -53,10 +53,10 @@ typedef struct
   usbd_control_xfer_cb_t complete_cb;
 } usbd_control_xfer_t;
 
-TU_STATIC usbd_control_xfer_t _ctrl_xfer;
+static _fuzz_thread usbd_control_xfer_t _ctrl_xfer;
 
 CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN
-TU_STATIC uint8_t _usbd_ctrl_buf[CFG_TUD_ENDPOINT0_SIZE];
+static _fuzz_thread uint8_t _usbd_ctrl_buf[CFG_TUD_ENDPOINT0_SIZE];
 
 //--------------------------------------------------------------------+
 // Application API

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -53,10 +53,10 @@ typedef struct
   usbd_control_xfer_cb_t complete_cb;
 } usbd_control_xfer_t;
 
-static usbd_control_xfer_t _ctrl_xfer;
+TU_STATIC usbd_control_xfer_t _ctrl_xfer;
 
 CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN
-static uint8_t _usbd_ctrl_buf[CFG_TUD_ENDPOINT0_SIZE];
+TU_STATIC uint8_t _usbd_ctrl_buf[CFG_TUD_ENDPOINT0_SIZE];
 
 //--------------------------------------------------------------------+
 // Application API

--- a/test/fuzz/dcd_fuzz.cc
+++ b/test/fuzz/dcd_fuzz.cc
@@ -39,7 +39,7 @@ struct State {
   uint8_t address;
 };
 
-static State state = {false, 0, 0};
+TU_STATIC State state = {false, 0, 0};
 
 //--------------------------------------------------------------------+
 // Controller API

--- a/test/fuzz/dcd_fuzz.cc
+++ b/test/fuzz/dcd_fuzz.cc
@@ -39,7 +39,7 @@ struct State {
   uint8_t address;
 };
 
-TU_STATIC State state = {false, 0, 0};
+static _fuzz_thread State state = {false, 0, 0};
 
 //--------------------------------------------------------------------+
 // Controller API

--- a/test/fuzz/device/msc/src/usb_descriptors.cc
+++ b/test/fuzz/device/msc/src/usb_descriptors.cc
@@ -44,7 +44,7 @@
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
 uint8_t const *tud_descriptor_device_cb(void) {
-  TU_STATIC tusb_desc_device_t const desc_device = {
+  static _fuzz_thread tusb_desc_device_t const desc_device = {
       .bLength = sizeof(tusb_desc_device_t),
       .bDescriptorType = TUSB_DESC_DEVICE,
       .bcdUSB = USB_BCD,
@@ -184,7 +184,7 @@ char const *string_desc_arr[] = {
 
 };
 
-TU_STATIC uint16_t _desc_str[32];
+static _fuzz_thread uint16_t _desc_str[32];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long

--- a/test/fuzz/device/msc/src/usb_descriptors.cc
+++ b/test/fuzz/device/msc/src/usb_descriptors.cc
@@ -44,7 +44,7 @@
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
 uint8_t const *tud_descriptor_device_cb(void) {
-  static tusb_desc_device_t const desc_device = {
+  TU_STATIC tusb_desc_device_t const desc_device = {
       .bLength = sizeof(tusb_desc_device_t),
       .bDescriptorType = TUSB_DESC_DEVICE,
       .bcdUSB = USB_BCD,
@@ -184,7 +184,7 @@ char const *string_desc_arr[] = {
 
 };
 
-static uint16_t _desc_str[32];
+TU_STATIC uint16_t _desc_str[32];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long

--- a/test/fuzz/device/net/src/usb_descriptors.cc
+++ b/test/fuzz/device/net/src/usb_descriptors.cc
@@ -45,7 +45,7 @@
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
 uint8_t const *tud_descriptor_device_cb(void) {
-  TU_STATIC tusb_desc_device_t const desc_device = {
+  static _fuzz_thread tusb_desc_device_t const desc_device = {
       .bLength = sizeof(tusb_desc_device_t),
       .bDescriptorType = TUSB_DESC_DEVICE,
       .bcdUSB = USB_BCD,
@@ -189,7 +189,7 @@ char const *string_desc_arr[] = {
     "TinyUSB CDC",              // 4: CDC Interface
 };
 
-TU_STATIC uint16_t _desc_str[32];
+static _fuzz_thread uint16_t _desc_str[32];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long

--- a/test/fuzz/device/net/src/usb_descriptors.cc
+++ b/test/fuzz/device/net/src/usb_descriptors.cc
@@ -45,7 +45,7 @@
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
 uint8_t const *tud_descriptor_device_cb(void) {
-  static tusb_desc_device_t const desc_device = {
+  TU_STATIC tusb_desc_device_t const desc_device = {
       .bLength = sizeof(tusb_desc_device_t),
       .bDescriptorType = TUSB_DESC_DEVICE,
       .bcdUSB = USB_BCD,
@@ -189,7 +189,7 @@ char const *string_desc_arr[] = {
     "TinyUSB CDC",              // 4: CDC Interface
 };
 
-static uint16_t _desc_str[32];
+TU_STATIC uint16_t _desc_str[32];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long

--- a/test/fuzz/make.mk
+++ b/test/fuzz/make.mk
@@ -79,7 +79,7 @@ CFLAGS += \
 	-Wno-error=unreachable-code \
   -DOPT_MCU_FUZZ=1 \
   -DCFG_TUSB_MCU=OPT_MCU_FUZZ \
-  -DFUZZ
+  -D_FUZZ
 
 CXXFLAGS += \
   -xc++ \

--- a/test/fuzz/make.mk
+++ b/test/fuzz/make.mk
@@ -78,7 +78,8 @@ CFLAGS += \
 CFLAGS += \
 	-Wno-error=unreachable-code \
   -DOPT_MCU_FUZZ=1 \
-  -DCFG_TUSB_MCU=OPT_MCU_FUZZ 
+  -DCFG_TUSB_MCU=OPT_MCU_FUZZ \
+  -DFUZZ
 
 CXXFLAGS += \
   -xc++ \


### PR DESCRIPTION
**Describe the PR**
Currently the AFL fuzzing engine makes the assumption that it can run a library in multiple threads without any shared state. To make this assumption consistent with tinyusb we need to make static globals thread local when fuzzing.

**Additional context**
_Discussed here:_
https://github.com/hathach/tinyusb/issues/1715#issuecomment-1396436517
_Actual issue here (see stability)_
https://oss-fuzz.com/fuzzer-stats?project=tinyusb&fuzzer=afl&job=afl_asan_tinyusb&group_by=by-fuzzer