### PR TITLE
Add STM32L5 support - no OTG similar to some L4s

### DIFF
--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -229,6 +229,12 @@
   #define TUP_USBIP_DWC2_STM32
   #define TUP_DCD_ENDPOINT_MAX    6
 
+#elif TU_CHECK_MCU(OPT_MCU_STM32L5)
+  #define TUP_USBIP_FSDEV
+  #define TUP_USBIP_FSDEV_STM32
+  #define TUP_DCD_ENDPOINT_MAX    8
+
+
 //--------------------------------------------------------------------+
 // Sony
 //--------------------------------------------------------------------+

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -362,6 +362,9 @@ void dcd_int_enable (uint8_t rhport)
   NVIC_EnableIRQ(USB_HP_IRQn);
   NVIC_EnableIRQ(USB_LP_IRQn);
 
+#elif CFG_TUSB_MCU == OPT_MCU_STM32L5
+  NVIC_EnableIRQ(USB_FS_IRQn);
+
 #else
   #error Unknown arch in USB driver
 #endif
@@ -408,6 +411,9 @@ void dcd_int_disable(uint8_t rhport)
 #elif CFG_TUSB_MCU == OPT_MCU_STM32WB
   NVIC_DisableIRQ(USB_HP_IRQn);
   NVIC_DisableIRQ(USB_LP_IRQn);
+
+#elif CFG_TUSB_MCU == OPT_MCU_STM32L5
+  NVIC_DisableIRQ(USB_FS_IRQn);
 
 #else
   #error Unknown arch in USB driver

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -93,6 +93,14 @@
   #include "stm32l4xx.h"
   #define PMA_LENGTH (1024u)
 
+#elif CFG_TUSB_MCU == OPT_MCU_STM32L5
+  #include "stm32l5xx.h"
+  #define PMA_LENGTH (1024u)
+
+  #ifndef USB_PMAADDR
+    #define USB_PMAADDR (USB_BASE + (USB_PMAADDR_NS - USB_BASE_NS))
+  #endif
+
 #else
   #error You are using an untested or unimplemented STM32 variant. Please update the driver.
   // This includes L1x0, L1x1, L1x2, L4x2 and L4x3, G1x1, G1x3, and G1x4

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -82,6 +82,7 @@
 #define OPT_MCU_STM32G4           311 ///< ST G4
 #define OPT_MCU_STM32WB           312 ///< ST WB
 #define OPT_MCU_STM32U5           313 ///< ST U5
+#define OPT_MCU_STM32L5           314 ///< ST L5
 
 // Sony
 #define OPT_MCU_CXD56             400 ///< SONY CXD56


### PR DESCRIPTION
**Describe the PR**
Adds support for STM32L5 MCUs

**Additional context**
Tested on STM32L552RCT on custom board in crystalless mode using clock recovery system (CRS).  Only additional setup required is APB clock to USB, CRS setup and enabling VDDUSB via PWR->CR2.

USB_PMAADDR is not defined in stm cmsis headers but rather USB_PMAADDR_S and USB_PMAADDR_NS (secure and non-secure modes respectively).  The definition here is relative to USB_BASE which defaults to USB_BASE_NS but the current implementation allows the user to redefine this to USB_BASE_S and the USB_PMAADDR define will be adjusted appropriately.
