### PR TITLE
Support for TUSB_REQ_FEATURE_TEST_MODE

### DIFF
--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -146,6 +146,8 @@ void dcd_disconnect(uint8_t rhport) TU_ATTR_WEAK;
 // Enable/Disable Start-of-frame interrupt. Default is disabled
 void dcd_sof_enable(uint8_t rhport, bool en);
 
+// Transition device to test mode
+void dcd_set_test_mode(uint16_t test_mode) TU_ATTR_WEAK;
 //--------------------------------------------------------------------+
 // Endpoint API
 //--------------------------------------------------------------------+

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -152,6 +152,9 @@ void tud_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_isr);
 // Invoked when received control request with VENDOR TYPE
 TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
 
+// Invoked when ZLP xfer stage of TUSB_REQ_FEATURE_TEST_MODE request completes
+TU_ATTR_WEAK bool tud_test_mode_req_status_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
+
 //--------------------------------------------------------------------+
 // Binary Device Object Store (BOS) Descriptor Templates
 //--------------------------------------------------------------------+
@@ -854,6 +857,14 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   7, TUSB_DESC_ENDPOINT, _epin, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0,\
   /* Endpoint Out */\
   7, TUSB_DESC_ENDPOINT, _epout, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0
+
+// Test selector defines for Test mode
+#define TUSB_USB_WINDEX_TEST_J               (0x1<<8)
+#define TUSB_USB_WINDEX_TEST_K               (0x2<<8)
+#define TUSB_USB_WINDEX_TEST_SE0_NAK         (0x3<<8)
+#define TUSB_USB_WINDEX_TEST_PACKET          (0x4<<8)
+#define TUSB_USB_WINDEX_TEST_FORCE_ENABLE    (0x5<<8)
+
 
 #ifdef __cplusplus
 }

--- a/src/device/usbd_pvt.h
+++ b/src/device/usbd_pvt.h
@@ -112,6 +112,9 @@ bool usbd_edpt_ready(uint8_t rhport, uint8_t ep_addr) {
 // Enable SOF interrupt
 void usbd_sof_enable(uint8_t rhport, bool en);
 
+// Set device in test mode in response to TUSB_REQ_FEATURE_TEST_MODE
+bool usbd_set_test_mode(uint16_t test_mode);
+
 /*------------------------------------------------------------------*/
 /* Helper
  *------------------------------------------------------------------*/


### PR DESCRIPTION
**Describe the PR**
Adds support for TUSB_REQ_FEATURE_TEST_MODE feature in usbd.c

**Additional context**
Added callback functions tud_test_mode_req_status_xfer_cb(), usbd_set_test_mode() and dcd_set_test_mode() that are
called to transition the USB device into the electrical compliance test mode.
