### PR TITLE
removed redundant result handling in CDCh Control Endpoint API

### DIFF
--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -531,15 +531,8 @@ bool tuh_cdc_set_control_line_state(uint8_t idx, uint16_t line_state, tuh_xfer_c
     return driver->set_control_line_state(p_cdc, line_state, complete_cb, user_data);
   } else {
     // blocking
-    xfer_result_t result = XFER_RESULT_INVALID;
-    bool ret = driver->set_control_line_state(p_cdc, line_state, complete_cb, (uintptr_t) &result);
-
-    if (user_data) {
-      // user_data is not NULL, return result via user_data
-      *((xfer_result_t*) user_data) = result;
-    }
-
-    TU_VERIFY(ret && result == XFER_RESULT_SUCCESS);
+    TU_VERIFY(driver->set_control_line_state(p_cdc, line_state, NULL, user_data));
+    TU_VERIFY(*((xfer_result_t*) user_data) == XFER_RESULT_SUCCESS);
     p_cdc->line_state = (uint8_t) line_state;
     return true;
   }
@@ -554,15 +547,8 @@ bool tuh_cdc_set_baudrate(uint8_t idx, uint32_t baudrate, tuh_xfer_cb_t complete
     return driver->set_baudrate(p_cdc, baudrate, complete_cb, user_data);
   } else {
     // blocking
-    xfer_result_t result = XFER_RESULT_INVALID;
-    bool ret = driver->set_baudrate(p_cdc, baudrate, complete_cb, (uintptr_t) &result);
-
-    if (user_data) {
-      // user_data is not NULL, return result via user_data
-      *((xfer_result_t*) user_data) = result;
-    }
-
-    TU_VERIFY(ret && result == XFER_RESULT_SUCCESS);
+    TU_VERIFY(driver->set_baudrate(p_cdc, baudrate, NULL, user_data));
+    TU_VERIFY(*((xfer_result_t*) user_data) == XFER_RESULT_SUCCESS);
     p_cdc->line_coding.bit_rate = baudrate;
     return true;
   }
@@ -578,15 +564,8 @@ bool tuh_cdc_set_data_format(uint8_t idx, uint8_t stop_bits, uint8_t parity, uin
     return driver->set_data_format(p_cdc, stop_bits, parity, data_bits, complete_cb, user_data);
   } else {
     // blocking
-    xfer_result_t result = XFER_RESULT_INVALID;
-    bool ret = driver->set_data_format(p_cdc, stop_bits, parity, data_bits, complete_cb, (uintptr_t) &result);
-
-    if (user_data) {
-      // user_data is not NULL, return result via user_data
-      *((xfer_result_t*) user_data) = result;
-    }
-
-    TU_VERIFY(ret && result == XFER_RESULT_SUCCESS);
+    TU_VERIFY(driver->set_data_format(p_cdc, stop_bits, parity, data_bits, NULL, user_data));
+    TU_VERIFY(*((xfer_result_t*) user_data) == XFER_RESULT_SUCCESS);
     p_cdc->line_coding.stop_bits = stop_bits;
     p_cdc->line_coding.parity = parity;
     p_cdc->line_coding.data_bits = data_bits;
@@ -603,15 +582,8 @@ bool tuh_cdc_set_line_coding(uint8_t idx, cdc_line_coding_t const* line_coding, 
     return driver->set_line_coding(p_cdc, line_coding, complete_cb, user_data);
   } else {
     // blocking
-    xfer_result_t result = XFER_RESULT_INVALID;
-    bool ret = driver->set_line_coding(p_cdc, line_coding, complete_cb, (uintptr_t) &result);
-
-    if (user_data) {
-      // user_data is not NULL, return result via user_data
-      *((xfer_result_t*) user_data) = result;
-    }
-
-    TU_VERIFY(ret && result == XFER_RESULT_SUCCESS);
+    TU_VERIFY(driver->set_line_coding(p_cdc, line_coding, NULL, user_data));
+    TU_VERIFY(*((xfer_result_t*) user_data) == XFER_RESULT_SUCCESS);
     p_cdc->line_coding = *line_coding;
     return true;
   }


### PR DESCRIPTION
it's already done in tuh_control_xfer()