### PR TITLE
[STM32 FSDEV] Fix ISR race conditions

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -673,13 +673,13 @@ void dcd_int_handler(uint8_t rhport) {
 
   /* Put SOF flag at the beginning of ISR in case to get least amount of jitter if it is used for timing purposes */
   if(int_status & USB_ISTR_SOF) {
-    USB->ISTR = ~USB_ISTR_SOF;
+    USB->ISTR = (fsdev_bus_t)~USB_ISTR_SOF;
     dcd_event_sof(0, USB->FNR & USB_FNR_FN, true);
   }
 
   if(int_status & USB_ISTR_RESET) {
     // USBRST is start of reset.
-    USB->ISTR = ~USB_ISTR_RESET;
+    USB->ISTR = (fsdev_bus_t)~USB_ISTR_RESET;
     dcd_handle_bus_reset();
     dcd_event_bus_reset(0, TUSB_SPEED_FULL, true);
     return; // Don't do the rest of the things here; perhaps they've been cleared?
@@ -697,7 +697,7 @@ void dcd_int_handler(uint8_t rhport) {
     USB->CNTR &= ~USB_CNTR_LPMODE;
     USB->CNTR &= ~USB_CNTR_FSUSP;
 
-    USB->ISTR = ~USB_ISTR_WKUP;
+    USB->ISTR = (fsdev_bus_t)~USB_ISTR_WKUP;
     dcd_event_bus_signal(0, DCD_EVENT_RESUME, true);
   }
 
@@ -711,7 +711,7 @@ void dcd_int_handler(uint8_t rhport) {
     USB->CNTR |= USB_CNTR_LPMODE;
 
     /* clear of the ISTR bit must be done after setting of CNTR_FSUSP */
-    USB->ISTR = ~USB_ISTR_SUSP;
+    USB->ISTR = (fsdev_bus_t)~USB_ISTR_SUSP;
     dcd_event_bus_signal(0, DCD_EVENT_SUSPEND, true);
   }
 
@@ -724,7 +724,7 @@ void dcd_int_handler(uint8_t rhport) {
     {
       remoteWakeCountdown--;
     }
-    USB->ISTR = ~USB_ISTR_ESOF;
+    USB->ISTR = (fsdev_bus_t)~USB_ISTR_ESOF;
   }
 }
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -673,13 +673,13 @@ void dcd_int_handler(uint8_t rhport) {
 
   /* Put SOF flag at the beginning of ISR in case to get least amount of jitter if it is used for timing purposes */
   if(int_status & USB_ISTR_SOF) {
-    USB->ISTR &=~USB_ISTR_SOF;
+    USB->ISTR = ~USB_ISTR_SOF;
     dcd_event_sof(0, USB->FNR & USB_FNR_FN, true);
   }
 
   if(int_status & USB_ISTR_RESET) {
     // USBRST is start of reset.
-    USB->ISTR &=~USB_ISTR_RESET;
+    USB->ISTR = ~USB_ISTR_RESET;
     dcd_handle_bus_reset();
     dcd_event_bus_reset(0, TUSB_SPEED_FULL, true);
     return; // Don't do the rest of the things here; perhaps they've been cleared?
@@ -697,7 +697,7 @@ void dcd_int_handler(uint8_t rhport) {
     USB->CNTR &= ~USB_CNTR_LPMODE;
     USB->CNTR &= ~USB_CNTR_FSUSP;
 
-    USB->ISTR &=~USB_ISTR_WKUP;
+    USB->ISTR = ~USB_ISTR_WKUP;
     dcd_event_bus_signal(0, DCD_EVENT_RESUME, true);
   }
 
@@ -711,7 +711,7 @@ void dcd_int_handler(uint8_t rhport) {
     USB->CNTR |= USB_CNTR_LPMODE;
 
     /* clear of the ISTR bit must be done after setting of CNTR_FSUSP */
-    USB->ISTR &=~USB_ISTR_SUSP;
+    USB->ISTR = ~USB_ISTR_SUSP;
     dcd_event_bus_signal(0, DCD_EVENT_SUSPEND, true);
   }
 
@@ -724,7 +724,7 @@ void dcd_int_handler(uint8_t rhport) {
     {
       remoteWakeCountdown--;
     }
-    USB->ISTR &=~USB_ISTR_ESOF;
+    USB->ISTR = ~USB_ISTR_ESOF;
   }
 }
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -173,8 +173,11 @@
 // For type-safety create a new macro for the volatile address of PMAADDR
 // The compiler should warn us if we cast it to a non-volatile type?
 #ifdef PMA_32BIT_ACCESS
+typedef uint32_t fsdev_bus_t;
 static __IO uint32_t * const pma32 = (__IO uint32_t*)USB_PMAADDR;
+
 #else
+typedef uint16_t fsdev_bus_t;
 // Volatile is also needed to prevent the optimizer from changing access to 32-bit (as 32-bit access is forbidden)
 static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
 


### PR DESCRIPTION
Doing RMW (read-modify-write) operations on interrupt status bits is always broken because the interrupts, which become pending during the RMW operation, are cleared without being processed. The same issue is discussed in details in https://github.com/libopencm3/libopencm3/issues/392.

This particular bug was introduced with commit [412b557](https://github.com/hathach/tinyusb/pull/1942/commits/412b557a080526fbfe7b42dd8aa07468c16413cc) by @HiFiPhile . I'm noting it to just serve as a reminder for everyone to be careful with RMW operations, especially for interrupt and other status bits. Because of this bug for me TinyUSB v0.16 on STM32L432 was failing completely 95% of the time. As this is a critical bug and affects about half of the STM32 devices, maybe this fix even deserves a v0.16.1 release?