### PR TITLE
Fixes #1018 the weak dcd_edpt0_status_complete for Keil Compiler

### DIFF
--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -155,7 +155,7 @@ void dcd_sof_enable(uint8_t rhport, bool en);
 
 // Invoked when a control transfer's status stage is complete.
 // May help DCD to prepare for next control transfer, this API is optional.
-void dcd_edpt0_status_complete(uint8_t rhport, tusb_control_request_t const * request) TU_ATTR_WEAK;
+void dcd_edpt0_status_complete(uint8_t rhport, tusb_control_request_t const * request);
 
 // Configure endpoint's registers according to descriptor
 bool dcd_edpt_open            (uint8_t rhport, tusb_desc_endpoint_t const * desc_ep);

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -135,6 +135,15 @@ bool tud_control_xfer(uint8_t rhport, tusb_control_request_t const * request, vo
 // USBD API
 //--------------------------------------------------------------------+
 
+TU_ATTR_WEAK void dcd_edpt0_status_complete(uint8_t rhport, tusb_control_request_t const * request)
+{
+  (void)rhport;
+  (void)request;
+
+  // this is the default implementation that is called when no "real" implementation
+  // of the function exists
+}
+
 void usbd_control_reset(void);
 void usbd_control_set_request(tusb_control_request_t const *request);
 void usbd_control_set_complete_callback( usbd_control_xfer_cb_t fp );
@@ -173,7 +182,7 @@ bool usbd_control_xfer_cb (uint8_t rhport, uint8_t ep_addr, xfer_result_t result
     TU_ASSERT(0 == xferred_bytes);
 
     // invoke optional dcd hook if available
-    if (dcd_edpt0_status_complete) dcd_edpt0_status_complete(rhport, &_ctrl_xfer.request);
+    dcd_edpt0_status_complete(rhport, &_ctrl_xfer.request);
 
     if (_ctrl_xfer.complete_cb)
     {


### PR DESCRIPTION
The Keil compiler seems to have different semantics and the defined function was never called.

The same is probably true for the other weak functions. I can change those too.