### PR TITLE
Turn data cache on

### DIFF
--- a/hw/bsp/imxrt/family.c
+++ b/hw/bsp/imxrt/family.c
@@ -55,6 +55,12 @@ const uint8_t dcd_data[] = { 0x00 };
 
 void board_init(void)
 {
+  // make sure the dcache is on.
+#if defined(__DCACHE_PRESENT) && __DCACHE_PRESENT
+    if (SCB_CCR_DC_Msk != (SCB_CCR_DC_Msk & SCB->CCR))
+        SCB_EnableDCache();
+#endif
+
   // Init clock
   BOARD_BootClockRUN();
   SystemCoreClockUpdate();


### PR DESCRIPTION
This fixes https://github.com/hathach/tinyusb/issues/1894.  I'm not really sure if this is the correct way to fix it, and I have not tested on all the rest of the family members, however, this lets the i.MX1010 work again.

The problem:  the latest SDK update does not enable the data cache by default This causes an assert in board_init() when attemping to control clock gating.  I haven't investigated further as to *why* it's a problem, but it is a problem.

**Describe the PR**
This PR solves an issue with the latest SDK, as reported in 1984.

**Additional context**
On the i.MX RT 1011, the board immediately crashes here:
```
Thread #1 57005 (Suspended : Signal : SIGTRAP:Trace/breakpoint trap)	
	HardFault_Handler() at startup_MIMXRT1011.S:457 0x600024ea	
	<signal handler called>() at 0xfffffff9	
	_vfprintf_r() at nano-vfprintf.c:531 0x60010660	
	fprintf() at fprintf.c:54 0x60010302	
	__assert_func() at assert.c:58 0x600102a8	
	CLOCK_ControlGate() at fsl_clock.h:1,085 0x60004640	
	CLOCK_EnableClock() at fsl_clock.h:1,098 0x60004692	
	GPIO_PinInit() at fsl_gpio.c:84 0x6000474a	
	board_init() at family.c:81 0x6000541e	
	main() at main.c:99 0x60005786	
```

Once the data cache is enabled, everything works swimmingly again.
