### PR TITLE
dcd_nrf5x: Fix dcd_edpt_open for iso endpoint

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -340,6 +340,9 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
       NRF_USBD->INTENSET = TU_BIT(USBD_INTEN_ENDEPIN0_Pos + epnum);
       NRF_USBD->EPINEN  |= TU_BIT(epnum);
     }
+    // clear stall and reset DataToggle
+    NRF_USBD->EPSTALL = (USBD_EPSTALL_STALL_UnStall << USBD_EPSTALL_STALL_Pos) | ep_addr;
+    NRF_USBD->DTOGGLE = (USBD_DTOGGLE_VALUE_Data0 << USBD_DTOGGLE_VALUE_Pos) | ep_addr;
   }
   else
   {
@@ -374,10 +377,6 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
       NRF_USBD->EPINEN  |= USBD_EPINEN_ISOIN_Msk;
     }
   }
-
-  // clear stall and reset DataToggle
-  NRF_USBD->EPSTALL = (USBD_EPSTALL_STALL_UnStall << USBD_EPSTALL_STALL_Pos) | ep_addr;
-  NRF_USBD->DTOGGLE = (USBD_DTOGGLE_VALUE_Data0 << USBD_DTOGGLE_VALUE_Pos) | ep_addr;
 
   __ISB(); __DSB();
 


### PR DESCRIPTION
**Describe the PR**
When ISO endpoint handling was introduced two lines that clear stall and data toggle bit were left unchanged and they were effective for ISO endpoint as well.
This is incorrect behavior since EPSTALL and DTOGGLE registers have only 3 bits for address.
Leaving code that clears toggle bit results in endpoint 0 toggle bit being reset when iso endpoint (8) is opened.

Now code that clears stall and toggle bit is applied to non-iso endpoint only as it was done before iso handling was introduced.

