### PR TITLE
Add tuh_hid_get_report(...) to hid_host.h

### DIFF
--- a/src/class/hid/hid_host.h
+++ b/src/class/hid/hid_host.h
@@ -105,6 +105,10 @@ void tuh_hid_set_default_protocol(uint8_t protocol);
 // This function is only supported by Boot interface (tuh_n_hid_interface_protocol() != NONE)
 bool tuh_hid_set_protocol(uint8_t dev_addr, uint8_t idx, uint8_t protocol);
 
+// Get Report using control endpoint
+// report_type is either Input, Output or Feature, (value from hid_report_type_t)
+bool tuh_hid_get_report(uint8_t dev_addr, uint8_t idx, uint8_t report_id, uint8_t report_type, void* report, uint16_t len);
+
 // Set Report using control endpoint
 // report_type is either Input, Output or Feature, (value from hid_report_type_t)
 bool tuh_hid_set_report(uint8_t dev_addr, uint8_t idx, uint8_t report_id, uint8_t report_type,
@@ -152,6 +156,10 @@ void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t idx, uint8_t const* re
 
 // Invoked when sent report to device successfully via interrupt endpoint
 TU_ATTR_WEAK void tuh_hid_report_sent_cb(uint8_t dev_addr, uint8_t idx, uint8_t const* report, uint16_t len);
+
+// Invoked when Get Report to device via either control endpoint
+// len = 0 indicate there is error in the transfer e.g stalled response
+TU_ATTR_WEAK void tuh_hid_get_report_complete_cb(uint8_t dev_addr, uint8_t idx, uint8_t report_id, uint8_t report_type, uint16_t len);
 
 // Invoked when Sent Report to device via either control endpoint
 // len = 0 indicate there is error in the transfer e.g stalled response


### PR DESCRIPTION
**Describe the PR**
This allows USB host functionality to call HID_REQ_CONTROL_GET_REPORT on the TUSB_DIR_IN direction, and read the report buffer in the callback function.

This extends the functionality of the hid_host.h/.c files and gives the host a way to call the HID get report features.

**Additional context**
I'm one of the main developers of https://gp2040-ce.info/ and we extensively use the TinyUSB library to handle USB calls. I wanted to try to keep our TUSB host code as hid_host friendly as possible, but I could not find a good way to call GET REPORT feature on the IN direction.

I just added a new authentication pass-through mode which requires 3 GET REPORT calls and 1 SET REPORT call to complete the authentication transaction. In order for our TUSB host to talk to the DS4 authentication mechanism, we have to run get report on the DS4 specific features and read in the buffer .

Right now, I manually added it to our program by retrieving the itf_num on hid_mount through the tuh_hid_mount_cb functionality, then passing that to the tuh_hid_get_report function we declare statically in our USB host manager code. This patch moves the functionality to the TinyUSB for anyone else who needs a get report feature call using hid_host.h callbacks.