### PR TITLE
Fix old picosdk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+#
+# SPDX-License-Identifier: Unlicense
+
+repos:
+-   repo: local
+    hooks:
+    -   id: codespell
+        name: codespell
+        entry: codespell
+        types_or: [c, header]
+        language: system
+
+    -   id: unit-test
+        name: unit-test
+        files: ^(src/|test/unit-test/)
+        entry: sh -c "cd test/unit-test && ceedling test:all"
+        pass_filenames: false
+        types_or: [c, header]
+        language: system

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -385,6 +385,11 @@ static void __tusb_irq_path_func(dcd_rp2040_irq)(void)
 /* Controller API
  *------------------------------------------------------------------*/
 
+// older SDK
+#ifndef PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY
+#define PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY 0xff
+#endif
+
 void dcd_init (uint8_t rhport)
 {
   assert(rhport == 0);


### PR DESCRIPTION
**Describe the PR**
- PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY is not defined in old sdk e.g arduino mbed core.
- Also add pre-commit yaml to run codespell and unit-test (locally)