### PR TITLE
Add critsec to rp2040 xfer, check endpoint status

### DIFF
--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -106,6 +106,7 @@ static void hw_endpoint_init(hw_endpoint_t *ep, uint8_t ep_addr, uint16_t wMaxPa
     hard_assert(hw_buffer_ptr < usb_dpram->epx_data + sizeof(usb_dpram->epx_data));
     pico_info("  Allocated %d bytes (0x%p)\r\n", size, ep->hw_data_buf);
   }
+  ep->configured = true;
 }
 
 static void hw_endpoint_enable(hw_endpoint_t *ep, uint8_t transfer_type) {

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -229,6 +229,12 @@ void __tusb_irq_path_func(hw_endpoint_start_next_buffer)(struct hw_endpoint* ep)
 void hw_endpoint_xfer_start(struct hw_endpoint *ep, uint8_t *buffer, tu_fifo_t *ff, uint16_t total_len) {
   hw_endpoint_lock_update(ep, 1);
 
+  // We need to make sure the ep didn't get cleared from under us by an IRQ
+  if (!ep->configured) {
+    hw_endpoint_lock_update(ep, -1);
+    return;
+  }
+
   if (ep->active) {
     // TODO: Is this acceptable for interrupt packets?
     TU_LOG(1, "WARN: starting new transfer on already active ep %02X\r\n", ep->ep_addr);


### PR DESCRIPTION
**Describe the PR**
`hw_endpoint_lock_update` is unimplemented for the rp2040 port. This PR takes a stab at implementing it. Without it, if the USB port is disconnected, say with `tud_disconnect`, a race condition can happen where a transfer is in progress and the USB IRQ can fire, calling `reset_non_control_endpoints` and leaving the ongoing transfer in a bad state, as it tries to access endpoint data structures that are now zero'd.

While debugging that main issue, I also found some cases of the rp2040 port assuming that an endpoint data structure exists for all endpoints, which is not the case as endpoint 0 has none. I've also included a few simple fixes for these.

**Additional context**
I've documented a lot of my debugging attempts in this discussion: https://github.com/hathach/tinyusb/discussions/1764

I'm not super familiar with the tinyusb coding style, and I'm not sure my lock implementation is right (very naive, likely bad reference counting, might need atomic_int instead of int?).