### PR TITLE
Extract common macros to separate header file

### DIFF
--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -32,30 +32,6 @@
 #endif
 
 //--------------------------------------------------------------------+
-// Macros Helper
-//--------------------------------------------------------------------+
-#define TU_ARRAY_SIZE(_arr)   ( sizeof(_arr) / sizeof(_arr[0]) )
-#define TU_MIN(_x, _y)        ( ( (_x) < (_y) ) ? (_x) : (_y) )
-#define TU_MAX(_x, _y)        ( ( (_x) > (_y) ) ? (_x) : (_y) )
-
-#define TU_U16(_high, _low)   ((uint16_t) (((_high) << 8) | (_low)))
-#define TU_U16_HIGH(_u16)     ((uint8_t) (((_u16) >> 8) & 0x00ff))
-#define TU_U16_LOW(_u16)      ((uint8_t) ((_u16)       & 0x00ff))
-#define U16_TO_U8S_BE(_u16)   TU_U16_HIGH(_u16), TU_U16_LOW(_u16)
-#define U16_TO_U8S_LE(_u16)   TU_U16_LOW(_u16), TU_U16_HIGH(_u16)
-
-#define TU_U32_BYTE3(_u32)    ((uint8_t) ((((uint32_t) _u32) >> 24) & 0x000000ff)) // MSB
-#define TU_U32_BYTE2(_u32)    ((uint8_t) ((((uint32_t) _u32) >> 16) & 0x000000ff))
-#define TU_U32_BYTE1(_u32)    ((uint8_t) ((((uint32_t) _u32) >>  8) & 0x000000ff))
-#define TU_U32_BYTE0(_u32)    ((uint8_t) (((uint32_t)  _u32)        & 0x000000ff)) // LSB
-
-#define U32_TO_U8S_BE(_u32)   TU_U32_BYTE3(_u32), TU_U32_BYTE2(_u32), TU_U32_BYTE1(_u32), TU_U32_BYTE0(_u32)
-#define U32_TO_U8S_LE(_u32)   TU_U32_BYTE0(_u32), TU_U32_BYTE1(_u32), TU_U32_BYTE2(_u32), TU_U32_BYTE3(_u32)
-
-#define TU_BIT(n)             (1UL << (n))
-#define TU_GENMASK(h, l)      ( (UINT32_MAX << (l)) & (UINT32_MAX >> (31 - (h))) )
-
-//--------------------------------------------------------------------+
 // Includes
 //--------------------------------------------------------------------+
 
@@ -67,6 +43,7 @@
 #include <stdio.h>
 
 // Tinyusb Common Headers
+#include "tusb_helper.h"
 #include "tusb_option.h"
 #include "tusb_compiler.h"
 #include "tusb_verify.h"

--- a/src/common/tusb_helper.h
+++ b/src/common/tusb_helper.h
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef _TUSB_HELPER_H_
+#define _TUSB_HELPER_H_
+
+//--------------------------------------------------------------------+
+// Macros Helper
+//--------------------------------------------------------------------+
+#define TU_ARRAY_SIZE(_arr)   ( sizeof(_arr) / sizeof(_arr[0]) )
+#define TU_MIN(_x, _y)        ( ( (_x) < (_y) ) ? (_x) : (_y) )
+#define TU_MAX(_x, _y)        ( ( (_x) > (_y) ) ? (_x) : (_y) )
+
+#define TU_U16(_high, _low)   ((uint16_t) (((_high) << 8) | (_low)))
+#define TU_U16_HIGH(_u16)     ((uint8_t) (((_u16) >> 8) & 0x00ff))
+#define TU_U16_LOW(_u16)      ((uint8_t) ((_u16)       & 0x00ff))
+#define U16_TO_U8S_BE(_u16)   TU_U16_HIGH(_u16), TU_U16_LOW(_u16)
+#define U16_TO_U8S_LE(_u16)   TU_U16_LOW(_u16), TU_U16_HIGH(_u16)
+
+#define TU_U32_BYTE3(_u32)    ((uint8_t) ((((uint32_t) _u32) >> 24) & 0x000000ff)) // MSB
+#define TU_U32_BYTE2(_u32)    ((uint8_t) ((((uint32_t) _u32) >> 16) & 0x000000ff))
+#define TU_U32_BYTE1(_u32)    ((uint8_t) ((((uint32_t) _u32) >>  8) & 0x000000ff))
+#define TU_U32_BYTE0(_u32)    ((uint8_t) (((uint32_t)  _u32)        & 0x000000ff)) // LSB
+
+#define U32_TO_U8S_BE(_u32)   TU_U32_BYTE3(_u32), TU_U32_BYTE2(_u32), TU_U32_BYTE1(_u32), TU_U32_BYTE0(_u32)
+#define U32_TO_U8S_LE(_u32)   TU_U32_BYTE0(_u32), TU_U32_BYTE1(_u32), TU_U32_BYTE2(_u32), TU_U32_BYTE3(_u32)
+
+#define TU_BIT(n)             (1UL << (n))
+#define TU_GENMASK(h, l)      ( (UINT32_MAX << (l)) & (UINT32_MAX >> (31 - (h))) )
+
+#endif /* _TUSB_HELPER_H_ */

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -33,6 +33,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "tusb_helper.h"
 #include "tusb_compiler.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
**Describe the PR**
This PR moves helper macros from `tusb_common.h` to separate file so it can be included from `tusb_types.h`.
This is needed for situations when user needs to include only types without the rest of the stack.
It is useful mainly for writing libraries using TinyUSB as a dependency.
Curently there is no way to import only types from a library without having a stack set up.

**Additional context**
I am writing a small [library](https://github.com/tomas-pecserke/pico_tusb_reset_interface) helping with implementation of custom vendor interfaces for RP2040, and I find myself in need of importing types, specifically for  `tusb_control_request_t`.

My library provides implementation for custom reset interface via callback function:
```c
bool reset_interface_cb(uint8_t stage, tusb_control_request_t const * request);
```
It is meant to be called like this:
```c
bool tud_vendor_control_xfer_cb(__unused uint8_t rhport, uint8_t stage, tusb_control_request_t const * request) {
    switch (request->wIndex) {
        case ITF_NUM_VENDOR_RESET:
            return reset_interface_cb(stage, request);
        // If you have more vendor interfaces, forward their calls here
    }
    return false;
}
```

But when I include `tusb_types.h`, I get compiler errors:
```gcc
In file included from ~/projects/personal/pico_tusb_reset_interface/pico_tusb_reset_interface.h:46,
                 from ~/projects/personal/pico_tusb_reset_interface/pico_tusb_reset_interface.c:26:
~pico-sdk/lib/tinyusb/src/common/tusb_types.h:229:40: warning: implicit declaration of function 'TU_BIT' [-Wimplicit-function-declaration]
  229 |   TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP = TU_BIT(5),
      |                                        ^~~~~~
~/pico-sdk/lib/tinyusb/src/common/tusb_types.h:229:3: error: enumerator value for 'TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP' is not an integer constant
  229 |   TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP = TU_BIT(5),
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/pico-sdk/lib/tinyusb/src/common/tusb_types.h:230:3: error: enumerator value for 'TUSB_DESC_CONFIG_ATT_SELF_POWERED' is not an integer constant
  230 |   TUSB_DESC_CONFIG_ATT_SELF_POWERED  = TU_BIT(6),
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ~/projects/personal/pico_tusb_reset_interface/pico_tusb_reset_interface.h:46,
                 from ~/projects/personal/pico_tusb_reset_interface/pico_tusb_reset_interface.c:26:
~/pico-sdk/lib/tinyusb/src/common/tusb_types.h: In function 'tu_edpt_packet_size':
~/pico-sdk/lib/tinyusb/src/common/tusb_types.h:526:48: warning: implicit declaration of function 'TU_GENMASK' [-Wimplicit-function-declaration]
  526 |   return tu_le16toh(desc_ep->wMaxPacketSize) & TU_GENMASK(10, 0);
      |                                                ^~~~~~~~~~
```

This is caused by helper macros from `tusb_common.h` are not included and including this header tries to pull in `tusb_config.h`, which is not present in the library, since it's up to the users to define their stack.

I have a workaround of redefining these 2 macros specifically for my library:
```c
// Workaround for missing macros
// It needs to be defined before including tusb_types.h
// TODO remove once https://github.com/hathach/tinyusb/pull/2097 is merged
#ifndef TU_BIT
#define TU_BIT(n)             (1UL << (n))
#endif
#ifndef TU_GENMASK
#define TU_GENMASK(h, l)      ( (UINT32_MAX << (l)) & (UINT32_MAX >> (31 - (h))) )
#endif

#include <tusb_types.h>
```

However as code duplication I would like to eliminate it, and it would be nice to solve universally, so others can write their libraries and contribute to the ecosystem.