### PR TITLE
added CDC specific debug logs

### DIFF
--- a/src/class/cdc/cdc_debug.h
+++ b/src/class/cdc/cdc_debug.h
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Ha Thach (tinyusb.org)
+ * Copyright (c) 2023 IngHK Heiko Kuester
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef _TUSB_CDC_DEBUG_H_
+#define _TUSB_CDC_DEBUG_H_
+
+#include "cdc.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+// logging of line coding
+#define TU_LOG_LINE_CODING(PRE_TEXT,LINE_CODING)                          \
+  TU_LOG_DRV(PRE_TEXT "Line Coding %luBd %u%c%s\r\n",                     \
+  LINE_CODING.bit_rate,                                                   \
+  LINE_CODING.data_bits,                                                  \
+  LINE_CODING.parity == CDC_LINE_CODING_PARITY_NONE ? 'N' :               \
+    LINE_CODING.parity == CDC_LINE_CODING_PARITY_ODD ? 'O' :              \
+      LINE_CODING.parity == CDC_LINE_CODING_PARITY_EVEN ? 'E' :           \
+        LINE_CODING.parity == CDC_LINE_CODING_PARITY_MARK ? 'M' :         \
+          LINE_CODING.parity == CDC_LINE_CODING_PARITY_SPACE ? 'S' : '?', \
+  LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_1 ? "1" :            \
+    LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_1_5 ? "1.5" :      \
+      LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_2 ? "2" : "?")
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_CDC_DEBUG_H_ */

--- a/src/class/cdc/cdc_debug.h
+++ b/src/class/cdc/cdc_debug.h
@@ -35,18 +35,28 @@
 #endif
 
 // logging of line coding
-#define TU_LOG_LINE_CODING(PRE_TEXT,LINE_CODING)                          \
-  TU_LOG_DRV(PRE_TEXT "Line Coding %luBd %u%c%s\r\n",                     \
-  LINE_CODING.bit_rate,                                                   \
-  LINE_CODING.data_bits,                                                  \
-  LINE_CODING.parity == CDC_LINE_CODING_PARITY_NONE ? 'N' :               \
-    LINE_CODING.parity == CDC_LINE_CODING_PARITY_ODD ? 'O' :              \
-      LINE_CODING.parity == CDC_LINE_CODING_PARITY_EVEN ? 'E' :           \
-        LINE_CODING.parity == CDC_LINE_CODING_PARITY_MARK ? 'M' :         \
-          LINE_CODING.parity == CDC_LINE_CODING_PARITY_SPACE ? 'S' : '?', \
-  LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_1 ? "1" :            \
-    LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_1_5 ? "1.5" :      \
-      LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_2 ? "2" : "?")
+#define TU_LOG_LINE_CODING(PRE_TEXT,LINE_CODING)                            \
+  TU_LOG_DRV(PRE_TEXT "Line Coding %luBd %u%c%s\r\n",                       \
+    LINE_CODING.bit_rate,                                                   \
+    LINE_CODING.data_bits,                                                  \
+    LINE_CODING.parity == CDC_LINE_CODING_PARITY_NONE ? 'N' :               \
+      LINE_CODING.parity == CDC_LINE_CODING_PARITY_ODD ? 'O' :              \
+        LINE_CODING.parity == CDC_LINE_CODING_PARITY_EVEN ? 'E' :           \
+          LINE_CODING.parity == CDC_LINE_CODING_PARITY_MARK ? 'M' :         \
+            LINE_CODING.parity == CDC_LINE_CODING_PARITY_SPACE ? 'S' : '?', \
+    LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_1 ? "1" :            \
+      LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_1_5 ? "1.5" :      \
+        LINE_CODING.stop_bits == CDC_LINE_CODING_STOP_BITS_2 ? "2" : "?")
+
+// logging of baudrate
+#define TU_LOG_BAUDRATE(PRE_TEXT,BAUDRATE) \
+  TU_LOG_DRV(PRE_TEXT "Baudrate %luBd\r\n", BAUDRATE)
+
+ // logging of control line state
+#define TU_LOG_CONTROL_LINE_STATE(PRE_TEXT,LINE_STATE)            \
+  TU_LOG_DRV(PRE_TEXT "Control Line State RTS%c DTR%c\r\n", \
+    LINE_STATE & CDC_CONTROL_LINE_STATE_RTS ? '+' : '-',           \
+    LINE_STATE & CDC_CONTROL_LINE_STATE_DTR ? '+' : '-' )
 
 #ifdef __cplusplus
  }

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -363,7 +363,7 @@ bool cdcd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
     case CDC_REQUEST_SET_LINE_CODING:
       if (stage == CONTROL_STAGE_SETUP)
       {
-        #if 0 // TODO activate and test
+        #if 0 // TODO activate, test and remove else
           TU_LOG_LINE_CODING("  Set ", p_cdc->line_coding);
         #else
           TU_LOG_DRV("  Set Line Coding\r\n");
@@ -379,7 +379,7 @@ bool cdcd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
     case CDC_REQUEST_GET_LINE_CODING:
       if (stage == CONTROL_STAGE_SETUP)
       {
-        #if 0 // TODO activate and test
+        #if 0 // TODO activate, test and remove else
           TU_LOG_LINE_CODING("  Get ", p_cdc->line_coding);
         #else
           TU_LOG_DRV("  Get Line Coding\r\n");
@@ -408,7 +408,11 @@ bool cdcd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
         // Disable fifo overwriting if DTR bit is set
         tu_fifo_set_overwritable(&p_cdc->tx_ff, !dtr);
 
-        TU_LOG_DRV("  Set Control Line State: DTR = %d, RTS = %d\r\n", dtr, rts);
+        #if 0 // TODO activate, test and remove else
+          TU_LOG_CONTROL_LINE_STATE("  Set ", p_cdc->line_state);
+        #else
+          TU_LOG_DRV("  Set Control Line State: DTR = %d, RTS = %d\r\n", dtr, rts);
+        #endif
 
         // Invoke callback
         if ( tud_cdc_line_state_cb ) tud_cdc_line_state_cb(itf, dtr, rts);

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -32,6 +32,9 @@
 #include "device/usbd_pvt.h"
 
 #include "cdc_device.h"
+#if 0 // TODO activate and test
+#include "cdc_debug.h"
+#endif
 
 // Level where CFG_TUSB_DEBUG must be at least for this driver is logged
 #ifndef CFG_TUD_CDC_LOG_LEVEL
@@ -360,7 +363,11 @@ bool cdcd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
     case CDC_REQUEST_SET_LINE_CODING:
       if (stage == CONTROL_STAGE_SETUP)
       {
-        TU_LOG_DRV("  Set Line Coding\r\n");
+        #if 0 // TODO activate and test
+          TU_LOG_LINE_CODING("  Set ", p_cdc->line_coding);
+        #else
+          TU_LOG_DRV("  Set Line Coding\r\n");
+        #endif
         tud_control_xfer(rhport, request, &p_cdc->line_coding, sizeof(cdc_line_coding_t));
       }
       else if ( stage == CONTROL_STAGE_ACK)
@@ -372,7 +379,11 @@ bool cdcd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t 
     case CDC_REQUEST_GET_LINE_CODING:
       if (stage == CONTROL_STAGE_SETUP)
       {
-        TU_LOG_DRV("  Get Line Coding\r\n");
+        #if 0 // TODO activate and test
+          TU_LOG_LINE_CODING("  Get ", p_cdc->line_coding);
+        #else
+          TU_LOG_DRV("  Get Line Coding\r\n");
+        #endif
         tud_control_xfer(rhport, request, &p_cdc->line_coding, sizeof(cdc_line_coding_t));
       }
     break;


### PR DESCRIPTION
added CDC specific debug logs in new file cdc_debug.h
initial version with logging of line_coding, baudrate and control line_stateaccepted
added to CDC host and tested
added to CDC device, but inactive (#if 0) and to test later