### PR TITLE
msc_device: Fix check for including MSC lookup tables

### DIFF
--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -203,7 +203,7 @@ uint8_t rdwr10_validate_cmd(msc_cbw_t const* cbw)
 //--------------------------------------------------------------------+
 // Debug
 //--------------------------------------------------------------------+
-#if CFG_TUSB_DEBUG >= 2
+#if CFG_TUSB_DEBUG >= CFG_TUD_MSC_LOG_LEVEL
 
 TU_ATTR_UNUSED tu_static tu_lookup_entry_t const _msc_scsi_cmd_lookup[] =
 {


### PR DESCRIPTION
The `_msc_scsi_cmd_lookup` and `_msc_scsi_cmd_table` variables are needed when logging is enabled for the MSC device via `CFG_TUD_MSC_LOG_LEVEL`. Update the preprocessor check around them to use that definition when deciding whether to define those variables.

Closes #2419