### PR TITLE
Host usb reset

### DIFF
--- a/hw/bsp/lpc18/boards/mcb1800/ozone/lpc1857.jdebug
+++ b/hw/bsp/lpc18/boards/mcb1800/ozone/lpc1857.jdebug
@@ -10,7 +10,7 @@
 */
 void OnProjectLoad (void) {
   Project.AddSvdFile ("Cortex-M3.svd");
-  Project.AddSvdFile ("./LPC18xx.svd");
+  Project.AddSvdFile ("../../../../../../../cmsis-svd/data/NXP/LPC18xx.svd");
 
   Project.SetDevice ("LPC1857");
   Project.SetHostIF ("USB", "");
@@ -20,7 +20,8 @@ void OnProjectLoad (void) {
   Project.SetTraceSource ("Trace Pins");
   Project.SetTracePortWidth (4);
 
-  File.Open ("../../../../../../examples/device/cdc_msc/cmake-build-mcb1800/cdc_msc.elf");
+  //File.Open ("../../../../../../examples/cmake-build-mcb1800/device/cdc_msc/cdc_msc.elf");
+  File.Open ("../../../../../../examples/cmake-build-mcb1800/host/cdc_msc_hid/cdc_msc_hid.elf");
 }
 /*********************************************************************
 *

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -421,8 +421,7 @@ bool msch_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *de
   return true;
 }
 
-bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
-{
+bool msch_set_config(uint8_t dev_addr, uint8_t itf_num) {
   msch_interface_t* p_msc = get_itf(dev_addr);
   TU_ASSERT(p_msc->itf_num == itf_num);
 
@@ -430,10 +429,8 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
 
   //------------- Get Max Lun -------------//
   TU_LOG_DRV("MSC Get Max Lun\r\n");
-  tusb_control_request_t const request =
-  {
-    .bmRequestType_bit =
-    {
+  tusb_control_request_t const request = {
+    .bmRequestType_bit = {
       .recipient = TUSB_REQ_RCPT_INTERFACE,
       .type      = TUSB_REQ_TYPE_CLASS,
       .direction = TUSB_DIR_IN
@@ -444,12 +441,11 @@ bool msch_set_config(uint8_t dev_addr, uint8_t itf_num)
     .wLength  = 1
   };
 
-  tuh_xfer_t xfer =
-  {
+  tuh_xfer_t xfer = {
     .daddr       = dev_addr,
     .ep_addr     = 0,
     .setup       = &request,
-    .buffer      = &p_msc->max_lun,
+    .buffer      = _msch_buffer,
     .complete_cb = config_get_maxlun_complete,
     .user_data    = 0
   };
@@ -466,6 +462,8 @@ static void config_get_maxlun_complete (tuh_xfer_t* xfer)
   // STALL means zero
   p_msc->max_lun = (XFER_RESULT_SUCCESS == xfer->result) ? _msch_buffer[0] : 0;
   p_msc->max_lun++; // MAX LUN is minus 1 by specs
+
+  TU_LOG_DRV("  Max LUN = %u\r\n", p_msc->max_lun);
 
   // TODO multiple LUN support
   TU_LOG_DRV("SCSI Test Unit Ready\r\n");

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -149,10 +149,11 @@ uint32_t hcd_frame_number(uint8_t rhport);
 // Get the current connect status of roothub port
 bool hcd_port_connect_status(uint8_t rhport);
 
-// Reset USB bus on the port
+// Reset USB bus on the port. Return immediately, bus reset sequence may not be complete.
+// Some port would require hcd_port_reset_end() to be invoked after 10ms to complete the reset sequence.
 void hcd_port_reset(uint8_t rhport);
 
-// TODO implement later
+// Complete bus reset sequence, may be required by some controllers
 void hcd_port_reset_end(uint8_t rhport);
 
 // Get port link speed

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -330,7 +330,7 @@ static void connection_port_reset_complete (tuh_xfer_t* xfer);
 bool hub_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes) {
   (void) xferred_bytes; // TODO can be more than 1 for hub with lots of ports
   (void) ep_addr;
-  TU_ASSERT(result == XFER_RESULT_SUCCESS);
+  TU_VERIFY(result == XFER_RESULT_SUCCESS);
 
   hub_interface_t* p_hub = get_itf(dev_addr);
 

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -47,8 +47,7 @@ typedef void (*tuh_xfer_cb_t)(tuh_xfer_t* xfer);
 // it is advised to initialize it using member name
 // Note2: not all field is available/meaningful in callback,
 // some info is not saved by usbh to save SRAM
-struct tuh_xfer_s
-{
+struct tuh_xfer_s {
   uint8_t daddr;
   uint8_t ep_addr;
   uint8_t TU_RESERVED;      // reserved
@@ -56,8 +55,7 @@ struct tuh_xfer_s
 
   uint32_t actual_len;      // excluding setup packet
 
-  union
-  {
+  union {
     tusb_control_request_t const* setup; // setup packet pointer if control transfer
     uint32_t buflen;                     // expected length if not control transfer (not available in callback)
   };
@@ -70,15 +68,13 @@ struct tuh_xfer_s
 };
 
 // Subject to change
-typedef struct
-{
+typedef struct {
   uint8_t daddr;
   tusb_desc_interface_t desc;
 } tuh_itf_info_t;
 
 // ConfigID for tuh_config()
-enum
-{
+enum {
   TUH_CFGID_RPI_PIO_USB_CONFIGURATION = OPT_MCU_RP2040 << 8 // cfg_param: pio_usb_configuration_t
 };
 
@@ -105,12 +101,12 @@ TU_ATTR_WEAK void tuh_umount_cb(uint8_t daddr);
 // Should be called before tuh_init()
 // - cfg_id   : configure ID (TBD)
 // - cfg_param: configure data, structure depends on the ID
-bool tuh_configure(uint8_t controller_id, uint32_t cfg_id, const void* cfg_param);
+bool tuh_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param);
 
 // Init host stack
-bool tuh_init(uint8_t controller_id);
+bool tuh_init(uint8_t rhport);
 
-// Check if host stack is already initialized
+// Check if host stack is already initialized with any roothub ports
 bool tuh_inited(void);
 
 // Task function should be called in main/rtos loop, extended version of tuh_task()
@@ -120,8 +116,7 @@ void tuh_task_ext(uint32_t timeout_ms, bool in_isr);
 
 // Task function should be called in main/rtos loop
 TU_ATTR_ALWAYS_INLINE static inline
-void tuh_task(void)
-{
+void tuh_task(void) {
   tuh_task_ext(UINT32_MAX, false);
 }
 
@@ -135,8 +130,20 @@ extern void hcd_int_handler(uint8_t rhport);
 // Interrupt handler, name alias to HCD
 #define tuh_int_handler   hcd_int_handler
 
+// Check if roothub port is initialized and active as a host
+bool tuh_rhport_is_active(uint8_t rhport);
+
+// Assert/de-assert Bus Reset signal to roothub port. USB specs: it should last 10-50ms
+bool tuh_rhport_reset_bus(uint8_t rhport, bool active);
+
+//--------------------------------------------------------------------+
+// Device API
+//--------------------------------------------------------------------+
+
+// Get VID/PID of device
 bool tuh_vid_pid_get(uint8_t daddr, uint16_t* vid, uint16_t* pid);
 
+// Get speed of device
 tusb_speed_t tuh_speed_get(uint8_t daddr);
 
 // Check if device is connected and configured
@@ -144,8 +151,7 @@ bool tuh_mounted(uint8_t daddr);
 
 // Check if device is suspended
 TU_ATTR_ALWAYS_INLINE static inline
-bool tuh_suspended(uint8_t daddr)
-{
+bool tuh_suspended(uint8_t daddr) {
   // TODO implement suspend & resume on host
   (void) daddr;
   return false;
@@ -153,8 +159,7 @@ bool tuh_suspended(uint8_t daddr)
 
 // Check if device is ready to communicate with
 TU_ATTR_ALWAYS_INLINE static inline
-bool tuh_ready(uint8_t daddr)
-{
+bool tuh_ready(uint8_t daddr) {
   return tuh_mounted(daddr) && !tuh_suspended(daddr);
 }
 

--- a/src/portable/chipidea/ci_hs/hcd_ci_hs.c
+++ b/src/portable/chipidea/ci_hs/hcd_ci_hs.c
@@ -39,24 +39,27 @@
 #include "ci_hs_type.h"
 
 #if CFG_TUSB_MCU == OPT_MCU_MIMXRT1XXX
-  #include "ci_hs_imxrt.h"
 
-  bool hcd_dcache_clean(void const* addr, uint32_t data_size) {
-    return imxrt_dcache_clean(addr, data_size);
-  }
+#include "ci_hs_imxrt.h"
 
-  bool hcd_dcache_invalidate(void const* addr, uint32_t data_size) {
-    return imxrt_dcache_invalidate(addr, data_size);
-  }
+bool hcd_dcache_clean(void const* addr, uint32_t data_size) {
+  return imxrt_dcache_clean(addr, data_size);
+}
 
-  bool hcd_dcache_clean_invalidate(void const* addr, uint32_t data_size) {
-    return imxrt_dcache_clean_invalidate(addr, data_size);
-  }
+bool hcd_dcache_invalidate(void const* addr, uint32_t data_size) {
+  return imxrt_dcache_invalidate(addr, data_size);
+}
+
+bool hcd_dcache_clean_invalidate(void const* addr, uint32_t data_size) {
+  return imxrt_dcache_clean_invalidate(addr, data_size);
+}
 
 #elif TU_CHECK_MCU(OPT_MCU_LPC18XX, OPT_MCU_LPC43XX)
-  #include "ci_hs_lpc18_43.h"
+
+#include "ci_hs_lpc18_43.h"
+
 #else
-  #error "Unsupported MCUs"
+#error "Unsupported MCUs"
 #endif
 
 //--------------------------------------------------------------------+
@@ -67,25 +70,25 @@
 // Controller API
 //--------------------------------------------------------------------+
 
-bool hcd_init(uint8_t rhport)
-{
-  ci_hs_regs_t* hcd_reg = CI_HS_REG(rhport);
+bool hcd_init(uint8_t rhport) {
+  ci_hs_regs_t *hcd_reg = CI_HS_REG(rhport);
 
   // Reset controller
   hcd_reg->USBCMD |= USBCMD_RESET;
-  while( hcd_reg->USBCMD & USBCMD_RESET ) {}
+  while ( hcd_reg->USBCMD & USBCMD_RESET ) {}
 
   // Set mode to device, must be set immediately after reset
 #if CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_LPC43XX
   // LPC18XX/43XX need to set VBUS Power Select to HIGH
   // RHPORT1 is fullspeed only (need external PHY for Highspeed)
   hcd_reg->USBMODE = USBMODE_CM_HOST | USBMODE_VBUS_POWER_SELECT;
-  if (rhport == 1) hcd_reg->PORTSC1 |= PORTSC1_FORCE_FULL_SPEED;
+  if ( rhport == 1 ) hcd_reg->PORTSC1 |= PORTSC1_FORCE_FULL_SPEED;
 #else
   hcd_reg->USBMODE = USBMODE_CM_HOST;
 #endif
 
   // FIXME force full speed, still have issue with Highspeed enumeration
+  // probably due to physical connection bouncing when plug/unplug
   // 1. Have issue when plug/unplug devices, maybe the port is not reset properly
   // 2. Also does not seems to detect disconnection
   hcd_reg->PORTSC1 |= PORTSC1_FORCE_FULL_SPEED;
@@ -93,13 +96,11 @@ bool hcd_init(uint8_t rhport)
   return ehci_init(rhport, (uint32_t) &hcd_reg->CAPLENGTH, (uint32_t) &hcd_reg->USBCMD);
 }
 
-void hcd_int_enable(uint8_t rhport)
-{
+void hcd_int_enable(uint8_t rhport) {
   CI_HCD_INT_ENABLE(rhport);
 }
 
-void hcd_int_disable(uint8_t rhport)
-{
+void hcd_int_disable(uint8_t rhport) {
   CI_HCD_INT_DISABLE(rhport);
 }
 

--- a/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
+++ b/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
@@ -48,16 +48,14 @@ static pio_usb_configuration_t pio_host_cfg = PIO_USB_DEFAULT_CONFIG;
 //--------------------------------------------------------------------+
 // HCD API
 //--------------------------------------------------------------------+
-bool hcd_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param)
-{
+bool hcd_configure(uint8_t rhport, uint32_t cfg_id, const void *cfg_param) {
   (void) rhport;
   TU_VERIFY(cfg_id == TUH_CFGID_RPI_PIO_USB_CONFIGURATION);
   memcpy(&pio_host_cfg, cfg_param, sizeof(pio_usb_configuration_t));
   return true;
 }
 
-bool hcd_init(uint8_t rhport)
-{
+bool hcd_init(uint8_t rhport) {
   (void) rhport;
 
   // To run USB SOF interrupt in core1, call this init in core1
@@ -66,20 +64,17 @@ bool hcd_init(uint8_t rhport)
   return true;
 }
 
-void hcd_port_reset(uint8_t rhport)
-{
+void hcd_port_reset(uint8_t rhport) {
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
   pio_usb_host_port_reset_start(pio_rhport);
 }
 
-void hcd_port_reset_end(uint8_t rhport)
-{
+void hcd_port_reset_end(uint8_t rhport) {
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
   pio_usb_host_port_reset_end(pio_rhport);
 }
 
-bool hcd_port_connect_status(uint8_t rhport)
-{
+bool hcd_port_connect_status(uint8_t rhport) {
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
 
   root_port_t *root = PIO_USB_ROOT_PORT(pio_rhport);
@@ -88,33 +83,28 @@ bool hcd_port_connect_status(uint8_t rhport)
   return line_state != PORT_PIN_SE0;
 }
 
-tusb_speed_t hcd_port_speed_get(uint8_t rhport)
-{
+tusb_speed_t hcd_port_speed_get(uint8_t rhport) {
   // TODO determine link speed
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
   return PIO_USB_ROOT_PORT(pio_rhport)->is_fullspeed ? TUSB_SPEED_FULL : TUSB_SPEED_LOW;
 }
 
 // Close all opened endpoint belong to this device
-void hcd_device_close(uint8_t rhport, uint8_t dev_addr)
-{
+void hcd_device_close(uint8_t rhport, uint8_t dev_addr) {
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
   pio_usb_host_close_device(pio_rhport, dev_addr);
 }
 
-uint32_t hcd_frame_number(uint8_t rhport)
-{
+uint32_t hcd_frame_number(uint8_t rhport) {
   (void) rhport;
   return pio_usb_host_get_frame_number();
 }
 
-void hcd_int_enable(uint8_t rhport)
-{
+void hcd_int_enable(uint8_t rhport) {
   (void) rhport;
 }
 
-void hcd_int_disable(uint8_t rhport)
-{
+void hcd_int_disable(uint8_t rhport) {
   (void) rhport;
 }
 
@@ -122,18 +112,16 @@ void hcd_int_disable(uint8_t rhport)
 // Endpoint API
 //--------------------------------------------------------------------+
 
-bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const * desc_ep)
-{
+bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const *desc_ep) {
   hcd_devtree_info_t dev_tree;
   hcd_devtree_get_info(dev_addr, &dev_tree);
   bool const need_pre = (dev_tree.hub_addr && dev_tree.speed == TUSB_SPEED_LOW);
 
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
-  return pio_usb_host_endpoint_open(pio_rhport, dev_addr, (uint8_t const*) desc_ep, need_pre);
+  return pio_usb_host_endpoint_open(pio_rhport, dev_addr, (uint8_t const *) desc_ep, need_pre);
 }
 
-bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t * buffer, uint16_t buflen)
-{
+bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t *buffer, uint16_t buflen) {
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
   return pio_usb_host_endpoint_transfer(pio_rhport, dev_addr, ep_addr, buffer, buflen);
 }
@@ -143,8 +131,7 @@ bool hcd_edpt_abort_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr) {
   return pio_usb_host_endpoint_abort_transfer(pio_rhport, dev_addr, ep_addr);
 }
 
-bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet[8])
-{
+bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet[8]) {
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
   return pio_usb_host_send_setup(pio_rhport, dev_addr, setup_packet);
 }
@@ -171,18 +158,16 @@ bool hcd_edpt_clear_stall(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr) {
   return true;
 }
 
-static void __no_inline_not_in_flash_func(handle_endpoint_irq)(root_port_t* rport, xfer_result_t result, volatile uint32_t* ep_reg)
-{
+static void __no_inline_not_in_flash_func(handle_endpoint_irq)(root_port_t *rport, xfer_result_t result,
+                                                               volatile uint32_t *ep_reg) {
   (void) rport;
   const uint32_t ep_all = *ep_reg;
 
-  for(uint8_t ep_idx = 0; ep_idx < PIO_USB_EP_POOL_CNT; ep_idx++)
-  {
+  for ( uint8_t ep_idx = 0; ep_idx < PIO_USB_EP_POOL_CNT; ep_idx++ ) {
     uint32_t const mask = (1u << ep_idx);
 
-    if (ep_all & mask)
-    {
-      endpoint_t* ep = PIO_USB_ENDPOINT(ep_idx);
+    if ( ep_all & mask ) {
+      endpoint_t * ep = PIO_USB_ENDPOINT(ep_idx);
       hcd_event_xfer_complete(ep->dev_addr, ep->ep_num, ep->actual_len, result, true);
     }
   }
@@ -192,34 +177,28 @@ static void __no_inline_not_in_flash_func(handle_endpoint_irq)(root_port_t* rpor
 }
 
 // IRQ Handler
-void __no_inline_not_in_flash_func(pio_usb_host_irq_handler)(uint8_t root_id)
-{
+void __no_inline_not_in_flash_func(pio_usb_host_irq_handler)(uint8_t root_id) {
   uint8_t const tu_rhport = root_id + 1;
-  root_port_t* rport = PIO_USB_ROOT_PORT(root_id);
+  root_port_t *rport = PIO_USB_ROOT_PORT(root_id);
   uint32_t const ints = rport->ints;
 
-  if ( ints & PIO_USB_INTS_CONNECT_BITS )
-  {
+  if ( ints & PIO_USB_INTS_CONNECT_BITS ) {
     hcd_event_device_attach(tu_rhport, true);
   }
 
-  if ( ints & PIO_USB_INTS_DISCONNECT_BITS )
-  {
+  if ( ints & PIO_USB_INTS_DISCONNECT_BITS ) {
     hcd_event_device_remove(tu_rhport, true);
   }
 
-  if ( ints & PIO_USB_INTS_ENDPOINT_COMPLETE_BITS )
-  {
+  if ( ints & PIO_USB_INTS_ENDPOINT_COMPLETE_BITS ) {
     handle_endpoint_irq(rport, XFER_RESULT_SUCCESS, &rport->ep_complete);
   }
 
-  if ( ints & PIO_USB_INTS_ENDPOINT_STALLED_BITS )
-  {
+  if ( ints & PIO_USB_INTS_ENDPOINT_STALLED_BITS ) {
     handle_endpoint_irq(rport, XFER_RESULT_STALLED, &rport->ep_stalled);
   }
 
-  if ( ints & PIO_USB_INTS_ENDPOINT_ERROR_BITS )
-  {
+  if ( ints & PIO_USB_INTS_ENDPOINT_ERROR_BITS ) {
     handle_endpoint_irq(rport, XFER_RESULT_FAILED, &rport->ep_error);
   }
 


### PR DESCRIPTION
**Describe the PR**
- Add tuh_rhport_reset_bus() for reset downstream port.
- Add tuh_rhport_is_active() to check if rhport is running as host
- EHCI improve bus reset, fix send_setup() not carried out if halted previously
- seperate bus reset delay and contact debouncing delay in enumeration
- fix host msc get maxlun not using aligned section memory

usage

```C
tuh_rhport_reset_bus(BOARD_TUH_RHPORT, true);
delay(20); // USB specs: reset signal must last 10-50 ms 
tuh_rhport_reset_bus(BOARD_TUH_RHPORT, false);
```

@tannewt 