### PR TITLE
cdc: fix line_coding aligment

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -53,7 +53,7 @@ typedef struct
 
   /*------------- From this point, data is not cleared by bus reset -------------*/
   char    wanted_char;
-  cdc_line_coding_t line_coding;
+  CFG_TUSB_MEM_ALIGN cdc_line_coding_t line_coding;
 
   // FIFO
   tu_fifo_t rx_ff;

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -53,7 +53,7 @@ typedef struct
 
   /*------------- From this point, data is not cleared by bus reset -------------*/
   char    wanted_char;
-  CFG_TUSB_MEM_ALIGN cdc_line_coding_t line_coding;
+  TU_ATTR_ALIGNED(4) cdc_line_coding_t line_coding;
 
   // FIFO
   tu_fifo_t rx_ff;

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -58,8 +58,8 @@ typedef struct {
   cdc_acm_capability_t acm_capability;
   uint8_t ep_notif;
 
-  cdc_line_coding_t line_coding;  // Baudrate, stop bits, parity, data width
-  uint8_t line_state;             // DTR (bit0), RTS (bit1)
+  uint8_t line_state;                               // DTR (bit0), RTS (bit1)
+  TU_ATTR_ALIGNED(4) cdc_line_coding_t line_coding; // Baudrate, stop bits, parity, data width
 
   tuh_xfer_cb_t user_control_cb;
 


### PR DESCRIPTION
While calling tud_cdc_n_get_line_coding, the structure is copied into the destination.

Dump of assembler code for function tud_cdc_n_get_line_coding:
   0x000193f4 <+0>:	mov.w	r2, #2112	@ 0x840
0x000193f8 <+4>:	ldr	r3, [pc, #20]	@ (0x19410
<tud_cdc_n_get_line_coding+28>)
   0x000193fa <+6>:	mla	r0, r2, r0, r3
=> 0x000193fe <+10>:	ldr.w	r3, [r0, #6]
   0x00019402 <+14>:	str	r3, [r1, #0]

On some platform (tested on LPC55S28), the address needs to be 4-bytes aligned. Without this, the address is

(gdb) p &_cdcd_itf.line_coding
$3 = (cdc_line_coding_t *) 0x40100006 <_cdcd_itf+6>

which leads to a HardFault. With this fix

(gdb) p &_cdcd_itf.line_coding
$5 = (cdc_line_coding_t *) 0x40100008 <_cdcd_itf+8>

and the function can be called properly
