### PR TITLE
Add featherwing max3421e support

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -40,7 +40,9 @@
         </ADDITIONAL_GENERATION_ENVIRONMENT>
       </configuration>
       <configuration PROFILE_NAME="metro_m0_express" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=metro_m0_express -DLOG=3 -DLOGGER=RTT -DMAX3421_HOST=1" />
+      <configuration PROFILE_NAME="feather_m0_express" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=feather_m0_express -DLOG=3 -DLOGGER=RTT -DMAX3421_HOST=1" />
       <configuration PROFILE_NAME="metro_m4_express" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=metro_m4_express -DLOG=3 -DLOGGER=RTT -DMAX3421_HOST=1" />
+      <configuration PROFILE_NAME="feather_m4_express" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=feather_m4_express -DLOG=3 -DLOGGER=RTT -DMAX3421_HOST=1" />
       <configuration PROFILE_NAME="feather_nrf52840_express" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=feather_nrf52840_express -DLOG=3 -DLOGGER=RTT -DMAX3421_HOST=1" />
       <configuration PROFILE_NAME="pca10056" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=pca10056 -DLOG=3 -DLOGGER=RTT -DTRACE_ETM=1" />
       <configuration PROFILE_NAME="pca10095" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=pca10095 -DLOG=3 -DLOGGER=RTT -DTRACE_ETM=1" />

--- a/examples/host/cdc_msc_hid/src/main.c
+++ b/examples/host/cdc_msc_hid/src/main.c
@@ -34,13 +34,17 @@
 // MACRO CONSTANT TYPEDEF PROTYPES
 //--------------------------------------------------------------------+
 void led_blinking_task(void);
-
 extern void cdc_app_task(void);
 extern void hid_app_task(void);
 
+#if CFG_TUH_ENABLED && CFG_TUH_MAX3421
+// API to read/rite MAX3421's register. Implemented by TinyUSB
+extern uint8_t tuh_max3421_reg_read(uint8_t rhport, uint8_t reg, bool in_isr);
+extern bool tuh_max3421_reg_write(uint8_t rhport, uint8_t reg, uint8_t data, bool in_isr);
+#endif
+
 /*------------- MAIN -------------*/
-int main(void)
-{
+int main(void) {
   board_init();
 
   printf("TinyUSB Host CDC MSC HID Example\r\n");
@@ -52,8 +56,13 @@ int main(void)
     board_init_after_tusb();
   }
 
-  while (1)
-  {
+#if CFG_TUH_ENABLED && CFG_TUH_MAX3421
+  // FeatherWing MAX3421E use MAX3421E's GPIO0 for VBUS enable
+  enum { IOPINS1_ADDR  = 20u << 3, /* 0xA0 */ };
+  tuh_max3421_reg_write(BOARD_TUH_RHPORT, IOPINS1_ADDR, 0x01, false);
+#endif
+
+  while (1) {
     // tinyusb host task
     tuh_task();
 
@@ -67,14 +76,12 @@ int main(void)
 // TinyUSB Callbacks
 //--------------------------------------------------------------------+
 
-void tuh_mount_cb(uint8_t dev_addr)
-{
+void tuh_mount_cb(uint8_t dev_addr) {
   // application set-up
   printf("A device with address %d is mounted\r\n", dev_addr);
 }
 
-void tuh_umount_cb(uint8_t dev_addr)
-{
+void tuh_umount_cb(uint8_t dev_addr) {
   // application tear-down
   printf("A device with address %d is unmounted \r\n", dev_addr);
 }
@@ -83,15 +90,14 @@ void tuh_umount_cb(uint8_t dev_addr)
 //--------------------------------------------------------------------+
 // Blinking Task
 //--------------------------------------------------------------------+
-void led_blinking_task(void)
-{
+void led_blinking_task(void) {
   const uint32_t interval_ms = 1000;
   static uint32_t start_ms = 0;
 
   static bool led_state = false;
 
   // Blink every interval ms
-  if ( board_millis() - start_ms < interval_ms) return; // not enough time
+  if (board_millis() - start_ms < interval_ms) return; // not enough time
   start_ms += interval_ms;
 
   board_led_write(led_state);

--- a/examples/host/cdc_msc_hid_freertos/src/main.c
+++ b/examples/host/cdc_msc_hid_freertos/src/main.c
@@ -83,6 +83,12 @@ extern void cdc_app_init(void);
 extern void hid_app_init(void);
 extern void msc_app_init(void);
 
+#if CFG_TUH_ENABLED && CFG_TUH_MAX3421
+// API to read/rite MAX3421's register. Implemented by TinyUSB
+extern uint8_t tuh_max3421_reg_read(uint8_t rhport, uint8_t reg, bool in_isr);
+extern bool tuh_max3421_reg_write(uint8_t rhport, uint8_t reg, uint8_t data, bool in_isr);
+#endif
+
 /*------------- MAIN -------------*/
 int main(void) {
   board_init();
@@ -125,6 +131,12 @@ static void usb_host_task(void *param) {
   if (board_init_after_tusb) {
     board_init_after_tusb();
   }
+
+#if CFG_TUH_ENABLED && CFG_TUH_MAX3421
+  // FeatherWing MAX3421E use MAX3421E's GPIO0 for VBUS enable
+  enum { IOPINS1_ADDR  = 20u << 3, /* 0xA0 */ };
+  tuh_max3421_reg_write(BOARD_TUH_RHPORT, IOPINS1_ADDR, 0x01, false);
+#endif
 
   cdc_app_init();
   hid_app_init();

--- a/hw/bsp/nrf/boards/feather_nrf52840_express/board.h
+++ b/hw/bsp/nrf/boards/feather_nrf52840_express/board.h
@@ -49,8 +49,8 @@
 #define MAX3421_SCK_PIN  14
 #define MAX3421_MOSI_PIN 13
 #define MAX3421_MISO_PIN 15
-#define MAX3421_CS_PIN   27 // D10
-#define MAX3421_INTR_PIN 26 // D9
+#define MAX3421_CS_PIN   6  // D11
+#define MAX3421_INTR_PIN 27 // D10
 
 #ifdef __cplusplus
  }

--- a/hw/bsp/nrf/family.c
+++ b/hw/bsp/nrf/family.c
@@ -95,9 +95,7 @@ TU_ATTR_UNUSED static void power_event_handler(nrfx_power_usb_evt_t event) {
 
 //------------- Host using MAX2341E -------------//
 #if CFG_TUH_ENABLED && defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
-
 static void max3421_init(void);
-
 static nrfx_spim_t _spi = NRFX_SPIM_INSTANCE(1);
 #endif
 

--- a/hw/bsp/samd21/boards/feather_m0_express/board.h
+++ b/hw/bsp/samd21/boards/feather_m0_express/board.h
@@ -43,6 +43,21 @@
 #define UART_RX_PIN           4
 #define UART_TX_PIN           5
 
+// SPI for USB host shield
+#define MAX3421_SERCOM_ID       4       // SERCOM4
+#define MAX3421_SERCOM_FUNCTION 3       // function D (Sercom Alt)
+
+#define MAX3421_SCK_PIN         (32+11)
+#define MAX3421_MOSI_PIN        (32+10)
+#define MAX3421_MISO_PIN        12
+#define MAX3421_TX_PAD          1 // MOSI = PAD_2, SCK = PAD_3
+#define MAX3421_RX_PAD          0 // MISO = PAD_2
+
+#define MAX3421_CS_PIN          16      // D11
+
+#define MAX3421_INTR_PIN        18      // D10
+#define MAX3421_INTR_EIC_ID     2       // EIC2
+
 #ifdef __cplusplus
  }
 #endif

--- a/hw/bsp/samd51/boards/feather_m4_express/board.h
+++ b/hw/bsp/samd51/boards/feather_m4_express/board.h
@@ -31,6 +31,8 @@
  extern "C" {
 #endif
 
+#define _PINNUM(port, pin)    ((port)*32 + (pin))
+
 // LED
 #define LED_PIN               23
 #define LED_STATE_ON          1
@@ -42,6 +44,21 @@
 // UART
 #define UART_TX_PIN           (32 + 17)
 #define UART_RX_PIN           (32 + 16)
+
+// SPI for USB host shield
+#define MAX3421_SERCOM_ID       1  // SERCOM2
+#define MAX3421_SERCOM_FUNCTION 2  // function C
+
+#define MAX3421_SCK_PIN         _PINNUM(0, 17)
+#define MAX3421_MOSI_PIN        _PINNUM(1, 23)
+#define MAX3421_MISO_PIN        _PINNUM(1, 22)
+#define MAX3421_TX_PAD          2 // MOSI = PAD_3, SCK = PAD_1
+#define MAX3421_RX_PAD          2 // MISO = PAD_2
+
+#define MAX3421_CS_PIN          21 // D11
+
+#define MAX3421_INTR_PIN        20 // D10
+#define MAX3421_INTR_EIC_ID     4  // EIC4
 
 #ifdef __cplusplus
  }

--- a/hw/bsp/samd51/family.c
+++ b/hw/bsp/samd51/family.c
@@ -78,12 +78,6 @@ void USB_3_Handler(void) {
 
 #if CFG_TUH_ENABLED && CFG_TUH_MAX3421
 
-// API to read MAX3421's register. Implemented by TinyUSB
-extern uint8_t tuh_max3421_reg_read(uint8_t rhport, uint8_t reg, bool in_isr);
-
-// API to write MAX3421's register. Implemented by TinyUSB
-extern bool tuh_max3421_reg_write(uint8_t rhport, uint8_t reg, uint8_t data, bool in_isr);
-
 #define MAX3421_SERCOM TU_XSTRCAT(SERCOM, MAX3421_SERCOM_ID)
 #define MAX3421_EIC_Handler TU_XSTRCAT3(EIC_, MAX3421_INTR_EIC_ID, _Handler)
 
@@ -148,15 +142,6 @@ void board_init(void) {
 }
 
 void board_init_after_tusb(void) {
-#if CFG_TUH_ENABLED && CFG_TUH_MAX3421
-  // FeatherWing MAX3421E use MAX3421E's GPIO0 for VBUS enable
-  enum {
-    IOPINS1_ADDR  = 20u << 3, // 0xA0
-  };
-
-  uint8_t rhport = 1;
-  tuh_max3421_reg_write(rhport, IOPINS1_ADDR, 0x01, false);
-#endif
 }
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
- add tuh_max3421_reg_read(), tuh_max3421_reg_read() for application usage 
- update example to work with featherwing max3421, set max3421 GPIO0 for vbus
- tested with feather nrf52840, m0, m4