### PR TITLE
Fix host buffer alignment setting

### DIFF
--- a/src/portable/chipidea/ci_hs/ci_hs_imxrt.h
+++ b/src/portable/chipidea/ci_hs/ci_hs_imxrt.h
@@ -78,6 +78,12 @@ TU_ATTR_ALWAYS_INLINE static inline void imxrt_dcache_clean(void const* addr, ui
 TU_ATTR_ALWAYS_INLINE static inline void imxrt_dcache_invalidate(void const* addr, uint32_t data_size) {
   const uintptr_t addr32 = (uintptr_t) addr;
   if (imxrt_is_cache_mem(addr32)) {
+    // Invalidating does not push cached changes back to RAM so we need to be
+    // *very* careful when we do it. If we're not aligned, then we risk resetting
+    // values back to their RAM state.
+    // if (addr32 % 32 != 0) {
+    //   TU_BREAKPOINT();
+    // }
     SCB_InvalidateDCache_by_Addr((void*) addr32, (int32_t) data_size);
   }
 }

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -431,7 +431,11 @@
 
 // Attribute to align memory for host controller
 #ifndef CFG_TUH_MEM_ALIGN
-  #define CFG_TUH_MEM_ALIGN   TU_ATTR_ALIGNED(4)
+  #ifdef CFG_TUSB_MEM_ALIGN
+    #define CFG_TUH_MEM_ALIGN   CFG_TUSB_MEM_ALIGN
+  #else
+    #define CFG_TUH_MEM_ALIGN   TU_ATTR_ALIGNED(4)
+  #endif
 #endif
 
 //------------- CLASS -------------//


### PR DESCRIPTION
When buffer alignment isn't given for TUH, it defaults to 4. The iMX needs 32 to match the cache and is set using the universal setting in CircuitPython. Change the default to fall back to the universal setting before being 4.

If the alignment is 4, we risk invalidating addresses outside the buffer that haven't been written back.