### PR TITLE
Refactor hid host

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   rev: v2.2.4
   hooks:
   - id: codespell
-    #args: [-w]
+    args: [-w]
     exclude: ^lib/
 
 - repo: local

--- a/examples/dual/host_hid_to_device_cdc/src/tusb_config.h
+++ b/examples/dual/host_hid_to_device_cdc/src/tusb_config.h
@@ -132,7 +132,7 @@
 // max device support (excluding hub device)
 #define CFG_TUH_DEVICE_MAX          (CFG_TUH_HUB ? 4 : 1) // hub typically has 4 ports
 
-#define CFG_TUH_HID                  4
+#define CFG_TUH_HID                 (4*CFG_TUH_DEVICE_MAX)
 #define CFG_TUH_HID_EPIN_BUFSIZE    64
 #define CFG_TUH_HID_EPOUT_BUFSIZE   64
 

--- a/examples/dual/host_hid_to_device_cdc/src/tusb_config.h
+++ b/examples/dual/host_hid_to_device_cdc/src/tusb_config.h
@@ -132,7 +132,7 @@
 // max device support (excluding hub device)
 #define CFG_TUH_DEVICE_MAX          (CFG_TUH_HUB ? 4 : 1) // hub typically has 4 ports
 
-#define CFG_TUH_HID                 (4*CFG_TUH_DEVICE_MAX)
+#define CFG_TUH_HID                 (3*CFG_TUH_DEVICE_MAX)
 #define CFG_TUH_HID_EPIN_BUFSIZE    64
 #define CFG_TUH_HID_EPOUT_BUFSIZE   64
 

--- a/examples/host/cdc_msc_hid/src/cdc_app.c
+++ b/examples/host/cdc_msc_hid/src/cdc_app.c
@@ -87,10 +87,10 @@ void tuh_cdc_rx_cb(uint8_t idx)
 
 void tuh_cdc_mount_cb(uint8_t idx)
 {
-  tuh_cdc_itf_info_t itf_info = { 0 };
+  tuh_itf_info_t itf_info = { 0 };
   tuh_cdc_itf_get_info(idx, &itf_info);
 
-  printf("CDC Interface is mounted: address = %u, itf_num = %u\r\n", itf_info.daddr, itf_info.bInterfaceNumber);
+  printf("CDC Interface is mounted: address = %u, itf_num = %u\r\n", itf_info.daddr, itf_info.desc.bInterfaceNumber);
 
 #ifdef CFG_TUH_CDC_LINE_CODING_ON_ENUM
   // CFG_TUH_CDC_LINE_CODING_ON_ENUM must be defined for line coding is set by tinyusb in enumeration
@@ -106,8 +106,8 @@ void tuh_cdc_mount_cb(uint8_t idx)
 
 void tuh_cdc_umount_cb(uint8_t idx)
 {
-  tuh_cdc_itf_info_t itf_info = { 0 };
+  tuh_itf_info_t itf_info = { 0 };
   tuh_cdc_itf_get_info(idx, &itf_info);
 
-  printf("CDC Interface is unmounted: address = %u, itf_num = %u\r\n", itf_info.daddr, itf_info.bInterfaceNumber);
+  printf("CDC Interface is unmounted: address = %u, itf_num = %u\r\n", itf_info.daddr, itf_info.desc.bInterfaceNumber);
 }

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -36,7 +36,7 @@
 
 #if CFG_TUSB_MCU == OPT_MCU_RP2040
 // change to 1 if using pico-pio-usb as host controller for raspberry rp2040
-#define CFG_TUH_RPI_PIO_USB   0
+#define CFG_TUH_RPI_PIO_USB   1
 #define BOARD_TUH_RHPORT      CFG_TUH_RPI_PIO_USB
 #endif
 
@@ -97,7 +97,7 @@
 
 #define CFG_TUH_HUB                 1 // number of supported hubs
 #define CFG_TUH_CDC                 1
-#define CFG_TUH_HID                 4 // typical keyboard + mouse device can have 3-4 HID interfaces
+#define CFG_TUH_HID                 (4*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 1
 #define CFG_TUH_VENDOR              0
 

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -97,7 +97,7 @@
 
 #define CFG_TUH_HUB                 1 // number of supported hubs
 #define CFG_TUH_CDC                 1
-#define CFG_TUH_HID                 (4*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
+#define CFG_TUH_HID                 (3*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 1
 #define CFG_TUH_VENDOR              0
 

--- a/examples/host/hid_controller/src/tusb_config.h
+++ b/examples/host/hid_controller/src/tusb_config.h
@@ -97,7 +97,7 @@
 
 #define CFG_TUH_HUB                 0
 #define CFG_TUH_CDC                 0
-#define CFG_TUH_HID                 (4*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
+#define CFG_TUH_HID                 (3*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 0
 #define CFG_TUH_VENDOR              0
 

--- a/examples/host/hid_controller/src/tusb_config.h
+++ b/examples/host/hid_controller/src/tusb_config.h
@@ -97,7 +97,7 @@
 
 #define CFG_TUH_HUB                 0
 #define CFG_TUH_CDC                 0
-#define CFG_TUH_HID                 4 // typical keyboard + mouse device can have 3-4 HID interfaces
+#define CFG_TUH_HID                 (4*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 0
 #define CFG_TUH_VENDOR              0
 

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -127,15 +127,25 @@ uint8_t tuh_cdc_itf_get_index(uint8_t daddr, uint8_t itf_num)
   return TUSB_INDEX_INVALID_8;
 }
 
-bool tuh_cdc_itf_get_info(uint8_t idx, tuh_cdc_itf_info_t* info)
+bool tuh_cdc_itf_get_info(uint8_t idx, tuh_itf_info_t* info)
 {
   cdch_interface_t* p_cdc = get_itf(idx);
   TU_VERIFY(p_cdc && info);
 
-  info->daddr              = p_cdc->daddr;
-  info->bInterfaceNumber   = p_cdc->bInterfaceNumber;
-  info->bInterfaceSubClass = p_cdc->bInterfaceSubClass;
-  info->bInterfaceProtocol = p_cdc->bInterfaceProtocol;
+  info->daddr = p_cdc->daddr;
+
+  // re-construct descriptor
+  tusb_desc_interface_t* desc = &info->desc;
+  desc->bLength            = sizeof(tusb_desc_interface_t);
+  desc->bDescriptorType    = TUSB_DESC_INTERFACE;
+
+  desc->bInterfaceNumber   = p_cdc->bInterfaceNumber;
+  desc->bAlternateSetting  = 0;
+  desc->bNumEndpoints      = 2u + (p_cdc->ep_notif ? 1u : 0u);
+  desc->bInterfaceClass    = TUSB_CLASS_CDC;
+  desc->bInterfaceSubClass = p_cdc->bInterfaceSubClass;
+  desc->bInterfaceProtocol = p_cdc->bInterfaceProtocol;
+  desc->iInterface         = 0; // not used yet
 
   return true;
 }

--- a/src/class/cdc/cdc_host.h
+++ b/src/class/cdc/cdc_host.h
@@ -71,21 +71,13 @@
 // Application API
 //--------------------------------------------------------------------+
 
-typedef struct
-{
-  uint8_t daddr;
-  uint8_t bInterfaceNumber;
-  uint8_t bInterfaceSubClass;
-  uint8_t bInterfaceProtocol;
-} tuh_cdc_itf_info_t;
-
 // Get Interface index from device address + interface number
 // return TUSB_INDEX_INVALID_8 (0xFF) if not found
 uint8_t tuh_cdc_itf_get_index(uint8_t daddr, uint8_t itf_num);
 
 // Get Interface information
 // return true if index is correct and interface is currently mounted
-bool tuh_cdc_itf_get_info(uint8_t idx, tuh_cdc_itf_info_t* info);
+bool tuh_cdc_itf_get_info(uint8_t idx, tuh_itf_info_t* info);
 
 // Check if a interface is mounted
 bool tuh_cdc_mounted(uint8_t idx);

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -39,6 +39,8 @@
 
 typedef struct
 {
+  uint8_t daddr;
+
   uint8_t itf_num;
   uint8_t ep_in;
   uint8_t ep_out;
@@ -56,74 +58,131 @@ typedef struct
   uint8_t epout_buf[CFG_TUH_HID_EPOUT_BUFSIZE];
 } hidh_interface_t;
 
-typedef struct
-{
-  uint8_t inst_count;
-  hidh_interface_t instances[CFG_TUH_HID];
-} hidh_device_t;
-
 CFG_TUSB_MEM_SECTION
-static hidh_device_t _hidh_dev[CFG_TUH_DEVICE_MAX];
+tu_static hidh_interface_t _hidh_itf[CFG_TUH_HID];
 
-//------------- Internal prototypes -------------//
+//--------------------------------------------------------------------+
+// Helper
+//--------------------------------------------------------------------+
 
-// Get HID device & interface
-TU_ATTR_ALWAYS_INLINE static inline hidh_device_t* get_dev(uint8_t dev_addr);
-TU_ATTR_ALWAYS_INLINE static inline hidh_interface_t* get_instance(uint8_t dev_addr, uint8_t instance);
-static uint8_t get_instance_id_by_itfnum(uint8_t dev_addr, uint8_t itf);
-static uint8_t get_instance_id_by_epaddr(uint8_t dev_addr, uint8_t ep_addr);
+TU_ATTR_ALWAYS_INLINE static inline
+hidh_interface_t* get_hid_itf(uint8_t daddr, uint8_t idx)
+{
+  TU_ASSERT(daddr && idx < CFG_TUH_HID, NULL);
+  hidh_interface_t* p_hid = &_hidh_itf[idx];
+  return (p_hid->daddr == daddr) ? p_hid : NULL;
+}
+
+// Get instance ID by endpoint address
+static uint8_t get_idx_by_epaddr(uint8_t daddr, uint8_t ep_addr)
+{
+  for ( uint8_t idx = 0; idx < CFG_TUH_HID; idx++ )
+  {
+    hidh_interface_t const * p_hid = &_hidh_itf[idx];
+
+    if ( p_hid->daddr == daddr &&
+         (p_hid->ep_in == ep_addr || p_hid->ep_out == ep_addr) )
+    {
+      return idx;
+    }
+  }
+
+  return TUSB_INDEX_INVALID_8;
+}
+
+static hidh_interface_t* find_new_itf(void)
+{
+  for(uint8_t i=0; i<CFG_TUH_HID; i++)
+  {
+    if (_hidh_itf[i].daddr == 0) return &_hidh_itf[i];
+  }
+
+  return NULL;
+}
 
 //--------------------------------------------------------------------+
 // Interface API
 //--------------------------------------------------------------------+
 
-uint8_t tuh_hid_instance_count(uint8_t dev_addr)
+uint8_t tuh_hid_itf_get_count(uint8_t daddr)
 {
-  return get_dev(dev_addr)->inst_count;
+  uint8_t count = 0;
+
+  for(uint8_t i=0; i<CFG_TUH_HID; i++)
+  {
+    if (_hidh_itf[i].daddr == daddr) count++;
+  }
+
+  return count;
 }
 
-bool tuh_hid_mounted(uint8_t dev_addr, uint8_t instance)
+uint8_t tuh_hid_itf_get_total_count(void)
 {
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
-  return (hid_itf->ep_in != 0) || (hid_itf->ep_out != 0);
+  uint8_t count = 0;
+
+  for(uint8_t i=0; i<CFG_TUH_HID; i++)
+  {
+    if (_hidh_itf[i].daddr != 0) count++;
+  }
+
+  return count;
 }
 
-uint8_t tuh_hid_interface_protocol(uint8_t dev_addr, uint8_t instance)
+bool tuh_hid_mounted(uint8_t daddr, uint8_t idx)
 {
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
-  return hid_itf->itf_protocol;
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  return p_hid != NULL;
+}
+
+uint8_t tuh_hid_itf_get_index(uint8_t daddr, uint8_t itf_num)
+{
+  for ( uint8_t idx = 0; idx < CFG_TUH_HID; idx++ )
+  {
+    hidh_interface_t const * p_hid = &_hidh_itf[idx];
+
+    if ( p_hid->daddr == daddr && p_hid->itf_num == itf_num) return idx;
+  }
+
+  return TUSB_INDEX_INVALID_8;
+}
+
+uint8_t tuh_hid_interface_protocol(uint8_t daddr, uint8_t idx)
+{
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  return p_hid ? p_hid->itf_protocol : 0;
 }
 
 //--------------------------------------------------------------------+
 // Control Endpoint API
 //--------------------------------------------------------------------+
 
-uint8_t tuh_hid_get_protocol(uint8_t dev_addr, uint8_t instance)
+uint8_t tuh_hid_get_protocol(uint8_t daddr, uint8_t idx)
 {
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
-  return hid_itf->protocol_mode;
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  return p_hid ? p_hid->protocol_mode : 0;
 }
 
 static void set_protocol_complete(tuh_xfer_t* xfer)
 {
-  uint8_t const itf_num     = (uint8_t) tu_le16toh(xfer->setup->wIndex);
-  uint8_t const daddr       = xfer->daddr;
-  uint8_t const instance    = get_instance_id_by_itfnum(daddr, itf_num);
-  hidh_interface_t* hid_itf = get_instance(daddr, instance);
+  uint8_t const itf_num = (uint8_t) tu_le16toh(xfer->setup->wIndex);
+  uint8_t const daddr   = xfer->daddr;
+  uint8_t const idx     = tuh_hid_itf_get_index(daddr, itf_num);
+
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid, );
 
   if (XFER_RESULT_SUCCESS == xfer->result)
   {
-    hid_itf->protocol_mode = (uint8_t) tu_le16toh(xfer->setup->wValue);
+    p_hid->protocol_mode = (uint8_t) tu_le16toh(xfer->setup->wValue);
   }
 
   if (tuh_hid_set_protocol_complete_cb)
   {
-    tuh_hid_set_protocol_complete_cb(daddr, instance, hid_itf->protocol_mode);
+    tuh_hid_set_protocol_complete_cb(daddr, idx, p_hid->protocol_mode);
   }
 }
 
-
-static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protocol, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
+static bool _hidh_set_protocol(uint8_t daddr, uint8_t itf_num, uint8_t protocol, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   TU_LOG2("HID Set Protocol = %d\r\n", protocol);
 
@@ -143,7 +202,7 @@ static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protoc
 
   tuh_xfer_t xfer =
   {
-    .daddr       = dev_addr,
+    .daddr       = daddr,
     .ep_addr     = 0,
     .setup       = &request,
     .buffer      = NULL,
@@ -151,16 +210,15 @@ static bool _hidh_set_protocol(uint8_t dev_addr, uint8_t itf_num, uint8_t protoc
     .user_data   = user_data
   };
 
-  TU_ASSERT( tuh_control_xfer(&xfer) );
-  return true;
+  return tuh_control_xfer(&xfer);
 }
 
-bool tuh_hid_set_protocol(uint8_t dev_addr, uint8_t instance, uint8_t protocol)
+bool tuh_hid_set_protocol(uint8_t daddr, uint8_t idx, uint8_t protocol)
 {
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
-  TU_VERIFY(hid_itf->itf_protocol != HID_ITF_PROTOCOL_NONE);
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid && p_hid->itf_protocol != HID_ITF_PROTOCOL_NONE);
 
-  return _hidh_set_protocol(dev_addr, hid_itf->itf_num, protocol, set_protocol_complete, 0);
+  return _hidh_set_protocol(daddr, p_hid->itf_num, protocol, set_protocol_complete, 0);
 }
 
 static void set_report_complete(tuh_xfer_t* xfer)
@@ -169,20 +227,22 @@ static void set_report_complete(tuh_xfer_t* xfer)
 
   if (tuh_hid_set_report_complete_cb)
   {
-    uint8_t const itf_num     = (uint8_t) tu_le16toh(xfer->setup->wIndex);
-    uint8_t const instance    = get_instance_id_by_itfnum(xfer->daddr, itf_num);
+    uint8_t const itf_num = (uint8_t) tu_le16toh(xfer->setup->wIndex);
+    uint8_t const idx     = tuh_hid_itf_get_index(xfer->daddr, itf_num);
 
     uint8_t const report_type = tu_u16_high(xfer->setup->wValue);
     uint8_t const report_id   = tu_u16_low(xfer->setup->wValue);
 
-    tuh_hid_set_report_complete_cb(xfer->daddr, instance, report_id, report_type,
+    tuh_hid_set_report_complete_cb(xfer->daddr, idx, report_id, report_type,
                                    (xfer->result == XFER_RESULT_SUCCESS) ? xfer->setup->wLength : 0);
   }
 }
 
-bool tuh_hid_set_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, uint8_t report_type, void* report, uint16_t len)
+bool tuh_hid_set_report(uint8_t daddr, uint8_t idx, uint8_t report_id, uint8_t report_type, void* report, uint16_t len)
 {
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid);
+
   TU_LOG2("HID Set Report: id = %u, type = %u, len = %u\r\n", report_id, report_type, len);
 
   tusb_control_request_t const request =
@@ -194,14 +254,14 @@ bool tuh_hid_set_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, u
       .direction = TUSB_DIR_OUT
     },
     .bRequest = HID_REQ_CONTROL_SET_REPORT,
-    .wValue   = tu_u16(report_type, report_id),
-    .wIndex   = hid_itf->itf_num,
+    .wValue   = tu_htole16(tu_u16(report_type, report_id)),
+    .wIndex   = tu_htole16((uint16_t)p_hid->itf_num),
     .wLength  = len
   };
 
   tuh_xfer_t xfer =
   {
-    .daddr       = dev_addr,
+    .daddr       = daddr,
     .ep_addr     = 0,
     .setup       = &request,
     .buffer      = report,
@@ -209,14 +269,14 @@ bool tuh_hid_set_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, u
     .user_data   = 0
   };
 
-  TU_ASSERT( tuh_control_xfer(&xfer) );
-  return true;
+  return tuh_control_xfer(&xfer);
 }
 
-static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
+static bool _hidh_set_idle(uint8_t daddr, uint8_t itf_num, uint16_t idle_rate, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   // SET IDLE request, device can stall if not support this request
   TU_LOG2("HID Set Idle \r\n");
+
   tusb_control_request_t const request =
   {
     .bmRequestType_bit =
@@ -226,14 +286,14 @@ static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate
       .direction = TUSB_DIR_OUT
     },
     .bRequest = HID_REQ_CONTROL_SET_IDLE,
-    .wValue   = idle_rate,
-    .wIndex   = itf_num,
+    .wValue   = tu_htole16(idle_rate),
+    .wIndex   = tu_htole16((uint16_t)itf_num),
     .wLength  = 0
   };
 
   tuh_xfer_t xfer =
   {
-    .daddr       = dev_addr,
+    .daddr       = daddr,
     .ep_addr     = 0,
     .setup       = &request,
     .buffer      = NULL,
@@ -241,25 +301,24 @@ static bool _hidh_set_idle(uint8_t dev_addr, uint8_t itf_num, uint16_t idle_rate
     .user_data   = user_data
   };
 
-  TU_ASSERT( tuh_control_xfer(&xfer) );
-
-  return true;
+  return tuh_control_xfer(&xfer);
 }
 
 //--------------------------------------------------------------------+
 // Interrupt Endpoint API
 //--------------------------------------------------------------------+
 
-bool tuh_hid_receive_report(uint8_t dev_addr, uint8_t instance)
+bool tuh_hid_receive_report(uint8_t daddr, uint8_t idx)
 {
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid);
 
   // claim endpoint
-  TU_VERIFY( usbh_edpt_claim(dev_addr, hid_itf->ep_in) );
+  TU_VERIFY( usbh_edpt_claim(daddr, p_hid->ep_in) );
 
-  if ( !usbh_edpt_xfer(dev_addr, hid_itf->ep_in, hid_itf->epin_buf, hid_itf->epin_size) )
+  if ( !usbh_edpt_xfer(daddr, p_hid->ep_in, p_hid->epin_buf, p_hid->epin_size) )
   {
-    usbh_edpt_release(dev_addr, hid_itf->ep_in);
+    usbh_edpt_release(daddr, p_hid->ep_in);
     return false;
   }
 
@@ -274,44 +333,45 @@ bool tuh_hid_receive_report(uint8_t dev_addr, uint8_t instance)
 //  return !usbh_edpt_busy(dev_addr, hid_itf->ep_in);
 //}
 
-bool tuh_hid_send_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, const void* report, uint16_t len)
+bool tuh_hid_send_report(uint8_t daddr, uint8_t idx, uint8_t report_id, const void* report, uint16_t len)
 {
   TU_LOG2("HID Send Report %d\r\n", report_id);
 
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid);
 
-  if (hid_itf->ep_out == 0)
+  if (p_hid->ep_out == 0)
   {
     // This HID does not have an out endpoint (other than control)
     return false;
   }
-  else if (len > CFG_TUH_HID_EPOUT_BUFSIZE
-           || (report_id != 0 && len > (CFG_TUH_HID_EPOUT_BUFSIZE - 1)))
+  else if (len > CFG_TUH_HID_EPOUT_BUFSIZE ||
+           (report_id != 0 && len > (CFG_TUH_HID_EPOUT_BUFSIZE - 1)))
   {
     // ep_out buffer is not large enough to hold contents
     return false;
   }
 
   // claim endpoint
-  TU_VERIFY( usbh_edpt_claim(dev_addr, hid_itf->ep_out) );
+  TU_VERIFY( usbh_edpt_claim(daddr, p_hid->ep_out) );
 
   if (report_id == 0)
   {
     // No report ID in transmission
-    memcpy(&hid_itf->epout_buf[0], report, len);
+    memcpy(&p_hid->epout_buf[0], report, len);
   }
   else
   {
-    hid_itf->epout_buf[0] = report_id;
-    memcpy(&hid_itf->epout_buf[1], report, len);
+    p_hid->epout_buf[0] = report_id;
+    memcpy(&p_hid->epout_buf[1], report, len);
     ++len; // 1 more byte for report_id
   }
 
-  TU_LOG3_MEM(hid_itf->epout_buf, len, 2);
+  TU_LOG3_MEM(p_hid->epout_buf, len, 2);
 
-  if ( !usbh_edpt_xfer(dev_addr, hid_itf->ep_out, hid_itf->epout_buf, len) )
+  if ( !usbh_edpt_xfer(daddr, p_hid->ep_out, p_hid->epout_buf, len) )
   {
-    usbh_edpt_release(dev_addr, hid_itf->ep_out);
+    usbh_edpt_release(daddr, p_hid->ep_out);
     return false;
   }
 
@@ -323,56 +383,57 @@ bool tuh_hid_send_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, 
 //--------------------------------------------------------------------+
 void hidh_init(void)
 {
-  tu_memclr(_hidh_dev, sizeof(_hidh_dev));
+  tu_memclr(_hidh_itf, sizeof(_hidh_itf));
 }
 
-bool hidh_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
+bool hidh_xfer_cb(uint8_t daddr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
 {
   (void) result;
 
   uint8_t const dir = tu_edpt_dir(ep_addr);
-  uint8_t const instance = get_instance_id_by_epaddr(dev_addr, ep_addr);
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
+  uint8_t const idx = get_idx_by_epaddr(daddr, ep_addr);
+
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid);
 
   if ( dir == TUSB_DIR_IN )
   {
-    TU_LOG2("  Get Report callback (%u, %u)\r\n", dev_addr, instance);
-    TU_LOG3_MEM(hid_itf->epin_buf, xferred_bytes, 2);
-    tuh_hid_report_received_cb(dev_addr, instance, hid_itf->epin_buf, (uint16_t) xferred_bytes);
+    TU_LOG2("  Get Report callback (%u, %u)\r\n", daddr, idx);
+    TU_LOG3_MEM(p_hid->epin_buf, xferred_bytes, 2);
+    tuh_hid_report_received_cb(daddr, idx, p_hid->epin_buf, (uint16_t) xferred_bytes);
   }else
   {
-    if (tuh_hid_report_sent_cb) tuh_hid_report_sent_cb(dev_addr, instance, hid_itf->epout_buf, (uint16_t) xferred_bytes);
+    if (tuh_hid_report_sent_cb) tuh_hid_report_sent_cb(daddr, idx, p_hid->epout_buf, (uint16_t) xferred_bytes);
   }
 
   return true;
 }
 
-void hidh_close(uint8_t dev_addr)
+void hidh_close(uint8_t daddr)
 {
-  TU_VERIFY(dev_addr <= CFG_TUH_DEVICE_MAX, );
-
-  hidh_device_t* hid_dev = get_dev(dev_addr);
-
-  if (tuh_hid_umount_cb)
+  for(uint8_t i=0; i<CFG_TUH_HID; i++)
   {
-    for (uint8_t inst = 0; inst < hid_dev->inst_count; inst++ ) tuh_hid_umount_cb(dev_addr, inst);
+    hidh_interface_t* p_hid = &_hidh_itf[i];
+    if (p_hid->daddr == daddr)
+    {
+       if(tuh_hid_umount_cb) tuh_hid_umount_cb(daddr, i);
+       p_hid->daddr = 0;
+    }
   }
-
-  tu_memclr(hid_dev, sizeof(hidh_device_t));
 }
 
 //--------------------------------------------------------------------+
 // Enumeration
 //--------------------------------------------------------------------+
 
-bool hidh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
+bool hidh_open(uint8_t rhport, uint8_t daddr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
 {
   (void) rhport;
   (void) max_len;
 
   TU_VERIFY(TUSB_CLASS_HID == desc_itf->bInterfaceClass);
 
-  TU_LOG2("[%u] HID opening Interface %u\r\n", dev_addr, desc_itf->bInterfaceNumber);
+  TU_LOG2("[%u] HID opening Interface %u\r\n", daddr, desc_itf->bInterfaceNumber);
 
   // len = interface + hid + n*endpoints
   uint16_t const drv_len = (uint16_t) (sizeof(tusb_desc_interface_t) + sizeof(tusb_hid_descriptor_hid_t) +
@@ -386,12 +447,9 @@ bool hidh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *de
   tusb_hid_descriptor_hid_t const *desc_hid = (tusb_hid_descriptor_hid_t const *) p_desc;
   TU_ASSERT(HID_DESC_TYPE_HID == desc_hid->bDescriptorType);
 
-  // not enough interface, try to increase CFG_TUH_HID
-  // TODO multiple devices
-  hidh_device_t* hid_dev = get_dev(dev_addr);
-  TU_ASSERT(hid_dev->inst_count < CFG_TUH_HID, 0);
-
-  hidh_interface_t* hid_itf = get_instance(dev_addr, hid_dev->inst_count);
+  hidh_interface_t* p_hid = find_new_itf();
+  TU_ASSERT(p_hid); // not enough interface, try to increase CFG_TUH_HID
+  p_hid->daddr = daddr;
 
   //------------- Endpoint Descriptors -------------//
   p_desc = tu_desc_next(p_desc);
@@ -400,34 +458,35 @@ bool hidh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *de
   for(int i = 0; i < desc_itf->bNumEndpoints; i++)
   {
     TU_ASSERT(TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType);
-    TU_ASSERT( tuh_edpt_open(dev_addr, desc_ep) );
+    TU_ASSERT( tuh_edpt_open(daddr, desc_ep) );
 
     if(tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN)
     {
-      hid_itf->ep_in     = desc_ep->bEndpointAddress;
-      hid_itf->epin_size = tu_edpt_packet_size(desc_ep);
+      p_hid->ep_in     = desc_ep->bEndpointAddress;
+      p_hid->epin_size = tu_edpt_packet_size(desc_ep);
     }
     else
     {
-      hid_itf->ep_out     = desc_ep->bEndpointAddress;
-      hid_itf->epout_size = tu_edpt_packet_size(desc_ep);
+      p_hid->ep_out     = desc_ep->bEndpointAddress;
+      p_hid->epout_size = tu_edpt_packet_size(desc_ep);
     }
 
     p_desc = tu_desc_next(p_desc);
     desc_ep = (tusb_desc_endpoint_t const *) p_desc;
   }
 
-  hid_dev->inst_count++;
-
-  hid_itf->itf_num   = desc_itf->bInterfaceNumber;
+  p_hid->itf_num   = desc_itf->bInterfaceNumber;
 
   // Assume bNumDescriptors = 1
-  hid_itf->report_desc_type = desc_hid->bReportType;
-  hid_itf->report_desc_len  = tu_unaligned_read16(&desc_hid->wReportLength);
+  p_hid->report_desc_type = desc_hid->bReportType;
+  p_hid->report_desc_len  = tu_unaligned_read16(&desc_hid->wReportLength);
 
   // Per HID Specs: default is Report protocol, though we will force Boot protocol when set_config
-  hid_itf->protocol_mode = HID_PROTOCOL_BOOT;
-  if ( HID_SUBCLASS_BOOT == desc_itf->bInterfaceSubClass ) hid_itf->itf_protocol = desc_itf->bInterfaceProtocol;
+  p_hid->protocol_mode = HID_PROTOCOL_BOOT;
+  if ( HID_SUBCLASS_BOOT == desc_itf->bInterfaceSubClass )
+  {
+    p_hid->itf_protocol = desc_itf->bInterfaceProtocol;
+  }
 
   return true;
 }
@@ -443,16 +502,16 @@ enum {
   CONFIG_COMPLETE
 };
 
-static void config_driver_mount_complete(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len);
+static void config_driver_mount_complete(uint8_t daddr, uint8_t idx, uint8_t const* desc_report, uint16_t desc_len);
 static void process_set_config(tuh_xfer_t* xfer);
 
-bool hidh_set_config(uint8_t dev_addr, uint8_t itf_num)
+bool hidh_set_config(uint8_t daddr, uint8_t itf_num)
 {
   tusb_control_request_t request;
   request.wIndex = tu_htole16((uint16_t) itf_num);
 
   tuh_xfer_t xfer;
-  xfer.daddr     = dev_addr;
+  xfer.daddr     = daddr;
   xfer.result    = XFER_RESULT_SUCCESS;
   xfer.setup     = &request;
   xfer.user_data = CONFG_SET_IDLE;
@@ -477,8 +536,9 @@ static void process_set_config(tuh_xfer_t* xfer)
   uint8_t const itf_num = (uint8_t) tu_le16toh(xfer->setup->wIndex);
   uint8_t const daddr   = xfer->daddr;
 
-  uint8_t const instance    = get_instance_id_by_itfnum(daddr, itf_num);
-  hidh_interface_t* hid_itf = get_instance(daddr, instance);
+  uint8_t const idx       = tuh_hid_itf_get_index(daddr, itf_num);
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid, );
 
   switch(state)
   {
@@ -486,27 +546,27 @@ static void process_set_config(tuh_xfer_t* xfer)
     {
       // Idle rate = 0 mean only report when there is changes
       const uint16_t idle_rate = 0;
-      const uintptr_t next_state = (hid_itf->itf_protocol != HID_ITF_PROTOCOL_NONE) ? CONFIG_SET_PROTOCOL : CONFIG_GET_REPORT_DESC;
+      const uintptr_t next_state = (p_hid->itf_protocol != HID_ITF_PROTOCOL_NONE) ? CONFIG_SET_PROTOCOL : CONFIG_GET_REPORT_DESC;
       _hidh_set_idle(daddr, itf_num, idle_rate, process_set_config, next_state);
     }
     break;
 
     case CONFIG_SET_PROTOCOL:
-      _hidh_set_protocol(daddr, hid_itf->itf_num, HID_PROTOCOL_BOOT, process_set_config, CONFIG_GET_REPORT_DESC);
+      _hidh_set_protocol(daddr, p_hid->itf_num, HID_PROTOCOL_BOOT, process_set_config, CONFIG_GET_REPORT_DESC);
     break;
 
     case CONFIG_GET_REPORT_DESC:
       // Get Report Descriptor if possible
       // using usbh enumeration buffer since report descriptor can be very long
-      if( hid_itf->report_desc_len > CFG_TUH_ENUMERATION_BUFSIZE )
+      if( p_hid->report_desc_len > CFG_TUH_ENUMERATION_BUFSIZE )
       {
-        TU_LOG2("HID Skip Report Descriptor since it is too large %u bytes\r\n", hid_itf->report_desc_len);
+        TU_LOG2("HID Skip Report Descriptor since it is too large %u bytes\r\n", p_hid->report_desc_len);
 
         // Driver is mounted without report descriptor
-        config_driver_mount_complete(daddr, instance, NULL, 0);
+        config_driver_mount_complete(daddr, idx, NULL, 0);
       }else
       {
-        tuh_descriptor_get_hid_report(daddr, itf_num, hid_itf->report_desc_type, 0, usbh_get_enum_buf(), hid_itf->report_desc_len, process_set_config, CONFIG_COMPLETE);
+        tuh_descriptor_get_hid_report(daddr, itf_num, p_hid->report_desc_type, 0, usbh_get_enum_buf(), p_hid->report_desc_len, process_set_config, CONFIG_COMPLETE);
       }
       break;
 
@@ -515,7 +575,7 @@ static void process_set_config(tuh_xfer_t* xfer)
       uint8_t const* desc_report = usbh_get_enum_buf();
       uint16_t const desc_len    = tu_le16toh(xfer->setup->wLength);
 
-      config_driver_mount_complete(daddr, instance, desc_report, desc_len);
+      config_driver_mount_complete(daddr, idx, desc_report, desc_len);
     }
     break;
 
@@ -523,15 +583,16 @@ static void process_set_config(tuh_xfer_t* xfer)
   }
 }
 
-static void config_driver_mount_complete(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len)
+static void config_driver_mount_complete(uint8_t daddr, uint8_t idx, uint8_t const* desc_report, uint16_t desc_len)
 {
-  hidh_interface_t* hid_itf = get_instance(dev_addr, instance);
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid, );
 
   // enumeration is complete
-  tuh_hid_mount_cb(dev_addr, instance, desc_report, desc_len);
+  if (tuh_hid_mount_cb) tuh_hid_mount_cb(daddr, idx, desc_report, desc_len);
 
   // notify usbh that driver enumeration is complete
-  usbh_driver_set_config_complete(dev_addr, hid_itf->itf_num);
+  usbh_driver_set_config_complete(daddr, p_hid->itf_num);
 }
 
 //--------------------------------------------------------------------+
@@ -674,48 +735,6 @@ uint8_t tuh_hid_parse_report_descriptor(tuh_hid_report_info_t* report_info_arr, 
   }
 
   return report_num;
-}
-
-//--------------------------------------------------------------------+
-// Helper
-//--------------------------------------------------------------------+
-
-// Get Device by address
-TU_ATTR_ALWAYS_INLINE static inline hidh_device_t* get_dev(uint8_t dev_addr)
-{
-  return &_hidh_dev[dev_addr-1];
-}
-
-// Get Interface by instance number
-TU_ATTR_ALWAYS_INLINE static inline hidh_interface_t* get_instance(uint8_t dev_addr, uint8_t instance)
-{
-  return &_hidh_dev[dev_addr-1].instances[instance];
-}
-
-// Get instance ID by interface number
-static uint8_t get_instance_id_by_itfnum(uint8_t dev_addr, uint8_t itf)
-{
-  for ( uint8_t inst = 0; inst < CFG_TUH_HID; inst++ )
-  {
-    hidh_interface_t *hid = get_instance(dev_addr, inst);
-
-    if ( (hid->itf_num == itf) && (hid->ep_in || hid->ep_out) ) return inst;
-  }
-
-  return 0xff;
-}
-
-// Get instance ID by endpoint address
-static uint8_t get_instance_id_by_epaddr(uint8_t dev_addr, uint8_t ep_addr)
-{
-  for ( uint8_t inst = 0; inst < CFG_TUH_HID; inst++ )
-  {
-    hidh_interface_t *hid = get_instance(dev_addr, inst);
-
-    if ( (ep_addr == hid->ep_in) || ( ep_addr == hid->ep_out) ) return inst;
-  }
-
-  return 0xff;
 }
 
 #endif

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -465,8 +465,10 @@ bool hidh_set_config(uint8_t dev_addr, uint8_t itf_num)
 
 static void process_set_config(tuh_xfer_t* xfer)
 {
-  // Stall is a valid response for SET_IDLE, therefore we could ignore its result
-  if ( xfer->setup->bRequest != HID_REQ_CONTROL_SET_IDLE )
+  // Stall is a valid response for SET_IDLE, sometime SET_PROTOCOL as well
+  // therefore we could ignore its result
+  if ( !(xfer->setup->bRequest == HID_REQ_CONTROL_SET_IDLE ||
+         xfer->setup->bRequest == HID_REQ_CONTROL_SET_PROTOCOL) )
   {
     TU_ASSERT(xfer->result == XFER_RESULT_SUCCESS, );
   }

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -134,6 +134,29 @@ bool tuh_hid_mounted(uint8_t daddr, uint8_t idx)
   return p_hid != NULL;
 }
 
+bool tuh_hid_itf_get_info(uint8_t daddr, uint8_t idx, tuh_itf_info_t* info)
+{
+  hidh_interface_t* p_hid = get_hid_itf(daddr, idx);
+  TU_VERIFY(p_hid && info);
+
+  info->daddr = daddr;
+
+  // re-construct descriptor
+  tusb_desc_interface_t* desc = &info->desc;
+  desc->bLength            = sizeof(tusb_desc_interface_t);
+  desc->bDescriptorType    = TUSB_DESC_INTERFACE;
+
+  desc->bInterfaceNumber   = p_hid->itf_num;
+  desc->bAlternateSetting  = 0;
+  desc->bNumEndpoints      = (uint8_t) ((p_hid->ep_in ? 1u : 0u) + (p_hid->ep_out ? 1u : 0u));
+  desc->bInterfaceClass    = TUSB_CLASS_HID;
+  desc->bInterfaceSubClass = (p_hid->itf_protocol ? HID_SUBCLASS_BOOT : HID_SUBCLASS_NONE);
+  desc->bInterfaceProtocol = p_hid->itf_protocol;
+  desc->iInterface         = 0; // not used yet
+
+  return true;
+}
+
 uint8_t tuh_hid_itf_get_index(uint8_t daddr, uint8_t itf_num)
 {
   for ( uint8_t idx = 0; idx < CFG_TUH_HID; idx++ )

--- a/src/class/hid/hid_host.h
+++ b/src/class/hid/hid_host.h
@@ -71,8 +71,8 @@ uint8_t tuh_hid_itf_get_total_count(void);
 // backward compatible rename
 #define tuh_hid_instance_count    tuh_hid_itf_get_count
 
-// Check if HID interface is mounted
-bool tuh_hid_mounted(uint8_t dev_addr, uint8_t idx);
+// Get Interface information
+bool tuh_hid_itf_get_info(uint8_t daddr, uint8_t idx, tuh_itf_info_t* itf_info);
 
 // Get Interface index from device address + interface number
 // return TUSB_INDEX_INVALID_8 (0xFF) if not found
@@ -80,6 +80,9 @@ uint8_t tuh_hid_itf_get_index(uint8_t daddr, uint8_t itf_num);
 
 // Get interface supported protocol (bInterfaceProtocol) check out hid_interface_protocol_enum_t for possible values
 uint8_t tuh_hid_interface_protocol(uint8_t dev_addr, uint8_t idx);
+
+// Check if HID interface is mounted
+bool tuh_hid_mounted(uint8_t dev_addr, uint8_t idx);
 
 // Parse report descriptor into array of report_info struct and return number of reports.
 // For complicated report, application should write its own parser.

--- a/src/class/hid/hid_host.h
+++ b/src/class/hid/hid_host.h
@@ -62,14 +62,24 @@ typedef struct
 // Interface API
 //--------------------------------------------------------------------+
 
-// Get the number of HID instances
-uint8_t tuh_hid_instance_count(uint8_t dev_addr);
+// Get the number of mounted HID interfaces of a device
+uint8_t tuh_hid_itf_get_count(uint8_t dev_addr);
 
-// Check if HID instance is mounted
-bool tuh_hid_mounted(uint8_t dev_addr, uint8_t instance);
+// Get all mounted interfaces across devices
+uint8_t tuh_hid_itf_get_total_count(void);
+
+// backward compatible rename
+#define tuh_hid_instance_count    tuh_hid_itf_get_count
+
+// Check if HID interface is mounted
+bool tuh_hid_mounted(uint8_t dev_addr, uint8_t idx);
+
+// Get Interface index from device address + interface number
+// return TUSB_INDEX_INVALID_8 (0xFF) if not found
+uint8_t tuh_hid_itf_get_index(uint8_t daddr, uint8_t itf_num);
 
 // Get interface supported protocol (bInterfaceProtocol) check out hid_interface_protocol_enum_t for possible values
-uint8_t tuh_hid_interface_protocol(uint8_t dev_addr, uint8_t instance);
+uint8_t tuh_hid_interface_protocol(uint8_t dev_addr, uint8_t idx);
 
 // Parse report descriptor into array of report_info struct and return number of reports.
 // For complicated report, application should write its own parser.
@@ -82,31 +92,31 @@ uint8_t tuh_hid_parse_report_descriptor(tuh_hid_report_info_t* reports_info_arr,
 // Get current protocol: HID_PROTOCOL_BOOT (0) or HID_PROTOCOL_REPORT (1)
 // Note: Device will be initialized in Boot protocol for simplicity.
 //       Application can use set_protocol() to switch back to Report protocol.
-uint8_t tuh_hid_get_protocol(uint8_t dev_addr, uint8_t instance);
+uint8_t tuh_hid_get_protocol(uint8_t dev_addr, uint8_t idx);
 
 // Set protocol to HID_PROTOCOL_BOOT (0) or HID_PROTOCOL_REPORT (1)
 // This function is only supported by Boot interface (tuh_n_hid_interface_protocol() != NONE)
-bool tuh_hid_set_protocol(uint8_t dev_addr, uint8_t instance, uint8_t protocol);
+bool tuh_hid_set_protocol(uint8_t dev_addr, uint8_t idx, uint8_t protocol);
 
 // Set Report using control endpoint
 // report_type is either Input, Output or Feature, (value from hid_report_type_t)
-bool tuh_hid_set_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, uint8_t report_type, void* report, uint16_t len);
+bool tuh_hid_set_report(uint8_t dev_addr, uint8_t idx, uint8_t report_id, uint8_t report_type, void* report, uint16_t len);
 
 //--------------------------------------------------------------------+
 // Interrupt Endpoint API
 //--------------------------------------------------------------------+
 
 // Check if the interface is ready to use
-//bool tuh_n_hid_n_ready(uint8_t dev_addr, uint8_t instance);
+//bool tuh_n_hid_n_ready(uint8_t dev_addr, uint8_t idx);
 
 // Try to receive next report on Interrupt Endpoint. Immediately return
 // - true If succeeded, tuh_hid_report_received_cb() callback will be invoked when report is available
 // - false if failed to queue the transfer e.g endpoint is busy
-bool tuh_hid_receive_report(uint8_t dev_addr, uint8_t instance);
+bool tuh_hid_receive_report(uint8_t dev_addr, uint8_t idx);
 
 // Send report using interrupt endpoint
 // If report_id > 0 (composite), it will be sent as 1st byte, then report contents. Otherwise only report content is sent.
-bool tuh_hid_send_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, const void* report, uint16_t len);
+bool tuh_hid_send_report(uint8_t dev_addr, uint8_t idx, uint8_t report_id, const void* report, uint16_t len);
 
 //--------------------------------------------------------------------+
 // Callbacks (Weak is optional)
@@ -117,24 +127,24 @@ bool tuh_hid_send_report(uint8_t dev_addr, uint8_t instance, uint8_t report_id, 
 // can be used to parse common/simple enough descriptor.
 // Note: if report descriptor length > CFG_TUH_ENUMERATION_BUFSIZE, it will be skipped
 // therefore report_desc = NULL, desc_len = 0
-void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* report_desc, uint16_t desc_len);
+TU_ATTR_WEAK void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t idx, uint8_t const* report_desc, uint16_t desc_len);
 
 // Invoked when device with hid interface is un-mounted
-TU_ATTR_WEAK void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance);
+TU_ATTR_WEAK void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t idx);
 
 // Invoked when received report from device via interrupt endpoint
 // Note: if there is report ID (composite), it is 1st byte of report
-void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len);
+void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t idx, uint8_t const* report, uint16_t len);
 
 // Invoked when sent report to device successfully via interrupt endpoint
-TU_ATTR_WEAK void tuh_hid_report_sent_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len);
+TU_ATTR_WEAK void tuh_hid_report_sent_cb(uint8_t dev_addr, uint8_t idx, uint8_t const* report, uint16_t len);
 
 // Invoked when Sent Report to device via either control endpoint
 // len = 0 indicate there is error in the transfer e.g stalled response
-TU_ATTR_WEAK void tuh_hid_set_report_complete_cb(uint8_t dev_addr, uint8_t instance, uint8_t report_id, uint8_t report_type, uint16_t len);
+TU_ATTR_WEAK void tuh_hid_set_report_complete_cb(uint8_t dev_addr, uint8_t idx, uint8_t report_id, uint8_t report_type, uint16_t len);
 
 // Invoked when Set Protocol request is complete
-TU_ATTR_WEAK void tuh_hid_set_protocol_complete_cb(uint8_t dev_addr, uint8_t instance, uint8_t protocol);
+TU_ATTR_WEAK void tuh_hid_set_protocol_complete_cb(uint8_t dev_addr, uint8_t idx, uint8_t protocol);
 
 //--------------------------------------------------------------------+
 // Internal Class Driver API

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -450,7 +450,7 @@ static void usbd_reset(uint8_t rhport)
 bool tud_task_event_ready(void)
 {
   // Skip if stack is not initialized
-  if ( !tusb_inited() ) return false;
+  if ( !tud_inited() ) return false;
 
   return !osal_queue_empty(_usbd_q);
 }
@@ -478,7 +478,7 @@ void tud_task_ext(uint32_t timeout_ms, bool in_isr)
   (void) in_isr; // not implemented yet
 
   // Skip if stack is not initialized
-  if ( !tusb_inited() ) return;
+  if ( !tud_inited() ) return;
 
   // Loop until there is no more events in the queue
   while (1)

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -360,6 +360,14 @@ bool tuh_init(uint8_t controller_id)
   return true;
 }
 
+bool tuh_task_event_ready(void)
+{
+  // Skip if stack is not initialized
+  if ( !tuh_inited() ) return false;
+
+  return !osal_queue_empty(_usbh_q);
+}
+
 /* USB Host Driver task
  * This top level thread manages all host controller event and delegates events to class-specific drivers.
  * This should be called periodically within the mainloop or rtos thread.
@@ -383,7 +391,7 @@ void tuh_task_ext(uint32_t timeout_ms, bool in_isr)
   (void) in_isr; // not implemented yet
 
   // Skip if stack is not initialized
-  if ( !tusb_inited() ) return;
+  if ( !tuh_inited() ) return;
 
   // Loop until there is no more events in the queue
   while (1)
@@ -565,12 +573,12 @@ bool tuh_control_xfer (tuh_xfer_t* xfer)
 
     while (result == XFER_RESULT_INVALID)
     {
-      // only need to call task if not preempted RTOS
-      #if CFG_TUSB_OS == OPT_OS_NONE || CFG_TUSB_OS == OPT_OS_PICO
-      tuh_task();
-      #else
-      osal_task_delay(1); // TODO maybe yield()
-      #endif
+      // Note: this can be called within an callback ie. part of tuh_task()
+      // therefore event with RTOS tuh_task() still need to be invoked
+      if (tuh_task_event_ready())
+      {
+        tuh_task();
+      }
 
       // TODO probably some timeout to prevent hanged
     }

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1030,7 +1030,15 @@ bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
     .user_data   = user_data
   };
 
-  return tuh_control_xfer(&xfer);
+  bool ret = tuh_control_xfer(&xfer);
+
+  // if blocking, user_data could be pointed to xfer_result
+  if ( !complete_cb && user_data )
+  {
+    *((xfer_result_t*) user_data) = xfer.result;
+  }
+
+  return ret;
 }
 
 bool tuh_interface_set(uint8_t daddr, uint8_t itf_num, uint8_t itf_alt,
@@ -1062,7 +1070,15 @@ bool tuh_interface_set(uint8_t daddr, uint8_t itf_num, uint8_t itf_alt,
     .user_data   = user_data
   };
 
-  return tuh_control_xfer(&xfer);
+  bool ret = tuh_control_xfer(&xfer);
+
+  // if blocking, user_data could be pointed to xfer_result
+  if ( !complete_cb && user_data )
+  {
+    *((xfer_result_t*) user_data) = xfer.result;
+  }
+
+  return ret;
 }
 
 //--------------------------------------------------------------------+

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -568,6 +568,8 @@ bool tuh_control_xfer (tuh_xfer_t* xfer)
       // only need to call task if not preempted RTOS
       #if CFG_TUSB_OS == OPT_OS_NONE || CFG_TUSB_OS == OPT_OS_PICO
       tuh_task();
+      #else
+      osal_task_delay(1); // TODO maybe yield()
       #endif
 
       // TODO probably some timeout to prevent hanged

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -168,11 +168,13 @@ bool tuh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep);
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1
 // true on success, false if there is on-going control transfer or incorrect parameters
+// if complete_cb == NULL i.e blocking, user_data should be pointed to xfer_reuslt_t*
 bool tuh_configuration_set(uint8_t daddr, uint8_t config_num,
                            tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Set Interface (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
+// if complete_cb == NULL i.e blocking, user_data should be pointed to xfer_reuslt_t*
 bool tuh_interface_set(uint8_t daddr, uint8_t itf_num, uint8_t itf_alt,
                        tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -69,6 +69,13 @@ struct tuh_xfer_s
   // uint32_t timeout_ms;    // place holder, not supported yet
 };
 
+// Subject to change
+typedef struct
+{
+  uint8_t daddr;
+  tusb_desc_interface_t desc;
+} tuh_itf_info_t;
+
 // ConfigID for tuh_config()
 enum
 {
@@ -117,6 +124,9 @@ void tuh_task(void)
 {
   tuh_task_ext(UINT32_MAX, false);
 }
+
+// Check if there is pending events need processing by tuh_task()
+bool tuh_task_event_ready(void);
 
 #ifndef _TUSB_HCD_H_
 extern void hcd_int_handler(uint8_t rhport);

--- a/test/unit-test/test/device/msc/test_msc_device.c
+++ b/test/unit-test/test/device/msc/test_msc_device.c
@@ -197,7 +197,7 @@ void setUp(void)
   dcd_int_disable_Ignore();
   dcd_int_enable_Ignore();
 
-  if ( !tusb_inited() )
+  if ( !tud_inited() )
   {
     dcd_init_Expect(rhport);
     tusb_init();

--- a/test/unit-test/test/device/usbd/test_usbd.c
+++ b/test/unit-test/test/device/usbd/test_usbd.c
@@ -124,7 +124,7 @@ void setUp(void)
   dcd_int_disable_Ignore();
   dcd_int_enable_Ignore();
 
-  if ( !tusb_inited() )
+  if ( !tud_inited() )
   {
     mscd_init_Expect();
     dcd_init_Expect(rhport);

--- a/tools/build_family.py
+++ b/tools/build_family.py
@@ -34,7 +34,6 @@ def build_family(example, family, make_option):
         # sum all element of same index (column sum)
         return list(map(sum, list(zip(*result))))
 
-
 if __name__ == '__main__':
     # IAR CC
     if make_iar_option not in sys.argv:
@@ -68,7 +67,8 @@ if __name__ == '__main__':
         print(build_separator)
         for family in all_families:
             fret = build_family(example, family, make_iar_option)
-            total_result = list(map(lambda x, y: x + y, total_result, fret))
+            if len(fret) == len(total_result):
+                total_result = [total_result[i] + fret[i] for i in range(len(fret))]
 
     total_time = time.monotonic() - total_time
     print(build_separator)

--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -105,7 +105,13 @@ def get_a_dep(d):
 
 if __name__ == "__main__":
     status = 0
-    deps = list(deps_mandatory.keys()) + sys.argv[1:]
+    deps = list(deps_mandatory.keys())
+    # get all if executed with all as argument
+    if len(sys.argv) == 2 and sys.argv[1] == 'all':
+        deps += deps_optional
+    else:
+        deps += sys.argv[1:]
+
     with Pool() as pool:
         status = sum(pool.map(get_a_dep, deps))
     sys.exit(status)


### PR DESCRIPTION
**Describe the PR**
- relax hid host enumeration, allow set protocol to be stalled
- add note for blocking tuh_configuration_set(), tuh_interface_set()
- change meaning of CFG_TUH_HID to total number of HID interfaces supported. Previously CFG_TUH_HID is max number of interfaces per device which is rather limited and consume more resources than needed.
- fine tune CFG_TUH_HID value to `3*max_device` (previously must be 4*dev and yet couldn't support 1 device with 5 interfaces while other left unused) 
- change hid host instance in API to index
- add tuh_task_event_ready(), better implement blocking control transfer for rtos
- add tuh_hid_itf_get_info() and change tuh_cdc_itf_get_info() to use new tuh_itf_info_t