### PR TITLE
Update net_device.h to make MAC addresses not const.

### DIFF
--- a/examples/device/net_lwip_webserver/src/main.c
+++ b/examples/device/net_lwip_webserver/src/main.c
@@ -64,7 +64,7 @@ static struct pbuf *received_frame;
 /* this is used by this code, ./class/net/net_driver.c, and usb_descriptors.c */
 /* ideally speaking, this should be generated from the hardware's unique ID (if available) */
 /* it is suggested that the first byte is 0x02 to indicate a link-local address */
-const uint8_t tud_network_mac_address[6] = {0x02,0x02,0x84,0x6A,0x96,0x00};
+uint8_t tud_network_mac_address[6] = {0x02,0x02,0x84,0x6A,0x96,0x00};
 
 /* network parameters of this MCU */
 static const ip4_addr_t ipaddr  = INIT_IP4(192, 168, 7, 1);

--- a/src/class/net/net_device.h
+++ b/src/class/net/net_device.h
@@ -94,7 +94,7 @@ void tud_network_init_cb(void);
 
 // client must provide this: 48-bit MAC address
 // TODO removed later since it is not part of tinyusb stack
-extern const uint8_t tud_network_mac_address[6];
+extern uint8_t tud_network_mac_address[6];
 
 //------------- NCM -------------//
 

--- a/test/fuzz/net_fuzz.cc
+++ b/test/fuzz/net_fuzz.cc
@@ -67,7 +67,7 @@ void tud_network_init_cb(void) {
 
 // client must provide this: 48-bit MAC address
 // TODO removed later since it is not part of tinyusb stack
-const uint8_t tud_network_mac_address[6] = {0};
+uint8_t tud_network_mac_address[6] = {0};
 
 //------------- NCM -------------//
 


### PR DESCRIPTION
Per https://github.com/hathach/tinyusb/issues/718, MAC addresses are intended to be device unique, and thus should NOT be defined as consts.

I'm not sure what the longer term fix in the TODO should be, but this is a simple fix.
