### PR TITLE
more compatible with IAR

### DIFF
--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -36,8 +36,8 @@
 #define __tusb_irq_path_func(x) x
 #endif
 
-#define usb_hw_set    ((usb_hw_t *) hw_set_alias(usb_hw))
-#define usb_hw_clear  ((usb_hw_t *) hw_clear_alias(usb_hw))
+#define usb_hw_set    ((usb_hw_t *) hw_set_alias_untyped(usb_hw))
+#define usb_hw_clear  ((usb_hw_t *) hw_clear_alias_untyped(usb_hw))
 
 #define pico_info(...)  TU_LOG(2, __VA_ARGS__)
 #define pico_trace(...) TU_LOG(3, __VA_ARGS__)


### PR DESCRIPTION
**Describe the PR**

It should read

```
#define usb_hw_set    ((usb_hw_t *) hw_set_alias_untyped(usb_hw))
#define usb_hw_clear  ((usb_hw_t *) hw_clear_alias_untyped(usb_hw))
```
(Note the `hw_xxx_alias_untyped` vs `hw_xxx_alias`)

_Originally posted by @kilograham in https://github.com/hathach/tinyusb/issues/1639#issuecomment-1474874082_
            