### PR TITLE
Fix typos in HCD rusb file

### DIFF
--- a/src/portable/renesas/rusb2/hcd_rusb2.c
+++ b/src/portable/renesas/rusb2/hcd_rusb2.c
@@ -265,7 +265,7 @@ static bool pipe_xfer_in(rusb2_reg_t* rusb, unsigned num)
     pipe->buf = (uint8_t*)buf + len;
   }
   if (len < mps) {
-    rusb->D0FIFOCTR = RUSB2_CFIFOCTR_BCLR_Msk;
+    rusb->D0FIFOCTR = RUSB2_D0FIFOCTR_BCLR_Msk;
   }
   rusb->D0FIFOSEL = 0;
   while (rusb->D0FIFOSEL_b.CURPIPE) ; /* if CURPIPE bits changes, check written value */
@@ -297,7 +297,7 @@ static bool pipe_xfer_out(rusb2_reg_t* rusb, unsigned num)
     pipe->buf = (uint8_t*)buf + len;
   }
   if (len < mps) {
-    rusb->D0FIFOCTR = RUSB2_CFIFOCTR_BVAL_Msk;
+    rusb->D0FIFOCTR = RUSB2_D0FIFOCTR_BVAL_Msk;
   }
   rusb->D0FIFOSEL = 0;
   while (rusb->D0FIFOSEL_b.CURPIPE) ; /* if CURPIPE bits changes, check written value */
@@ -367,7 +367,7 @@ static bool process_pipe_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr,
     } else { /* ZLP */
       rusb->D0FIFOSEL = num;
       pipe_wait_for_ready(rusb, num);
-      rusb->D0FIFOCTR = RUSB2_CFIFOCTR_BVAL_Msk;
+      rusb->D0FIFOCTR = RUSB2_D0FIFOCTR_BVAL_Msk;
       rusb->D0FIFOSEL = 0;
       while (rusb->D0FIFOSEL_b.CURPIPE) {} /* if CURPIPE bits changes, check written value */
     }


### PR DESCRIPTION
**Describe the PR**
Host Library:
The unplugging process of the USB device might lead to an infinite loop. It is easy to run into this situation if unplugging occurs during the enumeration process. Also, it happens when unplugging while the host and the USB device are doing something. 

The issue is really big. As the stack enters an infinite loop when this is happening.

**Additional context**
I am testing with the RA4M2 family, with no OS. I know this fix is not meant if you are hosting a hub device. However, if you are planning to host a single device, it increases the robustness of plugging/unplugging while busy issue.
This was tested with MSC devices, I can see the improvement. 

@hathach I am not sure if this fix is contagious for other scenarios. Please let me know if I need to take care of something else.

Thank you.

