### PR TITLE
openh743i: initialize USB3300 reset pin

### DIFF
--- a/hw/bsp/stm32h7/boards/waveshare_openh743i/board.h
+++ b/hw/bsp/stm32h7/boards/waveshare_openh743i/board.h
@@ -192,6 +192,14 @@ static inline void board_stm32h7_post_init(void)
   // Init timer
   TIM_HandleTypeDef tim2Handle;
   TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+  GPIO_InitTypeDef  GPIO_InitStruct;
+
+  // ULPI_RST
+  GPIO_InitStruct.Pin   = ULPI_RST_PIN;
+  GPIO_InitStruct.Mode  = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull  = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = 0;
+  HAL_GPIO_Init(ULPI_RST_PORT, &GPIO_InitStruct);
 
   __HAL_RCC_TIM2_CLK_ENABLE();
 


### PR DESCRIPTION
The USB3300 reset pin for Waveshare openh743i board was never initialized, so resetting the chip doesn't work correctly. This PR initialize the pin as OUTPUT before any use.