### PR TITLE
Add HID Lighting and Illumination functionality

### DIFF
--- a/src/class/hid/hid.h
+++ b/src/class/hid/hid.h
@@ -684,32 +684,33 @@ enum {
 
 /// HID Usage Table - Table 1: Usage Page Summary
 enum {
-  HID_USAGE_PAGE_DESKTOP         = 0x01,
-  HID_USAGE_PAGE_SIMULATE        = 0x02,
-  HID_USAGE_PAGE_VIRTUAL_REALITY = 0x03,
-  HID_USAGE_PAGE_SPORT           = 0x04,
-  HID_USAGE_PAGE_GAME            = 0x05,
-  HID_USAGE_PAGE_GENERIC_DEVICE  = 0x06,
-  HID_USAGE_PAGE_KEYBOARD        = 0x07,
-  HID_USAGE_PAGE_LED             = 0x08,
-  HID_USAGE_PAGE_BUTTON          = 0x09,
-  HID_USAGE_PAGE_ORDINAL         = 0x0a,
-  HID_USAGE_PAGE_TELEPHONY       = 0x0b,
-  HID_USAGE_PAGE_CONSUMER        = 0x0c,
-  HID_USAGE_PAGE_DIGITIZER       = 0x0d,
-  HID_USAGE_PAGE_PID             = 0x0f,
-  HID_USAGE_PAGE_UNICODE         = 0x10,
-  HID_USAGE_PAGE_ALPHA_DISPLAY   = 0x14,
-  HID_USAGE_PAGE_MEDICAL         = 0x40,
-  HID_USAGE_PAGE_MONITOR         = 0x80, //0x80 - 0x83
-  HID_USAGE_PAGE_POWER           = 0x84, // 0x084 - 0x87
-  HID_USAGE_PAGE_BARCODE_SCANNER = 0x8c,
-  HID_USAGE_PAGE_SCALE           = 0x8d,
-  HID_USAGE_PAGE_MSR             = 0x8e,
-  HID_USAGE_PAGE_CAMERA          = 0x90,
-  HID_USAGE_PAGE_ARCADE          = 0x91,
-  HID_USAGE_PAGE_FIDO            = 0xF1D0, // FIDO alliance HID usage page
-  HID_USAGE_PAGE_VENDOR          = 0xFF00 // 0xFF00 - 0xFFFF
+  HID_USAGE_PAGE_DESKTOP                   = 0x01,
+  HID_USAGE_PAGE_SIMULATE                  = 0x02,
+  HID_USAGE_PAGE_VIRTUAL_REALITY           = 0x03,
+  HID_USAGE_PAGE_SPORT                     = 0x04,
+  HID_USAGE_PAGE_GAME                      = 0x05,
+  HID_USAGE_PAGE_GENERIC_DEVICE            = 0x06,
+  HID_USAGE_PAGE_KEYBOARD                  = 0x07,
+  HID_USAGE_PAGE_LED                       = 0x08,
+  HID_USAGE_PAGE_BUTTON                    = 0x09,
+  HID_USAGE_PAGE_ORDINAL                   = 0x0a,
+  HID_USAGE_PAGE_TELEPHONY                 = 0x0b,
+  HID_USAGE_PAGE_CONSUMER                  = 0x0c,
+  HID_USAGE_PAGE_DIGITIZER                 = 0x0d,
+  HID_USAGE_PAGE_PID                       = 0x0f,
+  HID_USAGE_PAGE_UNICODE                   = 0x10,
+  HID_USAGE_PAGE_ALPHA_DISPLAY             = 0x14,
+  HID_USAGE_PAGE_MEDICAL                   = 0x40,
+  HID_USAGE_PAGE_LIGHTING_AND_ILLUMINATION = 0x59,
+  HID_USAGE_PAGE_MONITOR                   = 0x80, //0x80 - 0x83
+  HID_USAGE_PAGE_POWER                     = 0x84, // 0x084 - 0x87
+  HID_USAGE_PAGE_BARCODE_SCANNER           = 0x8c,
+  HID_USAGE_PAGE_SCALE                     = 0x8d,
+  HID_USAGE_PAGE_MSR                       = 0x8e,
+  HID_USAGE_PAGE_CAMERA                    = 0x90,
+  HID_USAGE_PAGE_ARCADE                    = 0x91,
+  HID_USAGE_PAGE_FIDO                      = 0xF1D0, // FIDO alliance HID usage page
+  HID_USAGE_PAGE_VENDOR                    = 0xFF00 // 0xFF00 - 0xFFFF
 };
 
 /// HID Usage Table - Table 6: Generic Desktop Page
@@ -788,8 +789,7 @@ enum {
 
 /// HID Usage Table: Consumer Page (0x0C)
 /// Only contains controls that supported by Windows (whole list is too long)
-enum
-{
+enum {
   // Generic Control
   HID_USAGE_CONSUMER_CONTROL                           = 0x0001,
 
@@ -845,9 +845,45 @@ enum
   HID_USAGE_CONSUMER_AC_PAN                            = 0x0238,
 };
 
+/// HID Usage Table - Lighting And Illumination Page (0x59)
+enum {
+  HID_USAGE_LIGHTING_LAMP_ARRAY                          = 0x01,
+  HID_USAGE_LIGHTING_LAMP_ARRAY_ATTRIBUTES_REPORT        = 0x02,
+  HID_USAGE_LIGHTING_LAMP_COUNT                          = 0x03,
+  HID_USAGE_LIGHTING_BOUNDING_BOX_WIDTH_IN_MICROMETERS   = 0x04,
+  HID_USAGE_LIGHTING_BOUNDING_BOX_HEIGHT_IN_MICROMETERS  = 0x05,
+  HID_USAGE_LIGHTING_BOUNDING_BOX_DEPTH_IN_MICROMETERS   = 0x06,
+  HID_USAGE_LIGHTING_LAMP_ARRAY_KIND                     = 0x07,
+  HID_USAGE_LIGHTING_MIN_UPDATE_INTERVAL_IN_MICROSECONDS = 0x08,
+  HID_USAGE_LIGHTING_LAMP_ATTRIBUTES_REQUEST_REPORT      = 0x20,
+  HID_USAGE_LIGHTING_LAMP_ID                             = 0x21,
+  HID_USAGE_LIGHTING_LAMP_ATTRIBUTES_RESPONSE_REPORT     = 0x22,
+  HID_USAGE_LIGHTING_POSITION_X_IN_MICROMETERS           = 0x23,
+  HID_USAGE_LIGHTING_POSITION_Y_IN_MICROMETERS           = 0x24,
+  HID_USAGE_LIGHTING_POSITION_Z_IN_MICROMETERS           = 0x25,
+  HID_USAGE_LIGHTING_LAMP_PURPOSES                       = 0x26,
+  HID_USAGE_LIGHTING_UPDATE_LATENCY_IN_MICROSECONDS      = 0x27,
+  HID_USAGE_LIGHTING_RED_LEVEL_COUNT                     = 0x28,
+  HID_USAGE_LIGHTING_GREEN_LEVEL_COUNT                   = 0x29,
+  HID_USAGE_LIGHTING_BLUE_LEVEL_COUNT                    = 0x2A,
+  HID_USAGE_LIGHTING_INTENSITY_LEVEL_COUNT               = 0x2B,
+  HID_USAGE_LIGHTING_IS_PROGRAMMABLE                     = 0x2C,
+  HID_USAGE_LIGHTING_INPUT_BINDING                       = 0x2D,
+  HID_USAGE_LIGHTING_LAMP_MULTI_UPDATE_REPORT            = 0x50,
+  HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL                  = 0x51,
+  HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL                = 0x52,
+  HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL                 = 0x53,
+  HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL            = 0x54,
+  HID_USAGE_LIGHTING_LAMP_UPDATE_FLAGS                   = 0x55,
+  HID_USAGE_LIGHTING_LAMP_RANGE_UPDATE_REPORT            = 0x60,
+  HID_USAGE_LIGHTING_LAMP_ID_START                       = 0x61,
+  HID_USAGE_LIGHTING_LAMP_ID_END                         = 0x62,
+  HID_USAGE_LIGHTING_LAMP_ARRAY_CONTROL_REPORT           = 0x70,
+  HID_USAGE_LIGHTING_AUTONOMOUS_MODE                     = 0x71,
+};
+
 /// HID Usage Table: FIDO Alliance Page (0xF1D0)
-enum
-{
+enum {
   HID_USAGE_FIDO_U2FHID   = 0x01, // U2FHID usage for top-level collection
   HID_USAGE_FIDO_DATA_IN  = 0x20, // Raw IN data report
   HID_USAGE_FIDO_DATA_OUT = 0x21  // Raw OUT data report

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -402,6 +402,171 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
       HID_OUTPUT      ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE  ),\
     HID_COLLECTION_END \
 
+// HID Lighting and Illumination Report Descriptor Template
+// - 1st parameter is report id HID_REPORT_ID(n) (optional)
+#define TUD_HID_REPORT_DESC_LIGHTING(report_id) \
+  HID_USAGE_PAGE ( HID_USAGE_PAGE_LIGHTING_AND_ILLUMINATION ),\
+  HID_USAGE      ( HID_USAGE_LIGHTING_LAMP_ARRAY            ),\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION               ),\
+    /* Lamp Array Attributes Report */ \
+    HID_REPORT_ID (report_id                                    ) \
+    HID_USAGE ( HID_USAGE_LIGHTING_LAMP_ARRAY_ATTRIBUTES_REPORT ),\
+    HID_COLLECTION ( HID_COLLECTION_LOGICAL                     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_COUNT                          ),\
+      HID_LOGICAL_MIN   ( 0                                                      ),\
+      HID_LOGICAL_MAX_N ( 65535, 3                                               ),\
+      HID_REPORT_SIZE   ( 16                                                     ),\
+      HID_REPORT_COUNT  ( 1                                                      ),\
+      HID_FEATURE       ( HID_CONSTANT | HID_VARIABLE | HID_ABSOLUTE             ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BOUNDING_BOX_WIDTH_IN_MICROMETERS   ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BOUNDING_BOX_HEIGHT_IN_MICROMETERS  ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BOUNDING_BOX_DEPTH_IN_MICROMETERS   ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_ARRAY_KIND                     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_MIN_UPDATE_INTERVAL_IN_MICROSECONDS ),\
+      HID_LOGICAL_MIN   ( 0                                                      ),\
+      HID_LOGICAL_MAX_N ( 2147483647, 3                                          ),\
+      HID_REPORT_SIZE   ( 32                                                     ),\
+      HID_REPORT_COUNT  ( 5                                                      ),\
+      HID_FEATURE       ( HID_CONSTANT | HID_VARIABLE | HID_ABSOLUTE             ),\
+    HID_COLLECTION_END ,\
+    /* Lamp Attributes Request Report */ \
+    HID_REPORT_ID       ( report_id + 1                                     ) \
+    HID_USAGE           ( HID_USAGE_LIGHTING_LAMP_ATTRIBUTES_REQUEST_REPORT ),\
+    HID_COLLECTION      ( HID_COLLECTION_LOGICAL                            ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_ID             ),\
+      HID_LOGICAL_MIN   ( 0                                      ),\
+      HID_LOGICAL_MAX_N ( 65535, 3                               ),\
+      HID_REPORT_SIZE   ( 16                                     ),\
+      HID_REPORT_COUNT  ( 1                                      ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ),\
+    HID_COLLECTION_END ,\
+    /* Lamp Attributes Response Report */ \
+    HID_REPORT_ID       ( report_id + 2                                      ) \
+    HID_USAGE           ( HID_USAGE_LIGHTING_LAMP_ATTRIBUTES_RESPONSE_REPORT ),\
+    HID_COLLECTION      ( HID_COLLECTION_LOGICAL                             ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_ID                        ),\
+      HID_LOGICAL_MIN   ( 0                                                 ),\
+      HID_LOGICAL_MAX_N ( 65535, 3                                          ),\
+      HID_REPORT_SIZE   ( 16                                                ),\
+      HID_REPORT_COUNT  ( 1                                                 ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE            ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_POSITION_X_IN_MICROMETERS      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_POSITION_Y_IN_MICROMETERS      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_POSITION_Z_IN_MICROMETERS      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_UPDATE_LATENCY_IN_MICROSECONDS ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_PURPOSES                  ),\
+      HID_LOGICAL_MIN   ( 0                                                 ),\
+      HID_LOGICAL_MAX_N ( 2147483647, 3                                     ),\
+      HID_REPORT_SIZE   ( 32                                                ),\
+      HID_REPORT_COUNT  ( 5                                                 ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE            ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_LEVEL_COUNT                ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_LEVEL_COUNT              ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_LEVEL_COUNT               ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_LEVEL_COUNT          ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_IS_PROGRAMMABLE                ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INPUT_BINDING                  ),\
+      HID_LOGICAL_MIN   ( 0                                                 ),\
+      HID_LOGICAL_MAX_N ( 255, 2                                            ),\
+      HID_REPORT_SIZE   ( 8                                                 ),\
+      HID_REPORT_COUNT  ( 6                                                 ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE            ),\
+    HID_COLLECTION_END ,\
+    /* Lamp Multi-Update Report */ \
+    HID_REPORT_ID       ( report_id + 3                               ) \
+    HID_USAGE           ( HID_USAGE_LIGHTING_LAMP_MULTI_UPDATE_REPORT ),\
+    HID_COLLECTION      ( HID_COLLECTION_LOGICAL                      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_COUNT               ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_UPDATE_FLAGS        ),\
+      HID_LOGICAL_MIN   ( 0                                           ),\
+      HID_LOGICAL_MAX   ( 8                                           ),\
+      HID_REPORT_SIZE   ( 8                                           ),\
+      HID_REPORT_COUNT  ( 2                                           ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_ID                  ),\
+      HID_LOGICAL_MIN   ( 0                                           ),\
+      HID_LOGICAL_MAX_N ( 65535, 3                                    ),\
+      HID_REPORT_SIZE   ( 16                                          ),\
+      HID_REPORT_COUNT  ( 8                                           ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_LOGICAL_MIN   ( 0                                           ),\
+      HID_LOGICAL_MAX_N ( 255, 2                                      ),\
+      HID_REPORT_SIZE   ( 8                                           ),\
+      HID_REPORT_COUNT  ( 32                                          ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE      ),\
+    HID_COLLECTION_END ,\
+    /* Lamp Range Update Report */ \
+    HID_REPORT_ID       ( report_id + 4 ) \
+    HID_USAGE           ( HID_USAGE_LIGHTING_LAMP_RANGE_UPDATE_REPORT ),\
+    HID_COLLECTION      ( HID_COLLECTION_LOGICAL                      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_UPDATE_FLAGS        ),\
+      HID_LOGICAL_MIN   ( 0                                           ),\
+      HID_LOGICAL_MAX   ( 8                                           ),\
+      HID_REPORT_SIZE   ( 8                                           ),\
+      HID_REPORT_COUNT  ( 1                                           ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_ID_START            ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_LAMP_ID_END              ),\
+      HID_LOGICAL_MIN   ( 0                                           ),\
+      HID_LOGICAL_MAX_N ( 65535, 3                                    ),\
+      HID_REPORT_SIZE   ( 16                                          ),\
+      HID_REPORT_COUNT  ( 2                                           ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_RED_UPDATE_CHANNEL       ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_GREEN_UPDATE_CHANNEL     ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_BLUE_UPDATE_CHANNEL      ),\
+      HID_USAGE         ( HID_USAGE_LIGHTING_INTENSITY_UPDATE_CHANNEL ),\
+      HID_LOGICAL_MIN   ( 0                                           ),\
+      HID_LOGICAL_MAX_N ( 255, 2                                      ),\
+      HID_REPORT_SIZE   ( 8                                           ),\
+      HID_REPORT_COUNT  ( 4                                           ),\
+      HID_FEATURE       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE      ),\
+    HID_COLLECTION_END ,\
+    /* Lamp Array Control Report */ \
+    HID_REPORT_ID      ( report_id + 5                                ) \
+    HID_USAGE          ( HID_USAGE_LIGHTING_LAMP_ARRAY_CONTROL_REPORT ),\
+    HID_COLLECTION     ( HID_COLLECTION_LOGICAL                       ),\
+      HID_USAGE        ( HID_USAGE_LIGHTING_AUTONOMOUS_MODE     ),\
+      HID_LOGICAL_MIN  ( 0                                      ),\
+      HID_LOGICAL_MAX  ( 1                                      ),\
+      HID_REPORT_SIZE  ( 8                                      ),\
+      HID_REPORT_COUNT ( 1                                      ),\
+      HID_FEATURE      ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ),\
+    HID_COLLECTION_END ,\
+  HID_COLLECTION_END \
+
 //--------------------------------------------------------------------+
 // Internal Class Driver API
 //--------------------------------------------------------------------+

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -403,7 +403,14 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
     HID_COLLECTION_END \
 
 // HID Lighting and Illumination Report Descriptor Template
-// - 1st parameter is report id HID_REPORT_ID(n) (optional)
+// - 1st parameter is report id (required)
+//   Creates 6 report ids for lighting HID usages in the following order:
+//     report_id+0: HID_USAGE_LIGHTING_LAMP_ARRAY_ATTRIBUTES_REPORT
+//     report_id+1: HID_USAGE_LIGHTING_LAMP_ATTRIBUTES_REQUEST_REPORT
+//     report_id+2: HID_USAGE_LIGHTING_LAMP_ATTRIBUTES_RESPONSE_REPORT
+//     report_id+3: HID_USAGE_LIGHTING_LAMP_MULTI_UPDATE_REPORT
+//     report_id+4: HID_USAGE_LIGHTING_LAMP_RANGE_UPDATE_REPORT
+//     report_id+5: HID_USAGE_LIGHTING_LAMP_ARRAY_CONTROL_REPORT
 #define TUD_HID_REPORT_DESC_LIGHTING(report_id) \
   HID_USAGE_PAGE ( HID_USAGE_PAGE_LIGHTING_AND_ILLUMINATION ),\
   HID_USAGE      ( HID_USAGE_LIGHTING_LAMP_ARRAY            ),\


### PR DESCRIPTION
**Describe the PR**
This PR adds Lighting and Illumination usage page and descriptor template for HID class.

**Additional context**
The descriptor in hid_device.h was taken from the [lighting and illumination page](https://www.usb.org/sites/default/files/hutrr84_-_lighting_and_illumination_page.pdf), and all definitions in hid.h are taken from there as well. Adding this functionality allows TinyUSB devices that have lighting capabilities to be controlled by the host machine. In Windows, this can be developers with the [LampArray API](https://learn.microsoft.com/en-us/uwp/api/windows.devices.lights.lamparray?view=winrt-22621), or through [Dynamic Lighting](https://blogs.windows.com/windowsdeveloper/2023/05/23/bringing-the-power-of-ai-to-windows-11-unlocking-a-new-era-of-productivity-for-customers-and-developers-with-windows-copilot-and-dev-home/), a feature available to Windows Insiders. 

Functionality was tested on an Adafruit Macropad.