### PR TITLE
rp2040: include hardware/sync.h explicitly

### DIFF
--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -29,6 +29,7 @@
 #if CFG_TUD_ENABLED && (CFG_TUSB_MCU == OPT_MCU_RP2040) && !CFG_TUD_RPI_PIO_USB
 
 #include "pico.h"
+#include "hardware/sync.h"
 #include "rp2040_usb.h"
 
 #if TUD_OPT_RP2040_USB_DEVICE_ENUMERATION_FIX


### PR DESCRIPTION
- Fixes #1944.

https://github.com/hathach/tinyusb/blob/990fb6ae5c4d9d4b77c5a9ecb3a2abe899dd2712/src/portable/raspberrypi/rp2040/dcd_rp2040.c#L300
`dcd_rp2040.c` uses `remove_volatile_cast()`, which is defined in the `pico-sdk` in `hardware/sync.h`. But `dcd_rp2040.c` does not `#include hardware/sync.h`. When not using the `pico-sdk` build environment and `OSAL_PICO`, `remove_volatile_cast()` will not be defined. This PR adds an explicit `#include` to fix that.
