### PR TITLE
Fix msd extraneus bytes on reading

### DIFF
--- a/src/portable/renesas/rusb2/dcd_rusb2.c
+++ b/src/portable/renesas/rusb2/dcd_rusb2.c
@@ -267,9 +267,10 @@ static void pipe_read_packet_ff(rusb2_reg_t * rusb, tu_fifo_t *f, volatile void 
 }
 
 
-static void wait_pipe_fifo_empty(rusb2_reg_t* rusb, uint8_t num) {
+static bool wait_pipe_fifo_empty(rusb2_reg_t* rusb, uint8_t num) {
   TU_ASSERT(num);
   while( (rusb->PIPE_CTR[num-1] & RUSB2_PIPE_CTR_INBUFM_Msk) > 0 ) {}
+  return true;
 }
 
 

--- a/src/portable/renesas/rusb2/dcd_rusb2.c
+++ b/src/portable/renesas/rusb2/dcd_rusb2.c
@@ -266,6 +266,13 @@ static void pipe_read_packet_ff(rusb2_reg_t * rusb, tu_fifo_t *f, volatile void 
   tu_fifo_advance_write_pointer(f, count);
 }
 
+
+static void wait_pipe_fifo_empty(rusb2_reg_t* rusb, uint8_t num) {
+  TU_ASSERT(num);
+  while( (rusb->PIPE_CTR[num-1] & RUSB2_PIPE_CTR_INBUFM_Msk) > 0 ) {}
+}
+
+
 //--------------------------------------------------------------------+
 // Pipe Transfer
 //--------------------------------------------------------------------+
@@ -339,6 +346,7 @@ static bool pipe_xfer_in(rusb2_reg_t* rusb, unsigned num)
   const unsigned rem  = pipe->remaining;
 
   if (!rem) {
+    wait_pipe_fifo_empty(rusb, num);
     pipe->buf = NULL;
     return true;
   }


### PR DESCRIPTION
Fix the fact that MSD status msg sometimes goes in the payload of data read from disk

This fixes: https://github.com/arduino/ArduinoCore-renesas/issues/84
The problem: when issuing a reading command on MSD class, sometimes data read form disk (QSPI flash device) are corrupted with status message (the one that should "end" the transmission of data read from disk, i.e. "USBS..."). According to our analysis this is due to the fact that given that MSC_STAGE_STATUS case is executed always "after" the state machine implemented in `mscd_xfer_cb` function, if data are still present in the hw pipe fifo while the status message is sent by the function,  the status message overwrites part of the data present in the hw pipe fifo.
The solution: a function that checks the status of the hw pipe fifo has been implemented. This is a weak function implemented only on RA hw. This function waits until the hw pipe fifo is empty. The function is then called in `mscd_xfer_cb` function when the status message is about to be sent while a reading from disk is finishing. This ensure that data in hw pipe fifo are not overwritten due to lack of sync.

If you have a better solution or a more general approach, please feel free to provide us with your implementation, we will test this on our device. Thanks!

@facchinm 
