### PR TITLE
add board: DshanMCU Pitaya Lite

### DIFF
--- a/hw/bsp/mm32/boards/mm32f327x_bluepillplus/board.mk
+++ b/hw/bsp/mm32/boards/mm32f327x_bluepillplus/board.mk
@@ -1,0 +1,8 @@
+LD_FILE = $(BOARD_PATH)/flash.ld
+SRC_S += $(SDK_DIR)/mm32f327x/MM32F327x/Source/GCC_StartAsm/startup_mm32m3ux_u_gcc.S
+
+# For flash-jlink target
+#JLINK_DEVICE = stm32f411ve
+
+# flash target using on-board stlink
+#flash: flash-jlink

--- a/hw/bsp/mm32/boards/mm32f327x_bluepillplus/board.mk
+++ b/hw/bsp/mm32/boards/mm32f327x_bluepillplus/board.mk
@@ -1,3 +1,6 @@
+CFLAGS += \
+	-DHSE_VALUE=8000000
+
 LD_FILE = $(BOARD_PATH)/flash.ld
 SRC_S += $(SDK_DIR)/mm32f327x/MM32F327x/Source/GCC_StartAsm/startup_mm32m3ux_u_gcc.S
 

--- a/hw/bsp/mm32/boards/mm32f327x_bluepillplus/flash.ld
+++ b/hw/bsp/mm32/boards/mm32f327x_bluepillplus/flash.ld
@@ -1,0 +1,163 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 MM32 SE TEAM
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = 0x2001FFFF;    /* end of RAM */
+
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K
+RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data : 
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+  
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/hw/bsp/mm32/boards/mm32f327x_bluepillplus/flash.ld
+++ b/hw/bsp/mm32/boards/mm32f327x_bluepillplus/flash.ld
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2020 MM32 SE TEAM
@@ -110,7 +110,7 @@ SECTIONS
   _sidata = LOADADDR(.data);
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
-  .data : 
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -121,7 +121,7 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
   } >RAM AT> FLASH
 
-  
+
   /* Uninitialized data section */
   . = ALIGN(4);
   .bss :
@@ -149,7 +149,7 @@ SECTIONS
     . = ALIGN(8);
   } >RAM
 
-  
+
 
   /* Remove information from the standard libraries */
   /DISCARD/ :

--- a/hw/bsp/mm32/boards/mm32f327x_bluepillplus/mm32f327x_bluepillplus.c
+++ b/hw/bsp/mm32/boards/mm32f327x_bluepillplus/mm32f327x_bluepillplus.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2020 MM32 SE TEAM
@@ -59,7 +59,7 @@ const int baudrate = 115200;
 
 void board_init (void)
 {
-//   usb clock	
+//   usb clock
   USB_DeviceClockInit();
 
   if ( SysTick_Config(SystemCoreClock / 1000) )

--- a/hw/bsp/mm32/boards/mm32f327x_bluepillplus/mm32f327x_bluepillplus.c
+++ b/hw/bsp/mm32/boards/mm32f327x_bluepillplus/mm32f327x_bluepillplus.c
@@ -1,0 +1,182 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 MM32 SE TEAM
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+/* WeAct BluePillPlus with MM32F3273G6P */
+
+#include "mm32_device.h"
+#include "hal_conf.h"
+#include "tusb.h"
+#include "../board.h"
+
+//--------------------------------------------------------------------+
+// Forward USB interrupt events to TinyUSB IRQ Handler
+//--------------------------------------------------------------------+
+void OTG_FS_IRQHandler (void)
+{
+  tud_int_handler(0);
+
+}
+void USB_DeviceClockInit (void)
+{
+  /* Select USBCLK source */
+  //  RCC_USBCLKConfig(RCC_USBCLKSource_PLLCLK_Div1);
+  RCC->CFGR &= ~(0x3 << 22);
+  RCC->CFGR |= (0x1 << 22);
+
+  /* Enable USB clock */
+  RCC->AHB2ENR |= 0x1 << 7;
+}
+//--------------------------------------------------------------------+
+// MACRO TYPEDEF CONSTANT ENUM DECLARATION
+//--------------------------------------------------------------------+
+// LED
+
+extern u32 SystemCoreClock;
+const int baudrate = 115200;
+
+void board_init (void)
+{
+//   usb clock	
+  USB_DeviceClockInit();
+
+  if ( SysTick_Config(SystemCoreClock / 1000) )
+  {
+    while ( 1 )
+      ;
+  }
+  NVIC_SetPriority(SysTick_IRQn, 0x0);
+
+  // LED on PB2
+  GPIO_InitTypeDef GPIO_InitStruct;
+  RCC_AHBPeriphClockCmd(RCC_AHBENR_GPIOB, ENABLE);
+  GPIO_StructInit(&GPIO_InitStruct);
+
+  GPIO_InitStruct.GPIO_Pin = GPIO_Pin_2;
+  GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
+  GPIO_InitStruct.GPIO_Mode = GPIO_Mode_Out_PP;
+  GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+  board_led_write(true);
+
+  // KEY on PA0
+  RCC_AHBPeriphClockCmd(RCC_AHBENR_GPIOA, ENABLE);
+  GPIO_StructInit(&GPIO_InitStruct);
+  GPIO_InitStruct.GPIO_Pin = GPIO_Pin_0;
+  GPIO_InitStruct.GPIO_Speed = GPIO_Speed_10MHz;
+  GPIO_InitStruct.GPIO_Mode = GPIO_Mode_IPD;
+  GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  // UART
+  UART_InitTypeDef UART_InitStruct;
+
+  RCC_APB2PeriphClockCmd(RCC_APB2ENR_UART1, ENABLE);    //enableUART1,GPIOAclock
+  RCC_AHBPeriphClockCmd(RCC_AHBENR_GPIOA, ENABLE);      //
+  //UART initialset
+
+  GPIO_PinAFConfig(GPIOA, GPIO_PinSource9, GPIO_AF_7);
+  GPIO_PinAFConfig(GPIOA, GPIO_PinSource10, GPIO_AF_7);
+
+  UART_StructInit(&UART_InitStruct);
+  UART_InitStruct.UART_BaudRate = baudrate;
+  UART_InitStruct.UART_WordLength = UART_WordLength_8b;
+  UART_InitStruct.UART_StopBits = UART_StopBits_1;    //one stopbit
+  UART_InitStruct.UART_Parity = UART_Parity_No;    //none odd-even  verify bit
+  UART_InitStruct.UART_HardwareFlowControl = UART_HardwareFlowControl_None;    //No hardware flow control
+  UART_InitStruct.UART_Mode = UART_Mode_Rx | UART_Mode_Tx;    // receive and sent  mode
+
+  UART_Init(UART1, &UART_InitStruct);    //initial uart 1
+  UART_Cmd(UART1, ENABLE);                    //enable uart 1
+
+  //UART1_TX   GPIOA.9
+  GPIO_StructInit(&GPIO_InitStruct);
+  GPIO_InitStruct.GPIO_Pin = GPIO_Pin_9;
+  GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
+  GPIO_InitStruct.GPIO_Mode = GPIO_Mode_AF_PP;
+  GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  //UART1_RX    GPIOA.10
+  GPIO_InitStruct.GPIO_Pin = GPIO_Pin_5;
+  GPIO_InitStruct.GPIO_Mode = GPIO_Mode_IPU;
+  GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+}
+
+
+//--------------------------------------------------------------------+
+// Board porting API
+//--------------------------------------------------------------------+
+
+void board_led_write (bool state)
+{
+  state ? (GPIO_ResetBits(GPIOB, GPIO_Pin_2)) : (GPIO_SetBits(GPIOB, GPIO_Pin_2));
+}
+
+uint32_t board_button_read (void)
+{
+  uint32_t key = GPIO_ReadInputDataBit(GPIOA, GPIO_Pin_0) == Bit_SET;
+  return key;
+}
+
+int board_uart_read (uint8_t *buf, int len)
+{
+  (void) buf;
+  (void) len;
+  return 0;
+}
+
+int board_uart_write (void const *buf, int len)
+{
+  const char *buff = buf;
+  while ( len )
+  {
+    while ( (UART1->CSR & UART_IT_TXIEN) == 0 )
+      ;    //The loop is sent until it is finished
+    UART1->TDR = (*buff & 0xFF);
+    buff++;
+    len--;
+  }
+  return len;
+}
+
+#if CFG_TUSB_OS == OPT_OS_NONE
+volatile uint32_t system_ticks = 0;
+void SysTick_Handler (void)
+{
+  system_ticks++;
+}
+
+uint32_t board_millis (void)
+{
+  return system_ticks;
+}
+#endif
+
+// Required by __libc_init_array in startup code if we are compiling using
+// -nostdlib/-nostartfiles.
+void _init(void)
+{
+
+}

--- a/hw/bsp/mm32/boards/mm32f327x_mb39/board.mk
+++ b/hw/bsp/mm32/boards/mm32f327x_mb39/board.mk
@@ -1,5 +1,9 @@
+CFLAGS += \
+	-DHSE_VALUE=8000000
+
 LD_FILE = $(BOARD_PATH)/flash.ld
 SRC_S += $(SDK_DIR)/mm32f327x/MM32F327x/Source/GCC_StartAsm/startup_mm32m3ux_u_gcc.S
+
 
 # For flash-jlink target
 #JLINK_DEVICE = stm32f411ve

--- a/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/board.mk
+++ b/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/board.mk
@@ -1,3 +1,6 @@
+CFLAGS += \
+	-DHSE_VALUE=12000000
+
 LD_FILE = $(BOARD_PATH)/flash.ld
 SRC_S += $(SDK_DIR)/mm32f327x/MM32F327x/Source/GCC_StartAsm/startup_mm32m3ux_u_gcc.S
 

--- a/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/board.mk
+++ b/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/board.mk
@@ -1,0 +1,8 @@
+LD_FILE = $(BOARD_PATH)/flash.ld
+SRC_S += $(SDK_DIR)/mm32f327x/MM32F327x/Source/GCC_StartAsm/startup_mm32m3ux_u_gcc.S
+
+# For flash-jlink target
+#JLINK_DEVICE = MM32F3273G8P
+
+# flash target using on-board stlink
+#flash: flash-jlink

--- a/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/flash.ld
+++ b/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/flash.ld
@@ -1,0 +1,163 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 MM32 SE TEAM
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = 0x2001FFFF;    /* end of RAM */
+
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K
+RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data : 
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+  
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/flash.ld
+++ b/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/flash.ld
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2020 MM32 SE TEAM
@@ -110,7 +110,7 @@ SECTIONS
   _sidata = LOADADDR(.data);
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
-  .data : 
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -121,7 +121,7 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
   } >RAM AT> FLASH
 
-  
+
   /* Uninitialized data section */
   . = ALIGN(4);
   .bss :
@@ -149,7 +149,7 @@ SECTIONS
     . = ALIGN(8);
   } >RAM
 
-  
+
 
   /* Remove information from the standard libraries */
   /DISCARD/ :

--- a/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/mm32f327x_pitaya_lite.c
+++ b/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/mm32f327x_pitaya_lite.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2020 MM32 SE TEAM

--- a/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/mm32f327x_pitaya_lite.c
+++ b/hw/bsp/mm32/boards/mm32f327x_pitaya_lite/mm32f327x_pitaya_lite.c
@@ -1,0 +1,182 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 MM32 SE TEAM
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+/* DshanMCU Pitaya Lite with MM32F3273 */
+
+#include "mm32_device.h"
+#include "hal_conf.h"
+#include "tusb.h"
+#include "../board.h"
+
+//--------------------------------------------------------------------+
+// Forward USB interrupt events to TinyUSB IRQ Handler
+//--------------------------------------------------------------------+
+void OTG_FS_IRQHandler (void)
+{
+  tud_int_handler(0);
+
+}
+void USB_DeviceClockInit (void)
+{
+  /* Select USBCLK source */
+  //  RCC_USBCLKConfig(RCC_USBCLKSource_PLLCLK_Div1);
+  RCC->CFGR &= ~(0x3 << 22);
+  RCC->CFGR |= (0x1 << 22);
+
+  /* Enable USB clock */
+  RCC->AHB2ENR |= 0x1 << 7;
+}
+//--------------------------------------------------------------------+
+// MACRO TYPEDEF CONSTANT ENUM DECLARATION
+//--------------------------------------------------------------------+
+// LED
+
+extern u32 SystemCoreClock;
+const int baudrate = 115200;
+
+void board_init (void)
+{
+//   usb clock
+// requires SYSCLK_FREQ_XXMHz  (HSE_VALUE*8) in system_mm32f327x.c
+  USB_DeviceClockInit();
+
+  if ( SysTick_Config(SystemCoreClock / 1000) )
+  {
+    while ( 1 )
+      ;
+  }
+  NVIC_SetPriority(SysTick_IRQn, 0x0);
+
+  // LED on PA1
+  GPIO_InitTypeDef GPIO_InitStruct;
+  RCC_AHBPeriphClockCmd(RCC_AHBENR_GPIOA, ENABLE);
+  GPIO_StructInit(&GPIO_InitStruct);
+
+  GPIO_InitStruct.GPIO_Pin = GPIO_Pin_1;
+  GPIO_InitStruct.GPIO_Speed = GPIO_Speed_10MHz;
+  GPIO_InitStruct.GPIO_Mode = GPIO_Mode_Out_PP;
+  GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  board_led_write(true);
+
+  // KEY on PA0
+  GPIO_StructInit(&GPIO_InitStruct);
+  GPIO_InitStruct.GPIO_Pin = GPIO_Pin_0;
+  GPIO_InitStruct.GPIO_Speed = GPIO_Speed_10MHz;
+  GPIO_InitStruct.GPIO_Mode = GPIO_Mode_FLOATING;
+  GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  // UART
+  UART_InitTypeDef UART_InitStruct;
+
+  RCC_APB2PeriphClockCmd(RCC_APB2ENR_UART1, ENABLE);    //enableUART1,GPIOAclock
+  RCC_AHBPeriphClockCmd(RCC_AHBENR_GPIOA, ENABLE);      //
+  //UART initialset
+
+  GPIO_PinAFConfig(GPIOA, GPIO_PinSource9, GPIO_AF_7);
+  GPIO_PinAFConfig(GPIOA, GPIO_PinSource10, GPIO_AF_7);
+
+  UART_StructInit(&UART_InitStruct);
+  UART_InitStruct.UART_BaudRate = baudrate;
+  UART_InitStruct.UART_WordLength = UART_WordLength_8b;
+  UART_InitStruct.UART_StopBits = UART_StopBits_1;    //one stopbit
+  UART_InitStruct.UART_Parity = UART_Parity_No;    //none odd-even  verify bit
+  UART_InitStruct.UART_HardwareFlowControl = UART_HardwareFlowControl_None;    //No hardware flow control
+  UART_InitStruct.UART_Mode = UART_Mode_Rx | UART_Mode_Tx;    // receive and sent  mode
+
+  UART_Init(UART1, &UART_InitStruct);    //initial uart 1
+  UART_Cmd(UART1, ENABLE);                    //enable uart 1
+
+  //UART1_TX   GPIOA.9
+  GPIO_StructInit(&GPIO_InitStruct);
+  GPIO_InitStruct.GPIO_Pin = GPIO_Pin_9;
+  GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
+  GPIO_InitStruct.GPIO_Mode = GPIO_Mode_AF_PP;
+  GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  //UART1_RX    GPIOA.10
+  GPIO_InitStruct.GPIO_Pin = GPIO_Pin_5;
+  GPIO_InitStruct.GPIO_Mode = GPIO_Mode_IPU;
+  GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+}
+
+
+//--------------------------------------------------------------------+
+// Board porting API
+//--------------------------------------------------------------------+
+
+void board_led_write (bool state)
+{
+  state ? (GPIO_ResetBits(GPIOA, GPIO_Pin_1)) : (GPIO_SetBits(GPIOA, GPIO_Pin_1));
+}
+
+uint32_t board_button_read (void)
+{
+  uint32_t key = GPIO_ReadInputDataBit(GPIOA, GPIO_Pin_0) == Bit_RESET;
+  return key;
+}
+
+int board_uart_read (uint8_t *buf, int len)
+{
+  (void) buf;
+  (void) len;
+  return 0;
+}
+
+int board_uart_write (void const *buf, int len)
+{
+  const char *buff = buf;
+  while ( len )
+  {
+    while ( (UART1->CSR & UART_IT_TXIEN) == 0 )
+      ;    //The loop is sent until it is finished
+    UART1->TDR = (*buff & 0xFF);
+    buff++;
+    len--;
+  }
+  return len;
+}
+
+#if CFG_TUSB_OS == OPT_OS_NONE
+volatile uint32_t system_ticks = 0;
+void SysTick_Handler (void)
+{
+  system_ticks++;
+}
+
+uint32_t board_millis (void)
+{
+  return system_ticks;
+}
+#endif
+
+// Required by __libc_init_array in startup code if we are compiling using
+// -nostdlib/-nostartfiles.
+void _init(void)
+{
+
+}

--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -20,7 +20,7 @@ deps_optional = {
     'hw/mcu/gd/nuclei-sdk'                     : ['7eb7bfa9ea4fbeacfafe1d5f77d5a0e6ed3922e7', 'https://github.com/Nuclei-Software/nuclei-sdk.git'             ],
     'hw/mcu/infineon/mtb-xmclib-cat3'          : ['daf5500d03cba23e68c2f241c30af79cd9d63880', 'https://github.com/Infineon/mtb-xmclib-cat3.git'               ],
     'hw/mcu/microchip'                         : ['9e8b37e307d8404033bb881623a113931e1edf27', 'https://github.com/hathach/microchip_driver.git'               ],
-    'hw/mcu/mindmotion/mm32sdk'                : ['f6e458fea77074990ce011e3716c08cfeddbd6d5', 'https://github.com/hathach/mm32sdk.git'                        ],
+    'hw/mcu/mindmotion/mm32sdk'                : ['0b79559eb411149d36e073c1635c620e576308d4', 'https://github.com/hathach/mm32sdk.git'                        ],
     'hw/mcu/nordic/nrfx'                       : ['281cc2e178fd9a470d844b3afdea9eb322a0b0e8', 'https://github.com/NordicSemiconductor/nrfx.git'               ],
     'hw/mcu/nuvoton'                           : ['2204191ec76283371419fbcec207da02e1bc22fa', 'https://github.com/majbthrd/nuc_driver.git'                    ],
     'hw/mcu/nxp/lpcopen'                       : ['43c45c85405a5dd114fff0ea95cca62837740c13', 'https://github.com/hathach/nxp_lpcopen.git'                    ],

--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -20,7 +20,7 @@ deps_optional = {
     'hw/mcu/gd/nuclei-sdk'                     : ['7eb7bfa9ea4fbeacfafe1d5f77d5a0e6ed3922e7', 'https://github.com/Nuclei-Software/nuclei-sdk.git'             ],
     'hw/mcu/infineon/mtb-xmclib-cat3'          : ['daf5500d03cba23e68c2f241c30af79cd9d63880', 'https://github.com/Infineon/mtb-xmclib-cat3.git'               ],
     'hw/mcu/microchip'                         : ['9e8b37e307d8404033bb881623a113931e1edf27', 'https://github.com/hathach/microchip_driver.git'               ],
-    'hw/mcu/mindmotion/mm32sdk'                : ['708a7152952ac595d24837069dcc0f7f59a4c30b', 'https://github.com/hathach/mm32sdk.git'                        ],
+    'hw/mcu/mindmotion/mm32sdk'                : ['f6e458fea77074990ce011e3716c08cfeddbd6d5', 'https://github.com/hathach/mm32sdk.git'                        ],
     'hw/mcu/nordic/nrfx'                       : ['281cc2e178fd9a470d844b3afdea9eb322a0b0e8', 'https://github.com/NordicSemiconductor/nrfx.git'               ],
     'hw/mcu/nuvoton'                           : ['2204191ec76283371419fbcec207da02e1bc22fa', 'https://github.com/majbthrd/nuc_driver.git'                    ],
     'hw/mcu/nxp/lpcopen'                       : ['43c45c85405a5dd114fff0ea95cca62837740c13', 'https://github.com/hathach/nxp_lpcopen.git'                    ],


### PR DESCRIPTION
**Describe the PR**
This PR adds support for DshanMCU Pitaya Lite and Blue Pill boards with MM32F3273 cpu.

**Additional context**
I have tested tinyusb on:
- [DshanMCU Pitaya Lite](https://gitee.com/weidongshan/DshanMCU-Pitaya-c) with MM32F3273G8P
- WeAct Blue Pill boards with the STM32F103 replaced by a MM32F3273G6P

tinyusb works, but care has to be taken to choose the correct  SYSCLK_FREQ.

For the MM32F3273 with a 12 MHz crystal, in ``tinyusb/hw/mcu/mindmotion/mm32sdk/mm32f327x/MM32F327x/Source/system_mm32f327x.c`` choose 
```
#define SYSCLK_FREQ_XXMHz  (HSE_VALUE*8)      //96000000 based HSE_VALUE = 12000000
```

For the MM32F3273 with a 8 MHz crystal, choose
```
#define SYSCLK_FREQ_XXMHz  (HSE_VALUE*12)      //96000000 based HSE_VALUE = 8000000
```
Thank you for your useful software.
