### PR TITLE
Log outbound xfer bytes while in debug

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1232,6 +1232,11 @@ bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
   // TU_VERIFY(tud_ready());
 
   TU_LOG_USBD("  Queue EP %02X with %u bytes ...\r\n", ep_addr, total_bytes);
+#if CFG_TUD_LOG_LEVEL >= 3
+  if(tu_edpt_dir(ep_addr) == TUSB_DIR_IN) {
+    TU_LOG_MEM(CFG_TUD_LOG_LEVEL, buffer, total_bytes, 2);
+  }
+#endif
 
   // Attempt to transfer on a busy endpoint, sound like an race condition !
   TU_ASSERT(_usbd_dev.ep_status[epnum][dir].busy == 0);

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1233,7 +1233,7 @@ bool usbd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
 
   TU_LOG_USBD("  Queue EP %02X with %u bytes ...\r\n", ep_addr, total_bytes);
 #if CFG_TUD_LOG_LEVEL >= 3
-  if(tu_edpt_dir(ep_addr) == TUSB_DIR_IN) {
+  if(dir == TUSB_DIR_IN) {
     TU_LOG_MEM(CFG_TUD_LOG_LEVEL, buffer, total_bytes, 2);
   }
 #endif


### PR DESCRIPTION
**Describe the PR**
This simple PR logs outbound xfer bytes when log level is set to debug. It is useful to be able to dissect the full conversation and not only incoming packets.
While this may be too verbose, it is quite useful when things go south.

**Additional context**
This is really nice in combination with a simple USB dissector. I am currently using scapy to parse the logs. I may create a PR to scapy with the relevant USB layers and may post an example on how to use them in a future PR.
