### PR TITLE
dcd_nrf5x: make it compile also with old Nordic SDK

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -244,7 +244,7 @@ void dcd_init (uint8_t rhport)
 void dcd_int_enable(uint8_t rhport)
 {
   (void) rhport;
-#ifdef SOFTDEVICE_PRESENT
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
   if (sd_nvic_EnableIRQ(USBD_IRQn) != NRF_SUCCESS)
   {
     NVIC_EnableIRQ(USBD_IRQn);
@@ -257,7 +257,7 @@ void dcd_int_enable(uint8_t rhport)
 void dcd_int_disable(uint8_t rhport)
 {
   (void) rhport;
-#ifdef SOFTDEVICE_PRESENT
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
   if (sd_nvic_DisableIRQ(USBD_IRQn) != NRF_SUCCESS)
   {
     NVIC_DisableIRQ(USBD_IRQn);
@@ -1118,7 +1118,7 @@ void tusb_hal_nrf_power_event (uint32_t event)
       NRF_USBD->INTENSET = USBD_INTEN_USBRESET_Msk;
 
       // Enable interrupt, priorities should be set by application
-#ifdef SOFTDEVICE_PRESENT
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
       if (sd_nvic_ClearPendingIRQ(USBD_IRQn) != NRF_SUCCESS)
       {
         NVIC_ClearPendingIRQ(USBD_IRQn);
@@ -1131,7 +1131,7 @@ void tusb_hal_nrf_power_event (uint32_t event)
       // to handle interrupts.
       if (tud_inited())
       {
-#ifdef SOFTDEVICE_PRESENT
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
         if (sd_nvic_EnableIRQ(USBD_IRQn) != NRF_SUCCESS)
         {
           NVIC_EnableIRQ(USBD_IRQn);
@@ -1159,7 +1159,7 @@ void tusb_hal_nrf_power_event (uint32_t event)
         __ISB(); __DSB(); // for sync
 
         // Disable Interrupt
-#ifdef SOFTDEVICE_PRESENT
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
         if (sd_nvic_DisableIRQ(USBD_IRQn) != NRF_SUCCESS)
         {
           NVIC_DisableIRQ(USBD_IRQn);

--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -258,27 +258,13 @@ void dcd_init (uint8_t rhport)
 void dcd_int_enable(uint8_t rhport)
 {
   (void) rhport;
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
-  if (sd_nvic_EnableIRQ(USBD_IRQn) != NRF_SUCCESS)
-  {
-    NVIC_EnableIRQ(USBD_IRQn);
-  }
-#else
   NVIC_EnableIRQ(USBD_IRQn);
-#endif
 }
 
 void dcd_int_disable(uint8_t rhport)
 {
   (void) rhport;
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
-  if (sd_nvic_DisableIRQ(USBD_IRQn) != NRF_SUCCESS)
-  {
-    NVIC_DisableIRQ(USBD_IRQn);
-  }
-#else
   NVIC_DisableIRQ(USBD_IRQn);
-#endif
 }
 
 void dcd_set_address (uint8_t rhport, uint8_t dev_addr)
@@ -1132,27 +1118,14 @@ void tusb_hal_nrf_power_event (uint32_t event)
       NRF_USBD->INTENSET = USBD_INTEN_USBRESET_Msk;
 
       // Enable interrupt, priorities should be set by application
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
-      if (sd_nvic_ClearPendingIRQ(USBD_IRQn) != NRF_SUCCESS)
-      {
-        NVIC_ClearPendingIRQ(USBD_IRQn);
-      }
-#else
       NVIC_ClearPendingIRQ(USBD_IRQn);
-#endif
+
       // Don't enable USBD interrupt yet, if dcd_init() did not finish yet
       // Interrupt will be enabled by tud_init(), when USB stack is ready
       // to handle interrupts.
       if (tud_inited())
       {
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
-        if (sd_nvic_EnableIRQ(USBD_IRQn) != NRF_SUCCESS)
-        {
-          NVIC_EnableIRQ(USBD_IRQn);
-        }
-#else
         NVIC_EnableIRQ(USBD_IRQn);
-#endif
       }
 
       // Wait for HFCLK
@@ -1173,14 +1146,7 @@ void tusb_hal_nrf_power_event (uint32_t event)
         __ISB(); __DSB(); // for sync
 
         // Disable Interrupt
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
-        if (sd_nvic_DisableIRQ(USBD_IRQn) != NRF_SUCCESS)
-        {
-          NVIC_DisableIRQ(USBD_IRQn);
-        }
-#else
         NVIC_DisableIRQ(USBD_IRQn);
-#endif
 
         // disable all interrupt
         NRF_USBD->INTENCLR = NRF_USBD->INTEN;

--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -56,11 +56,25 @@
 #include "mcu/mcu.h"
 #endif
 
-#if 1000*MDK_MAJOR_VERSION + MDK_MINOR_VERSION <= 8040
-// Nordic actually has generated a mess here: nrfx==1.9.0 has MDK 8.40.3 while nrfx==2.0.0 has MDK 8.29.0
-// Unfortunately there are API differences between nrfx<2.0.0 and nrfx>=2.0.0.  Hoping that everyone uses
-// nRF Connect SDK keeps the libraries up to date.
-#define OLD_NORDIC_SDK
+// Unfortunately there are API differences between nrfx<2.0.0 and nrfx>=2.0.0
+// Nordic actually has generated a mess here: nrfx==1.9.0 has MDK 8.40.3 while nrfx==2.0.0 has MDK 8.29.0.
+// See the below statement to catch all nrfx versions with an old API.
+#define _MDK_VERSION 10000*MDK_MAJOR_VERSION + 100*MDK_MINOR_VERSION + MDK_MICRO_VERSION
+#if _MDK_VERSION <= 82701
+    // nrfx <= 1.8.1
+    #define NORDIC_SDK_OLD_API
+#elif  _MDK_VERSION == 83201
+    // nrfx 1.8.2 / 1.8.4
+    #define NORDIC_SDK_OLD_API
+#elif  _MDK_VERSION == 83203
+    // nrfx 1.8.5
+    #define NORDIC_SDK_OLD_API
+#elif  _MDK_VERSION == 83500
+    // nrfx 1.8.6
+    #define NORDIC_SDK_OLD_API
+#elif _MDK_VERSION == 84003
+    // nrfx 1.9.0
+    #define NORDIC_SDK_OLD_API
 #endif
 
 /*------------------------------------------------------------------*/
@@ -244,7 +258,7 @@ void dcd_init (uint8_t rhport)
 void dcd_int_enable(uint8_t rhport)
 {
   (void) rhport;
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
   if (sd_nvic_EnableIRQ(USBD_IRQn) != NRF_SUCCESS)
   {
     NVIC_EnableIRQ(USBD_IRQn);
@@ -257,7 +271,7 @@ void dcd_int_enable(uint8_t rhport)
 void dcd_int_disable(uint8_t rhport)
 {
   (void) rhport;
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
   if (sd_nvic_DisableIRQ(USBD_IRQn) != NRF_SUCCESS)
   {
     NVIC_DisableIRQ(USBD_IRQn);
@@ -921,7 +935,7 @@ static bool hfclk_running(void)
   }
 #endif
 
-#ifdef OLD_NORDIC_SDK
+#ifdef NORDIC_SDK_OLD_API
   return nrf_clock_hf_is_running(NRF_CLOCK_HFCLK_HIGH_ACCURACY);
 #else
   return nrf_clock_hf_is_running(NRF_CLOCK, NRF_CLOCK_HFCLK_HIGH_ACCURACY);
@@ -946,7 +960,7 @@ static void hfclk_enable(void)
   }
 #endif
 
-#ifdef OLD_NORDIC_SDK
+#ifdef NORDIC_SDK_OLD_API
   nrf_clock_event_clear(NRF_CLOCK_EVENT_HFCLKSTARTED);
   nrf_clock_task_trigger(NRF_CLOCK_TASK_HFCLKSTART);
 #else
@@ -971,7 +985,7 @@ static void hfclk_disable(void)
   }
 #endif
 
-#ifdef OLD_NORDIC_SDK
+#ifdef NORDIC_SDK_OLD_API
   nrf_clock_task_trigger(NRF_CLOCK_TASK_HFCLKSTOP);
 #else
   nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTOP);
@@ -1118,7 +1132,7 @@ void tusb_hal_nrf_power_event (uint32_t event)
       NRF_USBD->INTENSET = USBD_INTEN_USBRESET_Msk;
 
       // Enable interrupt, priorities should be set by application
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
       if (sd_nvic_ClearPendingIRQ(USBD_IRQn) != NRF_SUCCESS)
       {
         NVIC_ClearPendingIRQ(USBD_IRQn);
@@ -1131,7 +1145,7 @@ void tusb_hal_nrf_power_event (uint32_t event)
       // to handle interrupts.
       if (tud_inited())
       {
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
         if (sd_nvic_EnableIRQ(USBD_IRQn) != NRF_SUCCESS)
         {
           NVIC_EnableIRQ(USBD_IRQn);
@@ -1159,7 +1173,7 @@ void tusb_hal_nrf_power_event (uint32_t event)
         __ISB(); __DSB(); // for sync
 
         // Disable Interrupt
-#if defined(SOFTDEVICE_PRESENT)  &&  defined(OLD_NORDIC_SDK)
+#if defined(SOFTDEVICE_PRESENT)  &&  defined(NORDIC_SDK_OLD_API)
         if (sd_nvic_DisableIRQ(USBD_IRQn) != NRF_SUCCESS)
         {
           NVIC_DisableIRQ(USBD_IRQn);


### PR DESCRIPTION
**Describe the PR**
With this PR it is also possible to compile the dcd_nrf5x with old Nordic SDKs.  The current version of the driver uses API calls to nrf_clock with two parameters while the old SDK only uses one parameter for the call.
For correct behavior the NVIC calls also has to be directed thru the softdevice.

**Additional context**
--
