### PR TITLE
For STM32H7 BSP boards, initialize RCC_...TypeDef structs as empty

### DIFF
--- a/hw/bsp/stm32h7/boards/daisyseed/board.h
+++ b/hw/bsp/stm32h7/boards/daisyseed/board.h
@@ -57,9 +57,9 @@
 //--------------------------------------------------------------------+
 static inline void board_stm32h7_clock_init(void)
 {
-  RCC_ClkInitTypeDef RCC_ClkInitStruct;
-  RCC_OscInitTypeDef RCC_OscInitStruct;
-  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
+  RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
+  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = { 0 };
 
   /*!< Supply configuration update enable */
   /* For STM32H750XB, use "HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);" */

--- a/hw/bsp/stm32h7/boards/stm32h723nucleo/board.h
+++ b/hw/bsp/stm32h7/boards/stm32h723nucleo/board.h
@@ -64,8 +64,8 @@
 //--------------------------------------------------------------------+
 static inline void board_stm32h7_clock_init(void)
 {
-  RCC_ClkInitTypeDef RCC_ClkInitStruct;
-  RCC_OscInitTypeDef RCC_OscInitStruct;
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
+  RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
 
   /* The PWR block is always enabled on the H7 series- there is no clock
      enable. For now, use the default VOS3 scale mode (lowest) and limit clock

--- a/hw/bsp/stm32h7/boards/stm32h723nucleo/board.h
+++ b/hw/bsp/stm32h7/boards/stm32h723nucleo/board.h
@@ -111,7 +111,7 @@ static inline void board_stm32h7_clock_init(void)
      separate. However, the main system PLL (PLL1) doesn't have a direct
      connection to the USB peripheral clock to generate 48 MHz, so we do this
      dance. This will connect PLL1's Q output to the USB peripheral clock. */
-  RCC_PeriphCLKInitTypeDef RCC_PeriphCLKInitStruct;
+  RCC_PeriphCLKInitTypeDef RCC_PeriphCLKInitStruct = { 0 };
 
   RCC_PeriphCLKInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
   RCC_PeriphCLKInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_PLL;

--- a/hw/bsp/stm32h7/boards/stm32h743eval/board.h
+++ b/hw/bsp/stm32h7/boards/stm32h743eval/board.h
@@ -63,9 +63,9 @@
 //--------------------------------------------------------------------+
 static inline void board_stm32h7_clock_init(void)
 {
-  RCC_ClkInitTypeDef RCC_ClkInitStruct;
-  RCC_OscInitTypeDef RCC_OscInitStruct;
-  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
+  RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
+  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = { 0 };
 
   /*!< Supply configuration update enable */
   HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);

--- a/hw/bsp/stm32h7/boards/stm32h743nucleo/board.h
+++ b/hw/bsp/stm32h7/boards/stm32h743nucleo/board.h
@@ -102,7 +102,7 @@ static inline void board_stm32h7_clock_init(void)
      separate. However, the main system PLL (PLL1) doesn't have a direct
      connection to the USB peripheral clock to generate 48 MHz, so we do this
      dance. This will connect PLL1's Q output to the USB peripheral clock. */
-  RCC_PeriphCLKInitTypeDef RCC_PeriphCLKInitStruct;
+  RCC_PeriphCLKInitTypeDef RCC_PeriphCLKInitStruct = { 0 };
 
   RCC_PeriphCLKInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
   RCC_PeriphCLKInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_PLL;

--- a/hw/bsp/stm32h7/boards/stm32h743nucleo/board.h
+++ b/hw/bsp/stm32h7/boards/stm32h743nucleo/board.h
@@ -55,8 +55,8 @@
 //--------------------------------------------------------------------+
 static inline void board_stm32h7_clock_init(void)
 {
-  RCC_ClkInitTypeDef RCC_ClkInitStruct;
-  RCC_OscInitTypeDef RCC_OscInitStruct;
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
+  RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
 
   /* The PWR block is always enabled on the H7 series- there is no clock
      enable. For now, use the default VOS3 scale mode (lowest) and limit clock

--- a/hw/bsp/stm32h7/boards/stm32h745disco/board.h
+++ b/hw/bsp/stm32h7/boards/stm32h745disco/board.h
@@ -57,9 +57,9 @@
 //--------------------------------------------------------------------+
 static inline void board_stm32h7_clock_init(void)
 {
-  RCC_ClkInitTypeDef RCC_ClkInitStruct;
-  RCC_OscInitTypeDef RCC_OscInitStruct;
-  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
+  RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
+  RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
+  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = { 0 };
 
   /*!< Supply configuration update enable */
   /* For STM32H750XB, use "HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);" */


### PR DESCRIPTION
Following how ST's CubeMX/CubeIDE tools generate RCC init structs and general best practice for usage of a struct like this, instances of `RCC_ClkInitTypeDef`, `RCC_OscInitTypeDef`, and `RCC_PeriphClkInitTypeDef` should all be initialized as empty with `= {0};`. I've confirmed that failing to do this in the stm32h723nucleo example causes some undefined behavior when implementing a TUSB stack on my own STM32H723 board (I didn't use the example directly but I lifted the contents of the
`board_stm32h7_clock_init()` function and tested both with/without initializing the struct). 

From looking at the examples, the initialization may not be needed in all cases since the subsequent population of struct members is sufficient to eliminate any issues, but just to be consistent I applied the change to all occurrences of the aforementioned structs in the STM32H7 BSP examples.

This is my first PR on Github so apologies in advance if I've made any errors; I know this is a fairly minor set of changes but thought it would be good to include.