### PR TITLE
fix HAL_Delay no effect bug on st platform

### DIFF
--- a/hw/bsp/stm32f0/family.c
+++ b/hw/bsp/stm32f0/family.c
@@ -143,6 +143,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32f1/family.c
+++ b/hw/bsp/stm32f1/family.c
@@ -129,6 +129,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32f207nucleo/stm32f207nucleo.c
+++ b/hw/bsp/stm32f207nucleo/stm32f207nucleo.c
@@ -191,6 +191,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32f303disco/stm32f303disco.c
+++ b/hw/bsp/stm32f303disco/stm32f303disco.c
@@ -193,6 +193,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32f4/family.c
+++ b/hw/bsp/stm32f4/family.c
@@ -180,6 +180,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32f7/family.c
+++ b/hw/bsp/stm32f7/family.c
@@ -293,6 +293,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32g4/family.c
+++ b/hw/bsp/stm32g4/family.c
@@ -167,6 +167,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32h7/family.c
+++ b/hw/bsp/stm32h7/family.c
@@ -251,6 +251,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler(void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32l0/family.c
+++ b/hw/bsp/stm32l0/family.c
@@ -141,6 +141,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32l0538disco/stm32l0538disco.c
+++ b/hw/bsp/stm32l0538disco/stm32l0538disco.c
@@ -183,6 +183,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32l4/family.c
+++ b/hw/bsp/stm32l4/family.c
@@ -204,6 +204,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32u5/family.c
+++ b/hw/bsp/stm32u5/family.c
@@ -179,6 +179,7 @@ int board_uart_write(void const *buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler(void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 

--- a/hw/bsp/stm32wb/family.c
+++ b/hw/bsp/stm32wb/family.c
@@ -169,6 +169,7 @@ int board_uart_write(void const * buf, int len)
 volatile uint32_t system_ticks = 0;
 void SysTick_Handler (void)
 {
+  HAL_IncTick();
   system_ticks++;
 }
 


### PR DESCRIPTION
**Describe the PR**
fix `HAL_Delay` no effect bug on st platform

**Additional context**

due overwrite `SysTick_Handler`, so when my hardware driver call `HAL_Delay` function ,it's can work!!!.  add `HAL_IncTick` in `SysTick_Handler`