### PR TITLE
Fixed typo in binary declaration RP2040 hw bspw family.c

### DIFF
--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -149,7 +149,7 @@ void board_init(void)
 #endif
 
 #ifdef UART_DEV
-  bi_decl(bi_2pins_with_func(UART_TX_PIN, UART_TX_PIN, GPIO_FUNC_UART));
+  bi_decl(bi_2pins_with_func(UART_TX_PIN, UART_RX_PIN, GPIO_FUNC_UART));
   uart_inst = uart_get_instance(UART_DEV);
   stdio_uart_init_full(uart_inst, CFG_BOARD_UART_BAUDRATE, UART_TX_PIN, UART_RX_PIN);
 #endif


### PR DESCRIPTION
**Description**
There is a typo in the following line:
https://github.com/hathach/tinyusb/blob/86c416d4c0fb38432460b3e11b08b9de76941bf5/hw/bsp/rp2040/family.c#L152

The interface declaration should declare the `UART_TX_PIN` and `UART_RX_PIN` pin instead of declaring the `UART_TX_PIN` pin twice.