### PR TITLE
fix issue 2188: support usbh_app_driver_get_cb()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,8 @@ Host Stack
 - Mass Storage Class (MSC)
 - Hub with multiple-level support
 
+Similar to the Device Stack, if you have a special requirement, `usbh_app_driver_get_cb()` can be used to write your own class driver without modifying the stack.
+
 TypeC PD Stack
 ==============
 

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -29,7 +29,7 @@
 #if (CFG_TUH_ENABLED && CFG_TUH_CDC)
 
 #include "host/usbh.h"
-#include "host/usbh_classdriver.h"
+#include "host/usbh_pvt.h"
 
 #include "cdc_host.h"
 

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -29,7 +29,7 @@
 #if (CFG_TUH_ENABLED && CFG_TUH_HID)
 
 #include "host/usbh.h"
-#include "host/usbh_classdriver.h"
+#include "host/usbh_pvt.h"
 
 #include "hid_host.h"
 

--- a/src/class/msc/msc_host.c
+++ b/src/class/msc/msc_host.c
@@ -29,7 +29,7 @@
 #if CFG_TUH_ENABLED && CFG_TUH_MSC
 
 #include "host/usbh.h"
-#include "host/usbh_classdriver.h"
+#include "host/usbh_pvt.h"
 
 #include "msc_host.h"
 

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -238,34 +238,25 @@ enum { BUILTIN_DRIVER_COUNT = TU_ARRAY_SIZE(_usbd_driver) };
 tu_static usbd_class_driver_t const * _app_driver = NULL;
 tu_static uint8_t _app_driver_count = 0;
 
+#define TOTAL_DRIVER_COUNT    (_app_driver_count + BUILTIN_DRIVER_COUNT)
+
 // virtually joins built-in and application drivers together.
 // Application is positioned first to allow overwriting built-in ones.
 static inline usbd_class_driver_t const * get_driver(uint8_t drvid)
 {
-  // Application drivers
-  if ( usbd_app_driver_get_cb )
-  {
-    if ( drvid < _app_driver_count ) return &_app_driver[drvid];
-    drvid -= _app_driver_count;
+  usbd_class_driver_t const * driver = NULL;
+
+  if ( drvid < _app_driver_count ) {
+    // Application drivers
+    driver = &_app_driver[drvid];
+  } else if ( drvid < TOTAL_DRIVER_COUNT && BUILTIN_DRIVER_COUNT > 0 ){
+    driver = &_usbd_driver[drvid - _app_driver_count];
   }
 
-  // when there is no built-in drivers BUILTIN_DRIVER_COUNT = 0 will cause -Wtype-limits warning
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtype-limits"
-#endif
-
-  // Built-in drivers
-  if (drvid < BUILTIN_DRIVER_COUNT) return &_usbd_driver[drvid];
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
-
-  return NULL;
+  return driver;
 }
 
-#define TOTAL_DRIVER_COUNT    (_app_driver_count + BUILTIN_DRIVER_COUNT)
+
 
 //--------------------------------------------------------------------+
 // DCD Event

--- a/src/device/usbd_pvt.h
+++ b/src/device/usbd_pvt.h
@@ -59,7 +59,7 @@ typedef struct
 } usbd_class_driver_t;
 
 // Invoked when initializing device stack to get additional class drivers.
-// Can optionally implemented by application to extend/overwrite class driver support.
+// Can be implemented by application to extend/overwrite class driver support.
 // Note: The drivers array must be accessible at all time when stack is active
 usbd_class_driver_t const* usbd_app_driver_get_cb(uint8_t* driver_count) TU_ATTR_WEAK;
 

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -30,7 +30,7 @@
 
 #include "hcd.h"
 #include "usbh.h"
-#include "usbh_classdriver.h"
+#include "usbh_pvt.h"
 #include "hub.h"
 
 // Debug level, TUSB_CFG_DEBUG must be at least this level for debug message

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -180,7 +180,7 @@ static usbh_class_driver_t const usbh_class_drivers[] =
   #endif
 };
 
-enum { USBH_CLASS_DRIVER_COUNT = TU_ARRAY_SIZE(usbh_class_drivers) };
+enum { USBH_BUILTIN_DRIVER_COUNT = TU_ARRAY_SIZE(usbh_class_drivers) };
 enum { CONFIG_NUM = 1 }; // default to use configuration 1
 
 
@@ -245,6 +245,21 @@ static bool enum_new_device(hcd_event_t* event);
 static void process_removing_device(uint8_t rhport, uint8_t hub_addr, uint8_t hub_port);
 static bool usbh_edpt_control_open(uint8_t dev_addr, uint8_t max_packet_size);
 static bool usbh_control_xfer_cb (uint8_t daddr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes);
+
+// Additional class drivers implemented by application
+tu_static usbh_class_driver_t const * _app_driver = NULL;
+tu_static uint8_t _app_driver_count = 0;
+tu_static uint8_t _total_driver_count = USBH_BUILTIN_DRIVER_COUNT;
+
+static usbh_class_driver_t const * usbh_get_driver(uint8_t drv_id)
+{
+  usbh_class_driver_t const * driver = NULL;
+  if ( drv_id < _app_driver_count )
+    driver = &_app_driver[drv_id];
+  else if ( drv_id < _total_driver_count )
+    driver = &usbh_class_drivers[drv_id - _app_driver_count];
+  return driver;
+}
 
 #if CFG_TUSB_OS == OPT_OS_NONE
 // TODO rework time-related function later
@@ -339,6 +354,12 @@ bool tuh_init(uint8_t controller_id) {
   _usbh_mutex = osal_mutex_create(&_usbh_mutexdef);
   TU_ASSERT(_usbh_mutex);
 #endif
+  // Get application driver if available
+  if ( usbh_app_driver_get_cb )
+  {
+    _app_driver = usbh_app_driver_get_cb(&_app_driver_count);
+    _total_driver_count = USBH_BUILTIN_DRIVER_COUNT + _app_driver_count;
+  }
 
   // Device
   tu_memclr(&_dev0, sizeof(_dev0));
@@ -351,10 +372,14 @@ bool tuh_init(uint8_t controller_id) {
   }
 
   // Class drivers
-  for (uint8_t drv_id = 0; drv_id < USBH_CLASS_DRIVER_COUNT; drv_id++)
+  for (uint8_t drv_id = 0; drv_id < _total_driver_count; drv_id++)
   {
-    TU_LOG_USBH("%s init\r\n", usbh_class_drivers[drv_id].name);
-    usbh_class_drivers[drv_id].init();
+    usbh_class_driver_t const * driver = usbh_get_driver(drv_id);
+    if ( driver )
+    {
+      TU_LOG_USBH("%s init\r\n", driver->name);
+      driver->init();
+    }
   }
 
   _usbh_controller = controller_id;;
@@ -482,12 +507,16 @@ void tuh_task_ext(uint32_t timeout_ms, bool in_isr) {
             }else
             #endif
             {
-              uint8_t const drv_id = dev->ep2drv[epnum][ep_dir];
-              if ( drv_id < USBH_CLASS_DRIVER_COUNT ) {
-                TU_LOG_USBH("%s xfer callback\r\n", usbh_class_drivers[drv_id].name);
-                usbh_class_drivers[drv_id].xfer_cb(event.dev_addr, ep_addr, (xfer_result_t) event.xfer_complete.result,
+              uint8_t drv_id = dev->ep2drv[epnum][ep_dir];
+              usbh_class_driver_t const * driver = usbh_get_driver(drv_id);
+              if ( driver )
+              {
+                TU_LOG_USBH("%s xfer callback\r\n", driver->name);
+                driver->xfer_cb(event.dev_addr, ep_addr, (xfer_result_t) event.xfer_complete.result,
                                                    event.xfer_complete.len);
-              } else {
+              }
+              else
+              {
                 // no driver/callback responsible for this transfer
                 TU_ASSERT(false,);
               }
@@ -1183,17 +1212,20 @@ static void process_removing_device(uint8_t rhport, uint8_t hub_addr, uint8_t hu
   uint8_t nop_count = 0;
 #endif
 
-  for (uint8_t dev_id = 0; dev_id < TOTAL_DEVICES; dev_id++) {
+  for (uint8_t dev_id = 0; dev_id < TOTAL_DEVICES; dev_id++)
+  {
     usbh_device_t *dev = &_usbh_devices[dev_id];
     uint8_t const daddr = dev_id + 1;
 
     // hub_addr = 0 means roothub, hub_port = 0 means all devices of downstream hub
     if (dev->rhport == rhport && dev->connected &&
         (hub_addr == 0 || dev->hub_addr == hub_addr) &&
-        (hub_port == 0 || dev->hub_port == hub_port)) {
+        (hub_port == 0 || dev->hub_port == hub_port))
+    {
       TU_LOG_USBH("Device unplugged address = %u\r\n", daddr);
 
-      if (is_hub_addr(daddr)) {
+      if (is_hub_addr(daddr))
+      {
         TU_LOG(CFG_TUH_LOG_LEVEL, "  is a HUB device %u\r\n", daddr);
 
         // Submit removed event If the device itself is a hub (un-rolled recursive)
@@ -1211,10 +1243,14 @@ static void process_removing_device(uint8_t rhport, uint8_t hub_addr, uint8_t hu
       }
 
       // Close class driver
-      for (uint8_t drv_id = 0; drv_id < USBH_CLASS_DRIVER_COUNT; drv_id++) {
-        usbh_class_drivers[drv_id].close(daddr);
+      for (uint8_t drv_id = 0; drv_id < _total_driver_count; drv_id++)
+      {
+        usbh_class_driver_t const * driver = usbh_get_driver(drv_id);
+        if ( driver )
+        {
+          driver->close(daddr);
+        }
       }
-
       hcd_device_close(rhport, daddr);
       clear_device(dev);
       // abort on-going control xfer if any
@@ -1643,11 +1679,12 @@ static bool _parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configur
     TU_ASSERT(drv_len >= sizeof(tusb_desc_interface_t));
 
     // Find driver for this interface
-    for (uint8_t drv_id = 0; drv_id < USBH_CLASS_DRIVER_COUNT; drv_id++)
+    uint8_t drv_id = 0;
+    for (; drv_id < _total_driver_count; drv_id++)
     {
-      usbh_class_driver_t const * driver = &usbh_class_drivers[drv_id];
+      usbh_class_driver_t const * driver = usbh_get_driver(drv_id);
 
-      if ( driver->open(dev->rhport, dev_addr, desc_itf, drv_len) )
+      if (driver && driver->open(dev->rhport, dev_addr, desc_itf, drv_len) )
       {
         // open successfully
         TU_LOG_USBH("  %s opened\r\n", driver->name);
@@ -1668,11 +1705,12 @@ static bool _parse_configuration_descriptor(uint8_t dev_addr, tusb_desc_configur
         break; // exit driver find loop
       }
 
-      if( drv_id >= USBH_CLASS_DRIVER_COUNT )
-      {
-        TU_LOG(CFG_TUH_LOG_LEVEL, "Interface %u: class = %u subclass = %u protocol = %u is not supported\r\n",
-               desc_itf->bInterfaceNumber, desc_itf->bInterfaceClass, desc_itf->bInterfaceSubClass, desc_itf->bInterfaceProtocol);
-      }
+    }
+
+    if( drv_id >= _total_driver_count )
+    {
+      TU_LOG(CFG_TUH_LOG_LEVEL, "Interface %u: class = %u subclass = %u protocol = %u is not supported\r\n",
+            desc_itf->bInterfaceNumber, desc_itf->bInterfaceClass, desc_itf->bInterfaceSubClass, desc_itf->bInterfaceProtocol);
     }
 
     // next Interface or IAD descriptor
@@ -1694,7 +1732,7 @@ void usbh_driver_set_config_complete(uint8_t dev_addr, uint8_t itf_num)
     uint8_t const drv_id = dev->itf2drv[itf_num];
     if (drv_id != TUSB_INDEX_INVALID_8)
     {
-      usbh_class_driver_t const * driver = &usbh_class_drivers[drv_id];
+      usbh_class_driver_t const * driver = usbh_get_driver(drv_id);
       TU_LOG_USBH("%s set config: itf = %u\r\n", driver->name, itf_num);
       driver->set_config(dev_addr, itf_num);
       break;

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -180,21 +180,21 @@ static usbh_class_driver_t const usbh_class_drivers[] =
   #endif
 };
 
-enum { USBH_BUILTIN_DRIVER_COUNT = TU_ARRAY_SIZE(usbh_class_drivers) };
+enum { BUILTIN_DRIVER_COUNT = TU_ARRAY_SIZE(usbh_class_drivers) };
 enum { CONFIG_NUM = 1 }; // default to use configuration 1
 
 // Additional class drivers implemented by application
 tu_static usbh_class_driver_t const * _app_driver = NULL;
 tu_static uint8_t _app_driver_count = 0;
 
-#define TOTAL_DRIVER_COUNT    (_app_driver_count + USBH_BUILTIN_DRIVER_COUNT)
+#define TOTAL_DRIVER_COUNT    (_app_driver_count + BUILTIN_DRIVER_COUNT)
 
 static inline usbh_class_driver_t const *get_driver(uint8_t drv_id) {
   usbh_class_driver_t const *driver = NULL;
 
   if ( drv_id < _app_driver_count ) {
     driver = &_app_driver[drv_id];
-  } else if ( drv_id < TOTAL_DRIVER_COUNT && USBH_BUILTIN_DRIVER_COUNT > 0) {
+  } else if ( drv_id < TOTAL_DRIVER_COUNT && BUILTIN_DRIVER_COUNT > 0) {
     driver = &usbh_class_drivers[drv_id - _app_driver_count];
   }
 

--- a/src/host/usbh_classdriver.h
+++ b/src/host/usbh_classdriver.h
@@ -96,6 +96,14 @@ bool usbh_edpt_release(uint8_t dev_addr, uint8_t ep_addr);
 // Check if endpoint transferring is complete
 bool usbh_edpt_busy(uint8_t dev_addr, uint8_t ep_addr);
 
+//--------------------------------------------------------------------+
+// USBH application additional driver API
+//--------------------------------------------------------------------+
+// Invoked when initializing host stack to get additional class drivers.
+// Can optionally implemented by application to extend/overwrite class driver support.
+// Note: The drivers array must be accessible at all time when stack is active
+usbh_class_driver_t const* usbh_app_driver_get_cb(uint8_t* driver_count) TU_ATTR_WEAK;
+
 #ifdef __cplusplus
  }
 #endif

--- a/src/host/usbh_pvt.h
+++ b/src/host/usbh_pvt.h
@@ -62,6 +62,11 @@ typedef struct {
   void (* const close      )(uint8_t dev_addr);
 } usbh_class_driver_t;
 
+// Invoked when initializing host stack to get additional class drivers.
+// Can be implemented by application to extend/overwrite class driver support.
+// Note: The drivers array must be accessible at all time when stack is active
+usbh_class_driver_t const* usbh_app_driver_get_cb(uint8_t* driver_count) TU_ATTR_WEAK;
+
 // Call by class driver to tell USBH that it has complete the enumeration
 void usbh_driver_set_config_complete(uint8_t dev_addr, uint8_t itf_num);
 
@@ -95,14 +100,6 @@ bool usbh_edpt_release(uint8_t dev_addr, uint8_t ep_addr);
 
 // Check if endpoint transferring is complete
 bool usbh_edpt_busy(uint8_t dev_addr, uint8_t ep_addr);
-
-//--------------------------------------------------------------------+
-// USBH application additional driver API
-//--------------------------------------------------------------------+
-// Invoked when initializing host stack to get additional class drivers.
-// Can optionally implemented by application to extend/overwrite class driver support.
-// Note: The drivers array must be accessible at all time when stack is active
-usbh_class_driver_t const* usbh_app_driver_get_cb(uint8_t* driver_count) TU_ATTR_WEAK;
 
 #ifdef __cplusplus
  }

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -36,7 +36,7 @@
 #endif
 
 #if CFG_TUH_ENABLED
-#include "host/usbh_classdriver.h"
+#include "host/usbh_pvt.h"
 #endif
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
This pull request implements a fix to issue #2188. To add an application host driver, implement the callback `usbh_app_driver_get_cb()`.

**Additional context**
This implementation should be consistent with the `usbd_app_driver_get_cb()` method implemented for application defined USB device drivers.
