### PR TITLE
separate CFG_TUSB_MEM_SECTION/ALIGN to host and device specific macros 

### DIFF
--- a/examples/dual/host_hid_to_device_cdc/src/tusb_config.h
+++ b/examples/dual/host_hid_to_device_cdc/src/tusb_config.h
@@ -95,12 +95,12 @@
  * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
  * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
  */
-#ifndef CFG_TUSB_MEM_SECTION
-#define CFG_TUSB_MEM_SECTION
+#ifndef CFG_TUD_MEM_SECTION
+#define CFG_TUD_MEM_SECTION
 #endif
 
-#ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN        __attribute__ ((aligned(4)))
+#ifndef CFG_TUD_MEM_ALIGN
+#define CFG_TUD_MEM_ALIGN        __attribute__ ((aligned(4)))
 #endif
 
 //--------------------------------------------------------------------
@@ -127,6 +127,14 @@
 
 // Size of buffer to hold descriptors and other data used for enumeration
 #define CFG_TUH_ENUMERATION_BUFSIZE 256
+
+#ifndef CFG_TUH_MEM_SECTION
+#define CFG_TUH_MEM_SECTION
+#endif
+
+#ifndef CFG_TUH_MEM_ALIGN
+#define CFG_TUH_MEM_ALIGN        __attribute__ ((aligned(4)))
+#endif
 
 #define CFG_TUH_HUB                 1
 // max device support (excluding hub device)

--- a/examples/host/bare_api/src/tusb_config.h
+++ b/examples/host/bare_api/src/tusb_config.h
@@ -80,12 +80,12 @@
  * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
  * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
  */
-#ifndef CFG_TUSB_MEM_SECTION
-#define CFG_TUSB_MEM_SECTION
+#ifndef CFG_TUH_MEM_SECTION
+#define CFG_TUH_MEM_SECTION
 #endif
 
-#ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#ifndef CFG_TUH_MEM_ALIGN
+#define CFG_TUH_MEM_ALIGN        __attribute__ ((aligned(4)))
 #endif
 
 //--------------------------------------------------------------------

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -80,12 +80,12 @@
  * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
  * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
  */
-#ifndef CFG_TUSB_MEM_SECTION
-#define CFG_TUSB_MEM_SECTION
+#ifndef CFG_TUH_MEM_SECTION
+#define CFG_TUH_MEM_SECTION
 #endif
 
-#ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#ifndef CFG_TUH_MEM_ALIGN
+#define CFG_TUH_MEM_ALIGN        __attribute__ ((aligned(4)))
 #endif
 
 //--------------------------------------------------------------------

--- a/examples/host/hid_controller/src/tusb_config.h
+++ b/examples/host/hid_controller/src/tusb_config.h
@@ -80,12 +80,12 @@
  * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
  * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
  */
-#ifndef CFG_TUSB_MEM_SECTION
-#define CFG_TUSB_MEM_SECTION
+#ifndef CFG_TUH_MEM_SECTION
+#define CFG_TUH_MEM_SECTION
 #endif
 
-#ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#ifndef CFG_TUH_MEM_ALIGN
+#define CFG_TUH_MEM_ALIGN        __attribute__ ((aligned(4)))
 #endif
 
 //--------------------------------------------------------------------

--- a/examples/host/msc_file_explorer/src/tusb_config.h
+++ b/examples/host/msc_file_explorer/src/tusb_config.h
@@ -80,12 +80,12 @@
  * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
  * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
  */
-#ifndef CFG_TUSB_MEM_SECTION
-#define CFG_TUSB_MEM_SECTION
+#ifndef CFG_TUH_MEM_SECTION
+#define CFG_TUH_MEM_SECTION
 #endif
 
-#ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#ifndef CFG_TUH_MEM_ALIGN
+#define CFG_TUH_MEM_ALIGN        __attribute__ ((aligned(4)))
 #endif
 
 //--------------------------------------------------------------------

--- a/hw/bsp/ea4088qs/board.mk
+++ b/hw/bsp/ea4088qs/board.mk
@@ -10,7 +10,8 @@ CFLAGS += \
   -nostdlib \
   -DCORE_M4 \
   -D__USE_LPCOPEN \
-  -DCFG_TUSB_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
+  -DCFG_TUD_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
+  -DCFG_TUH_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
   -DCFG_TUSB_MCU=OPT_MCU_LPC40XX
 
 # mcu driver cause following warnings

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -62,10 +62,10 @@ typedef struct {
     tu_edpt_stream_t rx;
 
     uint8_t tx_ff_buf[CFG_TUH_CDC_TX_BUFSIZE];
-    CFG_TUSB_MEM_ALIGN uint8_t tx_ep_buf[CFG_TUH_CDC_TX_EPSIZE];
+    CFG_TUH_MEM_ALIGN uint8_t tx_ep_buf[CFG_TUH_CDC_TX_EPSIZE];
 
     uint8_t rx_ff_buf[CFG_TUH_CDC_TX_BUFSIZE];
-    CFG_TUSB_MEM_ALIGN uint8_t rx_ep_buf[CFG_TUH_CDC_TX_EPSIZE];
+    CFG_TUH_MEM_ALIGN uint8_t rx_ep_buf[CFG_TUH_CDC_TX_EPSIZE];
   } stream;
 
 } cdch_interface_t;
@@ -74,7 +74,7 @@ typedef struct {
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 
-CFG_TUSB_MEM_SECTION
+CFG_TUH_MEM_SECTION
 static cdch_interface_t cdch_data[CFG_TUH_CDC];
 
 static inline cdch_interface_t* get_itf(uint8_t idx)

--- a/src/class/cdc/cdc_rndis_host.c
+++ b/src/class/cdc/cdc_rndis_host.c
@@ -50,8 +50,8 @@
 //--------------------------------------------------------------------+
 #define RNDIS_MSG_PAYLOAD_MAX   (1024*4)
 
-CFG_TUSB_MEM_SECTION static uint8_t msg_notification[CFG_TUH_DEVICE_MAX][8];
-CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4) static uint8_t msg_payload[RNDIS_MSG_PAYLOAD_MAX];
+CFG_TUH_MEM_SECTION static uint8_t msg_notification[CFG_TUH_DEVICE_MAX][8];
+CFG_TUH_MEM_SECTION CFG_TUH_MEM_ALIGN static uint8_t msg_payload[RNDIS_MSG_PAYLOAD_MAX];
 
 static rndish_data_t rndish_data[CFG_TUH_DEVICE_MAX];
 

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -54,11 +54,11 @@ typedef struct
   uint16_t epin_size;
   uint16_t epout_size;
 
-  uint8_t epin_buf[CFG_TUH_HID_EPIN_BUFSIZE];
-  uint8_t epout_buf[CFG_TUH_HID_EPOUT_BUFSIZE];
+  CFG_TUH_MEM_ALIGN uint8_t epin_buf[CFG_TUH_HID_EPIN_BUFSIZE];
+  CFG_TUH_MEM_ALIGN uint8_t epout_buf[CFG_TUH_HID_EPOUT_BUFSIZE];
 } hidh_interface_t;
 
-CFG_TUSB_MEM_SECTION
+CFG_TUH_MEM_SECTION
 tu_static hidh_interface_t _hidh_itf[CFG_TUH_HID];
 
 //--------------------------------------------------------------------+

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -71,15 +71,15 @@ typedef struct
   tuh_msc_complete_cb_t complete_cb;
   uintptr_t complete_arg;
 
-  msc_cbw_t cbw;
-  msc_csw_t csw;
+  CFG_TUH_MEM_ALIGN msc_cbw_t cbw;
+  CFG_TUH_MEM_ALIGN msc_csw_t csw;
 }msch_interface_t;
 
-CFG_TUSB_MEM_SECTION static msch_interface_t _msch_itf[CFG_TUH_DEVICE_MAX];
+CFG_TUH_MEM_SECTION static msch_interface_t _msch_itf[CFG_TUH_DEVICE_MAX];
 
 // buffer used to read scsi information when mounted
 // largest response data currently is inquiry TODO Inquiry is not part of enum anymore
-CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4)
+CFG_TUH_MEM_SECTION CFG_TUH_MEM_ALIGN
 static uint8_t _msch_buffer[sizeof(scsi_inquiry_resp_t)];
 
 TU_ATTR_ALWAYS_INLINE

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -43,12 +43,12 @@ typedef struct
   uint8_t port_count;
   uint8_t status_change; // data from status change interrupt endpoint
 
-  hub_port_status_response_t port_status;
-  hub_status_response_t hub_status;
+  CFG_TUH_MEM_ALIGN hub_port_status_response_t port_status;
+  CFG_TUH_MEM_ALIGN hub_status_response_t hub_status;
 } hub_interface_t;
 
-CFG_TUSB_MEM_SECTION static hub_interface_t hub_data[CFG_TUH_HUB];
-CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4) static uint8_t _hub_buffer[sizeof(descriptor_hub_desc_t)];
+CFG_TUH_MEM_SECTION static hub_interface_t hub_data[CFG_TUH_HUB];
+CFG_TUH_MEM_SECTION CFG_TUH_MEM_ALIGN static uint8_t _hub_buffer[sizeof(descriptor_hub_desc_t)];
 
 TU_ATTR_ALWAYS_INLINE
 static inline hub_interface_t* get_itf(uint8_t dev_addr)

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -203,7 +203,7 @@ static usbh_dev0_t _dev0;
 // all devices excluding zero-address
 // hub address start from CFG_TUH_DEVICE_MAX+1
 // TODO: hub can has its own simpler struct to save memory
-CFG_TUSB_MEM_SECTION usbh_device_t _usbh_devices[TOTAL_DEVICES];
+static usbh_device_t _usbh_devices[TOTAL_DEVICES];
 
 // Mutex for claiming endpoint
 #if OSAL_MUTEX_REQUIRED
@@ -218,15 +218,15 @@ CFG_TUSB_MEM_SECTION usbh_device_t _usbh_devices[TOTAL_DEVICES];
 OSAL_QUEUE_DEF(usbh_int_set, _usbh_qdef, CFG_TUH_TASK_QUEUE_SZ, hcd_event_t);
 static osal_queue_t _usbh_q;
 
-CFG_TUSB_MEM_SECTION CFG_TUSB_MEM_ALIGN
+CFG_TUH_MEM_SECTION CFG_TUH_MEM_ALIGN
 static uint8_t _usbh_ctrl_buf[CFG_TUH_ENUMERATION_BUFSIZE];
 
 // Control transfers: since most controllers do not support multiple control transfers
 // on multiple devices concurrently and control transfers are not used much except for
 // enumeration, we will only execute control transfers one at a time.
-CFG_TUSB_MEM_SECTION struct
+CFG_TUH_MEM_SECTION struct
 {
-  tusb_control_request_t request TU_ATTR_ALIGNED(4);
+  CFG_TUH_MEM_ALIGN tusb_control_request_t request;
   uint8_t* buffer;
   tuh_xfer_cb_t complete_cb;
   uintptr_t user_data;

--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -85,7 +85,7 @@ typedef struct
 }ehci_data_t;
 
 // Periodic frame list must be 4K alignment
-CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4096) static ehci_data_t ehci_data;
+CFG_TUH_MEM_SECTION TU_ATTR_ALIGNED(4096) static ehci_data_t ehci_data;
 
 //--------------------------------------------------------------------+
 // PROTOTYPE

--- a/src/portable/nxp/khci/hcd_khci.c
+++ b/src/portable/nxp/khci/hcd_khci.c
@@ -137,8 +137,8 @@ typedef struct
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
 // BDT(Buffer Descriptor Table) must be 256-byte aligned
-CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(512) static hcd_data_t _hcd;
-//CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(4) static uint8_t _rx_buf[1024];
+CFG_TUH_MEM_SECTION TU_ATTR_ALIGNED(512) static hcd_data_t _hcd;
+//CFG_TUH_MEM_SECTION TU_ATTR_ALIGNED(4) static uint8_t _rx_buf[1024];
 
 int find_pipe(uint8_t dev_addr, uint8_t ep_addr)
 {

--- a/src/portable/ohci/ohci.c
+++ b/src/portable/ohci/ohci.c
@@ -145,7 +145,7 @@ enum {
 //--------------------------------------------------------------------+
 // INTERNAL OBJECT & FUNCTION DECLARATION
 //--------------------------------------------------------------------+
-CFG_TUSB_MEM_SECTION TU_ATTR_ALIGNED(256) static ohci_data_t ohci_data;
+CFG_TUH_MEM_SECTION TU_ATTR_ALIGNED(256) static ohci_data_t ohci_data;
 
 static ohci_ed_t * const p_ed_head[] =
 {

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -289,12 +289,15 @@
   #define CFG_TUSB_DEBUG 0
 #endif
 
-// place data in accessible RAM for usb controller
+// TODO MEM_SECTION can be different for host and device controller
+// should use CFG_TUD_MEM_SECTION, CFG_TUH_MEM_SECTION
 #ifndef CFG_TUSB_MEM_SECTION
   #define CFG_TUSB_MEM_SECTION
 #endif
 
 // alignment requirement of buffer used for endpoint transferring
+// TODO MEM_ALIGN can be different for host and device controller
+// should use CFG_TUD_MEM_ALIGN, CFG_TUH_MEM_ALIGN
 #ifndef CFG_TUSB_MEM_ALIGN
   #define CFG_TUSB_MEM_ALIGN      TU_ATTR_ALIGNED(4)
 #endif
@@ -311,6 +314,26 @@
 //--------------------------------------------------------------------
 // Device Options (Default)
 //--------------------------------------------------------------------
+
+// Attribute to place data in accessible RAM for device controller
+// default to CFG_TUSB_MEM_SECTION for backward-compatible
+#ifndef CFG_TUD_MEM_SECTION
+  #ifdef CFG_TUSB_MEM_SECTION
+    #define CFG_TUD_MEM_SECTION   CFG_TUSB_MEM_SECTION
+  #else
+    #define CFG_TUD_MEM_SECTION
+  #endif
+#endif
+
+// Attribute to align memory for device controller
+// default to CFG_TUSB_MEM_ALIGN for backward-compatible
+#ifndef CFG_TUD_MEM_ALIGN
+  #ifdef CFG_TUSB_MEM_ALIGN
+    #define CFG_TUD_MEM_ALIGN   CFG_TUSB_MEM_ALIGN
+  #else
+    #define CFG_TUD_MEM_ALIGN   TU_ATTR_ALIGNED(4)
+  #endif
+#endif
 
 #ifndef CFG_TUD_ENDPOINT0_SIZE
   #define CFG_TUD_ENDPOINT0_SIZE  64
@@ -389,6 +412,21 @@
     #define CFG_TUH_ENUMERATION_BUFSIZE 256
   #endif
 #endif // CFG_TUH_ENABLED
+
+// Attribute to place data in accessible RAM for host controller
+// default to CFG_TUSB_MEM_SECTION for backward-compatible
+#ifndef CFG_TUH_MEM_SECTION
+  #ifdef CFG_TUSB_MEM_SECTION
+    #define CFG_TUH_MEM_SECTION   CFG_TUSB_MEM_SECTION
+  #else
+    #define CFG_TUH_MEM_SECTION
+  #endif
+#endif
+
+// Attribute to align memory for host controller
+#ifndef CFG_TUH_MEM_ALIGN
+  #define CFG_TUH_MEM_ALIGN   TU_ATTR_ALIGNED(4)
+#endif
 
 //------------- CLASS -------------//
 

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -93,7 +93,7 @@ def build_example(example, board, make_option):
         ret[2] = 1
         print(build_format.format(example, board, status, '-', flash_size, sram_size))
     else:
-        subprocess.run(make_cmd + " clean", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        #subprocess.run(make_cmd + " clean", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         build_result = subprocess.run(make_cmd + " all", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         if build_result.returncode == 0:

--- a/tools/gen_doc.py
+++ b/tools/gen_doc.py
@@ -6,9 +6,11 @@ from get_deps import deps_all
 # TOP is tinyusb root dir
 TOP = Path(__file__).parent.parent.resolve()
 
+
 ###########################################
 # Dependencies
 ###########################################
+
 def gen_deps_doc():
     deps_rst = Path(TOP) / "docs/reference/dependencies.rst"
     df = pd.DataFrame.from_dict(deps_all, orient='index', columns=['Commit', 'Project'])


### PR DESCRIPTION
**Describe the PR**
fix #1976 , host and device controller may have different requirement for memory section (location) and alignment. It is better to separte these configuration. CFG_TUSB_MEM_SECTION and CFG_TUSB_MEM_ALIGN can still be used as backward compatible. However, these should be used in the future (gradually migrate device & example later)
- CFG_TUD_MEM_SECTION and CFG_TUD_MEM_ALIGN
- CFG_TUH_MEM_SECTION and CFG_TUH_MEM_ALIGN

