### PR TITLE
dwc2: add endpoint allocation support.

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -96,8 +96,8 @@
   #define  USE_LINEAR_BUFFER     1
 #endif
 
-// Temporarily put the check here for stm32_fsdev
-#ifdef TUP_USBIP_FSDEV
+// Temporarily put the check here
+#if defined(TUP_USBIP_FSDEV) || defined(TUP_USBIP_DWC2)
   #define  USE_ISO_EP_ALLOCATION   1
 #else
   #define  USE_ISO_EP_ALLOCATION   0

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -139,6 +139,14 @@ static void bus_reset(uint8_t rhport) {
     dwc2->epout[n].doepctl |= DOEPCTL_SNAK;
   }
 
+  // flush all TX fifo and wait for it cleared
+  dwc2->grstctl = GRSTCTL_TXFFLSH | (0x10u << GRSTCTL_TXFNUM_Pos);
+  while (dwc2->grstctl & GRSTCTL_TXFFLSH_Msk) {}
+
+  // flush RX fifo and wait for it cleared
+  dwc2->grstctl = GRSTCTL_RXFFLSH;
+  while (dwc2->grstctl & GRSTCTL_RXFFLSH_Msk) {}
+
   // 2. Set up interrupt mask
   dwc2->daintmsk = TU_BIT(DAINTMSK_OEPM_Pos) | TU_BIT(DAINTMSK_IEPM_Pos);
   dwc2->doepmsk = DOEPMSK_STUPM | DOEPMSK_XFRCM;


### PR DESCRIPTION
**Describe the PR**
Add endpoint buffer allocation support, to avoid USB buffer alloc/free at runtime.

Currently something is wrong with runtime buffer size adjustment, after some endpoint close/open cycle there is a chance that the device stop transferring/receiving packets.

Also flush FIFO on bus reset, as incomplete iso transfers can cause some strange issues, seems flushing FIFO is a work around.