### PR TITLE
osal_none: make it possible to override the task delay function

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -256,7 +256,7 @@ static bool usbh_control_xfer_cb (uint8_t daddr, uint8_t ep_addr, xfer_result_t 
 
 #if CFG_TUSB_OS == OPT_OS_NONE
 // TODO rework time-related function later
-void osal_task_delay(uint32_t msec)
+TU_ATTR_WEAK void osal_task_delay(uint32_t msec)
 {
   const uint32_t start = hcd_frame_number(_usbh_controller);
   while ( ( hcd_frame_number(_usbh_controller) - start ) < msec ) {}

--- a/src/osal/osal_none.h
+++ b/src/osal/osal_none.h
@@ -37,7 +37,7 @@
 
 #if CFG_TUH_ENABLED
 // currently only needed/available in host mode
-void osal_task_delay(uint32_t msec);
+TU_ATTR_WEAK void osal_task_delay(uint32_t msec);
 #endif
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
I am having an issue with the current implementation of the osal_task_delay function. It was also not stable if you are trying to connect and disconnect the USB device very fast. This will make it possible to override the function to your implemented delay function. Otherwise, it will keep the current implementation.
