### PR TITLE
fix: Fix wrong destsz used with tu_memcpy_s

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -2290,7 +2290,7 @@ bool tud_audio_buffer_and_schedule_control_xfer(uint8_t rhport, tusb_control_req
   if (len > _audiod_fct[func_id].ctrl_buf_sz) len = _audiod_fct[func_id].ctrl_buf_sz;
 
   // Copy into buffer
-  TU_VERIFY(0 == tu_memcpy_s(_audiod_fct[func_id].ctrl_buf, sizeof(_audiod_fct[func_id].ctrl_buf), data, (size_t)len));
+  TU_VERIFY(0 == tu_memcpy_s(_audiod_fct[func_id].ctrl_buf, _audiod_fct[func_id].ctrl_buf_sz, data, (size_t)len));
 
   // Schedule transmit
   return tud_control_xfer(rhport, p_request, (void*)_audiod_fct[func_id].ctrl_buf, len);


### PR DESCRIPTION
Bug: #1935

**Describe the PR**
There was a bug introduced in https://github.com/hathach/tinyusb/pull/1852#issuecomment-1455102835, that was filed in #1935. I'm hoping that this fixes the issue.