### PR TITLE
nrf5x: Handle ISOOUT CRC errors

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -653,7 +653,11 @@ void dcd_int_handler(uint8_t rhport)
     if (NRF_USBD->EPOUTEN & USBD_EPOUTEN_ISOOUT_Msk)
     {
       iso_enabled = true;
-      xact_out_dma(EP_ISO_NUM);
+      // Transfer from endpoint to RAM only if data is not corrupted
+      if ((int_status & USBD_INTEN_USBEVENT_Msk) == 0 ||
+          (NRF_USBD->EVENTCAUSE & USBD_EVENTCAUSE_ISOOUTCRC_Msk) == 0) {
+        xact_out_dma(EP_ISO_NUM);
+      }
     }
 
     // ISOIN: Notify client that data was transferred
@@ -683,7 +687,7 @@ void dcd_int_handler(uint8_t rhport)
   {
     TU_LOG(2, "EVENTCAUSE = 0x%04lX\r\n", NRF_USBD->EVENTCAUSE);
 
-    enum { EVT_CAUSE_MASK = USBD_EVENTCAUSE_SUSPEND_Msk | USBD_EVENTCAUSE_RESUME_Msk | USBD_EVENTCAUSE_USBWUALLOWED_Msk };
+    enum { EVT_CAUSE_MASK = USBD_EVENTCAUSE_SUSPEND_Msk | USBD_EVENTCAUSE_RESUME_Msk | USBD_EVENTCAUSE_USBWUALLOWED_Msk | USBD_EVENTCAUSE_ISOOUTCRC_Msk };
     uint32_t const evt_cause = NRF_USBD->EVENTCAUSE & EVT_CAUSE_MASK;
     NRF_USBD->EVENTCAUSE = evt_cause; // clear interrupt
 


### PR DESCRIPTION
**Describe the PR**
NRF5x USB controller can detect ISO OUT CRC errors. In such case USBEVENT is signaled with EVENTCAUSE_ISOOUTCRC set. Even if controller detects corrupted ISO OUT packet it allows to data transfer from endpoint to RAM however packet is corrupted and code could just as well drop packet altogether.

With current implementation incoming ISO OUT packets were put in FIFO and exact information how much data already in FIFO is correct was hard to keep track of.
If was observed that on certain configurations HS hub when FS device was connected occasionally sent invalid (short) packet. In such case if packet length was reported odd audio stream was not recognizable any more.

With this change corrupted packets are not passed to upper layers and are silently dropped.

**Additional context**
Change touches only ISO OUT related code path.

This was observed on NRF5340 that was connected to Windows 11 PC with docking station and DELL monitor hub
![image](https://github.com/hathach/tinyusb/assets/23063648/41f8648e-bf74-42f5-89ae-6cb3f03c3b1d)

In this setup there were several level of HUB's involved (presumable Super Speed).
Invalid packet (167 bytes) was received and detected by USB following packet (22 bytes) was not reported.

It may be that this happens for for packets of 192 Bytes (48kHz PCM audio).
Previously when audio was 32kHz similar situation was not observed.