### PR TITLE
Add configuration option CFG_TUH_CDC_FTDI_PID_LIST to tusb_option.h

### DIFF
--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -90,7 +90,7 @@ static bool acm_set_baudrate(cdch_interface_t* p_cdc, uint32_t baudrate, tuh_xfe
 #if CFG_TUH_CDC_FTDI
 #include "serial/ftdi_sio.h"
 
-static uint16_t const ftdi_pids[] = { TU_FTDI_PID_LIST };
+static uint16_t const ftdi_pids[] = { CFG_TUH_CDC_FTDI_PID_LIST };
 enum {
   FTDI_PID_COUNT = sizeof(ftdi_pids) / sizeof(ftdi_pids[0])
 };

--- a/src/class/cdc/serial/ftdi_sio.h
+++ b/src/class/cdc/serial/ftdi_sio.h
@@ -25,11 +25,8 @@
 #ifndef TUSB_FTDI_SIO_H
 #define TUSB_FTDI_SIO_H
 
-// VID/PID for matching FTDI devices
+// VID for matching FTDI devices
 #define TU_FTDI_VID 0x0403
-#define TU_FTDI_PID_LIST \
-  0x6001, 0x6006, 0x6010, 0x6011, 0x6014, 0x6015, 0x8372, 0xFBFA, \
-  0xcd18
 
 // Commands
 #define FTDI_SIO_RESET             	0    /* Reset the port */

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -442,6 +442,12 @@
   #define CFG_TUH_CDC_FTDI 0
 #endif
 
+#ifndef CFG_TUH_CDC_FTDI_PID_LIST
+  // List of product IDs that can use the FTDI CDC driver
+  #define CFG_TUH_CDC_FTDI_PID_LIST \
+    0x6001, 0x6006, 0x6010, 0x6011, 0x6014, 0x6015, 0x8372, 0xFBFA, 0xCD18
+#endif
+
 #ifndef CFG_TUH_CDC_CP210X
   // CP210X is not part of CDC class, only to re-use CDC driver API
   #define CFG_TUH_CDC_CP210X 0


### PR DESCRIPTION
**Describe the PR**
Allow configuration of PIDs to consider applicable for FTDI serial. 

**Additional context**
This brings the FTDI configuration in-line with the previously modified CP210X configuration options (#2296).
