### PR TITLE
fix(RA Host Portable): implement missing function __builtin_ctz(x)

### DIFF
--- a/src/portable/renesas/rusb2/hcd_rusb2.c
+++ b/src/portable/renesas/rusb2/hcd_rusb2.c
@@ -407,7 +407,7 @@ static void process_pipe0_bemp(uint8_t rhport)
 static void process_pipe_nrdy(uint8_t rhport, unsigned num)
 {
   (void)rhport;
-  unsigned result;
+  xfer_result_t result;
   uint16_t volatile *ctr = get_pipectr(num);
   // TU_LOG1("NRDY %d %x\n", num, *ctr);
   switch (*ctr & RUSB2_PIPE_CTR_PID_Msk) {

--- a/src/portable/renesas/rusb2/rusb2_ra.h
+++ b/src/portable/renesas/rusb2/rusb2_ra.h
@@ -36,6 +36,10 @@ extern "C" {
 
 #define RUSB2_REG_BASE (0x40090000)
 
+#if defined(__ICCARM__)
+  #define __builtin_ctz(x)             __iar_builtin_CLZ(__iar_builtin_RBIT(x))
+#endif
+
 TU_ATTR_ALWAYS_INLINE static inline void rusb2_int_enable(uint8_t rhport)
 {
   (void) rhport;


### PR DESCRIPTION
Implemntation __builtin_ctz(x) for IAR , see issue #2060

**Describe the PR**
eliminate all the warnings for IAR host portable module for the Renesas RA family.

**Additional context**
Please see the table describing the __packed macro. This should work for ARM and RX families on IAR.
I only tested this on RA4M2 and RA4M3
![myimg](https://github.com/hathach/tinyusb/assets/36272850/4144e2b3-5cb6-403f-b068-a39ffb6a596b)
