### PR TITLE
Usbh xfer user callback

### DIFF
--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -34,13 +34,16 @@
 
 #include "msc_device.h"
 
+// Level where CFG_TUSB_DEBUG must be at least for this driver is logged
+#ifndef CFG_TUD_MSC_LOG_LEVEL
+  #define CFG_TUD_MSC_LOG_LEVEL   2
+#endif
+
+#define TU_LOG_DRV(...)   TU_LOG(CFG_TUD_MSC_LOG_LEVEL, __VA_ARGS__)
+
 //--------------------------------------------------------------------+
 // MACRO CONSTANT TYPEDEF
 //--------------------------------------------------------------------+
-
-// Can be selectively disabled to reduce logging when troubleshooting other driver
-#define MSC_DEBUG   2
-
 enum
 {
   MSC_STAGE_CMD  = 0,
@@ -164,7 +167,7 @@ uint8_t rdwr10_validate_cmd(msc_cbw_t const* cbw)
   {
     if ( block_count )
     {
-      TU_LOG(MSC_DEBUG, "  SCSI case 2 (Hn < Di) or case 3 (Hn < Do) \r\n");
+      TU_LOG_DRV("  SCSI case 2 (Hn < Di) or case 3 (Hn < Do) \r\n");
       status = MSC_CSW_STATUS_PHASE_ERROR;
     }else
     {
@@ -174,22 +177,22 @@ uint8_t rdwr10_validate_cmd(msc_cbw_t const* cbw)
   {
     if ( SCSI_CMD_READ_10 == cbw->command[0] && !is_data_in(cbw->dir) )
     {
-      TU_LOG(MSC_DEBUG, "  SCSI case 10 (Ho <> Di)\r\n");
+      TU_LOG_DRV("  SCSI case 10 (Ho <> Di)\r\n");
       status = MSC_CSW_STATUS_PHASE_ERROR;
     }
     else if ( SCSI_CMD_WRITE_10 == cbw->command[0] && is_data_in(cbw->dir) )
     {
-      TU_LOG(MSC_DEBUG, "  SCSI case 8 (Hi <> Do)\r\n");
+      TU_LOG_DRV("  SCSI case 8 (Hi <> Do)\r\n");
       status = MSC_CSW_STATUS_PHASE_ERROR;
     }
     else if ( 0 == block_count )
     {
-      TU_LOG(MSC_DEBUG, "  SCSI case 4 Hi > Dn (READ10) or case 9 Ho > Dn (WRITE10) \r\n");
+      TU_LOG_DRV("  SCSI case 4 Hi > Dn (READ10) or case 9 Ho > Dn (WRITE10) \r\n");
       status =  MSC_CSW_STATUS_FAILED;
     }
     else if ( cbw->total_bytes / block_count == 0 )
     {
-      TU_LOG(MSC_DEBUG, " Computed block size = 0. SCSI case 7 Hi < Di (READ10) or case 13 Ho < Do (WRIT10)\r\n");
+      TU_LOG_DRV(" Computed block size = 0. SCSI case 7 Hi < Di (READ10) or case 13 Ho < Do (WRIT10)\r\n");
       status = MSC_CSW_STATUS_PHASE_ERROR;
     }
   }
@@ -352,7 +355,7 @@ bool mscd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
   switch ( request->bRequest )
   {
     case MSC_REQ_RESET:
-      TU_LOG(MSC_DEBUG, "  MSC BOT Reset\r\n");
+      TU_LOG_DRV("  MSC BOT Reset\r\n");
       TU_VERIFY(request->wValue == 0 && request->wLength == 0);
 
       // driver state reset
@@ -363,7 +366,7 @@ bool mscd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
 
     case MSC_REQ_GET_MAX_LUN:
     {
-      TU_LOG(MSC_DEBUG, "  MSC Get Max Lun\r\n");
+      TU_LOG_DRV("  MSC Get Max Lun\r\n");
       TU_VERIFY(request->wValue == 0 && request->wLength == 1);
 
       uint8_t maxlun = 1;
@@ -400,7 +403,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
 
       if ( !(xferred_bytes == sizeof(msc_cbw_t) && p_cbw->signature == MSC_CBW_SIGNATURE) )
       {
-        TU_LOG(MSC_DEBUG, "  SCSI CBW is not valid\r\n");
+        TU_LOG_DRV("  SCSI CBW is not valid\r\n");
 
         // BOT 6.6.1 If CBW is not valid stall both endpoints until reset recovery
         p_msc->stage = MSC_STAGE_NEED_RESET;
@@ -412,7 +415,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
         return false;
       }
 
-      TU_LOG(MSC_DEBUG, "  SCSI Command [Lun%u]: %s\r\n", p_cbw->lun, tu_lookup_find(&_msc_scsi_cmd_table, p_cbw->command[0]));
+      TU_LOG_DRV("  SCSI Command [Lun%u]: %s\r\n", p_cbw->lun, tu_lookup_find(&_msc_scsi_cmd_table, p_cbw->command[0]));
       //TU_LOG_MEM(MSC_DEBUG, p_cbw, xferred_bytes, 2);
 
       p_csw->signature    = MSC_CSW_SIGNATURE;
@@ -457,7 +460,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
         {
           if (p_cbw->total_bytes > sizeof(_mscd_buf))
           {
-            TU_LOG(MSC_DEBUG, "  SCSI reject non READ10/WRITE10 with large data\r\n");
+            TU_LOG_DRV("  SCSI reject non READ10/WRITE10 with large data\r\n");
             fail_scsi_op(rhport, p_msc, MSC_CSW_STATUS_FAILED);
           }else
           {
@@ -479,7 +482,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
           if ( resplen < 0 )
           {
             // unsupported command
-            TU_LOG(MSC_DEBUG, "  SCSI unsupported or failed command\r\n");
+            TU_LOG_DRV("  SCSI unsupported or failed command\r\n");
             fail_scsi_op(rhport, p_msc, MSC_CSW_STATUS_FAILED);
           }
           else if (resplen == 0)
@@ -514,7 +517,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
     break;
 
     case MSC_STAGE_DATA:
-      TU_LOG(MSC_DEBUG, "  SCSI Data [Lun%u]\r\n", p_cbw->lun);
+      TU_LOG_DRV("  SCSI Data [Lun%u]\r\n", p_cbw->lun);
       //TU_LOG_MEM(MSC_DEBUG, _mscd_buf, xferred_bytes, 2);
 
       if (SCSI_CMD_READ_10 == p_cbw->command[0])
@@ -546,7 +549,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
           if ( cb_result < 0 )
           {
             // unsupported command
-            TU_LOG(MSC_DEBUG, "  SCSI unsupported command\r\n");
+            TU_LOG_DRV("  SCSI unsupported command\r\n");
             fail_scsi_op(rhport, p_msc, MSC_CSW_STATUS_FAILED);
           }else
           {
@@ -575,7 +578,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
       // Wait for the Status phase to complete
       if( (ep_addr == p_msc->ep_in) && (xferred_bytes == sizeof(msc_csw_t)) )
       {
-        TU_LOG(MSC_DEBUG, "  SCSI Status [Lun%u] = %u\r\n", p_cbw->lun, p_csw->status);
+        TU_LOG_DRV("  SCSI Status [Lun%u] = %u\r\n", p_cbw->lun, p_csw->status);
         // TU_LOG_MEM(MSC_DEBUG, p_csw, xferred_bytes, 2);
 
         // Invoke complete callback if defined
@@ -845,7 +848,7 @@ static void proc_read10_cmd(uint8_t rhport, mscd_interface_t* p_msc)
   if ( nbytes < 0 )
   {
     // negative means error -> endpoint is stalled & status in CSW set to failed
-    TU_LOG(MSC_DEBUG, "  tud_msc_read10_cb() return -1\r\n");
+    TU_LOG_DRV("  tud_msc_read10_cb() return -1\r\n");
 
     // set sense
     set_sense_medium_not_present(p_cbw->lun);
@@ -907,7 +910,7 @@ static void proc_write10_new_data(uint8_t rhport, mscd_interface_t* p_msc, uint3
   if ( nbytes < 0 )
   {
     // negative means error -> failed this scsi op
-    TU_LOG(MSC_DEBUG, "  tud_msc_write10_cb() return -1\r\n");
+    TU_LOG_DRV("  tud_msc_write10_cb() return -1\r\n");
 
     // update actual byte before failed
     p_msc->xferred_len += xferred_bytes;

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -32,10 +32,7 @@
 #include "tusb.h"
 #include "device/usbd_pvt.h"
 
-// Debug level of USBD Control
-#define USBD_CONTROL_DEBUG   2
-
-#if CFG_TUSB_DEBUG >= USBD_CONTROL_DEBUG
+#if CFG_TUSB_DEBUG >= CFG_TUD_LOG_LEVEL
 extern void usbd_driver_print_control_complete_name(usbd_control_xfer_cb_t callback);
 #endif
 
@@ -191,7 +188,7 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t result
   {
     TU_VERIFY(_ctrl_xfer.buffer);
     memcpy(_ctrl_xfer.buffer, _usbd_ctrl_buf, xferred_bytes);
-    TU_LOG_MEM(USBD_CONTROL_DEBUG, _usbd_ctrl_buf, xferred_bytes, 2);
+    TU_LOG_MEM(CFG_TUD_LOG_LEVEL, _usbd_ctrl_buf, xferred_bytes, 2);
   }
 
   _ctrl_xfer.total_xferred += (uint16_t) xferred_bytes;
@@ -208,7 +205,7 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t result
     // callback can still stall control in status phase e.g out data does not make sense
     if ( _ctrl_xfer.complete_cb )
     {
-      #if CFG_TUSB_DEBUG >= USBD_CONTROL_DEBUG
+      #if CFG_TUSB_DEBUG >= CFG_TUD_LOG_LEVEL
       usbd_driver_print_control_complete_name(_ctrl_xfer.complete_cb);
       #endif
 

--- a/src/device/usbd_pvt.h
+++ b/src/device/usbd_pvt.h
@@ -33,13 +33,20 @@
  extern "C" {
 #endif
 
+// Level where CFG_TUSB_DEBUG must be at least for USBD is logged
+#ifndef CFG_TUD_LOG_LEVEL
+#define CFG_TUD_LOG_LEVEL   2
+#endif
+
+#define TU_LOG_USBD(...)   TU_LOG(CFG_TUD_LOG_LEVEL, __VA_ARGS__)
+
 //--------------------------------------------------------------------+
 // Class Driver API
 //--------------------------------------------------------------------+
 
 typedef struct
 {
-  #if CFG_TUSB_DEBUG >= 2
+  #if CFG_TUSB_DEBUG >= CFG_TUD_LOG_LEVEL
   char const* name;
   #endif
 

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -38,17 +38,19 @@
 //--------------------------------------------------------------------+
 
 #ifndef CFG_TUH_TASK_QUEUE_SZ
-#define CFG_TUH_TASK_QUEUE_SZ   16
+  #define CFG_TUH_TASK_QUEUE_SZ   16
 #endif
 
 #ifndef CFG_TUH_INTERFACE_MAX
-#define CFG_TUH_INTERFACE_MAX   8
+  #define CFG_TUH_INTERFACE_MAX   8
 #endif
 
-// Debug level, TUSB_CFG_DEBUG must be at least this level for debug message
-#define USBH_DEBUG   2
+// Level where CFG_TUSB_DEBUG must be at least for USBH is logged
+#ifndef CFG_TUH_LOG_LEVEL
+  #define CFG_TUH_LOG_LEVEL   2
+#endif
 
-#define TU_LOG_USBH(...)   TU_LOG(USBH_DEBUG, __VA_ARGS__)
+#define TU_LOG_USBH(...)   TU_LOG(CFG_TUH_LOG_LEVEL, __VA_ARGS__)
 
 //--------------------------------------------------------------------+
 // USBH-HCD common data structure
@@ -322,12 +324,12 @@ bool tuh_init(uint8_t controller_id)
   if ( tuh_inited() ) return true;
 
   TU_LOG_USBH("USBH init on controller %u\r\n", controller_id);
-  TU_LOG_INT(USBH_DEBUG, sizeof(usbh_device_t));
-  TU_LOG_INT(USBH_DEBUG, sizeof(hcd_event_t));
-  TU_LOG_INT(USBH_DEBUG, sizeof(_ctrl_xfer));
-  TU_LOG_INT(USBH_DEBUG, sizeof(tuh_xfer_t));
-  TU_LOG_INT(USBH_DEBUG, sizeof(tu_fifo_t));
-  TU_LOG_INT(USBH_DEBUG, sizeof(tu_edpt_stream_t));
+  TU_LOG_INT(CFG_TUH_LOG_LEVEL, sizeof(usbh_device_t));
+  TU_LOG_INT(CFG_TUH_LOG_LEVEL, sizeof(hcd_event_t));
+  TU_LOG_INT(CFG_TUH_LOG_LEVEL, sizeof(_ctrl_xfer));
+  TU_LOG_INT(CFG_TUH_LOG_LEVEL, sizeof(tuh_xfer_t));
+  TU_LOG_INT(CFG_TUH_LOG_LEVEL, sizeof(tu_fifo_t));
+  TU_LOG_INT(CFG_TUH_LOG_LEVEL, sizeof(tu_edpt_stream_t));
 
   // Event queue
   _usbh_q = osal_queue_create( &_usbh_qdef );
@@ -565,7 +567,7 @@ bool tuh_control_xfer (tuh_xfer_t* xfer)
   TU_LOG_USBH("[%u:%u] %s: ", rhport, daddr,
               (xfer->setup->bmRequestType_bit.type == TUSB_REQ_TYPE_STANDARD && xfer->setup->bRequest <= TUSB_REQ_SYNCH_FRAME) ?
                   tu_str_std_request[xfer->setup->bRequest] : "Class Request");
-  TU_LOG_PTR(USBH_DEBUG, xfer->setup);
+  TU_LOG_PTR(CFG_TUH_LOG_LEVEL, xfer->setup);
   TU_LOG_USBH("\r\n");
 
   if (xfer->complete_cb)
@@ -671,7 +673,7 @@ static bool usbh_control_xfer_cb (uint8_t dev_addr, uint8_t ep_addr, xfer_result
         if (request->wLength)
         {
           TU_LOG_USBH("[%u:%u] Control data:\r\n", rhport, dev_addr);
-          TU_LOG_MEM(USBH_DEBUG, _ctrl_xfer.buffer, xferred_bytes, 2);
+          TU_LOG_MEM(CFG_TUH_LOG_LEVEL, _ctrl_xfer.buffer, xferred_bytes, 2);
         }
 
         _ctrl_xfer.actual_len = (uint16_t) xferred_bytes;
@@ -1186,7 +1188,7 @@ static void process_removing_device(uint8_t rhport, uint8_t hub_addr, uint8_t hu
       TU_LOG_USBH("Device unplugged address = %u\r\n", daddr);
 
       if (is_hub_addr(daddr)) {
-        TU_LOG(USBH_DEBUG, "  is a HUB device %u\r\n", daddr);
+        TU_LOG(CFG_TUH_LOG_LEVEL, "  is a HUB device %u\r\n", daddr);
 
         // Submit removed event If the device itself is a hub (un-rolled recursive)
         // TODO a better to unroll recursrive is using array of removing_hubs and mark it here
@@ -1657,7 +1659,7 @@ static bool _parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configur
 
       if( drv_id >= USBH_CLASS_DRIVER_COUNT )
       {
-        TU_LOG(USBH_DEBUG, "Interface %u: class = %u subclass = %u protocol = %u is not supported\r\n",
+        TU_LOG(CFG_TUH_LOG_LEVEL, "Interface %u: class = %u subclass = %u protocol = %u is not supported\r\n",
                desc_itf->bInterfaceNumber, desc_itf->bInterfaceClass, desc_itf->bInterfaceSubClass, desc_itf->bInterfaceProtocol);
       }
     }
@@ -1695,7 +1697,7 @@ void usbh_driver_set_config_complete(uint8_t dev_addr, uint8_t itf_num)
 
     if (is_hub_addr(dev_addr))
     {
-      TU_LOG(USBH_DEBUG, "HUB address = %u is mounted\r\n", dev_addr);
+      TU_LOG(CFG_TUH_LOG_LEVEL, "HUB address = %u is mounted\r\n", dev_addr);
     }else
     {
       // Invoke callback if available


### PR DESCRIPTION
**Describe the PR**
Per @tannewt request for CircuitPython full control over built-in driver
- When a transfer is complete on an endpoint, USBH will prefer application callback over built-in driver. This occurs when application uses tuh_edpt_xfer() on enabled driver e.g HID endpoint.
- When using built-in driver API, callback is set to NULL
- Take chance to add fine-grained debug support. CFG_TUD_LOG_LEVEL and CFG_TUD_MSC_LOG_LEVEL can be defined to requires higher level, can be useful when focusing on host stack.

