### PR TITLE
Adding extern C to definitions to allow link on C++ project

### DIFF
--- a/lib/networking/dhserver.h
+++ b/lib/networking/dhserver.h
@@ -56,7 +56,13 @@ typedef struct dhcp_config
 	dhcp_entry_t *entries;
 } dhcp_config_t;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 err_t dhserv_init(const dhcp_config_t *config);
 void dhserv_free(void);
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* DHSERVER_H */

--- a/lib/networking/dnserver.h
+++ b/lib/networking/dnserver.h
@@ -41,7 +41,13 @@
 
 typedef bool (*dns_query_proc_t)(const char *name, ip4_addr_t *addr);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 err_t dnserv_init(const ip_addr_t *bind, uint16_t port, dns_query_proc_t query_proc);
 void  dnserv_free(void);
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hi, 
I've found dhserver and dnserver gives a linkage error when you try to use on a C++ project, so the solution that I've found is to 
add extern c to the affected headers.