### PR TITLE
[HUB] Prevent status request to invalid ep_num

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -456,7 +456,7 @@ void tuh_task_ext(uint32_t timeout_ms, bool in_isr) {
 
         #if CFG_TUH_HUB
         // TODO remove
-        if ( event.connection.hub_addr != 0) {
+        if ( event.connection.hub_addr != 0 && event.connection.hub_port != 0) {
           // done with hub, waiting for next data on status pipe
           (void) hub_edpt_status_xfer( event.connection.hub_addr );
         }


### PR DESCRIPTION
**Describe the PR**
If you disconnect a USB hub tusb clears the hub device memory (to zeros). If its a hub, during disconnect it also creates a detach event on hub port 0 to unroll the loop. Problem occurs when it processes this detach event on the now cleared hub device and requests the next hub status packet

https://github.com/hathach/tinyusb/blob/ae364b1460b91153cd94b4b0303eeda6419ff1d1/src/host/usbh.c#L461

Resulting in this request onto the hub interrupt endpoint
`Queue EP 00 with 1 bytes ... `

The ep_num of 0 causes some backends to process it as a control transfer instead of a interrupt transfer This was resulting in a td leak on the OHCI backend.

This PR prevents this from occuring.
As USB hub ports start from 1, this should not cause any issues under normal operation.