### PR TITLE
add tuh_hid_set_default_protocol() to set default USB host HID protocol

### DIFF
--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -211,6 +211,13 @@ static void set_protocol_complete(tuh_xfer_t* xfer)
   }
 }
 
+CFG_TUH_MEM_SECTION
+tu_static uint8_t _hidh_default_protocol = HID_PROTOCOL_BOOT;
+
+void tuh_hid_set_default_protocol(uint8_t protocol) {
+  _hidh_default_protocol = protocol;
+}
+
 static bool _hidh_set_protocol(uint8_t daddr, uint8_t itf_num, uint8_t protocol, tuh_xfer_cb_t complete_cb, uintptr_t user_data)
 {
   TU_LOG_DRV("HID Set Protocol = %d\r\n", protocol);
@@ -521,7 +528,7 @@ bool hidh_open(uint8_t rhport, uint8_t daddr, tusb_desc_interface_t const *desc_
   p_hid->report_desc_len  = tu_unaligned_read16(&desc_hid->wReportLength);
 
   // Per HID Specs: default is Report protocol, though we will force Boot protocol when set_config
-  p_hid->protocol_mode = HID_PROTOCOL_BOOT;
+  p_hid->protocol_mode = _hidh_default_protocol;
   if ( HID_SUBCLASS_BOOT == desc_itf->bInterfaceSubClass )
   {
     p_hid->itf_protocol = desc_itf->bInterfaceProtocol;
@@ -591,7 +598,7 @@ static void process_set_config(tuh_xfer_t* xfer)
     break;
 
     case CONFIG_SET_PROTOCOL:
-      _hidh_set_protocol(daddr, p_hid->itf_num, HID_PROTOCOL_BOOT, process_set_config, CONFIG_GET_REPORT_DESC);
+      _hidh_set_protocol(daddr, p_hid->itf_num, _hidh_default_protocol, process_set_config, CONFIG_GET_REPORT_DESC);
     break;
 
     case CONFIG_GET_REPORT_DESC:

--- a/src/class/hid/hid_host.h
+++ b/src/class/hid/hid_host.h
@@ -97,6 +97,11 @@ uint8_t tuh_hid_parse_report_descriptor(tuh_hid_report_info_t* reports_info_arr,
 //       Application can use set_protocol() to switch back to Report protocol.
 uint8_t tuh_hid_get_protocol(uint8_t dev_addr, uint8_t idx);
 
+// Device by default is initialized in Boot protocol for simplicity. Application
+// can use this to modify the default protocol before calling tuh_init(), or use
+// set_protocol() to change the protocol after initialization.
+void tuh_hid_set_default_protocol(uint8_t protocol);
+
 // Set protocol to HID_PROTOCOL_BOOT (0) or HID_PROTOCOL_REPORT (1)
 // This function is only supported by Boot interface (tuh_n_hid_interface_protocol() != NONE)
 bool tuh_hid_set_protocol(uint8_t dev_addr, uint8_t idx, uint8_t protocol);


### PR DESCRIPTION
For applications that need HID report protocol instead of HID boot protocol, changing the default with `tuh_hid_set_default_protocol()` is simpler than changing for the devices one by one.