### PR TITLE
Add missing dependency tusb.h for tusb_private.h

### DIFF
--- a/src/common/tusb_private.h
+++ b/src/common/tusb_private.h
@@ -34,6 +34,8 @@
  extern "C" {
 #endif
 
+#include "tusb.h"
+
 typedef struct TU_ATTR_PACKED
 {
   volatile uint8_t busy    : 1;


### PR DESCRIPTION
**Describe the PR**
When working with TinyUSB, my IDE (VSCode) sorted the #includes for tusb_private.h as part of automated code formatting which revealed an implicit dependency on tusb.h via build breaks when tusb_private.h is #included without/before tusb.h.

This PR simply adds the implicit dependency as an explicit dependency, fixing the build break if the #include statements are ordered differently (for example in tusb.c).

**Additional context**
VSCode auto-formatting changed tusb.c from:

```
#include "tusb.h"
#include "common/tusb_private.h"
```

to 

```
#include "common/tusb_private.h"
#include "tusb.h"
```

which revealed the implicit dependency via a build break.