### PR TITLE
run ci with pico-examples

### DIFF
--- a/.github/workflows/cmake_arm.yml
+++ b/.github/workflows/cmake_arm.yml
@@ -73,6 +73,14 @@ jobs:
         ref: develop
         path: pico-sdk
 
+    - name: Checkout pico-examples for rp2040
+      if: matrix.family == 'rp2040'
+      uses: actions/checkout@v3
+      with:
+        repository: raspberrypi/pico-examples
+        ref: develop
+        path: pico-examples
+
     - name: Get Dependencies
       run: python3 tools/get_deps.py ${{ matrix.family }}
 
@@ -81,6 +89,25 @@ jobs:
       env:
         # for rp2040, there is no harm if defined for other families
         PICO_SDK_PATH: ${{ github.workspace }}/pico-sdk
+
+    - name: Build pico-examples
+      if: matrix.family == 'rp2040'
+      env:
+        PICO_SDK_PATH: ${{ github.workspace }}/pico-sdk
+        PICO_EXAMPLES_PATH: ${{ github.workspace }}/pico-examples
+      run: |
+        # symlink tinyusb to pico-sdk
+        rm -rf $PICO_SDK_PATH/lib/tinyusb
+        ln -s ${{ github.workspace }} $PICO_SDK_PATH/lib/
+        # change CMakelists.txt to only build selected examples
+        cd $PICO_EXAMPLES_PATH
+        sed -i -r 's/add_subdirectory/#add_subdirectory/g' CMakeLists.txt
+        echo "" >> CMakeLists.txt
+        echo "add_subdirectory(usb/device/dev_hid_composite)" >> CMakeLists.txt
+        # TODO temporarily disable host examples since tinyusb API is changed
+        # echo "add_subdirectory(usb/host/host_cdc_msc_hid)" >> CMakeLists.txt
+        cmake -S . -B _build -G Ninja -DFAMILY=rp2040 -DBOARD=pico_sdk
+        cmake --build _build
 
     # Upload binaries for hardware test with self-hosted
     - name: Prepare rp2040 Artifacts


### PR DESCRIPTION
**Describe the PR**
Build pico-examples usb in the CI to prevent changes in this repo break pico-examples #2151

Note: due to host API changes, currently only usb/device/dev_hid_composite is built, usb/host/host_cdc_msc_hid is commented out.

PS: dev_hid_composite failed to build as well due to latest rename of `bsp/board.h` to `bsp/board_api.h`