### PR TITLE
Fix makefile a warning when run on windows command prompt

### DIFF
--- a/examples/make.mk
+++ b/examples/make.mk
@@ -116,7 +116,7 @@ INC += \
   $(TOP)/$(FAMILY_PATH) \
   $(TOP)/src \
 
-BOARD_UPPER = $(shell echo $(subst -,_,$(BOARD)) | tr a-z A-Z)
+BOARD_UPPER = $(subst a,A,$(subst b,B,$(subst c,C,$(subst d,D,$(subst e,E,$(subst f,F,$(subst g,G,$(subst h,H,$(subst i,I,$(subst j,J,$(subst k,K,$(subst l,L,$(subst m,M,$(subst n,N,$(subst o,O,$(subst p,P,$(subst q,Q,$(subst r,R,$(subst s,S,$(subst t,T,$(subst u,U,$(subst v,V,$(subst w,W,$(subst x,X,$(subst y,Y,$(subst z,Z,$(subst -,_,$(BOARD))))))))))))))))))))))))))))
 CFLAGS += -DBOARD_$(BOARD_UPPER)
 
 # Log level is mapped to TUSB DEBUG option


### PR DESCRIPTION
**Describe the PR**
Because Windows command prompt has no `tr` command, it occurs a warning.

**Additional context**
I found some ways in stack overflow. 
https://stackoverflow.com/questions/664601/in-gnu-make-how-do-i-convert-a-variable-to-lower-case
For portability, I guess the simple way is better.