### PR TITLE
Allow external definition of TU_CP210X_PID_LIST

### DIFF
--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -109,7 +109,7 @@ static bool ftdi_sio_set_baudrate(cdch_interface_t* p_cdc, uint32_t baudrate, tu
 #if CFG_TUH_CDC_CP210X
 #include "serial/cp210x.h"
 
-static uint16_t const cp210x_pids[] = { TU_CP210X_PID_LIST };
+static uint16_t const cp210x_pids[] = { CFG_TUH_CDC_CP210X_PID_LIST };
 enum {
   CP210X_PID_COUNT = sizeof(cp210x_pids) / sizeof(cp210x_pids[0])
 };

--- a/src/class/cdc/serial/cp210x.h
+++ b/src/class/cdc/serial/cp210x.h
@@ -29,8 +29,6 @@
 // https://www.silabs.com/documents/public/application-notes/AN571.pdf
 
 #define TU_CP210X_VID 0x10C4
-#define TU_CP210X_PID_LIST \
-  0xEA60, 0xEA70
 
 /* Config request codes */
 #define CP210X_IFC_ENABLE      0x00

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -441,6 +441,12 @@
   #define CFG_TUH_CDC_CP210X 0
 #endif
 
+#ifndef CFG_TUH_CDC_CP210X_PID_LIST
+  // List of product IDs that can use the CP210X CDC driver
+  #define CFG_TUH_CDC_CP210X_PID_LIST \
+    0xEA60, 0xEA70
+#endif
+
 #ifndef CFG_TUH_HID
   #define CFG_TUH_HID    0
 #endif


### PR DESCRIPTION
**Describe the PR**

Currently, only devices with product IDs `0xEA60` and `0xEA70` are recognized by the cp210x driver. I've had some success with one of the other ids from [this list](https://devicehunt.com/view/type/usb/vendor/10C4). 

Optimally, it would be better if this is managed internally, but by allowing customization of the list at compile-time this may be more easily tweaked and experimented with in the meantime.

**Additional context**

