### PR TITLE
Add STM32F4 OTG_HS support to BSP

### DIFF
--- a/hw/bsp/stm32f4/boards/feather_stm32f405/board.cmake
+++ b/hw/bsp/stm32f4/boards/feather_stm32f405/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F405RGTx_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F405xx
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/boards/pyboardv11/board.cmake
+++ b/hw/bsp/stm32f4/boards/pyboardv11/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F405RGTx_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F405xx
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/boards/stm32f401blackpill/board.cmake
+++ b/hw/bsp/stm32f4/boards/stm32f401blackpill/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F401VCTx_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F405xx
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/boards/stm32f407disco/board.cmake
+++ b/hw/bsp/stm32f4/boards/stm32f407disco/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F407VGTx_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F407xx
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/boards/stm32f411blackpill/board.cmake
+++ b/hw/bsp/stm32f4/boards/stm32f411blackpill/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F411CEUx_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F411xE
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/boards/stm32f411disco/board.cmake
+++ b/hw/bsp/stm32f4/boards/stm32f411disco/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F411VETx_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F411xE
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/boards/stm32f412disco/board.cmake
+++ b/hw/bsp/stm32f4/boards/stm32f412disco/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F412ZGTx_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F412Zx
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/boards/stm32f412nucleo/board.cmake
+++ b/hw/bsp/stm32f4/boards/stm32f412nucleo/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F412ZGTx_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F412Zx
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/boards/stm32f439nucleo/board.cmake
+++ b/hw/bsp/stm32f4/boards/stm32f439nucleo/board.cmake
@@ -6,5 +6,6 @@ set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/STM32F439ZITX_FLASH.ld)
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     STM32F439xx
+    BOARD_TUD_RHPORT=0
     )
 endfunction()

--- a/hw/bsp/stm32f4/family.c
+++ b/hw/bsp/stm32f4/family.c
@@ -99,6 +99,7 @@ void board_init(void) {
   HAL_UART_Init(&UartHandle);
 #endif
 
+#if BOARD_TUD_RHPORT == 0
   /* Configure USB FS GPIOs */
   __HAL_RCC_GPIOA_CLK_ENABLE();
 
@@ -124,6 +125,38 @@ void board_init(void) {
   GPIO_InitStruct.Alternate = GPIO_AF10_OTG_FS;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
+  // Enable USB OTG clock
+  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+#else
+  /* Configure USB HS GPIOs */
+  __HAL_RCC_GPIOB_CLK_ENABLE();
+
+  /* Configure USB D+ D- Pins */
+  GPIO_InitStruct.Pin = GPIO_PIN_14 | GPIO_PIN_15;
+  GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
+  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Alternate = GPIO_AF12_OTG_HS_FS;
+  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+  /* Configure VBUS Pin */
+  GPIO_InitStruct.Pin = GPIO_PIN_13;
+  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+  /* ID Pin */
+  GPIO_InitStruct.Pin = GPIO_PIN_12;
+  GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
+  GPIO_InitStruct.Alternate = GPIO_AF12_OTG_HS_FS;
+  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+  // Enable USB OTG clock
+  __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
+#endif
+
 #ifdef STM32F412Zx
   /* Configure POWER_SWITCH IO pin */
   __HAL_RCC_GPIOG_CLK_ENABLE();
@@ -132,11 +165,6 @@ void board_init(void) {
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
 #endif
-
-  // Enable USB OTG clock
-  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
-
-//  __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
 
   board_vbus_sense_init();
 }

--- a/hw/bsp/stm32f4/family.mk
+++ b/hw/bsp/stm32f4/family.mk
@@ -8,11 +8,14 @@ ST_HAL_DRIVER = hw/mcu/st/stm32$(ST_FAMILY)xx_hal_driver
 include $(TOP)/$(BOARD_PATH)/board.mk
 CPU_CORE ?= cortex-m4
 
+PORT ?= 0
+
 # --------------
 # Compiler Flags
 # --------------
 CFLAGS += \
-  -DCFG_TUSB_MCU=OPT_MCU_STM32F4
+  -DCFG_TUSB_MCU=OPT_MCU_STM32F4 \
+  -DBOARD_TUD_RHPORT=$(PORT)
 
 # GCC Flags
 CFLAGS_GCC += \

--- a/hw/bsp/stm32f7/family.c
+++ b/hw/bsp/stm32f7/family.c
@@ -182,7 +182,7 @@ void board_init(void) {
   GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
   GPIO_InitStruct.Pull      = GPIO_NOPULL;
   GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_HIGH;
-  GPIO_InitStruct.Alternate = GPIO_AF10_OTG_HS;
+  GPIO_InitStruct.Alternate = GPIO_AF12_OTG_HS_FS;
   HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
   // Enable HS VBUS sense (B device) via pin PB13
@@ -192,8 +192,8 @@ void board_init(void) {
   GPIO_InitStruct.Pin       = GPIO_PIN_13;
   GPIO_InitStruct.Mode      = GPIO_MODE_AF_OD;
   GPIO_InitStruct.Pull      = GPIO_PULLUP;
-  GPIO_InitStruct.Alternate = GPIO_AF10_OTG_HS;
-  HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
+  GPIO_InitStruct.Alternate = GPIO_AF12_OTG_HS_FS;
+  HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
   /* Enable PHYC Clocks */
   __HAL_RCC_OTGPHYC_CLK_ENABLE();


### PR DESCRIPTION
**Describe the PR**
When OTG_HS configured to work on internal phy FS mode.

Also fix a F7 GPIO alternate mapping.