### PR TITLE
HID SOF interrupt support

### DIFF
--- a/src/class/hid/hid_device.c
+++ b/src/class/hid/hid_device.c
@@ -412,4 +412,9 @@ bool hidd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
   return true;
 }
 
+void hidd_sof_isr(uint8_t rhport, uint32_t frame_count)
+{
+  (void) rhport;
+  tud_hid_sof_cb(frame_count);
+}
 #endif

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -118,6 +118,8 @@ TU_ATTR_WEAK bool tud_hid_set_idle_cb(uint8_t instance, uint8_t idle_rate);
 // Note: For composite reports, report[0] is report ID
 TU_ATTR_WEAK void tud_hid_report_complete_cb(uint8_t instance, uint8_t const* report, uint16_t len);
 
+// Invoked when received SOF interrupt
+TU_ATTR_WEAK void tud_hid_sof_cb(uint32_t frame_count);
 
 //--------------------------------------------------------------------+
 // Inline Functions
@@ -410,6 +412,7 @@ void     hidd_reset           (uint8_t rhport);
 uint16_t hidd_open            (uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t max_len);
 bool     hidd_control_xfer_cb (uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
 bool     hidd_xfer_cb         (uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t xferred_bytes);
+void     hidd_sof_isr         (uint8_t rhport, uint32_t frame_count);
 
 #ifdef __cplusplus
  }

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -119,7 +119,7 @@ tu_static usbd_class_driver_t const _usbd_driver[] =
     .open             = hidd_open,
     .control_xfer_cb  = hidd_control_xfer_cb,
     .xfer_cb          = hidd_xfer_cb,
-    .sof              = NULL
+    .sof              = hidd_sof_isr
   },
   #endif
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -597,6 +597,16 @@ void tud_task_ext(uint32_t timeout_ms, bool in_isr)
       break;
 
       case DCD_EVENT_SOF:
+        TU_LOG_USBD("\r\n");
+        for (uint8_t i = 0; i < TOTAL_DRIVER_COUNT; i++)
+        {
+          usbd_class_driver_t const * driver = get_driver(i);
+          if (driver && driver->sof)
+          {
+            driver->sof(event.rhport, event.sof.frame_count);
+          }
+        }
+        break;
       default:
         TU_BREAKPOINT();
       break;


### PR DESCRIPTION
**Describe the PR**
Adds HID SOF support.

**Additional context**
~~Tested and working on CH32V307~~

**Questions**
1. Unsure if it should be called `hidd_sof_isr` or `hidd_sof_cb`? (used `isr` since the audio one uses that too)
2. Should I pass in `uint8_t rhport` into `hidd_sof_isr`?
