### PR TITLE
fix example of bare_api, check empty string

### DIFF
--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -410,6 +410,7 @@ static int _count_utf8_bytes(const uint16_t *buf, size_t len) {
 }
 
 static void print_utf16(uint16_t *temp_buf, size_t buf_len) {
+    if ((temp_buf[0] & 0xff) == 0) return;  // empty
     size_t utf16_len = ((temp_buf[0] & 0xff) - 2) / sizeof(uint16_t);
     size_t utf8_len = (size_t) _count_utf8_bytes(temp_buf + 1, utf16_len);
     _convert_utf16le_to_utf8(temp_buf + 1, utf16_len, (uint8_t *) temp_buf, sizeof(uint16_t) * buf_len);


### PR DESCRIPTION
**Describe the PR**

I tested using picosdk/lib/tinyusb/examples/host/bare_api almost as is for communication with Dynastream ANT-USB-m in a rp2040 /pico-w environment and found that incorrect memory access is occurring during the debugging device information output process.

I believe this is due to some misconfiguration and are still analyzing the problem, but I have added a check for cases where the result of tuh_descriptor_get_manufacturer_string_sync is not retrieved to prevent illegal memory accesses, even temporarily.

**Printing Dynastream ANT-USB-m Device Descriptor**
```
Device 1: ID 0fcf:1009                                                                               
Device Descriptor:                                                                                                   
  bLength             18                                                                                             
  bDescriptorType     1                                                                                              
  bcdUSB              0200                                                                                           
  bDeviceClass        0                                                                                              
  bDeviceSubClass     0                                                                                              
  bDeviceProtocol     0                                                                                              
  bMaxPacketSize0     32                                                                                             
  idVendor            0x0fcf                                                                                         
  idProduct           0x1009                                                                                         
  bcdDevice           0100                                                                                           
  iManufacturer       1                                                                                              
  iProduct            2                                                                                              
  iSerialNumber       3                                                                                              
  bNumConfigurations  1  
```