### PR TITLE
Add the capability for video class to handle a bulk endpoint in the streaming interface.

### DIFF
--- a/examples/device/video_capture/src/tusb_config.h
+++ b/examples/device/video_capture/src/tusb_config.h
@@ -100,6 +100,9 @@
 // video streaming endpoint size
 #define CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE  256
 
+// use bulk endpoint for streaming interface
+#define CFG_TUD_VIDEO_STREAMING_BULK 0
+
 #ifdef __cplusplus
  }
 #endif

--- a/examples/device/video_capture/src/usb_descriptors.c
+++ b/examples/device/video_capture/src/usb_descriptors.c
@@ -76,11 +76,17 @@ uint8_t const * tud_descriptor_device_cb(void)
 //--------------------------------------------------------------------+
 
 #if defined(CFG_EXAMPLE_VIDEO_READONLY) && !defined(CFG_EXAMPLE_VIDEO_DISABLE_MJPEG)
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_MJPEG_LEN)
-#elif 1 == CFG_TUD_VIDEO_STREAMING_BULK
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_UNCOMPR_BULK_LEN)
+# if 1 == CFG_TUD_VIDEO_STREAMING_BULK
+#  define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_MJPEG_BULK_LEN)
+# else
+#  define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_MJPEG_LEN)
+# endif
 #else
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_UNCOMPR_LEN)
+# if 1 == CFG_TUD_VIDEO_STREAMING_BULK
+#  define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_UNCOMPR_BULK_LEN)
+# else
+#  define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_UNCOMPR_LEN)
+# endif
 #endif
 
 #if TU_CHECK_MCU(OPT_MCU_LPC175X_6X, OPT_MCU_LPC177X_8X, OPT_MCU_LPC40XX)
@@ -108,17 +114,25 @@ uint8_t const desc_fs_configuration[] =
 
   // IAD for Video Control
 #if defined(CFG_EXAMPLE_VIDEO_READONLY) && !defined(CFG_EXAMPLE_VIDEO_DISABLE_MJPEG)
+# if 1 == CFG_TUD_VIDEO_STREAMING_BULK
+  TUD_VIDEO_CAPTURE_DESCRIPTOR_MJPEG_BULK(4, EPNUM_VIDEO_IN,
+                                          FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE,
+                                          64)
+# else
   TUD_VIDEO_CAPTURE_DESCRIPTOR_MJPEG(4, EPNUM_VIDEO_IN,
                                      FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE,
                                      CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE)
-#elif 1 == CFG_TUD_VIDEO_STREAMING_BULK
-  TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(4, EPNUM_VIDEO_IN,
-                                       FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE,
-                                       64)
+# endif
 #else
+# if 1 == CFG_TUD_VIDEO_STREAMING_BULK
+  TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(4, EPNUM_VIDEO_IN,
+                                            FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE,
+                                            64)
+# else
   TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR(4, EPNUM_VIDEO_IN,
                                        FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE,
                                        CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE)
+# endif
 #endif
 };
 

--- a/examples/device/video_capture/src/usb_descriptors.c
+++ b/examples/device/video_capture/src/usb_descriptors.c
@@ -77,6 +77,8 @@ uint8_t const * tud_descriptor_device_cb(void)
 
 #if defined(CFG_EXAMPLE_VIDEO_READONLY) && !defined(CFG_EXAMPLE_VIDEO_DISABLE_MJPEG)
 #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_MJPEG_LEN)
+#elif 1 == CFG_TUD_VIDEO_STREAMING_BULK
+#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_UNCOMPR_BULK_LEN)
 #else
 #define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VIDEO_CAPTURE_DESC_UNCOMPR_LEN)
 #endif
@@ -84,7 +86,11 @@ uint8_t const * tud_descriptor_device_cb(void)
 #if TU_CHECK_MCU(OPT_MCU_LPC175X_6X, OPT_MCU_LPC177X_8X, OPT_MCU_LPC40XX)
   // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
   // 0 control, 1 In, 2 Bulk, 3 Iso, 4 In, 5 Bulk etc ...
+#if 1 == CFG_TUD_VIDEO_STREAMING_BULK
+  #define EPNUM_VIDEO_IN    0x82
+#else
   #define EPNUM_VIDEO_IN    0x83
+#endif
 
 #elif TU_CHECK_MCU(OPT_MCU_NRF5X)
   // nRF5x ISO can only be endpoint 8
@@ -105,6 +111,10 @@ uint8_t const desc_fs_configuration[] =
   TUD_VIDEO_CAPTURE_DESCRIPTOR_MJPEG(4, EPNUM_VIDEO_IN,
                                      FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE,
                                      CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE)
+#elif 1 == CFG_TUD_VIDEO_STREAMING_BULK
+  TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(4, EPNUM_VIDEO_IN,
+                                       FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE,
+                                       64)
 #else
   TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR(4, EPNUM_VIDEO_IN,
                                        FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE,

--- a/examples/device/video_capture/src/usb_descriptors.h
+++ b/examples/device/video_capture/src/usb_descriptors.h
@@ -79,6 +79,22 @@ enum {
     + 7/* Endpoint */\
   )
 
+#define TUD_VIDEO_CAPTURE_DESC_UNCOMPR_BULK_LEN (\
+    TUD_VIDEO_DESC_IAD_LEN\
+    /* control */\
+    + TUD_VIDEO_DESC_STD_VC_LEN\
+    + (TUD_VIDEO_DESC_CS_VC_LEN + 1/*bInCollection*/)\
+    + TUD_VIDEO_DESC_CAMERA_TERM_LEN\
+    + TUD_VIDEO_DESC_OUTPUT_TERM_LEN\
+    /* Interface 1, Alternate 0 */\
+    + TUD_VIDEO_DESC_STD_VS_LEN\
+    + (TUD_VIDEO_DESC_CS_VS_IN_LEN + 1/*bNumFormats x bControlSize*/)\
+    + TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR_LEN\
+    + TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT_LEN\
+    + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN\
+    + 7/* Endpoint */\
+  )
+
 /* Windows support YUY2 and NV12
  * https://docs.microsoft.com/en-us/windows-hardware/drivers/stream/usb-video-class-driver-overview */
 
@@ -164,5 +180,40 @@ enum {
   TUD_VIDEO_DESC_STD_VS(ITF_NUM_VIDEO_STREAMING, 1, 1, _stridx), \
     /* EP */ \
     TUD_VIDEO_DESC_EP_ISO(_epin, _epsize, 1)
+
+
+#define TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(_stridx, _epin, _width, _height, _fps, _epsize) \
+  TUD_VIDEO_DESC_IAD(ITF_NUM_VIDEO_CONTROL, /* 2 Interfaces */ 0x02, _stridx), \
+  /* Video control 0 */ \
+  TUD_VIDEO_DESC_STD_VC(ITF_NUM_VIDEO_CONTROL, 0, _stridx), \
+    TUD_VIDEO_DESC_CS_VC( /* UVC 1.5*/ 0x0150, \
+         /* wTotalLength - bLength */ \
+         TUD_VIDEO_DESC_CAMERA_TERM_LEN + TUD_VIDEO_DESC_OUTPUT_TERM_LEN, \
+         UVC_CLOCK_FREQUENCY, ITF_NUM_VIDEO_STREAMING), \
+      TUD_VIDEO_DESC_CAMERA_TERM(UVC_ENTITY_CAP_INPUT_TERMINAL, 0, 0,\
+                                 /*wObjectiveFocalLengthMin*/0, /*wObjectiveFocalLengthMax*/0,\
+                                 /*wObjectiveFocalLength*/0, /*bmControls*/0), \
+      TUD_VIDEO_DESC_OUTPUT_TERM(UVC_ENTITY_CAP_OUTPUT_TERMINAL, VIDEO_TT_STREAMING, 0, 1, 0), \
+  /* Video stream alt. 0 */ \
+  TUD_VIDEO_DESC_STD_VS(ITF_NUM_VIDEO_STREAMING, 0, 1, _stridx), \
+    /* Video stream header for without still image capture */ \
+    TUD_VIDEO_DESC_CS_VS_INPUT( /*bNumFormats*/1, \
+        /*wTotalLength - bLength */\
+        TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR_LEN\
+        + TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT_LEN\
+        + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN,\
+        _epin, /*bmInfo*/0, /*bTerminalLink*/UVC_ENTITY_CAP_OUTPUT_TERMINAL, \
+        /*bStillCaptureMethod*/0, /*bTriggerSupport*/0, /*bTriggerUsage*/0, \
+        /*bmaControls(1)*/0), \
+      /* Video stream format */ \
+      TUD_VIDEO_DESC_CS_VS_FMT_YUY2(/*bFormatIndex*/1, /*bNumFrameDescriptors*/1, \
+        /*bDefaultFrameIndex*/1, 0, 0, 0, /*bCopyProtect*/0), \
+        /* Video stream frame format */ \
+        TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT(/*bFrameIndex */1, 0, _width, _height, \
+            _width * _height * 16, _width * _height * 16 * _fps, \
+            _width * _height * 16, \
+            (10000000/_fps), (10000000/_fps), (10000000/_fps)*_fps, (10000000/_fps)), \
+        TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING(VIDEO_COLOR_PRIMARIES_BT709, VIDEO_COLOR_XFER_CH_BT709, VIDEO_COLOR_COEF_SMPTE170M), \
+        TUD_VIDEO_DESC_EP_BULK(_epin, _epsize, 1)
 
 #endif

--- a/examples/device/video_capture/src/usb_descriptors.h
+++ b/examples/device/video_capture/src/usb_descriptors.h
@@ -95,6 +95,22 @@ enum {
     + 7/* Endpoint */\
   )
 
+#define TUD_VIDEO_CAPTURE_DESC_MJPEG_BULK_LEN (\
+    TUD_VIDEO_DESC_IAD_LEN\
+    /* control */\
+    + TUD_VIDEO_DESC_STD_VC_LEN\
+    + (TUD_VIDEO_DESC_CS_VC_LEN + 1/*bInCollection*/)\
+    + TUD_VIDEO_DESC_CAMERA_TERM_LEN\
+    + TUD_VIDEO_DESC_OUTPUT_TERM_LEN\
+    /* Interface 1, Alternate 0 */\
+    + TUD_VIDEO_DESC_STD_VS_LEN\
+    + (TUD_VIDEO_DESC_CS_VS_IN_LEN + 1/*bNumFormats x bControlSize*/)\
+    + TUD_VIDEO_DESC_CS_VS_FMT_MJPEG_LEN\
+    + TUD_VIDEO_DESC_CS_VS_FRM_MJPEG_CONT_LEN\
+    + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN\
+    + 7/* Endpoint */\
+  )
+
 /* Windows support YUY2 and NV12
  * https://docs.microsoft.com/en-us/windows-hardware/drivers/stream/usb-video-class-driver-overview */
 
@@ -215,5 +231,41 @@ enum {
             (10000000/_fps), (10000000/_fps), (10000000/_fps)*_fps, (10000000/_fps)), \
         TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING(VIDEO_COLOR_PRIMARIES_BT709, VIDEO_COLOR_XFER_CH_BT709, VIDEO_COLOR_COEF_SMPTE170M), \
         TUD_VIDEO_DESC_EP_BULK(_epin, _epsize, 1)
+
+#define TUD_VIDEO_CAPTURE_DESCRIPTOR_MJPEG_BULK(_stridx, _epin, _width, _height, _fps, _epsize) \
+  TUD_VIDEO_DESC_IAD(ITF_NUM_VIDEO_CONTROL, /* 2 Interfaces */ 0x02, _stridx), \
+  /* Video control 0 */ \
+  TUD_VIDEO_DESC_STD_VC(ITF_NUM_VIDEO_CONTROL, 0, _stridx), \
+    TUD_VIDEO_DESC_CS_VC( /* UVC 1.5*/ 0x0150, \
+         /* wTotalLength - bLength */ \
+         TUD_VIDEO_DESC_CAMERA_TERM_LEN + TUD_VIDEO_DESC_OUTPUT_TERM_LEN, \
+         UVC_CLOCK_FREQUENCY, ITF_NUM_VIDEO_STREAMING), \
+      TUD_VIDEO_DESC_CAMERA_TERM(UVC_ENTITY_CAP_INPUT_TERMINAL, 0, 0,\
+                                 /*wObjectiveFocalLengthMin*/0, /*wObjectiveFocalLengthMax*/0,\
+                                 /*wObjectiveFocalLength*/0, /*bmControls*/0), \
+      TUD_VIDEO_DESC_OUTPUT_TERM(UVC_ENTITY_CAP_OUTPUT_TERMINAL, VIDEO_TT_STREAMING, 0, 1, 0), \
+  /* Video stream alt. 0 */ \
+  TUD_VIDEO_DESC_STD_VS(ITF_NUM_VIDEO_STREAMING, 0, 1, _stridx), \
+    /* Video stream header for without still image capture */ \
+    TUD_VIDEO_DESC_CS_VS_INPUT( /*bNumFormats*/1, \
+        /*wTotalLength - bLength */\
+        TUD_VIDEO_DESC_CS_VS_FMT_MJPEG_LEN\
+        + TUD_VIDEO_DESC_CS_VS_FRM_MJPEG_CONT_LEN\
+        + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN,\
+        _epin, /*bmInfo*/0, /*bTerminalLink*/UVC_ENTITY_CAP_OUTPUT_TERMINAL, \
+        /*bStillCaptureMethod*/0, /*bTriggerSupport*/0, /*bTriggerUsage*/0, \
+        /*bmaControls(1)*/0), \
+      /* Video stream format */ \
+      TUD_VIDEO_DESC_CS_VS_FMT_MJPEG(/*bFormatIndex*/1, /*bNumFrameDescriptors*/1, \
+        /*bmFlags*/0, /*bDefaultFrameIndex*/1, 0, 0, 0, /*bCopyProtect*/0), \
+        /* Video stream frame format */ \
+        TUD_VIDEO_DESC_CS_VS_FRM_MJPEG_CONT(/*bFrameIndex */1, 0, _width, _height, \
+            _width * _height * 16, _width * _height * 16 * _fps, \
+            _width * _height * 16 / 8, \
+            (10000000/_fps), (10000000/_fps), (10000000/_fps)*_fps, (10000000/_fps)), \
+        TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING(VIDEO_COLOR_PRIMARIES_BT709, VIDEO_COLOR_XFER_CH_BT709, VIDEO_COLOR_COEF_SMPTE170M), \
+        /* EP */ \
+        TUD_VIDEO_DESC_EP_BULK(_epin, _epsize, 1)
+
 
 #endif


### PR DESCRIPTION
**Describe the PR**
Add handling bulk endpoints in streaming interface. This feature is only compatible with streaming, and the still image capture function is not yet implemented.

Using bulk endpoints may allow for more bandwidth utilization than isochronous endpoints. It may also enable higher image sizes and frame rates.

**Additional context**
I have tested this PR on Raspberry Pi Pico and Windows 11.
I have confirmed that the `video_capture` can display color bars up to 128x96 60fps.