### PR TITLE
CDCh ACM fixes and small changes

### DIFF
--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -102,7 +102,7 @@
 #define CFG_TUH_ENUMERATION_BUFSIZE 256
 
 #define CFG_TUH_HUB                 1 // number of supported hubs
-#define CFG_TUH_CDC                 1 // CDC ACM
+#define CFG_TUH_CDC                 1 // number of supported CDC devices. also activates CDC ACM
 #define CFG_TUH_CDC_FTDI            1 // FTDI Serial.  FTDI is not part of CDC class, only to re-use CDC driver API
 #define CFG_TUH_CDC_CP210X          1 // CP210x Serial. CP210X is not part of CDC class, only to re-use CDC driver API
 #define CFG_TUH_CDC_CH34X           1 // CH340 or CH341 Serial. CH34X is not part of CDC class, only to re-use CDC driver API

--- a/examples/host/cdc_msc_hid_freertos/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid_freertos/src/tusb_config.h
@@ -107,7 +107,7 @@
 #define CFG_TUH_ENUMERATION_BUFSIZE 256
 
 #define CFG_TUH_HUB                 1 // number of supported hubs
-#define CFG_TUH_CDC                 1 // CDC ACM
+#define CFG_TUH_CDC                 1 // number of supported CDC devices. also activates CDC ACM
 #define CFG_TUH_CDC_FTDI            1 // FTDI Serial.  FTDI is not part of CDC class, only to re-use CDC driver API
 #define CFG_TUH_CDC_CP210X          1 // CP210x Serial. CP210X is not part of CDC class, only to re-use CDC driver API
 #define CFG_TUH_CDC_CH34X           1 // CH340 or CH341 Serial. CH34X is not part of CDC class, only to re-use CDC driver API


### PR DESCRIPTION
- added check of `xfer->result` in `acm_process_config()`
- missing `TU_VERIFY(p_cdc->acm_capability.support_line_request);` in `acm_set_data_format()` => moved it to common `acm_set_line_coding()`
- added missing check of data bit quantity in `acm_set_line_coding()`
- better explanation of `CFG_TUH_CDC` in misc. example `tusb_config.h`
- TU_LOGs cleaned and harmonized with other drivers