### PR TITLE
EHCI more fixes

### DIFF
--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -578,8 +578,9 @@ void qhd_xfer_complete_isr(ehci_qhd_t * qhd) {
     if ( qtd_overlay->halted ) {
       if (qtd_overlay->xact_err || qtd_overlay->err_count == 0 || qtd_overlay->buffer_err || qtd_overlay->babble_err) {
         // Error count = 0 often occurs when device disconnected, or other bus-related error
+        // clear halted bit if not caused by STALL to allow more transfer
         xfer_result = XFER_RESULT_FAILED;
-        qtd_overlay->halted = false; // clear halted bit if it is not caused by STALL
+        qtd_overlay->halted = false;
         TU_LOG3("  QHD xfer err count: %d\n", qtd_overlay->err_count);
         // TU_BREAKPOINT(); // TODO skip unplugged device
       }else {

--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -579,6 +579,7 @@ void qhd_xfer_complete_isr(ehci_qhd_t * qhd) {
       if (qtd_overlay->xact_err || qtd_overlay->err_count == 0 || qtd_overlay->buffer_err || qtd_overlay->babble_err) {
         // Error count = 0 often occurs when device disconnected, or other bus-related error
         xfer_result = XFER_RESULT_FAILED;
+        qtd_overlay->halted = false; // clear halted bit if it is not caused by STALL
         TU_LOG3("  QHD xfer err count: %d\n", qtd_overlay->err_count);
         // TU_BREAKPOINT(); // TODO skip unplugged device
       }else {


### PR DESCRIPTION
**Describe the PR**
More fixes for EHCI, found when working with circuitpython auto-reload
- clear qhd halted bit if not caused by STALL protocol to allow for next transfer
- abort transfer API does not release claimed endpoint. Also reset control transfer state if applicable.