### PR TITLE
video_device: fix uninitialized variable warning

### DIFF
--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -559,6 +559,7 @@ static bool _negotiate_streaming_parameters(videod_streaming_interface_t const *
           uint_fast8_t num_intervals = frm->uncompressed.bFrameIntervalType;
           if (num_intervals) {
             interval = 0;
+            interval_ms = 0;
           } else {
             interval = frm->uncompressed.dwFrameInterval[2];
             interval_ms = interval / 10000;


### PR DESCRIPTION
**Describe the PR**
Fixes `may be used uninitialized` compiler warning for variable `interval_ms` when building at optimization level `-Og`. Compiler is `GCC 13.2`.

**Additional context**
```
../../lib/tinyusb/src/class/video/video_device.c: In function '_negotiate_streaming_parameters':
../../lib/tinyusb/src/class/video/video_device.c:578:36: error: 'interval_ms' may be used uninitialized [-Werror=maybe-uninitialized]
  578 |         payload_size = (frame_size + interval_ms - 1) / interval_ms + 2;
      |                         ~~~~~~~~~~~^~~~~~~~~~~~~
../../lib/tinyusb/src/class/video/video_device.c:530:29: note: 'interval_ms' was declared here
  530 |     uint_fast32_t interval, interval_ms;
      |                             ^~~~~~~~~~~
```
