### PR TITLE
HID input and output report fix

### DIFF
--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -152,7 +152,8 @@ bool tud_hid_n_mouse_report(uint8_t instance, uint8_t report_id,
 }
 
 bool tud_hid_n_gamepad_report(uint8_t instance, uint8_t report_id,
-                              int8_t x, int8_t y, int8_t z, int8_t rz, int8_t rx, int8_t ry, uint8_t hat, uint32_t buttons) {
+                              int8_t x, int8_t y, int8_t z, int8_t rz, int8_t rx, int8_t ry, uint8_t hat, uint32_t buttons)
+{
   hid_gamepad_report_t report =
   {
     .x       = x,
@@ -183,7 +184,7 @@ void hidd_reset(uint8_t rhport)
 }
 
 uint16_t hidd_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, uint16_t max_len)
- {
+{
   TU_VERIFY(TUSB_CLASS_HID == desc_itf->bInterfaceClass, 0);
 
   // len = interface + hid + n*endpoints

--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -50,6 +50,11 @@ typedef struct
   uint8_t idle_rate;     // up to application to handle idle rate
   uint16_t report_desc_len;
 
+  // for get/set feature reports (on control endpoint 0)
+  CFG_TUSB_MEM_ALIGN uint8_t epctrlin_buf[CFG_TUD_ENDPOINT0_SIZE];
+  CFG_TUSB_MEM_ALIGN uint8_t epctrlout_buf[CFG_TUD_ENDPOINT0_SIZE];
+
+  // for input/output reports (on hid endpoints)
   CFG_TUSB_MEM_ALIGN uint8_t epin_buf[CFG_TUD_HID_EP_BUFSIZE];
   CFG_TUSB_MEM_ALIGN uint8_t epout_buf[CFG_TUD_HID_EP_BUFSIZE];
 
@@ -279,8 +284,8 @@ bool hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t
           uint8_t const report_type = tu_u16_high(request->wValue);
           uint8_t const report_id   = tu_u16_low(request->wValue);
 
-          uint8_t* report_buf = p_hid->epin_buf;
-          uint16_t req_len = tu_min16(request->wLength, CFG_TUD_HID_EP_BUFSIZE);
+          uint8_t* report_buf = p_hid->epctrlin_buf;
+          uint16_t req_len = tu_min16(request->wLength, CFG_TUD_ENDPOINT0_SIZE);
 
           uint16_t xferlen = 0;
 
@@ -296,23 +301,23 @@ bool hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t
           xferlen += tud_hid_get_report_cb(hid_itf, report_id, (hid_report_type_t) report_type, report_buf, req_len);
           TU_ASSERT( xferlen > 0 );
 
-          tud_control_xfer(rhport, request, p_hid->epin_buf, xferlen);
+          tud_control_xfer(rhport, request, p_hid->epctrlin_buf, xferlen);
         }
       break;
 
       case  HID_REQ_CONTROL_SET_REPORT:
         if ( stage == CONTROL_STAGE_SETUP )
         {
-          TU_VERIFY(request->wLength <= sizeof(p_hid->epout_buf));
-          tud_control_xfer(rhport, request, p_hid->epout_buf, request->wLength);
+          TU_VERIFY(request->wLength <= sizeof(p_hid->epctrlout_buf));
+          tud_control_xfer(rhport, request, p_hid->epctrlout_buf, request->wLength);
         }
         else if ( stage == CONTROL_STAGE_ACK )
         {
           uint8_t const report_type = tu_u16_high(request->wValue);
           uint8_t const report_id   = tu_u16_low(request->wValue);
 
-          uint8_t const* report_buf = p_hid->epout_buf;
-          uint16_t report_len = tu_min16(request->wLength, CFG_TUD_HID_EP_BUFSIZE);
+          uint8_t const* report_buf = p_hid->epctrlout_buf;
+          uint16_t report_len = tu_min16(request->wLength, CFG_TUD_ENDPOINT0_SIZE);
 
           // If host request a specific Report ID, extract report ID in buffer before invoking callback
           if ( (report_id != HID_REPORT_TYPE_INVALID) && (report_len > 1) && (report_id == report_buf[0]) )


### PR DESCRIPTION
This fixes the handling of HID input and output interrupt reports in tinyusb, which are currently conflicting with get feature and set feature reports.

HID supports "get feature" and "set feature" reports over ep0 (control endpoint).
HID also supports "input" and "output" reports over endpoints specified in the hid interface section of the configuration descriptor.

Currently tinyusb uses the same buffer 'epin_buf' for output reports and get feature reports.
It also uses the same buffer 'epout_buf' for input reports and set feature reports.

The handling of two types of reports with the same buffer means that when one type of report is in progress, the other type of report can be initiated, resulting in the same buffer being used for handling two different reports at the same time. This results in corruption of the data in the buffer and so incorrect data returned to the host.

The fix I provided for this is to add two new buffers for handling input and output reports. This way each report type has its own buffer and so buffers are no longer accessed by more than one report handler at a time. 