### PR TITLE
Adjust reserved bitfields to make SDCC happy

### DIFF
--- a/src/class/cdc/cdc.h
+++ b/src/class/cdc/cdc.h
@@ -377,7 +377,9 @@ typedef struct TU_ATTR_PACKED
     uint32_t incoming_distinctive   : 1; ///< 0 : Reports only incoming ringing. 1 : Reports incoming distinctive ringing patterns.
     uint32_t dual_tone_multi_freq   : 1; ///< 0 : Cannot report dual tone multi-frequency (DTMF) digits input remotely over the telephone line. 1 : Can report DTMF digits input remotely over the telephone line.
     uint32_t line_state_change      : 1; ///< 0 : Does not support line state change notification. 1 : Does support line state change notification
-    uint32_t TU_RESERVED            : 26;
+    uint32_t TU_RESERVED0           : 2;
+    uint32_t TU_RESERVED1           : 16;
+    uint32_t TU_RESERVED2           : 4;
   } bmCapabilities;
 }cdc_desc_func_telephone_call_state_reporting_capabilities_t;
 
@@ -404,7 +406,8 @@ typedef struct TU_ATTR_PACKED
 {
   uint16_t dtr : 1;
   uint16_t rts : 1;
-  uint16_t : 14;
+  uint16_t : 6;
+  uint16_t : 8;
 } cdc_line_control_state_t;
 
 TU_VERIFY_STATIC(sizeof(cdc_line_control_state_t) == 2, "size is not correct");


### PR DESCRIPTION
The open-source SDCC compiler has many limitations, but I have managed, after considerable hacking, to compile TinyUSB with it. This is one issue that I think is legitimately universal: compiler-specific assumptions about bitfield alignment which are implementation-defined per the Standard. Please see [the discussion with the SDCC maintainers](https://sourceforge.net/p/sdcc/bugs/3530/).


**Describe the PR**
This PR tweaks some reserved bitfields so the assumptions made elsewhere in the code (particularly in an assert) are more portable, and so they hew to implementation-defined limits on size. In particular:

- keep each field at or under 16b
- For optimal packing, segment bitfields to 8b boundaries

**Additional context**
N/A

If merged this will resolve #1892 