### PR TITLE
fix(RA Host Portable): git rid of the IAR warnings for packed

### DIFF
--- a/src/portable/renesas/rusb2/rusb2_type.h
+++ b/src/portable/renesas/rusb2/rusb2_type.h
@@ -1599,6 +1599,7 @@ TU_ATTR_BIT_FIELD_ORDER_END
 //--------------------------------------------------------------------+
 
 TU_VERIFY_STATIC(sizeof(RUSB2_PIPE_TR_t) == 4, "incorrect size");
+TU_VERIFY_STATIC(sizeof(RUSB2_REG_t) == 1032, "incorrect size");
 
 TU_VERIFY_STATIC(offsetof(RUSB2_REG_t, SYSCFG     ) == 0x00000000, "incorrect offset");
 TU_VERIFY_STATIC(offsetof(RUSB2_REG_t, BUSWAIT    ) == 0x00000002, "incorrect offset");

--- a/src/portable/renesas/rusb2/rusb2_type.h
+++ b/src/portable/renesas/rusb2/rusb2_type.h
@@ -41,11 +41,11 @@ extern "C" {
 TU_ATTR_PACKED_BEGIN
 TU_ATTR_BIT_FIELD_ORDER_BEGIN
 
-typedef struct TU_ATTR_PACKED {
+typedef struct {
   union {
     volatile uint16_t E; /* (@ 0x00000000) Pipe Transaction Counter Enable Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint16_t : 8;
       volatile uint16_t TRCLR : 1; /* [8..8] Transaction Counter Clear */
       volatile uint16_t TRENB : 1; /* [9..9] Transaction Counter Enable */
@@ -56,18 +56,18 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t N; /* (@ 0x00000002) Pipe Transaction Counter Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t TRNCNT : 16; /* [15..0] Transaction Counter */
     } N_b;
   };
 } RUSB2_PIPE_TR_t; /* Size = 4 (0x4) */
 
 /* LINK_REG Structure */
-typedef struct TU_ATTR_PACKED {
+typedef struct {
   union {
     volatile uint16_t SYSCFG; /* (@ 0x00000000) System Configuration Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t USBE  : 1; /* [0..0] USB Operation Enable */
       uint16_t                : 2;
       volatile uint16_t DMRPU : 1; /* [3..3] D- Line Resistor Control */
@@ -85,7 +85,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t BUSWAIT; /* (@ 0x00000002) CPU Bus Wait Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t BWAIT : 4; /* [3..0] CPU Bus Access Wait Specification BWAIT waits (BWAIT+2 access cycles) */
       uint16_t : 12;
     } BUSWAIT_b;
@@ -94,7 +94,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile const uint16_t SYSSTS0; /* (@ 0x00000004) System Configuration Status Register 0 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t LNST   : 2; /* [1..0] USB Data Line Status Monitor */
       volatile const uint16_t IDMON  : 1; /* [2..2] External ID0 Input Pin Monitor */
       uint16_t                       : 2;
@@ -109,7 +109,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile const uint16_t PLLSTA; /* (@ 0x00000006) PLL Status Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t PLLLOCK : 1; /* [0..0] PLL Lock Flag */
       uint16_t : 15;
     } PLLSTA_b;
@@ -118,7 +118,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t DVSTCTR0; /* (@ 0x00000008) Device State Control Register 0 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t RHST : 3; /* [2..0] USB Bus Reset Status */
       uint16_t                     : 1;
       volatile uint16_t UACT       : 1; /* [4..4] USB Bus Enable */
@@ -137,7 +137,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t TESTMODE; /* (@ 0x0000000C) USB Test Mode Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t UTST : 4; /* [3..0] Test Mode */
       uint16_t : 12;
     } TESTMODE_b;
@@ -148,7 +148,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint32_t CFIFO; /* (@ 0x00000014) CFIFO Port Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       union {
         volatile uint16_t CFIFOL; /* (@ 0x00000014) CFIFO Port Register L */
         volatile uint8_t CFIFOLL; /* (@ 0x00000014) CFIFO Port Register LL */
@@ -157,7 +157,7 @@ typedef struct TU_ATTR_PACKED {
       union {
         volatile uint16_t CFIFOH; /* (@ 0x00000016) CFIFO Port Register H */
 
-        struct {
+        struct TU_ATTR_PACKED {
           volatile const uint8_t RESERVED3;
           volatile uint8_t CFIFOHH; /* (@ 0x00000017) CFIFO Port Register HH */
         };
@@ -168,7 +168,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint32_t D0FIFO; /* (@ 0x00000018) D0FIFO Port Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       union {
         volatile uint16_t D0FIFOL; /* (@ 0x00000018) D0FIFO Port Register L */
         volatile uint8_t D0FIFOLL; /* (@ 0x00000018) D0FIFO Port Register LL */
@@ -177,7 +177,7 @@ typedef struct TU_ATTR_PACKED {
       union {
         volatile uint16_t D0FIFOH; /* (@ 0x0000001A) D0FIFO Port Register H */
 
-        struct {
+        struct TU_ATTR_PACKED {
           volatile const uint8_t RESERVED4;
           volatile uint8_t D0FIFOHH; /* (@ 0x0000001B) D0FIFO Port Register HH */
         };
@@ -188,7 +188,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint32_t D1FIFO; /* (@ 0x0000001C) D1FIFO Port Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       union {
         volatile uint16_t D1FIFOL; /* (@ 0x0000001C) D1FIFO Port Register L */
         volatile uint8_t D1FIFOLL; /* (@ 0x0000001C) D1FIFO Port Register LL */
@@ -197,7 +197,7 @@ typedef struct TU_ATTR_PACKED {
       union {
         volatile uint16_t D1FIFOH; /* (@ 0x0000001E) D1FIFO Port Register H */
 
-        struct {
+        struct TU_ATTR_PACKED {
           volatile const uint8_t RESERVED5;
           volatile uint8_t D1FIFOHH; /* (@ 0x0000001F) D1FIFO Port Register HH */
         };
@@ -208,7 +208,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t CFIFOSEL; /* (@ 0x00000020) CFIFO Port Select Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t CURPIPE : 4; /* [3..0] CFIFO Port Access Pipe Specification */
       uint16_t                  : 1;
       volatile uint16_t ISEL    : 1; /* [5..5] CFIFO Port Access Direction When DCP is Selected */
@@ -225,12 +225,12 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t CFIFOCTR; /* (@ 0x00000022) CFIFO Port Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t DTLN : 12; /* [11..0] Receive Data LengthIndicates the length of the receive data. */
       uint16_t                     : 1;
       volatile const uint16_t FRDY : 1;  /* [13..13] FIFO Port Ready */
-      volatile uint16_t BCLR       : 1;	 /* [14..14] CPU Buffer ClearNote: Only 0 can be read. */
-      volatile uint16_t BVAL       : 1;	 /* [15..15] Buffer Memory Valid Flag */
+      volatile uint16_t BCLR       : 1;  /* [14..14] CPU Buffer ClearNote: Only 0 can be read. */
+      volatile uint16_t BVAL       : 1;  /* [15..15] Buffer Memory Valid Flag */
     } CFIFOCTR_b;
   };
   volatile const uint32_t RESERVED6;
@@ -238,7 +238,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t D0FIFOSEL; /* (@ 0x00000028) D0FIFO Port Select Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t CURPIPE : 4; /* [3..0] FIFO Port Access Pipe Specification */
       uint16_t                  : 4;
       volatile uint16_t BIGEND  : 1; /* [8..8] FIFO Port Endian Control */
@@ -254,19 +254,19 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t D0FIFOCTR; /* (@ 0x0000002A) D0FIFO Port Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t DTLN : 12; /* [11..0] Receive Data LengthIndicates the length of the receive data. */
       uint16_t                     : 1;
       volatile const uint16_t FRDY : 1;  /* [13..13] FIFO Port Ready */
-      volatile uint16_t BCLR       : 1;	 /* [14..14] CPU Buffer ClearNote: Only 0 can be read. */
-      volatile uint16_t BVAL       : 1;	 /* [15..15] Buffer Memory Valid Flag */
+      volatile uint16_t BCLR       : 1;  /* [14..14] CPU Buffer ClearNote: Only 0 can be read. */
+      volatile uint16_t BVAL       : 1;  /* [15..15] Buffer Memory Valid Flag */
     } D0FIFOCTR_b;
   };
 
   union {
     volatile uint16_t D1FIFOSEL; /* (@ 0x0000002C) D1FIFO Port Select Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t CURPIPE : 4; /* [3..0] FIFO Port Access Pipe Specification */
       uint16_t                  : 4;
       volatile uint16_t BIGEND  : 1; /* [8..8] FIFO Port Endian Control */
@@ -282,7 +282,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t D1FIFOCTR; /* (@ 0x0000002E) D1FIFO Port Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t DTLN : 12; /* [11..0] Receive Data LengthIndicates the length of the receive data. */
       uint16_t                     : 1;
       volatile const uint16_t FRDY : 1;  /* [13..13] FIFO Port Ready */
@@ -294,7 +294,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t INTENB0; /* (@ 0x00000030) Interrupt Enable Register 0 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint16_t : 8;
       volatile uint16_t BRDYE : 1; /* [8..8] Buffer Ready Interrupt Enable */
       volatile uint16_t NRDYE : 1; /* [9..9] Buffer Not Ready Response Interrupt Enable */
@@ -310,7 +310,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t INTENB1; /* (@ 0x00000032) Interrupt Enable Register 1 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PDDETINTE0 : 1; /* [0..0] PDDETINT0 Detection Interrupt Enable */
       uint16_t                     : 3;
       volatile uint16_t SACKE      : 1; /* [4..4] Setup Transaction Normal Response Interrupt Enable */
@@ -329,7 +329,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t BRDYENB; /* (@ 0x00000036) BRDY Interrupt Enable Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PIPE0BRDYE : 1; /* [0..0] BRDY Interrupt Enable for PIPE */
       volatile uint16_t PIPE1BRDYE : 1; /* [1..1] BRDY Interrupt Enable for PIPE */
       volatile uint16_t PIPE2BRDYE : 1; /* [2..2] BRDY Interrupt Enable for PIPE */
@@ -347,7 +347,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t NRDYENB; /* (@ 0x00000038) NRDY Interrupt Enable Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PIPE0NRDYE : 1; /* [0..0] NRDY Interrupt Enable for PIPE */
       volatile uint16_t PIPE1NRDYE : 1; /* [1..1] NRDY Interrupt Enable for PIPE */
       volatile uint16_t PIPE2NRDYE : 1; /* [2..2] NRDY Interrupt Enable for PIPE */
@@ -365,7 +365,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t BEMPENB; /* (@ 0x0000003A) BEMP Interrupt Enable Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PIPE0BEMPE : 1; /* [0..0] BEMP Interrupt Enable for PIPE */
       volatile uint16_t PIPE1BEMPE : 1; /* [1..1] BEMP Interrupt Enable for PIPE */
       volatile uint16_t PIPE2BEMPE : 1; /* [2..2] BEMP Interrupt Enable for PIPE */
@@ -383,7 +383,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t SOFCFG; /* (@ 0x0000003C) SOF Output Configuration Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint16_t                        : 4;
       volatile const uint16_t EDGESTS : 1; /* [4..4] Edge Interrupt Output Status Monitor */
       volatile uint16_t INTL          : 1; /* [5..5] Interrupt Output Sense Select */
@@ -397,7 +397,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t PHYSET; /* (@ 0x0000003E) PHY Setting Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t DIRPD    : 1; /* [0..0] Power-Down Control */
       volatile uint16_t PLLRESET : 1; /* [1..1] PLL Reset Control */
       uint16_t                   : 1;
@@ -415,7 +415,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t INTSTS0; /* (@ 0x00000040) Interrupt Status Register 0 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t CTSQ  : 3; /* [2..0] Control Transfer Stage */
       volatile uint16_t VALID       : 1; /* [3..3] USB Request Reception */
       volatile const uint16_t DVSQ  : 3; /* [6..4] Device State */
@@ -434,7 +434,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t INTSTS1; /* (@ 0x00000042) Interrupt Status Register 1 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PDDETINT0 : 1; /* [0..0] PDDET0 Detection Interrupt Status */
       uint16_t                    : 3;
       volatile uint16_t SACK      : 1; /* [4..4] Setup Transaction Normal Response Interrupt Status */
@@ -456,7 +456,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t BRDYSTS; /* (@ 0x00000046) BRDY Interrupt Status Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PIPE0BRDY : 1; /* [0..0] BRDY Interrupt Status for PIPE */
       volatile uint16_t PIPE1BRDY : 1; /* [1..1] BRDY Interrupt Status for PIPE */
       volatile uint16_t PIPE2BRDY : 1; /* [2..2] BRDY Interrupt Status for PIPE */
@@ -474,7 +474,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t NRDYSTS; /* (@ 0x00000048) NRDY Interrupt Status Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PIPE0NRDY : 1; /* [0..0] NRDY Interrupt Status for PIPE */
       volatile uint16_t PIPE1NRDY : 1; /* [1..1] NRDY Interrupt Status for PIPE */
       volatile uint16_t PIPE2NRDY : 1; /* [2..2] NRDY Interrupt Status for PIPE */
@@ -492,7 +492,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t BEMPSTS; /* (@ 0x0000004A) BEMP Interrupt Status Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PIPE0BEMP : 1; /* [0..0] BEMP Interrupt Status for PIPE */
       volatile uint16_t PIPE1BEMP : 1; /* [1..1] BEMP Interrupt Status for PIPE */
       volatile uint16_t PIPE2BEMP : 1; /* [2..2] BEMP Interrupt Status for PIPE */
@@ -510,7 +510,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t FRMNUM; /* (@ 0x0000004C) Frame Number Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t FRNM : 11; /* [10..0] Frame NumberLatest frame number */
       uint16_t                     : 3;
       volatile uint16_t CRCE       : 1; /* [14..14] Receive Data Error */
@@ -521,7 +521,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t UFRMNUM; /* (@ 0x0000004E) uFrame Number Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t UFRNM : 3; /* [2..0] MicroframeIndicate the microframe number. */
       uint16_t                      : 12;
       volatile uint16_t DVCHG       : 1; /* [15..15] Device State Change */
@@ -531,7 +531,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t USBADDR; /* (@ 0x00000050) USB Address Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t USBADDR : 7; /* [6..0] USB Address In device controller mode */
       uint16_t                        : 1;
       volatile uint16_t STSRECOV0     : 3; /* [10..8] Status Recovery */
@@ -543,7 +543,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t USBREQ; /* (@ 0x00000054) USB Request Type Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t BMREQUESTTYPE : 8; /* [7..0] Request TypeThese bits store the USB request bmRequestType value. */
       volatile uint16_t BREQUEST      : 8; /* [15..8] RequestThese bits store the USB request bRequest value. */
     } USBREQ_b;
@@ -552,7 +552,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t USBVAL; /* (@ 0x00000056) USB Request Value Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t WVALUE : 16; /* [15..0] ValueThese bits store the USB request Value value. */
     } USBVAL_b;
   };
@@ -560,7 +560,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t USBINDX; /* (@ 0x00000058) USB Request Index Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t WINDEX : 16; /* [15..0] IndexThese bits store the USB request wIndex value. */
     } USBINDX_b;
   };
@@ -568,7 +568,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t USBLENG; /* (@ 0x0000005A) USB Request Length Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t WLENGTH : 16; /* [15..0] LengthThese bits store the USB request wLength value. */
     } USBLENG_b;
   };
@@ -576,7 +576,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t DCPCFG; /* (@ 0x0000005C) DCP Configuration Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint16_t                 : 4;
       volatile uint16_t DIR    : 1; /* [4..4] Transfer Direction */
       uint16_t                 : 2;
@@ -589,7 +589,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t DCPMAXP; /* (@ 0x0000005E) DCP Maximum Packet Size Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t MXPS   : 7; /* [6..0] Maximum Packet Size */
       uint16_t                 : 5;
       volatile uint16_t DEVSEL : 4; /* [15..12] Device Select */
@@ -599,7 +599,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t DCPCTR; /* (@ 0x00000060) DCP Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PID         : 2; /* [1..0] Response PID */
       volatile uint16_t CCPL        : 1; /* [2..2] Control Transfer End Enable */
       uint16_t                      : 2;
@@ -619,7 +619,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t PIPESEL; /* (@ 0x00000064) Pipe Window Select Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PIPESEL : 4; /* [3..0] Pipe Window Select */
       uint16_t : 12;
     } PIPESEL_b;
@@ -629,7 +629,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t PIPECFG;      /* (@ 0x00000068) Pipe Configuration Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t EPNUM  : 4; /* [3..0] Endpoint Number */
       volatile uint16_t DIR    : 1; /* [4..4] Transfer Direction */
       uint16_t                 : 2;
@@ -646,7 +646,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t PIPEMAXP; /* (@ 0x0000006C) Pipe Maximum Packet Size Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t MXPS   : 9; /* [8..0] Maximum Packet Size */
       uint16_t                 : 3;
       volatile uint16_t DEVSEL : 4; /* [15..12] Device Select */
@@ -656,7 +656,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t PIPEPERI; /* (@ 0x0000006E) Pipe Cycle Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t IITV : 3; /* [2..0] Interval Error Detection Interval */
       uint16_t               : 9;
       volatile uint16_t IFIS : 1; /* [12..12] Isochronous IN Buffer Flush */
@@ -667,7 +667,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t PIPE_CTR[9];        /* (@ 0x00000070) Pipe [0..8] Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t PID          : 2; /* [1..0] Response PID */
       uint16_t                       : 3;
       volatile const uint16_t PBUSY  : 1; /* [5..5] Pipe Busy */
@@ -691,7 +691,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t USBBCCTRL0;             /* (@ 0x000000B0) BC Control Register 0 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t RPDME0           : 1; /* [0..0] D- Pin Pull-Down Control */
       volatile uint16_t IDPSRCE0         : 1; /* [1..1] D+ Pin IDPSRC Output Control */
       volatile uint16_t
@@ -713,7 +713,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t UCKSEL; /* (@ 0x000000C4) USB Clock Selection Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t UCKSELC : 1; /* [0..0] USB Clock Selection */
       uint16_t : 15;
     } UCKSEL_b;
@@ -724,7 +724,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t USBMC; /* (@ 0x000000CC) USB Module Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t VDDUSBE : 1; /* [0..0] USB Reference Power Supply Circuit On/Off Control */
       uint16_t                  : 6;
       volatile uint16_t VDCEN   : 1; /* [7..7] USB Regulator On/Off Control */
@@ -736,7 +736,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t DEVADD[10]; /* (@ 0x000000D0) Device Address Configuration Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint16_t : 6;
       volatile uint16_t USBSPD  : 2; /* [7..6] Transfer Speed of Communication Target Device */
       volatile uint16_t HUBPORT : 3; /* [10..8] Communication Target Connecting Hub Port */
@@ -749,7 +749,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint32_t PHYSLEW; /* (@ 0x000000F0) PHY Cross Point Adjustment Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint32_t SLEWR00 : 1; /* [0..0] Receiver Cross Point Adjustment 00 */
       volatile uint32_t SLEWR01 : 1; /* [1..1] Receiver Cross Point Adjustment 01 */
       volatile uint32_t SLEWF00 : 1; /* [2..2] Receiver Cross Point Adjustment 00 */
@@ -762,7 +762,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t LPCTRL; /* (@ 0x00000100) Low Power Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint16_t : 7;
       volatile uint16_t HWUPM : 1; /* [7..7] Resume Return Mode Setting */
       uint16_t : 8;
@@ -772,7 +772,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t LPSTS; /* (@ 0x00000102) Low Power Status Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint16_t : 14;
       volatile uint16_t SUSPENDM : 1; /* [14..14] UTMI SuspendM Control */
       uint16_t : 1;
@@ -783,7 +783,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t BCCTRL; /* (@ 0x00000140) Battery Charging Control Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t IDPSRCE         : 1; /* [0..0] IDPSRC Control */
       volatile uint16_t IDMSINKE        : 1; /* [1..1] IDMSINK Control */
       volatile uint16_t VDPSRCE         : 1; /* [2..2] VDPSRC Control */
@@ -801,7 +801,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t PL1CTRL1; /* (@ 0x00000144) Function L1 Control Register 1 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t L1RESPEN   : 1; /* [0..0] L1 Response Enable */
       volatile uint16_t L1RESPMD   : 2; /* [2..1] L1 Response Mode */
       volatile uint16_t L1NEGOMD   : 1; /* [3..3] L1 Response Negotiation Control. */
@@ -816,7 +816,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t PL1CTRL2; /* (@ 0x00000146) Function L1 Control Register 2 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint16_t : 8;
       volatile uint16_t HIRDMON : 4; /* [11..8] HIRD Value Monitor */
       volatile uint16_t RWEMON  : 1;  /* [12..12] RWE Value Monitor */
@@ -827,8 +827,8 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t HL1CTRL1; /* (@ 0x00000148) Host L1 Control Register 1 */
 
-    struct {
-      volatile uint16_t L1REQ          : 1;	      /* [0..0] L1 Transition Request */
+    struct TU_ATTR_PACKED {
+      volatile uint16_t L1REQ          : 1;       /* [0..0] L1 Transition Request */
       volatile const uint16_t L1STATUS : 2; /* [2..1] L1 Request Completion Status */
       uint16_t : 13;
     } HL1CTRL1_b;
@@ -837,7 +837,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t HL1CTRL2; /* (@ 0x0000014A) Host L1 Control Register 2 */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint16_t L1ADDR : 4; /* [3..0] LPM Token DeviceAddress */
       uint16_t                 : 4;
       volatile uint16_t HIRD   : 4; /* [11..8] LPM Token HIRD */
@@ -851,7 +851,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile const uint32_t DPUSR0R; /* (@ 0x00000160) Deep Standby USB Transceiver Control/Pin Monitor Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint32_t : 20;
       volatile const uint32_t DOVCAHM  : 1; /* [20..20] OVRCURA InputIndicates OVRCURA input signal on the HS side of USB port. */
       volatile const uint32_t DOVCBHM  : 1; /* [21..21] OVRCURB InputIndicates OVRCURB input signal on the HS side of USB port. */
@@ -864,7 +864,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint32_t DPUSR1R; /* (@ 0x00000164) Deep Standby USB Suspend/Resume Interrupt Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       uint32_t : 4;
       volatile uint32_t DOVCAHE       : 1; /* [4..4] OVRCURA Interrupt Enable Clear */
       volatile uint32_t DOVCBHE       : 1; /* [5..5] OVRCURB Interrupt Enable Clear */
@@ -882,7 +882,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t DPUSR2R; /* (@ 0x00000168) Deep Standby USB Suspend/Resume Interrupt Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile const uint16_t DPINT : 1; /* [0..0] Indication of Return from DP Interrupt Source */
       volatile const uint16_t DMINT : 1; /* [1..1] Indication of Return from DM Interrupt Source */
       uint16_t                      : 2;
@@ -898,8 +898,8 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint16_t DPUSRCR; /* (@ 0x0000016A) Deep Standby USB Suspend/Resume Command Register */
 
-    struct {
-      volatile uint16_t FIXPHY   : 1;	/* [0..0] USB Transceiver Control Fix */
+    struct TU_ATTR_PACKED {
+      volatile uint16_t FIXPHY   : 1; /* [0..0] USB Transceiver Control Fix */
       volatile uint16_t FIXPHYPD : 1; /* [1..1] USB Transceiver Control Fix for PLL */
       uint16_t : 14;
     } DPUSRCR_b;
@@ -910,7 +910,7 @@ typedef struct TU_ATTR_PACKED {
     volatile uint32_t
       DPUSR0R_FS; /* (@ 0x00000400) Deep Software Standby USB Transceiver Control/Pin Monitor Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint32_t SRPC0         : 1; /* [0..0] USB Single End Receiver Control */
       volatile uint32_t RPUE0         : 1; /* [1..1] DP Pull-Up Resistor Control */
       uint32_t                        : 1;
@@ -931,7 +931,7 @@ typedef struct TU_ATTR_PACKED {
   union {
     volatile uint32_t DPUSR1R_FS; /* (@ 0x00000404) Deep Software Standby USB Suspend/Resume Interrupt Register */
 
-    struct {
+    struct TU_ATTR_PACKED {
       volatile uint32_t DPINTE0        : 1; /* [0..0] USB DP Interrupt Enable/Clear */
       volatile uint32_t DMINTE0        : 1; /* [1..1] USB DM Interrupt Enable/Clear */
       uint32_t                         : 2;


### PR DESCRIPTION
This is a daughter PR from PR#2063

I am using the -e flag, for IAR workbench users it is under :
Options/ C_C++ compiler/ Language 1 / Language conformance / Standard with IAR extensions

TU_ATTR_PACKED is not solving the compiler warnings, I thought it should be enough. However, I am using IAR compiler 9.1, which seems insufficient for these structs. When I use the __packed I am getting rid of the warnings

Here is an example given by IAR, which somehow makes it seems that only __packed is supported.
https://www.iar.com/contentassets/e20cfa542d1a4734aa6b234bea42f11a/example-5.pdf
Another link that led me to use __packed on these structs:
https://www.iar.com/knowledge/support/technical-notes/compiler/accessing-unaligned-data/
