### PR TITLE
Disable ULPI clock during sleep on stm32f7 when using internal phy

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -149,7 +149,7 @@ static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
     // https://community.st.com/t5/stm32cubemx-mcus/why-stm32h743-usb-fs-doesn-t-work-if-freertos-tickless-idle/m-p/349480#M18867
     // H7 running on full-speed phy need to disable ULPI clock in sleep mode.
     // Otherwise, USB won't work when mcu executing WFI/WFE instruction i.e tick-less RTOS.
-    // Note: there may be other family that is affected by this, but only H7 is tested so far
+    // Note: there may be other family that is affected by this, but only H7 and F7 is tested so far
     #if defined(USB_OTG_FS_PERIPH_BASE) && defined(RCC_AHB1LPENR_USB2OTGFSULPILPEN)
     if ( USB_OTG_FS_PERIPH_BASE == (uint32_t) dwc2 ) {
       RCC->AHB1LPENR &= ~RCC_AHB1LPENR_USB2OTGFSULPILPEN;
@@ -161,6 +161,13 @@ static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
       RCC->AHB1LPENR &= ~RCC_AHB1LPENR_USB1OTGHSULPILPEN;
     }
     #endif
+
+    #if defined(USB_OTG_HS_PERIPH_BASE) && defined(RCC_AHB1LPENR_OTGHSULPILPEN)
+    if ( USB_OTG_HS_PERIPH_BASE == (uint32_t) dwc2 ) {
+      RCC->AHB1LPENR &= ~RCC_AHB1LPENR_OTGHSULPILPEN;
+    }
+    #endif
+
   } else {
 #if CFG_TUSB_MCU != OPT_MCU_STM32U5
     // Disable FS PHY, TODO on U5A5 (dwc2 4.11a) 16th bit is 'Host CDP behavior enable'


### PR DESCRIPTION
This PR addresses a bug I discovered on stm32f7 when using the OTG_HS dwc2 peripheral with the internal FS phy while also using tickless idle with freertos. The problem is identical to the issue described for the H7 series, but on the F7 different bit names are used. This patch also disables the ULPI clock during tickless idle for stm32f4 and stm32f2 series microcontrollers that have the OTG_HS peripheral. While I did not test the other MCUs, I don't see how this could harm since with this patch, the ULPI clock is disabled during sleep only if the ULPI interface is not used.
I tested this on an stm32f722ze with OTG_HS connected in FS mode with the internal phy in device mode. The examples do not use such a configuration afaik.
