### PR TITLE
Adding support for custom SOF ISR for CFG_TUD_VENDOR

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -167,7 +167,7 @@ tu_static usbd_class_driver_t const _usbd_driver[] =
     .open             = vendord_open,
     .control_xfer_cb  = tud_vendor_control_xfer_cb,
     .xfer_cb          = vendord_xfer_cb,
-    .sof              = tud_vendor_sof_isr ? tud_vendor_sof_isr : NULL
+    .sof              = tud_vendor_sof_isr
   },
   #endif
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -167,7 +167,7 @@ tu_static usbd_class_driver_t const _usbd_driver[] =
     .open             = vendord_open,
     .control_xfer_cb  = tud_vendor_control_xfer_cb,
     .xfer_cb          = vendord_xfer_cb,
-    .sof              = NULL
+    .sof              = tud_vendor_sof_isr ? tud_vendor_sof_isr : NULL
   },
   #endif
 

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -151,6 +151,9 @@ TU_ATTR_WEAK void tud_resume_cb(void);
 // Invoked when received control request with VENDOR TYPE
 TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
 
+// Invoked when received SOF packet with VENDOR TYPE
+TU_ATTR_WEAK void tud_vendor_sof_isr(uint8_t rhport, uint32_t frame_count);
+
 //--------------------------------------------------------------------+
 // Binary Device Object Store (BOS) Descriptor Templates
 //--------------------------------------------------------------------+


### PR DESCRIPTION
- Opens the driver SOF which is executed in the ISR to be changed by the vendor if the CFG_TUD_VENDOR configuration is used as a device driver

_A draft for a generic SOF callback which is executed in the main loop via `tud_task()` can be found here: #2213_