### PR TITLE
Some stm32_fsdev optimizations

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -660,7 +660,7 @@ void dcd_int_handler(uint8_t rhport) {
 
   (void) rhport;
 
-  // Only handle interrupts which are triggered and currently active 
+  // Only handle interrupts which are triggered and currently active
   uint32_t int_status = USB->ISTR & USB->CNTR;
 
   // Only continue if there is something to do
@@ -697,7 +697,7 @@ void dcd_int_handler(uint8_t rhport) {
 
     /* Drop all potential pending USB interrupts because of the upcoming reset */
     USB->ISTR = 0;
- 
+
     return; // Don't do the rest of the things here; perhaps they've been cleared?
   }
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -721,7 +721,8 @@ void dcd_int_handler(uint8_t rhport)
   if (int_status & USB_ISTR_SUSP)
   {
     /* Don't suspend as long there is a pending remote wakeup */
-    if (USB->CNTR & USB_CNTR_RESUME) {
+    if (!(USB->CNTR & USB_CNTR_RESUME))
+    {
       /* Suspend is asserted for both suspend and unplug events. without Vbus monitoring,
        * these events cannot be differentiated, so we only trigger suspend. */
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -299,7 +299,6 @@ void dcd_connect(uint8_t rhport)
 void dcd_sof_enable(uint8_t rhport, bool en)
 {
   (void) rhport;
-  (void) en;
 
   if (en)
   {

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -661,7 +661,8 @@ void dcd_int_handler(uint8_t rhport) {
   (void) rhport;
 
   // Only handle interrupts which are triggered and currently active
-  uint32_t int_status = USB->ISTR & USB->CNTR;
+  uint32_t int_status = USB->ISTR;
+  int_status & = USB->CNTR;
 
   // Only continue if there is something to do
   if (!int_status) {

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -662,7 +662,7 @@ void dcd_int_handler(uint8_t rhport) {
 
   // Only handle interrupts which are triggered and currently active
   uint32_t int_status = USB->ISTR;
-  int_status & = USB->CNTR;
+  int_status &= USB->CNTR;
 
   // Only continue if there is something to do
   if (!int_status) {


### PR DESCRIPTION
As requested, the suggested changes of the discussion from #2174

- Skip interrupt handler if there is nothing to do.
- Use the SOF as a failsafe to restore from sleep if the host don't trigger the remote wakeup.
- Drop pending interrupts which were skipped if a reset took place.
- Only suspend device if there is no pending remote wakeup.