### PR TITLE
Enhance UVC decriptors and example

### DIFF
--- a/examples/device/video_capture/src/usb_descriptors.c
+++ b/examples/device/video_capture/src/usb_descriptors.c
@@ -40,6 +40,26 @@
 #define USB_VID   0xCafe
 #define USB_BCD   0x0200
 
+// String Descriptor Index
+enum {
+  STRID_LANGID = 0,
+  STRID_MANUFACTURER,
+  STRID_PRODUCT,
+  STRID_SERIAL,
+  STRID_UVC_CONTROL,
+  STRID_UVC_STREAMING,
+};
+
+// array of pointer to string descriptors
+char const* string_desc_arr[] = {
+    (const char[]) {0x09, 0x04}, // 0: is supported language is English (0x0409)
+    "TinyUSB",                     // 1: Manufacturer
+    "TinyUSB Device",              // 2: Product
+    NULL,                          // 3: Serials will use unique ID if possible
+    "TinyUSB UVC Control",         // 4: UVC Interface
+    "TinyUSB UVC Streaming",       // 5: UVC Interface
+};
+
 //--------------------------------------------------------------------+
 // Device Descriptors
 //--------------------------------------------------------------------+
@@ -60,9 +80,9 @@ tusb_desc_device_t const desc_device = {
     .idProduct          = USB_PID,
     .bcdDevice          = 0x0100,
 
-    .iManufacturer      = 0x01,
-    .iProduct           = 0x02,
-    .iSerialNumber      = 0x03,
+    .iManufacturer      = STRID_MANUFACTURER,
+    .iProduct           = STRID_PRODUCT,
+    .iSerialNumber      = STRID_SERIAL,
 
     .bNumConfigurations = 0x01
 };
@@ -164,6 +184,193 @@ uint8_t const* tud_descriptor_other_speed_configuration_cb(uint8_t index) {
 }
 #endif // highspeed
 
+typedef struct TU_ATTR_PACKED {
+  tusb_desc_interface_t itf;
+  tusb_desc_video_control_header_1itf_t header;
+  tusb_desc_video_control_camera_terminal_t camera_terminal;
+  tusb_desc_video_control_output_terminal_t output_terminal;
+} uvc_control_desc_t;
+
+/* Windows support YUY2 and NV12
+ * https://docs.microsoft.com/en-us/windows-hardware/drivers/stream/usb-video-class-driver-overview */
+
+typedef struct TU_ATTR_PACKED {
+  tusb_desc_interface_t itf;
+  tusb_desc_video_streaming_input_header_1byte_t header;
+  tusb_desc_video_format_uncompressed_t format;
+  tusb_desc_video_frame_uncompressed_continuous_t frame;
+  tusb_desc_video_streaming_color_matching_t color;
+  tusb_desc_endpoint_t ep;
+} uvc_streaming_desc_t;
+
+typedef struct TU_ATTR_PACKED {
+  tusb_desc_configuration_t config;
+  tusb_desc_interface_assoc_t iad;
+  uvc_control_desc_t video_control;
+  uvc_streaming_desc_t video_streaming;
+} uvc_cfg_desc_t;
+
+const uvc_cfg_desc_t config_desc = {
+    .config = {
+        .bLength = sizeof(tusb_desc_configuration_t),
+        .bDescriptorType = TUSB_DESC_CONFIGURATION,
+
+        .wTotalLength = sizeof(uvc_cfg_desc_t),
+        .bNumInterfaces = ITF_NUM_TOTAL,
+        .bConfigurationValue = 1,
+        .iConfiguration = 0,
+        .bmAttributes = TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP,
+        .bMaxPower = 100 / 2
+    },
+    .iad = {
+        .bLength = sizeof(tusb_desc_interface_assoc_t),
+        .bDescriptorType = TUSB_DESC_INTERFACE_ASSOCIATION,
+
+        .bFirstInterface = ITF_NUM_VIDEO_CONTROL,
+        .bInterfaceCount = 2,
+        .bFunctionClass = TUSB_CLASS_VIDEO,
+        .bFunctionSubClass = VIDEO_SUBCLASS_INTERFACE_COLLECTION,
+        .bFunctionProtocol = VIDEO_ITF_PROTOCOL_UNDEFINED,
+        .iFunction = 0
+    },
+
+    .video_control = {
+        .itf = {
+            .bLength = sizeof(tusb_desc_interface_t),
+            .bDescriptorType = TUSB_DESC_INTERFACE,
+
+            .bInterfaceNumber = ITF_NUM_VIDEO_CONTROL,
+            .bAlternateSetting = 0,
+            .bNumEndpoints = 0,
+            .bInterfaceClass = TUSB_CLASS_VIDEO,
+            .bInterfaceSubClass = VIDEO_SUBCLASS_CONTROL,
+            .bInterfaceProtocol = VIDEO_ITF_PROTOCOL_15,
+            .iInterface = STRID_UVC_CONTROL
+        },
+        .header = {
+            .bLength = sizeof(tusb_desc_video_control_header_1itf_t),
+            .bDescriptorType = TUSB_DESC_CS_INTERFACE,
+            .bDescriptorSubType = VIDEO_CS_ITF_VC_HEADER,
+
+            .bcdUVC = VIDEO_BCD_1_50,
+            .wTotalLength = sizeof(uvc_control_desc_t) - sizeof(tusb_desc_interface_t), // CS VC descriptors only
+            .dwClockFrequency = UVC_CLOCK_FREQUENCY,
+            .bInCollection = 1,
+            .baInterfaceNr = { ITF_NUM_VIDEO_STREAMING }
+        },
+        .camera_terminal = {
+            .bLength = sizeof(tusb_desc_video_control_camera_terminal_t),
+            .bDescriptorType = TUSB_DESC_CS_INTERFACE,
+            .bDescriptorSubType = VIDEO_CS_ITF_VC_INPUT_TERMINAL,
+
+            .bTerminalID = UVC_ENTITY_CAP_INPUT_TERMINAL,
+            .wTerminalType = VIDEO_ITT_CAMERA,
+            .bAssocTerminal = 0,
+            .iTerminal = 0,
+            .wObjectiveFocalLengthMin = 0,
+            .wObjectiveFocalLengthMax = 0,
+            .wOcularFocalLength = 0,
+            .bControlSize = 3,
+            .bmControls = { 0, 0, 0 }
+        },
+        .output_terminal = {
+            .bLength = sizeof(tusb_desc_video_control_output_terminal_t),
+            .bDescriptorType = TUSB_DESC_CS_INTERFACE,
+            .bDescriptorSubType = VIDEO_CS_ITF_VC_OUTPUT_TERMINAL,
+
+            .bTerminalID = UVC_ENTITY_CAP_OUTPUT_TERMINAL,
+            .wTerminalType = VIDEO_TT_STREAMING,
+            .bAssocTerminal = 0,
+            .bSourceID = UVC_ENTITY_CAP_INPUT_TERMINAL,
+            .iTerminal = 0
+        }
+    },
+
+    .video_streaming = {
+        .itf = {
+            .bLength = sizeof(tusb_desc_interface_t),
+            .bDescriptorType = TUSB_DESC_INTERFACE,
+
+            .bInterfaceNumber = ITF_NUM_VIDEO_STREAMING,
+            .bAlternateSetting = 0,
+            .bNumEndpoints = 1,
+            .bInterfaceClass = TUSB_CLASS_VIDEO,
+            .bInterfaceSubClass = VIDEO_SUBCLASS_STREAMING,
+            .bInterfaceProtocol = VIDEO_ITF_PROTOCOL_15,
+            .iInterface = STRID_UVC_STREAMING
+        },
+        .header = {
+            .bLength = sizeof(tusb_desc_video_streaming_input_header_1byte_t),
+            .bDescriptorType = TUSB_DESC_CS_INTERFACE,
+            .bDescriptorSubType = VIDEO_CS_ITF_VS_INPUT_HEADER,
+
+            .bNumFormats = 1,
+            .wTotalLength = sizeof(uvc_streaming_desc_t) - sizeof(tusb_desc_interface_t) - sizeof(tusb_desc_endpoint_t), // CS VS descriptors only
+            .bEndpointAddress = EPNUM_VIDEO_IN,
+            .bmInfo = 0,
+            .bTerminalLink = UVC_ENTITY_CAP_OUTPUT_TERMINAL,
+            .bStillCaptureMethod = 0,
+            .bTriggerSupport = 0,
+            .bTriggerUsage = 0,
+            .bControlSize = 1,
+            .bmaControls = { 0 }
+        },
+        .format = {
+            .bLength = sizeof(tusb_desc_video_format_uncompressed_t),
+            .bDescriptorType = TUSB_DESC_CS_INTERFACE,
+            .bDescriptorSubType = VIDEO_CS_ITF_VS_FORMAT_UNCOMPRESSED,
+
+            .bFormatIndex = 1, // 1-based index
+            .bNumFrameDescriptors = 1,
+            .guidFormat = { TUD_VIDEO_GUID_YUY2 },
+            .bBitsPerPixel = 16,
+            .bDefaultFrameIndex = 1,
+            .bAspectRatioX = 0,
+            .bAspectRatioY = 0,
+            .bmInterlaceFlags = 0,
+            .bCopyProtect = 0
+        },
+        .frame = {
+            .bLength = sizeof(tusb_desc_video_frame_uncompressed_continuous_t),
+            .bDescriptorType = TUSB_DESC_CS_INTERFACE,
+            .bDescriptorSubType = VIDEO_CS_ITF_VS_FRAME_UNCOMPRESSED,
+
+            .bFrameIndex = 1, // 1-based index
+            .bmCapabilities = 0,
+            .wWidth = FRAME_WIDTH,
+            .wHeight = FRAME_HEIGHT,
+            .dwMinBitRate = FRAME_WIDTH * FRAME_HEIGHT * 16 * 1,
+            .dwMaxBitRate = FRAME_WIDTH * FRAME_HEIGHT * 16 * FRAME_RATE,
+            .dwMaxVideoFrameBufferSize = FRAME_WIDTH * FRAME_HEIGHT * 16 / 8,
+            .dwDefaultFrameInterval = 10000000 / FRAME_RATE,
+            .bFrameIntervalType = 0, // continuous
+            .dwFrameInterval = {
+                10000000 / FRAME_RATE, // min
+                10000000, // max
+                10000000 / FRAME_RATE // step
+            }
+        },
+        .color = {
+            .bLength = sizeof(tusb_desc_video_streaming_color_matching_t),
+            .bDescriptorType = TUSB_DESC_CS_INTERFACE,
+            .bDescriptorSubType = VIDEO_CS_ITF_VS_COLORFORMAT,
+
+            .bColorPrimaries = VIDEO_COLOR_PRIMARIES_BT709,
+            .bTransferCharacteristics = VIDEO_COLOR_XFER_CH_BT709,
+            .bMatrixCoefficients = VIDEO_COLOR_COEF_SMPTE170M
+        },
+        .ep = {
+            .bLength = sizeof(tusb_desc_endpoint_t),
+            .bDescriptorType = TUSB_DESC_ENDPOINT,
+
+            .bEndpointAddress = EPNUM_VIDEO_IN,
+            .bmAttributes = { .xfer = TUSB_XFER_BULK },
+            .wMaxPacketSize = CFG_TUD_VIDEO_STREAMING_BULK ? 64 : CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE,
+            .bInterval = 1
+        }
+    }
+};
+
 // Invoked when received GET CONFIGURATION DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
@@ -174,30 +381,14 @@ uint8_t const* tud_descriptor_configuration_cb(uint8_t index) {
   // Although we are highspeed, host may be fullspeed.
   return (tud_speed_get() == TUSB_SPEED_HIGH) ?  desc_hs_configuration : desc_fs_configuration;
 #else
-  return desc_fs_configuration;
+//  return desc_fs_configuration;
+  return (uint8_t const*) &config_desc;
 #endif
 }
 
 //--------------------------------------------------------------------+
 // String Descriptors
 //--------------------------------------------------------------------+
-
-// String Descriptor Index
-enum {
-  STRID_LANGID = 0,
-  STRID_MANUFACTURER,
-  STRID_PRODUCT,
-  STRID_SERIAL,
-};
-
-// array of pointer to string descriptors
-char const* string_desc_arr[] = {
-    (const char[]) {0x09, 0x04}, // 0: is supported language is English (0x0409)
-    "TinyUSB",                     // 1: Manufacturer
-    "TinyUSB Device",              // 2: Product
-    NULL,                          // 3: Serials will use unique ID if possible
-    "TinyUSB UVC",                 // 4: UVC Interface
-};
 
 static uint16_t _desc_str[32 + 1];
 

--- a/examples/device/video_capture/src/usb_descriptors.h
+++ b/examples/device/video_capture/src/usb_descriptors.h
@@ -210,7 +210,7 @@ enum {
         /* Video stream frame format */ \
         TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT(/*bFrameIndex */1, 0, _width, _height, \
             _width * _height * 16, _width * _height * 16 * _fps, \
-            _width * _height * 16, \
+            _width * _height * 16 / 8, \
             (10000000/_fps), (10000000/_fps), (10000000/_fps)*_fps, (10000000/_fps)), \
         TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING(VIDEO_COLOR_PRIMARIES_BT709, VIDEO_COLOR_XFER_CH_BT709, VIDEO_COLOR_COEF_SMPTE170M), \
         TUD_VIDEO_DESC_EP_BULK(_epin, _epsize, 1)
@@ -223,7 +223,7 @@ enum {
     TUD_VIDEO_DESC_CS_VC(0x0150, TUD_VIDEO_DESC_CAMERA_TERM_LEN + TUD_VIDEO_DESC_OUTPUT_TERM_LEN, UVC_CLOCK_FREQUENCY, ITF_NUM_VIDEO_STREAMING), \
       /* Camera Terminal: ID, bAssocTerminal, iTerminal, focal min, max, length, bmControl */ \
       TUD_VIDEO_DESC_CAMERA_TERM(UVC_ENTITY_CAP_INPUT_TERMINAL, 0, 0, 0, 0, 0, 0), \
-      TUD_VIDEO_DESC_OUTPUT_TERM(UVC_ENTITY_CAP_OUTPUT_TERMINAL, VIDEO_TT_STREAMING, 0, 1, 0), \
+      TUD_VIDEO_DESC_OUTPUT_TERM(UVC_ENTITY_CAP_OUTPUT_TERMINAL, VIDEO_TT_STREAMING, 0, UVC_ENTITY_CAP_INPUT_TERMINAL, 0), \
   /* Video stream alt. 0 */ \
   TUD_VIDEO_DESC_STD_VS(ITF_NUM_VIDEO_STREAMING, 0, 1, _stridx), \
     /* Video stream header for without still image capture */ \

--- a/examples/device/video_capture/src/usb_descriptors.h
+++ b/examples/device/video_capture/src/usb_descriptors.h
@@ -146,7 +146,7 @@ enum {
         /* Video stream frame format */ \
         TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT(/*bFrameIndex */1, 0, _width, _height, \
             _width * _height * 16, _width * _height * 16 * _fps, \
-            _width * _height * 16, \
+            _width * _height * 16 / 8, \
             (10000000/_fps), (10000000/_fps), (10000000/_fps)*_fps, (10000000/_fps)), \
         TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING(VIDEO_COLOR_PRIMARIES_BT709, VIDEO_COLOR_XFER_CH_BT709, VIDEO_COLOR_COEF_SMPTE170M), \
   /* VS alt 1 */\

--- a/src/class/video/video.h
+++ b/src/class/video/video.h
@@ -29,6 +29,10 @@
 
 #include "common/tusb_common.h"
 
+enum {
+  VIDEO_BCD_1_50 = 0x0150,
+};
+
 // Table 3-19 Color Matching Descriptor
 typedef enum {
   VIDEO_COLOR_PRIMARIES_UNDEFINED = 0x00,
@@ -198,55 +202,98 @@ typedef enum {
 } video_terminal_type_t;
 
 //--------------------------------------------------------------------+
-// Descriptors
+// Video Control (VC) Descriptors
 //--------------------------------------------------------------------+
 
 /* 2.3.4.2 */
+#define tusb_desc_video_control_header_nitf_t(_nitf) \
+  struct TU_ATTR_PACKED { \
+    uint8_t  bLength; \
+    uint8_t  bDescriptorType; \
+    uint8_t  bDescriptorSubType; \
+    uint16_t bcdUVC; \
+    uint16_t wTotalLength; \
+    uint32_t dwClockFrequency; /* deprecated */ \
+    uint8_t  bInCollection; \
+    uint8_t  baInterfaceNr[_nitf]; \
+  }
+
+typedef tusb_desc_video_control_header_nitf_t()  tusb_desc_video_control_header_t;
+typedef tusb_desc_video_control_header_nitf_t(1) tusb_desc_video_control_header_1itf_t;
+typedef tusb_desc_video_control_header_nitf_t(2) tusb_desc_video_control_header_2itf_t;
+typedef tusb_desc_video_control_header_nitf_t(3) tusb_desc_video_control_header_3itf_t;
+typedef tusb_desc_video_control_header_nitf_t(4) tusb_desc_video_control_header_4itf_t;
+
 typedef struct TU_ATTR_PACKED {
   uint8_t  bLength;
   uint8_t  bDescriptorType;
   uint8_t  bDescriptorSubType;
-  uint16_t bcdUVC;
-  uint16_t wTotalLength;
-  uint32_t dwClockFrequency;
-  uint8_t  bInCollection;
-  uint8_t  baInterfaceNr[];
-} tusb_desc_cs_video_ctl_itf_hdr_t;
+  uint8_t  bTerminalID;
+  uint16_t wTerminalType;
+  uint8_t  bAssocTerminal;
+  uint8_t  iTerminal;
+} tusb_desc_video_control_input_terminal_t;
 
-/* 2.4.3.3 */
+TU_VERIFY_STATIC(sizeof(tusb_desc_video_control_input_terminal_t) == 8, "size is not correct");
+
 typedef struct TU_ATTR_PACKED {
-  uint8_t bHeaderLength;
-  union {
-    uint8_t bmHeaderInfo;
-    struct {
-      uint8_t FrameID:              1;
-      uint8_t EndOfFrame:           1;
-      uint8_t PresentationTime:     1;
-      uint8_t SourceClockReference: 1;
-      uint8_t PayloadSpecific:      1;
-      uint8_t StillImage:           1;
-      uint8_t Error:                1;
-      uint8_t EndOfHeader:          1;
-    };
-  };
-} tusb_video_payload_header_t;
+  uint8_t  bLength;
+  uint8_t  bDescriptorType;
+  uint8_t  bDescriptorSubType;
+  uint8_t  bTerminalID;
+  uint16_t wTerminalType;
+  uint8_t  bAssocTerminal;
+  uint8_t  bSourceID;
+  uint8_t  iTerminal;
+} tusb_desc_video_control_output_terminal_t;
+
+TU_VERIFY_STATIC(sizeof(tusb_desc_video_control_output_terminal_t) == 9, "size is not correct");
+
+typedef struct TU_ATTR_PACKED {
+  uint8_t  bLength;
+  uint8_t  bDescriptorType;
+  uint8_t  bDescriptorSubType;
+  uint8_t  bTerminalID;
+  uint16_t wTerminalType;
+  uint8_t  bAssocTerminal;
+  uint8_t  iTerminal;
+
+  uint16_t wObjectiveFocalLengthMin;
+  uint16_t wObjectiveFocalLengthMax;
+  uint16_t wOcularFocalLength;
+  uint8_t  bControlSize;
+  uint8_t  bmControls[3];
+} tusb_desc_video_control_camera_terminal_t;
+
+TU_VERIFY_STATIC(sizeof(tusb_desc_video_control_camera_terminal_t) == 18, "size is not correct");
+
+//--------------------------------------------------------------------+
+// Video Streaming (VS) Descriptors
+//--------------------------------------------------------------------+
 
 /* 3.9.2.1 */
-typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;
-  uint8_t  bDescriptorType;
-  uint8_t  bDescriptorSubType;
-  uint8_t  bNumFormats;
-  uint16_t wTotalLength;
-  uint8_t  bEndpointAddress;
-  uint8_t  bmInfo;
-  uint8_t  bTerminalLink;
-  uint8_t  bStillCaptureMethod;
-  uint8_t  bTriggerSupport;
-  uint8_t  bTriggerUsage;
-  uint8_t  bControlSize;
-  uint8_t  bmaControls[];
-} tusb_desc_cs_video_stm_itf_in_hdr_t;
+#define tusb_desc_video_streaming_input_header_nbyte_t(_nb) \
+  struct TU_ATTR_PACKED { \
+    uint8_t  bLength; \
+    uint8_t  bDescriptorType; \
+    uint8_t  bDescriptorSubType; \
+    uint8_t  bNumFormats; /* Number of video payload Format descriptors for this interface */ \
+    uint16_t wTotalLength; \
+    uint8_t  bEndpointAddress; \
+    uint8_t  bmInfo; /* Bit 0: dynamic format change supported */ \
+    uint8_t  bTerminalLink; \
+    uint8_t  bStillCaptureMethod; \
+    uint8_t  bTriggerSupport; /* Hardware trigger supported */ \
+    uint8_t  bTriggerUsage; \
+    uint8_t  bControlSize; /* sizeof of each control item */ \
+    uint8_t  bmaControls[_nb]; \
+  }
+
+typedef tusb_desc_video_streaming_input_header_nbyte_t() tusb_desc_video_streaming_input_header_t;
+typedef tusb_desc_video_streaming_input_header_nbyte_t(1) tusb_desc_video_streaming_input_header_1byte_t;
+typedef tusb_desc_video_streaming_input_header_nbyte_t(2) tusb_desc_video_streaming_input_header_2byte_t;
+typedef tusb_desc_video_streaming_input_header_nbyte_t(3) tusb_desc_video_streaming_input_header_3byte_t;
+typedef tusb_desc_video_streaming_input_header_nbyte_t(4) tusb_desc_video_streaming_input_header_4byte_t;
 
 /* 3.9.2.2 */
 typedef struct TU_ATTR_PACKED {
@@ -259,7 +306,7 @@ typedef struct TU_ATTR_PACKED {
   uint8_t  bTerminalLink;
   uint8_t  bControlSize;
   uint8_t  bmaControls[];
-} tusb_desc_cs_video_stm_itf_out_hdr_t;
+} tusb_desc_video_streaming_output_header_t;
 
 typedef struct TU_ATTR_PACKED {
   uint8_t  bLength;
@@ -285,14 +332,33 @@ typedef struct TU_ATTR_PACKED {
       uint8_t  bmaControls[];
     } output;
   };
-} tusb_desc_cs_video_stm_itf_hdr_t;
+} tusb_desc_video_streaming_inout_header_t;
 
+// 3.9.2.6 Color Matching Descriptor
+typedef struct TU_ATTR_PACKED {
+  uint8_t  bLength;
+  uint8_t  bDescriptorType;
+  uint8_t  bDescriptorSubType;
+  uint8_t  bColorPrimaries;
+  uint8_t  bTransferCharacteristics;
+  uint8_t  bMatrixCoefficients;
+} tusb_desc_video_streaming_color_matching_t;
+
+TU_VERIFY_STATIC(sizeof(tusb_desc_video_streaming_color_matching_t) == 6, "size is not correct");
+
+//--------------------------------------------------------------------+
+// Format and Frame Descriptor
+// Note: bFormatIndex & bFrameIndex are 1-based index
+//--------------------------------------------------------------------+
+
+//------------- Uncompressed -------------//
+// Uncompressed payload specs: 3.1.1 format descriptor
 typedef struct TU_ATTR_PACKED {
   uint8_t bLength;
   uint8_t bDescriptorType;
   uint8_t bDescriptorSubType;
   uint8_t bFormatIndex;
-  uint8_t bNumFrameDescriptors;
+  uint8_t bNumFrameDescriptors; // Number of frame descriptors for this format
   uint8_t guidFormat[16];
   uint8_t bBitsPerPixel;
   uint8_t bDefaultFrameIndex;
@@ -300,8 +366,39 @@ typedef struct TU_ATTR_PACKED {
   uint8_t bAspectRatioY;
   uint8_t bmInterlaceFlags;
   uint8_t bCopyProtect;
-} tusb_desc_cs_video_fmt_uncompressed_t;
+} tusb_desc_video_format_uncompressed_t;
 
+// Uncompressed payload specs: 3.1.2 frame descriptor
+#define tusb_desc_video_frame_uncompressed_nint_t(_nint) \
+  struct TU_ATTR_PACKED { \
+    uint8_t  bLength; \
+    uint8_t  bDescriptorType; \
+    uint8_t  bDescriptorSubType; \
+    uint8_t  bFrameIndex; \
+    uint8_t  bmCapabilities; \
+    uint16_t wWidth; \
+    uint16_t wHeight; \
+    uint32_t dwMinBitRate; \
+    uint32_t dwMaxBitRate; \
+    uint32_t dwMaxVideoFrameBufferSize; /* deprecated in 1.5 */ \
+    uint32_t dwDefaultFrameInterval; \
+    uint8_t  bFrameIntervalType; \
+    uint32_t dwFrameInterval[_nint]; \
+  }
+
+typedef tusb_desc_video_frame_uncompressed_nint_t() tusb_desc_video_frame_uncompressed_t;
+typedef tusb_desc_video_frame_uncompressed_nint_t(1) tusb_desc_video_frame_uncompressed_1int_t;
+typedef tusb_desc_video_frame_uncompressed_nint_t(2) tusb_desc_video_frame_uncompressed_2int_t;
+typedef tusb_desc_video_frame_uncompressed_nint_t(3) tusb_desc_video_frame_uncompressed_3int_t;
+typedef tusb_desc_video_frame_uncompressed_nint_t(4) tusb_desc_video_frame_uncompressed_4int_t;
+
+// continuous = 3 intervals: min, max, step
+typedef tusb_desc_video_frame_uncompressed_3int_t tusb_desc_video_frame_uncompressed_continuous_t;
+
+TU_VERIFY_STATIC(sizeof(tusb_desc_video_frame_uncompressed_continuous_t) == 38, "size is not correct");
+
+//------------- MJPEG -------------//
+// MJPEG payload specs: 3.1.1 formatt descriptor
 typedef struct TU_ATTR_PACKED {
   uint8_t bLength;
   uint8_t bDescriptorType;
@@ -314,8 +411,12 @@ typedef struct TU_ATTR_PACKED {
   uint8_t bAspectRatioY;
   uint8_t bmInterlaceFlags;
   uint8_t bCopyProtect;
-} tusb_desc_cs_video_fmt_mjpeg_t;
+} tusb_desc_video_format_mjpeg_t;
 
+// MJPEG payload specs: 3.1.2 frame descriptor (same as uncompressed)
+typedef tusb_desc_video_frame_uncompressed_t tusb_desc_video_frame_mjpeg_t;
+
+// DV payload specs: 3.1.1
 typedef struct TU_ATTR_PACKED {
   uint8_t  bLength;
   uint8_t  bDescriptorType;
@@ -323,8 +424,9 @@ typedef struct TU_ATTR_PACKED {
   uint8_t  bFormatIndex;
   uint32_t dwMaxVideoFrameBufferSize; /* deprecated */
   uint8_t  bFormatType;
-} tusb_desc_cs_video_fmt_dv_t;
+} tusb_desc_video_format_dv_t;
 
+// Frame Based payload specs: 3.1.1
 typedef struct TU_ATTR_PACKED {
   uint8_t bLength;
   uint8_t bDescriptorType;
@@ -339,25 +441,7 @@ typedef struct TU_ATTR_PACKED {
   uint8_t bmInterlaceFlags;
   uint8_t bCopyProtect;
   uint8_t bVaribaleSize;
-} tusb_desc_cs_video_fmt_frame_based_t;
-
-typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;
-  uint8_t  bDescriptorType;
-  uint8_t  bDescriptorSubType;
-  uint8_t  bFrameIndex;
-  uint8_t  bmCapabilities;
-  uint16_t wWidth;
-  uint16_t wHeight;
-  uint32_t dwMinBitRate;
-  uint32_t dwMaxBitRate;
-  uint32_t dwMaxVideoFrameBufferSize; /* deprecated */
-  uint32_t dwDefaultFrameInterval;
-  uint8_t  bFrameIntervalType;
-  uint32_t dwFrameInterval[];
-} tusb_desc_cs_video_frm_uncompressed_t;
-
-typedef tusb_desc_cs_video_frm_uncompressed_t tusb_desc_cs_video_frm_mjpeg_t;
+} tusb_desc_video_format_framebased_t;
 
 typedef struct TU_ATTR_PACKED {
   uint8_t  bLength;
@@ -373,11 +457,29 @@ typedef struct TU_ATTR_PACKED {
   uint8_t  bFrameIntervalType;
   uint32_t dwBytesPerLine;
   uint32_t dwFrameInterval[];
-} tusb_desc_cs_video_frm_frame_based_t;
+} tusb_desc_video_frame_framebased_t;
 
 //--------------------------------------------------------------------+
 // Requests
 //--------------------------------------------------------------------+
+
+/* 2.4.3.3 */
+typedef struct TU_ATTR_PACKED {
+  uint8_t bHeaderLength;
+  union {
+    uint8_t bmHeaderInfo;
+    struct {
+      uint8_t FrameID:              1;
+      uint8_t EndOfFrame:           1;
+      uint8_t PresentationTime:     1;
+      uint8_t SourceClockReference: 1;
+      uint8_t PayloadSpecific:      1;
+      uint8_t StillImage:           1;
+      uint8_t Error:                1;
+      uint8_t EndOfHeader:          1;
+    };
+  };
+} tusb_video_payload_header_t;
 
 /* 4.3.1.1 */
 typedef struct TU_ATTR_PACKED {

--- a/src/class/video/video.h
+++ b/src/class/video/video.h
@@ -405,7 +405,7 @@ typedef struct TU_ATTR_PACKED {
   uint8_t bDescriptorSubType;
   uint8_t bFormatIndex;
   uint8_t bNumFrameDescriptors;
-  uint8_t bmFlags;
+  uint8_t bmFlags; // Bit 0: fixed size samples (1 = yes)
   uint8_t bDefaultFrameIndex;
   uint8_t bAspectRatioX;
   uint8_t bAspectRatioY;
@@ -415,7 +415,15 @@ typedef struct TU_ATTR_PACKED {
 
 // MJPEG payload specs: 3.1.2 frame descriptor (same as uncompressed)
 typedef tusb_desc_video_frame_uncompressed_t tusb_desc_video_frame_mjpeg_t;
+typedef tusb_desc_video_frame_uncompressed_1int_t tusb_desc_video_frame_mjpeg_1int_t;
+typedef tusb_desc_video_frame_uncompressed_2int_t tusb_desc_video_frame_mjpeg_2int_t;
+typedef tusb_desc_video_frame_uncompressed_3int_t tusb_desc_video_frame_mjpeg_3int_t;
+typedef tusb_desc_video_frame_uncompressed_4int_t tusb_desc_video_frame_mjpeg_4int_t;
 
+// continuous = 3 intervals: min, max, step
+typedef tusb_desc_video_frame_mjpeg_3int_t tusb_desc_video_frame_mjpeg_continuous_t;
+
+//------------- DV -------------//
 // DV payload specs: 3.1.1
 typedef struct TU_ATTR_PACKED {
   uint8_t  bLength;

--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -50,17 +50,17 @@
 
 typedef struct {
   tusb_desc_interface_t            std;
-  tusb_desc_cs_video_ctl_itf_hdr_t ctl;
+  tusb_desc_video_control_header_t ctl;
 } tusb_desc_vc_itf_t;
 
 typedef struct {
   tusb_desc_interface_t            std;
-  tusb_desc_cs_video_stm_itf_hdr_t stm;
+  tusb_desc_video_streaming_inout_header_t stm;
 } tusb_desc_vs_itf_t;
 
 typedef union {
-  tusb_desc_cs_video_ctl_itf_hdr_t ctl;
-  tusb_desc_cs_video_stm_itf_hdr_t stm;
+  tusb_desc_video_control_header_t ctl;
+  tusb_desc_video_streaming_inout_header_t stm;
 } tusb_desc_video_itf_hdr_t;
 
 typedef struct TU_ATTR_PACKED {
@@ -78,9 +78,9 @@ typedef union {
     uint8_t bFormatIndex;
     uint8_t bNumFrameDescriptors;
   };
-  tusb_desc_cs_video_fmt_uncompressed_t uncompressed;
-  tusb_desc_cs_video_fmt_mjpeg_t        mjpeg;
-  tusb_desc_cs_video_fmt_frame_based_t  frame_based;
+  tusb_desc_video_format_uncompressed_t uncompressed;
+  tusb_desc_video_format_mjpeg_t        mjpeg;
+  tusb_desc_video_format_framebased_t  frame_based;
 } tusb_desc_cs_video_fmt_t;
 
 typedef union {
@@ -93,9 +93,9 @@ typedef union {
     uint16_t wWidth;
     uint16_t wHeight;
   };
-  tusb_desc_cs_video_frm_uncompressed_t uncompressed;
-  tusb_desc_cs_video_frm_mjpeg_t        mjpeg;
-  tusb_desc_cs_video_frm_frame_based_t  frame_based;
+  tusb_desc_video_frame_uncompressed_t uncompressed;
+  tusb_desc_video_frame_mjpeg_t        mjpeg;
+  tusb_desc_video_frame_framebased_t  frame_based;
 } tusb_desc_cs_video_frm_t;
 
 /* video streaming interface */

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -399,6 +399,8 @@ typedef struct TU_ATTR_PACKED {
   uint8_t iFunction         ; ///< Index of the string descriptor describing the interface association.
 } tusb_desc_interface_assoc_t;
 
+TU_VERIFY_STATIC( sizeof(tusb_desc_interface_assoc_t) == 8, "size is not correct");
+
 // USB String Descriptor
 typedef struct TU_ATTR_PACKED {
   uint8_t  bLength         ; ///< Size of this descriptor in bytes
@@ -468,7 +470,6 @@ typedef struct TU_ATTR_PACKED {
 } tusb_control_request_t;
 
 TU_VERIFY_STATIC( sizeof(tusb_control_request_t) == 8, "size is not correct");
-
 
 TU_ATTR_PACKED_END  // End of all packed definitions
 TU_ATTR_BIT_FIELD_ORDER_END


### PR DESCRIPTION
**Describe the PR**
UVC (as well as UAC) has a sophisticated configuration descriptor depending on user application, which make defining template macros rather difficult. I have update video_capture example to use custom struct to define uvc configuration descriptor. In my opinion, it make thing a bit clearer and easier to customize and troubleshoot descriptor typo/errors. 

I also rename some of the video descritpor add several variant of struct/typedef with different number of trailing object. Since C only allow flexible array as the last member of a struct (custom configuration requires as few instance of these struct). There is still more update but @kkitayam please review and let me know what do you think 

```C
#define tusb_desc_video_control_header_nitf_t(_nitf) \
  struct TU_ATTR_PACKED { \
    uint8_t  bLength; \
    uint8_t  bDescriptorType; \
    uint8_t  bDescriptorSubType; \
    uint16_t bcdUVC; \
    uint16_t wTotalLength; \
    uint32_t dwClockFrequency; /* deprecated */ \
    uint8_t  bInCollection; \
    uint8_t  baInterfaceNr[_nitf]; \
  }

typedef tusb_desc_video_control_header_nitf_t()  tusb_desc_video_control_header_t;
typedef tusb_desc_video_control_header_nitf_t(1) tusb_desc_video_control_header_1itf_t;
typedef tusb_desc_video_control_header_nitf_t(2) tusb_desc_video_control_header_2itf_t;
typedef tusb_desc_video_control_header_nitf_t(3) tusb_desc_video_control_header_3itf_t;
typedef tusb_desc_video_control_header_nitf_t(4) tusb_desc_video_control_header_4itf_t;
```