### PR TITLE
dhserver: Fix a potential DoS vulnerability accidentially introduced by #1712

### DIFF
--- a/lib/networking/dhserver.c
+++ b/lib/networking/dhserver.c
@@ -86,7 +86,7 @@ typedef struct
     uint8_t  dp_giaddr[4];    /* gateway IP address */
     uint8_t  dp_chaddr[16];   /* client hardware address */
     uint8_t  dp_legacy[192];
-    uint8_t  dp_magic[4];     
+    uint8_t  dp_magic[4];
     uint8_t  dp_options[275]; /* options area */
 } DHCP_TYPE;
 
@@ -242,7 +242,11 @@ static void udp_recv_proc(void *arg, struct udp_pcb *upcb, struct pbuf *p, const
 	memcpy(&dhcp_data, p->payload, n);
 
 	ptr = find_dhcp_option(dhcp_data.dp_options, sizeof(dhcp_data.dp_options), DHCP_MESSAGETYPE);
-	if (ptr == NULL) return;
+	if (ptr == NULL)
+	{
+		pbuf_free(p);
+		return;
+	}
 
 	switch (ptr[2])
 	{


### PR DESCRIPTION
**Describe the PR**
My fix in dhcpserver.c for some DHCP clients (#1712) accidentally introduced a potential DoS vulnerability (I'm sorry!): In case a DHCP-packet WITHOUT `DHCP_MESSAGETYPE` was received, the code jumped out of the function without freeing the pbuf as it is required. When enough such messages are received, not pbufs are available anymore to handle traffic and the system might not be able to receive any more packets.
This PR fixes the problem by properly free()ing the pbuf in case no `DHCP_MESSAGETYPE` is detected in the packet.

Plus a trivial whitespace fix.