### PR TITLE
feat(network): add NCM connect/disconnect status

### DIFF
--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -102,6 +102,11 @@ struct ecm_notify_struct
   uint32_t downlink, uplink;
 };
 
+enum {
+  NETWORK_DISCONNECT = 0,
+  NETWORK_CONNECTED
+} network_state_t;
+
 typedef struct
 {
   uint8_t itf_num;      // Index number of Management Interface, +1 for Data Interface
@@ -157,6 +162,11 @@ CFG_TUD_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static transmit_ntb_t transmit_ntb[2];
 CFG_TUD_MEM_SECTION CFG_TUSB_MEM_ALIGN tu_static uint8_t receive_ntb[CFG_TUD_NCM_OUT_NTB_MAX_SIZE];
 
 tu_static ncm_interface_t ncm_interface;
+
+static void ncm_report(void);
+
+// default network state is connected, in case not actively call tud_network_connect
+static uint8_t network_state = NETWORK_CONNECTED;
 
 /*
  * Set up the NTB state in ncm_interface to be ready to add datagrams.
@@ -248,6 +258,42 @@ void tud_network_recv_renew(void)
   tud_network_recv_cb(receive_ntb + ndp->datagram[i].wDatagramIndex, ndp->datagram[i].wDatagramLength);
 }
 
+bool tud_network_disconnect(void)
+{
+  // already disconnected
+  if (network_state == NETWORK_DISCONNECT) {
+    return true;
+  }
+  
+  if (!ncm_interface.report_pending) {
+    ncm_interface.report_state = REPORT_CONNECTED;
+    network_state = NETWORK_DISCONNECT;
+    ncm_report();
+  } else {
+    // busy...
+    return false;
+  }
+  return true;
+}
+
+bool tud_network_connect(void)
+{
+  // already connected
+  if (network_state == NETWORK_CONNECTED) {
+    return true;
+  }
+
+  if (!ncm_interface.report_pending) {
+    ncm_interface.report_state = REPORT_CONNECTED;
+    network_state = NETWORK_CONNECTED;
+    ncm_report();
+    return true;
+  } else {
+    // busy...
+    return false;
+  }
+}
+
 //--------------------------------------------------------------------+
 // USBD Driver API
 //--------------------------------------------------------------------+
@@ -331,6 +377,7 @@ static void ncm_report(void)
     ncm_interface.report_pending = true;
   } else if (ncm_interface.report_state == REPORT_CONNECTED) {
     ncm_notify_connected.header.wIndex = ncm_interface.itf_num;
+    ncm_notify_connected.header.wValue = network_state;
     usbd_edpt_xfer(rhport, ncm_interface.ep_notif, (uint8_t *) &ncm_notify_connected, sizeof(ncm_notify_connected));
     ncm_interface.report_state = REPORT_DONE;
     ncm_interface.report_pending = true;

--- a/src/class/net/net_device.h
+++ b/src/class/net/net_device.h
@@ -101,6 +101,12 @@ extern uint8_t tud_network_mac_address[6];
 // callback to client providing optional indication of internal state of network driver
 void tud_network_link_state_cb(bool state);
 
+// indicate to network disconnect, only work in NCM
+bool tud_network_disconnect(void);
+
+// indicate to network connect, only work in NCM
+bool tud_network_connect(void);
+
 //--------------------------------------------------------------------+
 // INTERNAL USBD-CLASS DRIVER API
 //--------------------------------------------------------------------+


### PR DESCRIPTION
Device can notify the host about network connection status by CDC NetworkConnection.
In the current scheme, the host does not re-initiate the DHCP process even if WiFi is connected to a different router. We used it to solve the problem that WiFi devices would connect to different routers.