### PR TITLE
change serila host FTDI/CP210X pid list to vid/pid list

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -80,7 +80,7 @@
       <configuration PROFILE_NAME="ra6m5 PORT0" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=ra6m5_ek -DLOG=3 -DLOGGER=RTT -DTRACE_ETM=1 -DPORT=0" />
       <configuration PROFILE_NAME="uno_r4" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=uno_r4 -DLOG=4 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="portenta_c33" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=portenta_c33 -DLOG=3" />
-      <configuration PROFILE_NAME="lpcxpresso1769" ENABLED="true" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=lpcxpresso1769 -DLOG=3 -DLOGGER=RTT" />
+      <configuration PROFILE_NAME="lpcxpresso1769" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=lpcxpresso1769 -DLOG=3 -DLOGGER=RTT" />
     </configurations>
   </component>
 </project>

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -91,9 +91,9 @@ static bool acm_set_baudrate(cdch_interface_t* p_cdc, uint32_t baudrate, tuh_xfe
 #if CFG_TUH_CDC_FTDI
 #include "serial/ftdi_sio.h"
 
-static uint16_t const ftdi_pids[] = { CFG_TUH_CDC_FTDI_PID_LIST };
+static uint16_t const ftdi_vid_pid_list[][2] = {CFG_TUH_CDC_FTDI_VID_PID_LIST };
 enum {
-  FTDI_PID_COUNT = sizeof(ftdi_pids) / sizeof(ftdi_pids[0])
+  FTDI_PID_COUNT = sizeof(ftdi_vid_pid_list) / sizeof(ftdi_vid_pid_list[0])
 };
 
 // Store last request baudrate since divisor to baudrate is not easy
@@ -110,9 +110,9 @@ static bool ftdi_sio_set_baudrate(cdch_interface_t* p_cdc, uint32_t baudrate, tu
 #if CFG_TUH_CDC_CP210X
 #include "serial/cp210x.h"
 
-static uint16_t const cp210x_pids[] = { CFG_TUH_CDC_CP210X_PID_LIST };
+static uint16_t const cp210x_vid_pid_list[][2] = {CFG_TUH_CDC_CP210X_VID_PID_LIST };
 enum {
-  CP210X_PID_COUNT = sizeof(cp210x_pids) / sizeof(cp210x_pids[0])
+  CP210X_PID_COUNT = sizeof(cp210x_vid_pid_list) / sizeof(cp210x_vid_pid_list[0])
 };
 
 static bool cp210x_open(uint8_t daddr, tusb_desc_interface_t const *itf_desc, uint16_t max_len);
@@ -647,21 +647,17 @@ bool cdch_open(uint8_t rhport, uint8_t daddr, tusb_desc_interface_t const *itf_d
     TU_VERIFY(tuh_vid_pid_get(daddr, &vid, &pid));
 
     #if CFG_TUH_CDC_FTDI
-    if (TU_FTDI_VID == vid) {
-      for (size_t i = 0; i < FTDI_PID_COUNT; i++) {
-        if (ftdi_pids[i] == pid) {
-          return ftdi_open(daddr, itf_desc, max_len);
-        }
+    for (size_t i = 0; i < FTDI_PID_COUNT; i++) {
+      if (ftdi_vid_pid_list[i][0] == vid && ftdi_vid_pid_list[i][1] == pid) {
+        return ftdi_open(daddr, itf_desc, max_len);
       }
     }
     #endif
 
     #if CFG_TUH_CDC_CP210X
-    if (TU_CP210X_VID == vid) {
-      for (size_t i = 0; i < CP210X_PID_COUNT; i++) {
-        if (cp210x_pids[i] == pid) {
-          return cp210x_open(daddr, itf_desc, max_len);
-        }
+    for (size_t i = 0; i < CP210X_PID_COUNT; i++) {
+      if (cp210x_vid_pid_list[i][0] == vid && cp210x_vid_pid_list[i][1] == pid) {
+        return cp210x_open(daddr, itf_desc, max_len);
       }
     }
     #endif

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -453,10 +453,12 @@
   #define CFG_TUH_CDC_FTDI 0
 #endif
 
-#ifndef CFG_TUH_CDC_FTDI_PID_LIST
-  // List of product IDs that can use the FTDI CDC driver
-  #define CFG_TUH_CDC_FTDI_PID_LIST \
-    0x6001, 0x6006, 0x6010, 0x6011, 0x6014, 0x6015, 0x8372, 0xFBFA, 0xCD18
+#ifndef CFG_TUH_CDC_FTDI_VID_PID_LIST
+  // List of product IDs that can use the FTDI CDC driver. 0x0403 is FTDI's VID
+  #define CFG_TUH_CDC_FTDI_VID_PID_LIST \
+    {0x0403, 0x6001}, {0x0403, 0x6006}, {0x0403, 0x6010}, {0x0403, 0x6011}, \
+    {0x0403, 0x6014}, {0x0403, 0x6015}, {0x0403, 0x8372}, {0x0403, 0xFBFA}, \
+    {0x0403, 0xCD18}
 #endif
 
 #ifndef CFG_TUH_CDC_CP210X
@@ -464,10 +466,10 @@
   #define CFG_TUH_CDC_CP210X 0
 #endif
 
-#ifndef CFG_TUH_CDC_CP210X_PID_LIST
-  // List of product IDs that can use the CP210X CDC driver
-  #define CFG_TUH_CDC_CP210X_PID_LIST \
-    0xEA60, 0xEA70
+#ifndef CFG_TUH_CDC_CP210X_VID_PID_LIST
+  // List of product IDs that can use the CP210X CDC driver. 0x10C4 is Silicon Labs' VID
+  #define CFG_TUH_CDC_CP210X_VID_PID_LIST \
+    {0x10C4, 0xEA60}, {0x10C4, 0xEA70}
 #endif
 
 #ifndef CFG_TUH_HID


### PR DESCRIPTION
**Describe the PR**
FTDI support burning custom vid/pid for their chip, therefore it is possible to have different vid that needs to use ftdi driver. Same for cp210x 
- change CFG_TUH_CDC_FTDI/CP210X_PID_LIST to CFG_TUH_CDC_FTDI/CP210X_VD_PID_LIST which contains both vid and pid.
