### PR TITLE
STM32F7: correct USB_HS_PHYC_TUNE configuration

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -197,7 +197,12 @@ static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
 
       // Control the tuning interface of the High Speed PHY
       // Use magic value (USB_HS_PHYC_TUNE_VALUE) from ST driver for F7
-      USB_HS_PHYC->USB_HS_PHYC_TUNE |= 0x00000F13U;
+      //
+      // Note that we're assigning USB_HS_PHYC_TUNE to the magic value!
+      // Previously we were performing a bitwise-or with the magic value
+      // (which is what the ST driver does), but that's incorrect.
+      // See issue #2374.
+      USB_HS_PHYC->USB_HS_PHYC_TUNE = 0x00000F13U;
 
       // Enable PLL internal PHY
       USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL_PLLEN;


### PR DESCRIPTION
Fix issue #2374 by assigning `USB_HS_PHYC_TUNE` to the magic value, instead of performing a bitwise-or.

Previously, the bitwise-or caused the default value of the `LFSCAPEN` bit (bit 2) to be retained, where `LFSCAPEN` is described by the reference manual as:

> LFSCAPEN: Enables the Low Full Speed feedback capacitor.

This capacitor interferes with the D+/D- signals (which makes sense because it appears to be intended for low/full-speed mode, but we're in high-speed mode), which breaks USB comms with ARM-based Macs.