### PR TITLE
rename and change default pio usb pin to adafruit feather usb host

### DIFF
--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -36,7 +36,7 @@
 
 #if CFG_TUSB_MCU == OPT_MCU_RP2040
 // change to 1 if using pico-pio-usb as host controller for raspberry rp2040
-#define CFG_TUH_RPI_PIO_USB   1
+#define CFG_TUH_RPI_PIO_USB   0
 #define BOARD_TUH_RHPORT      CFG_TUH_RPI_PIO_USB
 #endif
 

--- a/hw/bsp/rp2040/board.h
+++ b/hw/bsp/rp2040/board.h
@@ -31,6 +31,7 @@
  extern "C" {
 #endif
 
+// LED
 #ifdef PICO_DEFAULT_LED_PIN
 #define LED_PIN               PICO_DEFAULT_LED_PIN
 #define LED_STATE_ON          (!(PICO_DEFAULT_LED_PIN_INVERTED))
@@ -40,6 +41,7 @@
 #define BUTTON_BOOTSEL
 #define BUTTON_STATE_ACTIVE   0
 
+// UART
 #if defined(PICO_DEFAULT_UART_TX_PIN) && defined(PICO_DEFAULT_UART_RX_PIN) && \
     defined(PICO_DEFAULT_UART) && defined(LIB_PICO_STDIO_UART)
 #define UART_DEV              PICO_DEFAULT_UART
@@ -47,16 +49,27 @@
 #define UART_RX_PIN           PICO_DEFAULT_UART_RX_PIN
 #endif
 
-// PIO_USB_DP_PIN_DEFAULT is 0, which conflict with UART, change to other pin
-#ifndef PIO_USB_DP_PIN
-#define PIO_USB_DP_PIN        20
+// PIO_USB
+
+// #define USE_ADAFRUIT_RP2040_TESTER
+#ifdef USE_ADAFRUIT_RP2040_TESTER
+#define PICO_DEFAULT_PIO_USB_DP_PIN       20
+#define PICO_DEFAULT_PIO_USB_VBUSEN_PIN   22
+#endif
+
+// following default to pin on Adafruit Feather rp2040 USB Host
+#ifndef PICO_DEFAULT_PIO_USB_DP_PIN
+#define PICO_DEFAULT_PIO_USB_DP_PIN       16
 #endif
 
 // VBUS enable pin and its active state
-#define PIO_USB_VBUSEN_PIN    22
+#ifndef PICO_DEFAULT_PIO_USB_VBUSEN_PIN
+#define PICO_DEFAULT_PIO_USB_VBUSEN_PIN   18
+#endif
 
-#ifndef PIO_USB_VBUSEN_STATE
-#define PIO_USB_VBUSEN_STATE  1
+// VBUS enable state
+#ifndef PICO_DEFAULT_PIO_USB_VBUSEN_STATE
+#define PICO_DEFAULT_PIO_USB_VBUSEN_STATE 1
 #endif
 
 #ifdef __cplusplus

--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -126,15 +126,15 @@ void board_init(void)
   set_sys_clock_khz(120000, true);
 
 #ifdef PIO_USB_VBUSEN_PIN
-  gpio_init(PIO_USB_VBUSEN_PIN);
-  gpio_set_dir(PIO_USB_VBUSEN_PIN, GPIO_OUT);
-  gpio_put(PIO_USB_VBUSEN_PIN, PIO_USB_VBUSEN_STATE);
+  gpio_init(PICO_DEFAULT_PIO_USB_VBUSEN_PIN);
+  gpio_set_dir(PICO_DEFAULT_PIO_USB_VBUSEN_PIN, GPIO_OUT);
+  gpio_put(PICO_DEFAULT_PIO_USB_VBUSEN_PIN, PIO_USB_VBUSEN_STATE);
 #endif
 
   // rp2040 use pico-pio-usb for host tuh_configure() can be used to passed pio configuration to the host stack
   // Note: tuh_configure() must be called before tuh_init()
   pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
-  pio_cfg.pin_dp = PIO_USB_DP_PIN;
+  pio_cfg.pin_dp = PICO_DEFAULT_PIO_USB_DP_PIN;
   tuh_configure(BOARD_TUH_RHPORT, TUH_CFGID_RPI_PIO_USB_CONFIGURATION, &pio_cfg);
 #endif
 


### PR DESCRIPTION
**Describe the PR**
Rename PIO_USB pin configure and value to match adafruit feather usb host. These should be part of board configure in pico-sdk later on
