### PR TITLE
Fix STM32G0 build.

### DIFF
--- a/hw/bsp/stm32g0/family.cmake
+++ b/hw/bsp/stm32g0/family.cmake
@@ -36,12 +36,14 @@ function(add_board_target BOARD_TARGET)
       ${ST_CMSIS}/Source/Templates/system_${ST_PREFIX}.c
       ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal.c
       ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_cortex.c
+      ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_pwr.c
       ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_pwr_ex.c
       ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_rcc.c
       ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_rcc_ex.c
       ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_gpio.c
       ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_uart.c
       ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_uart_ex.c
+      ${ST_HAL_DRIVER}/Src/${ST_PREFIX}_hal_dma.c
       ${STARTUP_FILE_${CMAKE_C_COMPILER_ID}}
       )
     target_include_directories(${BOARD_TARGET} PUBLIC

--- a/hw/bsp/stm32g0/family.mk
+++ b/hw/bsp/stm32g0/family.mk
@@ -30,12 +30,14 @@ SRC_C += \
 	$(ST_CMSIS)/Source/Templates/system_stm32$(ST_FAMILY)xx.c \
 	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal.c \
 	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_cortex.c \
+	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_pwr.c \
 	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_pwr_ex.c \
 	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_rcc.c \
 	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_rcc_ex.c \
 	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_uart.c \
 	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_uart_ex.c \
-	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_gpio.c
+	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_gpio.c \
+	$(ST_HAL_DRIVER)/Src/stm32$(ST_FAMILY)xx_hal_dma.c
 
 INC += \
 	$(TOP)/$(BOARD_PATH) \


### PR DESCRIPTION
**Describe the PR**
Fix complaining of missing HAL PWR & DMA source file.

Weird CI is passing...

```
python3 tools/build_family.py stm32g0
...
/Src/stm32g0xx_hal_rcc_ex.o: in function `??HAL_RCCEx_DisableLSCO_1':
/home/tusb/tinyusb/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_rcc_ex.c:(.text+0xb2e): undefined reference to `HAL_PWR_DisableBkUpAccess'
/opt/arm-none-eabi-gcc/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld: _build/stm32g0b1nucleo/obj/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.o: in function `??HAL_UART_Transmit_DMA_4':
/home/tusb/tinyusb/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.c:(.text+0x68c): undefined reference to `HAL_DMA_Start_IT'
/opt/arm-none-eabi-gcc/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld: _build/stm32g0b1nucleo/obj/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.o: in function `HAL_UART_DMAStop':
/home/tusb/tinyusb/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.c:(.text+0x8c2): undefined reference to `HAL_DMA_Abort'
/opt/arm-none-eabi-gcc/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld: /home/tusb/tinyusb/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.c:(.text+0x8cc): undefined reference to `HAL_DMA_GetError'
/opt/arm-none-eabi-gcc/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld: /home/tusb/tinyusb/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.c:(.text+0x916): undefined reference to `HAL_DMA_Abort'
/opt/arm-none-eabi-gcc/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld: /home/tusb/tinyusb/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.c:(.text+0x922): undefined reference to `HAL_DMA_GetError'
/opt/arm-none-eabi-gcc/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld: _build/stm32g0b1nucleo/obj/hw/mcu/st/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.o: in function `??HAL_UART_Abort_0':
```
**Additional context**
There is another error when RTT logger is enabled, but I'm not sure the best way to fix it.
```
tusb@tusb:~/tinyusb/examples/device/cdc_dual_ports$ make BOARD=stm32g0b1nucleo LOGGER=rtt
CC SEGGER_RTT.o
/home/tusb/tinyusb/lib/SEGGER_RTT/RTT/SEGGER_RTT.c: In function '_DoInit':
/home/tusb/tinyusb/lib/SEGGER_RTT/RTT/SEGGER_RTT.c:323:10: error: cast discards 'volatile' qualifier from pointer target type [-Werror=cast-qual]
  323 |   memset((SEGGER_RTT_CB*)p, 0, sizeof(_SEGGER_RTT));         // Make sure that the RTT CB is always zero initialized.
      |          ^
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
make: *** [/home/tusb/tinyusb/tools/make/toolchain/arm_gcc_rules.mk:56: _build/stm32g0b1nucleo/obj/lib/SEGGER_RTT/RTT/SEGGER_RTT.o] Error 1
```
