### PR TITLE
fix typo in cdc line coding enum

### DIFF
--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -118,7 +118,7 @@
 
 // Set Line Coding on enumeration/mounted, value for cdc_line_coding_t
 // bit rate = 115200, 1 stop bit, no parity, 8 bit data width
-#define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CONDING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
+#define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CODING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
 
 
 #ifdef __cplusplus

--- a/examples/host/cdc_msc_hid_freertos/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid_freertos/src/tusb_config.h
@@ -123,7 +123,7 @@
 
 // Set Line Coding on enumeration/mounted, value for cdc_line_coding_t
 // bit rate = 115200, 1 stop bit, no parity, 8 bit data width
-#define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CONDING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
+#define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CODING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
 
 
 #ifdef __cplusplus

--- a/src/class/cdc/cdc.h
+++ b/src/class/cdc/cdc.h
@@ -182,21 +182,23 @@ typedef enum
   CDC_REQUEST_MDLM_SEMANTIC_MODEL                          = 0x60,
 }cdc_management_request_t;
 
-enum
-{
+enum {
   CDC_CONTROL_LINE_STATE_DTR = 0x01,
   CDC_CONTROL_LINE_STATE_RTS = 0x02,
 };
 
-enum
-{
-  CDC_LINE_CONDING_STOP_BITS_1   = 0, // 1   bit
-  CDC_LINE_CONDING_STOP_BITS_1_5 = 1, // 1.5 bits
-  CDC_LINE_CONDING_STOP_BITS_2   = 2, // 2   bits
+enum {
+  CDC_LINE_CODING_STOP_BITS_1   = 0, // 1   bit
+  CDC_LINE_CODING_STOP_BITS_1_5 = 1, // 1.5 bits
+  CDC_LINE_CODING_STOP_BITS_2   = 2, // 2   bits
 };
 
-enum
-{
+// TODO Backward compatible for typos. Maybe removed in the future release
+#define CDC_LINE_CONDING_STOP_BITS_1   CDC_LINE_CODING_STOP_BITS_1
+#define CDC_LINE_CONDING_STOP_BITS_1_5 CDC_LINE_CODING_STOP_BITS_1_5
+#define CDC_LINE_CONDING_STOP_BITS_2   CDC_LINE_CODING_STOP_BITS_2
+
+enum {
   CDC_LINE_CODING_PARITY_NONE  = 0,
   CDC_LINE_CODING_PARITY_ODD   = 1,
   CDC_LINE_CODING_PARITY_EVEN  = 2,

--- a/src/class/cdc/cdc_host.h
+++ b/src/class/cdc/cdc_host.h
@@ -44,7 +44,7 @@
 
 // Set Line Coding on enumeration/mounted, value for cdc_line_coding_t
 //#ifndef CFG_TUH_CDC_LINE_CODING_ON_ENUM
-//#define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CONDING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
+//#define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CODING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
 //#endif
 
 // RX FIFO size


### PR DESCRIPTION
**Describe the PR**
fix #2330 , an macro with previous typo words are added for backward-compatible. Maybe removed in the future release.