### PR TITLE
Add usb2uart serial host driver

### DIFF
--- a/.codespell/ignore-words.txt
+++ b/.codespell/ignore-words.txt
@@ -1,6 +1,7 @@
 synopsys
 sie
 tre
+thre
 hsi
 fro
 dout

--- a/examples/host/cdc_msc_hid/CMakeLists.txt
+++ b/examples/host/cdc_msc_hid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.17)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../../hw/bsp/family_support.cmake)
 

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -97,7 +97,8 @@
 
 #define CFG_TUH_HUB                 1 // number of supported hubs
 #define CFG_TUH_CDC                 1 // CDC ACM
-#define CFG_TUH_CDC_FTDI            1 // FTDI UART
+#define CFG_TUH_CDC_FTDI            1 // FTDI Serial
+#define CFG_TUH_CDC_CP210X          1 // CP210x Serial
 #define CFG_TUH_HID                 (3*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 1
 #define CFG_TUH_VENDOR              0

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -97,8 +97,8 @@
 
 #define CFG_TUH_HUB                 1 // number of supported hubs
 #define CFG_TUH_CDC                 1 // CDC ACM
-#define CFG_TUH_CDC_FTDI            1 // FTDI Serial
-#define CFG_TUH_CDC_CP210X          1 // CP210x Serial
+#define CFG_TUH_CDC_FTDI            1 // FTDI Serial.  FTDI is not part of CDC class, only to re-use CDC driver API
+#define CFG_TUH_CDC_CP210X          1 // CP210x Serial. CP210X is not part of CDC class, only to re-use CDC driver API
 #define CFG_TUH_HID                 (3*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 1
 #define CFG_TUH_VENDOR              0

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -96,7 +96,8 @@
 #define CFG_TUH_ENUMERATION_BUFSIZE 256
 
 #define CFG_TUH_HUB                 1 // number of supported hubs
-#define CFG_TUH_CDC                 1
+#define CFG_TUH_CDC                 1 // CDC ACM
+#define CFG_TUH_CDC_FTDI            1 // FTDI UART
 #define CFG_TUH_HID                 (3*CFG_TUH_DEVICE_MAX) // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 1
 #define CFG_TUH_VENDOR              0

--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -125,10 +125,10 @@ void board_init(void)
   // Set the system clock to a multiple of 120mhz for bitbanging USB with pico-usb
   set_sys_clock_khz(120000, true);
 
-#ifdef PIO_USB_VBUSEN_PIN
+#ifdef PICO_DEFAULT_PIO_USB_VBUSEN_PIN
   gpio_init(PICO_DEFAULT_PIO_USB_VBUSEN_PIN);
   gpio_set_dir(PICO_DEFAULT_PIO_USB_VBUSEN_PIN, GPIO_OUT);
-  gpio_put(PICO_DEFAULT_PIO_USB_VBUSEN_PIN, PIO_USB_VBUSEN_STATE);
+  gpio_put(PICO_DEFAULT_PIO_USB_VBUSEN_PIN, PICO_DEFAULT_PIO_USB_VBUSEN_STATE);
 #endif
 
   // rp2040 use pico-pio-usb for host tuh_configure() can be used to passed pio configuration to the host stack

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -33,14 +33,6 @@
 
 #include "cdc_host.h"
 
-#if CFG_TUH_CDC_FTDI
-  #include "serial/ftdi_sio.h"
-#endif
-
-#if CFG_TUH_CDC_CP210X
-  #include "serial/cp210x.h"
-#endif
-
 // Debug level, TUSB_CFG_DEBUG must be at least this level for debug message
 #define CDCH_DEBUG   2
 
@@ -145,6 +137,8 @@ static void cdch_internal_control_complete(tuh_xfer_t* xfer);
 
 //------------- FTDI prototypes -------------//
 #if CFG_TUH_CDC_FTDI
+#include "serial/ftdi_sio.h"
+
 static uint16_t const ftdi_pids[] = { TU_FTDI_PID_LIST };
 enum {
   FTDI_PID_COUNT = sizeof(ftdi_pids) / sizeof(ftdi_pids[0])
@@ -159,6 +153,8 @@ static bool ftdi_sio_set_baudrate(cdch_interface_t* p_cdc, uint32_t baudrate, tu
 
 //------------- CP210X prototypes -------------//
 #if CFG_TUH_CDC_CP210X
+#include "serial/cp210x.h"
+
 static uint16_t const cp210x_pids[] = { TU_CP210X_PID_LIST };
 enum {
   CP210X_PID_COUNT = sizeof(cp210x_pids) / sizeof(cp210x_pids[0])

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -34,7 +34,7 @@
 #include "cdc_host.h"
 
 #if CFG_TUH_CDC_FTDI
-  #include "serial/ftdi_host.h"
+  #include "serial/ftdi_sio.h"
 #endif
 
 

--- a/src/class/cdc/cdc_host.h
+++ b/src/class/cdc/cdc_host.h
@@ -140,22 +140,27 @@ bool tuh_cdc_read_clear (uint8_t idx);
 // Request to Set Control Line State: DTR (bit 0), RTS (bit 1)
 bool tuh_cdc_set_control_line_state(uint8_t idx, uint16_t line_state, tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
-// Request to Set Line Coding
+// Request to set baudrate
+bool tuh_cdc_set_baudrate(uint8_t idx, uint32_t baudrate, tuh_xfer_cb_t complete_cb, uintptr_t user_data);
+
+// Request to Set Line Coding (ACM only)
 bool tuh_cdc_set_line_coding(uint8_t idx, cdc_line_coding_t const* line_coding, tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
-// Request to Get Line Coding
+// Request to Get Line Coding (ACM only)
 // Should only use if tuh_cdc_set_line_coding() / tuh_cdc_get_line_coding() never got invoked and
 // CFG_TUH_CDC_LINE_CODING_ON_ENUM is not defined
 // bool tuh_cdc_get_line_coding(uint8_t idx, cdc_line_coding_t* coding);
 
 // Connect by set both DTR, RTS
-static inline bool tuh_cdc_connect(uint8_t idx, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
+TU_ATTR_ALWAYS_INLINE static inline
+bool tuh_cdc_connect(uint8_t idx, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   return tuh_cdc_set_control_line_state(idx, CDC_CONTROL_LINE_STATE_DTR | CDC_CONTROL_LINE_STATE_RTS, complete_cb, user_data);
 }
 
 // Disconnect by clear both DTR, RTS
-static inline bool tuh_cdc_disconnect(uint8_t idx, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
+TU_ATTR_ALWAYS_INLINE static inline
+bool tuh_cdc_disconnect(uint8_t idx, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   return tuh_cdc_set_control_line_state(idx, 0x00, complete_cb, user_data);
 }

--- a/src/class/cdc/serial/cp210x.h
+++ b/src/class/cdc/serial/cp210x.h
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Ha Thach (thach@tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TUSB_CP210X_H
+#define TUSB_CP210X_H
+
+// Protocol details can be found at AN571: CP210x Virtual COM Port Interface
+// https://www.silabs.com/documents/public/application-notes/AN571.pdf
+
+#define TU_CP210X_VID 0x10C4
+#define TU_CP210X_PID_LIST \
+  0xEA60, 0xEA70
+
+/* Config request codes */
+#define CP210X_IFC_ENABLE      0x00
+#define CP210X_SET_BAUDDIV     0x01
+#define CP210X_GET_BAUDDIV     0x02
+#define CP210X_SET_LINE_CTL    0x03 // Set parity, data bits, stop bits
+#define CP210X_GET_LINE_CTL    0x04
+#define CP210X_SET_BREAK       0x05
+#define CP210X_IMM_CHAR        0x06
+#define CP210X_SET_MHS         0x07 // Set DTR, RTS
+#define CP210X_GET_MDMSTS      0x08 // Get modem status (DTR, RTS, CTS, DSR, RI, DCD)
+#define CP210X_SET_XON         0x09
+#define CP210X_SET_XOFF        0x0A
+#define CP210X_SET_EVENTMASK   0x0B
+#define CP210X_GET_EVENTMASK   0x0C
+#define CP210X_SET_CHAR        0x0D
+#define CP210X_GET_CHARS       0x0E
+#define CP210X_GET_PROPS       0x0F
+#define CP210X_GET_COMM_STATUS 0x10
+#define CP210X_RESET           0x11
+#define CP210X_PURGE           0x12
+#define CP210X_SET_FLOW        0x13
+#define CP210X_GET_FLOW        0x14
+#define CP210X_EMBED_EVENTS    0x15
+#define CP210X_GET_EVENTSTATE  0x16
+#define CP210X_SET_CHARS       0x19
+#define CP210X_GET_BAUDRATE    0x1D
+#define CP210X_SET_BAUDRATE    0x1E
+#define CP210X_VENDOR_SPECIFIC 0xFF // GPIO, Recipient must be Device
+
+#endif //TUSB_CP210X_H

--- a/src/class/cdc/serial/ftdi_host.h
+++ b/src/class/cdc/serial/ftdi_host.h
@@ -1,0 +1,258 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Ha Thach (thach@tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TUSB_FTDI_HOST_H
+#define TUSB_FTDI_HOST_H
+
+// VID/PID for matching FTDI devices
+#define TU_FTDI_VID 0x0403
+#define TU_FTDI_PID_LIST \
+  0x6001, 0x6006, 0x6010, 0x6011, 0x6014, 0x6015, 0x8372, 0xFBFA, \
+  0xcd18
+
+// Commands
+#define FTDI_SIO_RESET             	0    /* Reset the port */
+#define FTDI_SIO_MODEM_CTRL        	1    /* Set the modem control register */
+#define FTDI_SIO_SET_FLOW_CTRL     	2    /* Set flow control register */
+#define FTDI_SIO_SET_BAUD_RATE     	3    /* Set baud rate */
+#define FTDI_SIO_SET_DATA          	4    /* Set the data characteristics of the port */
+#define FTDI_SIO_GET_MODEM_STATUS  	5    /* Retrieve current value of modem status register */
+#define FTDI_SIO_SET_EVENT_CHAR    	6    /* Set the event character */
+#define FTDI_SIO_SET_ERROR_CHAR    	7    /* Set the error character */
+#define FTDI_SIO_SET_LATENCY_TIMER 	9    /* Set the latency timer */
+#define FTDI_SIO_GET_LATENCY_TIMER 	0x0a /* Get the latency timer */
+#define FTDI_SIO_SET_BITMODE       	0x0b /* Set bitbang mode */
+#define FTDI_SIO_READ_PINS         	0x0c /* Read immediate value of pins */
+#define FTDI_SIO_READ_EEPROM       	0x90 /* Read EEPROM */
+
+/* FTDI_SIO_RESET */
+#define FTDI_SIO_RESET_SIO 0
+#define FTDI_SIO_RESET_PURGE_RX 1
+#define FTDI_SIO_RESET_PURGE_TX 2
+
+/*
+ * BmRequestType:  0100 0000B
+ * bRequest:       FTDI_SIO_RESET
+ * wValue:         Control Value
+ *                   0 = Reset SIO
+ *                   1 = Purge RX buffer
+ *                   2 = Purge TX buffer
+ * wIndex:         Port
+ * wLength:        0
+ * Data:           None
+ *
+ * The Reset SIO command has this effect:
+ *
+ *    Sets flow control set to 'none'
+ *    Event char = $0D
+ *    Event trigger = disabled
+ *    Purge RX buffer
+ *    Purge TX buffer
+ *    Clear DTR
+ *    Clear RTS
+ *    baud and data format not reset
+ *
+ * The Purge RX and TX buffer commands affect nothing except the buffers
+ *
+   */
+
+/* FTDI_SIO_MODEM_CTRL */
+/*
+ * BmRequestType:   0100 0000B
+ * bRequest:        FTDI_SIO_MODEM_CTRL
+ * wValue:          ControlValue (see below)
+ * wIndex:          Port
+ * wLength:         0
+ * Data:            None
+ *
+ * NOTE: If the device is in RTS/CTS flow control, the RTS set by this
+ * command will be IGNORED without an error being returned
+ * Also - you can not set DTR and RTS with one control message
+ */
+
+#define FTDI_SIO_SET_DTR_MASK 0x1
+#define FTDI_SIO_SET_DTR_HIGH ((FTDI_SIO_SET_DTR_MASK << 8) | 1)
+#define FTDI_SIO_SET_DTR_LOW  ((FTDI_SIO_SET_DTR_MASK << 8) | 0)
+#define FTDI_SIO_SET_RTS_MASK 0x2
+#define FTDI_SIO_SET_RTS_HIGH ((FTDI_SIO_SET_RTS_MASK << 8) | 2)
+#define FTDI_SIO_SET_RTS_LOW  ((FTDI_SIO_SET_RTS_MASK << 8) | 0)
+
+/*
+ * ControlValue
+ * B0    DTR state
+ *          0 = reset
+ *          1 = set
+ * B1    RTS state
+ *          0 = reset
+ *          1 = set
+ * B2..7 Reserved
+ * B8    DTR state enable
+ *          0 = ignore
+ *          1 = use DTR state
+ * B9    RTS state enable
+ *          0 = ignore
+ *          1 = use RTS state
+ * B10..15 Reserved
+ */
+
+/* FTDI_SIO_SET_FLOW_CTRL */
+#define FTDI_SIO_DISABLE_FLOW_CTRL 0x0
+#define FTDI_SIO_RTS_CTS_HS (0x1 << 8)
+#define FTDI_SIO_DTR_DSR_HS (0x2 << 8)
+#define FTDI_SIO_XON_XOFF_HS (0x4 << 8)
+
+/*
+ *   BmRequestType:  0100 0000b
+ *   bRequest:       FTDI_SIO_SET_FLOW_CTRL
+ *   wValue:         Xoff/Xon
+ *   wIndex:         Protocol/Port - hIndex is protocol / lIndex is port
+ *   wLength:        0
+ *   Data:           None
+ *
+ * hIndex protocol is:
+ *   B0 Output handshaking using RTS/CTS
+ *       0 = disabled
+ *       1 = enabled
+ *   B1 Output handshaking using DTR/DSR
+ *       0 = disabled
+ *       1 = enabled
+ *   B2 Xon/Xoff handshaking
+ *       0 = disabled
+ *       1 = enabled
+ *
+ * A value of zero in the hIndex field disables handshaking
+ *
+ * If Xon/Xoff handshaking is specified, the hValue field should contain the
+ * XOFF character and the lValue field contains the XON character.
+ */
+
+/* FTDI_SIO_SET_BAUD_RATE */
+/*
+ * BmRequestType:  0100 0000B
+ * bRequest:       FTDI_SIO_SET_BAUDRATE
+ * wValue:         BaudDivisor value - see below
+ * wIndex:         Port
+ * wLength:        0
+ * Data:           None
+ * The BaudDivisor values are calculated as follows (too complicated):
+ */
+
+/* FTDI_SIO_SET_DATA */
+#define FTDI_SIO_SET_DATA_PARITY_NONE	(0x0 << 8)
+#define FTDI_SIO_SET_DATA_PARITY_ODD	(0x1 << 8)
+#define FTDI_SIO_SET_DATA_PARITY_EVEN	(0x2 << 8)
+#define FTDI_SIO_SET_DATA_PARITY_MARK	(0x3 << 8)
+#define FTDI_SIO_SET_DATA_PARITY_SPACE	(0x4 << 8)
+#define FTDI_SIO_SET_DATA_STOP_BITS_1	(0x0 << 11)
+#define FTDI_SIO_SET_DATA_STOP_BITS_15	(0x1 << 11)
+#define FTDI_SIO_SET_DATA_STOP_BITS_2	(0x2 << 11)
+#define FTDI_SIO_SET_BREAK		(0x1 << 14)
+
+/*
+ * BmRequestType:  0100 0000B
+ * bRequest:       FTDI_SIO_SET_DATA
+ * wValue:         Data characteristics (see below)
+ * wIndex:         Port
+ * wLength:        0
+ * Data:           No
+ *
+ * Data characteristics
+ *
+ *   B0..7   Number of data bits
+ *   B8..10  Parity
+ *           0 = None
+ *           1 = Odd
+ *           2 = Even
+ *           3 = Mark
+ *           4 = Space
+ *   B11..13 Stop Bits
+ *           0 = 1
+ *           1 = 1.5
+ *           2 = 2
+ *   B14
+ *           1 = TX ON (break)
+ *           0 = TX OFF (normal state)
+ *   B15 Reserved
+ *
+ */
+
+/*
+* DATA FORMAT
+*
+* IN Endpoint
+*
+* The device reserves the first two bytes of data on this endpoint to contain
+* the current values of the modem and line status registers. In the absence of
+* data, the device generates a message consisting of these two status bytes
+  * every 40 ms
+  *
+  * Byte 0: Modem Status
+*
+* Offset	Description
+* B0	Reserved - must be 1
+* B1	Reserved - must be 0
+* B2	Reserved - must be 0
+* B3	Reserved - must be 0
+* B4	Clear to Send (CTS)
+* B5	Data Set Ready (DSR)
+* B6	Ring Indicator (RI)
+* B7	Receive Line Signal Detect (RLSD)
+*
+* Byte 1: Line Status
+*
+* Offset	Description
+* B0	Data Ready (DR)
+* B1	Overrun Error (OE)
+* B2	Parity Error (PE)
+* B3	Framing Error (FE)
+* B4	Break Interrupt (BI)
+* B5	Transmitter Holding Register (THRE)
+* B6	Transmitter Empty (TEMT)
+* B7	Error in RCVR FIFO
+*
+*/
+#define FTDI_RS0_CTS	(1 << 4)
+#define FTDI_RS0_DSR	(1 << 5)
+#define FTDI_RS0_RI	(1 << 6)
+#define FTDI_RS0_RLSD	(1 << 7)
+
+#define FTDI_RS_DR	1
+#define FTDI_RS_OE	(1<<1)
+#define FTDI_RS_PE	(1<<2)
+#define FTDI_RS_FE	(1<<3)
+#define FTDI_RS_BI	(1<<4)
+#define FTDI_RS_THRE	(1<<5)
+#define FTDI_RS_TEMT	(1<<6)
+#define FTDI_RS_FIFO	(1<<7)
+
+//--------------------------------------------------------------------+
+// Internal Class Driver API
+//--------------------------------------------------------------------+
+void ftdih_init       (void);
+bool ftdih_open       (uint8_t daddr, tusb_desc_interface_t const *itf_desc, uint16_t max_len);
+bool ftdih_set_config (uint8_t daddr, uint8_t itf_num);
+bool ftdih_xfer_cb    (uint8_t daddr, uint8_t ep_addr, xfer_result_t event, uint32_t xferred_bytes);
+void ftdih_close      (uint8_t daddr);
+
+#endif //TUSB_FTDI_HOST_H

--- a/src/class/cdc/serial/ftdi_sio.h
+++ b/src/class/cdc/serial/ftdi_sio.h
@@ -22,8 +22,8 @@
  * THE SOFTWARE.
  */
 
-#ifndef TUSB_FTDI_HOST_H
-#define TUSB_FTDI_HOST_H
+#ifndef TUSB_FTDI_SIO_H
+#define TUSB_FTDI_SIO_H
 
 // VID/PID for matching FTDI devices
 #define TU_FTDI_VID 0x0403
@@ -246,13 +246,4 @@
 #define FTDI_RS_TEMT	(1<<6)
 #define FTDI_RS_FIFO	(1<<7)
 
-//--------------------------------------------------------------------+
-// Internal Class Driver API
-//--------------------------------------------------------------------+
-void ftdih_init       (void);
-bool ftdih_open       (uint8_t daddr, tusb_desc_interface_t const *itf_desc, uint16_t max_len);
-bool ftdih_set_config (uint8_t daddr, uint8_t itf_num);
-bool ftdih_xfer_cb    (uint8_t daddr, uint8_t ep_addr, xfer_result_t event, uint32_t xferred_bytes);
-void ftdih_close      (uint8_t daddr);
-
-#endif //TUSB_FTDI_HOST_H
+#endif //TUSB_FTDI_SIO_H

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -286,7 +286,7 @@ bool tuh_vid_pid_get(uint8_t dev_addr, uint16_t* vid, uint16_t* pid)
   *vid = *pid = 0;
 
   usbh_device_t const* dev = get_device(dev_addr);
-  TU_VERIFY(dev && dev->configured);
+  TU_VERIFY(dev && dev->addressed && dev->vid != 0);
 
   *vid = dev->vid;
   *pid = dev->pid;

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -440,8 +440,13 @@
 #endif
 
 #ifndef CFG_TUH_CDC_FTDI
-  // FTDI is not part of CDC class, CDC is used for Serial-over-USB here
+  // FTDI is not part of CDC class, only to re-use CDC driver API
   #define CFG_TUH_CDC_FTDI 0
+#endif
+
+#ifndef CFG_TUH_CDC_CP210X
+  // CP210X is not part of CDC class, only to re-use CDC driver API
+  #define CFG_TUH_CDC_CP210X 0
 #endif
 
 #ifndef CFG_TUH_HID

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -439,6 +439,11 @@
 #define CFG_TUH_CDC    0
 #endif
 
+#ifndef CFG_TUH_CDC_FTDI
+  // FTDI is not part of CDC class, CDC is used for Serial-over-USB here
+  #define CFG_TUH_CDC_FTDI 0
+#endif
+
 #ifndef CFG_TUH_HID
 #define CFG_TUH_HID    0
 #endif


### PR DESCRIPTION
**Describe the PR**
Add host serial driver for vendor chip, implement #1991 support 
- FTDI: need CFG_TUH_CDC_FTDI
- CP210x: need CFG_TUH_CDC_CP210X
- ch9102f: is std acm and also supported with a few tweak

Although FTDI and CP210x are not part of CDC class, it is defined as subclass to only to re-use CDC driver API. And these serial driver work as if it is a subclass of CDC, occupies an CDC interfaces with the same API for application simplicity/convenience.