### PR TITLE
STM32U5 HS Support

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -84,7 +84,17 @@
 
 #elif CFG_TUSB_MCU == OPT_MCU_STM32U5
   #include "stm32u5xx.h"
-  #define USB_OTG_FS_PERIPH_BASE       USB_OTG_FS_BASE
+  // NOTE: STM595/5A5/599/5A9 only have 1 USB port (with integrated HS PHY)
+  // USB_OTG_FS_BASE and OTG_FS_IRQn not defined
+  #if (! defined USB_OTG_FS)
+    #define USB_OTG_HS_PERIPH_BASE    USB_OTG_HS_BASE
+    #define EP_MAX_HS                 9
+    #define EP_FIFO_SIZE_HS           4096
+    #define USB_OTG_FS_PERIPH_BASE    USB_OTG_HS_BASE
+    #define OTG_FS_IRQn               OTG_HS_IRQn
+  #else
+    #define USB_OTG_FS_PERIPH_BASE    USB_OTG_FS_BASE
+  #endif
   #define EP_MAX_FS       6
   #define EP_FIFO_SIZE_FS 1280
 


### PR DESCRIPTION
Added support for USB2 HS peripheral (with integrated HS PHY) on STM32U59x & STM32U5Ax chips.

**Describe the PR**
The latest additions to the STM32U5 family have an OTG_HS peripheral (replacing the OTG_FS peripheral).
This requires modifications to the dwc2_stm32.h to reflect the lack of OTG_FS defines and set up the HS defines correctly.
I tried to keep this looking/feeling similar to the OPT_MCU_STM32H7 case above it.

**Additional context**
In my tusb_config.h (for device only) I set:
#define CFG_TUSB_MCU                 OPT_MCU_STM32U5
#define CFG_TUSB_RHPORT1_MODE       (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
#define CFG_TUD_MAX_SPEED     OPT_MODE_HIGH_SPEED

