### PR TITLE
fix crytsal-less access on unsupported kinetis mcu

### DIFF
--- a/src/portable/chipidea/ci_fs/dcd_ci_fs.c
+++ b/src/portable/chipidea/ci_fs/dcd_ci_fs.c
@@ -271,16 +271,20 @@ void dcd_init(uint8_t rhport)
 {
   (void) rhport;
 
-  // save crystal-less setting (recovery clock)
+  // save crystal-less setting (if available)
+  #if defined(FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED) && FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED == 1
   uint32_t clk_recover_irc_en = CI_REG->CLK_RECOVER_IRC_EN;
-  uint32_t clk_recover_ctrl = CI_REG->CLK_RECOVER_CTRL;;
+  uint32_t clk_recover_ctrl = CI_REG->CLK_RECOVER_CTRL;
+  #endif
 
   CI_REG->USBTRC0 |= USB_USBTRC0_USBRESET_MASK;
   while (CI_REG->USBTRC0 & USB_USBTRC0_USBRESET_MASK);
 
-  // restore crystal-less setting
+  // restore crystal-less setting (if available)
+  #if defined(FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED) && FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED == 1
   CI_REG->CLK_RECOVER_IRC_EN = clk_recover_irc_en;
   CI_REG->CLK_RECOVER_CTRL  |= clk_recover_ctrl;
+  #endif
 
   tu_memclr(&_dcd, sizeof(_dcd));
   CI_REG->USBTRC0 |= TU_BIT(6); /* software must set this bit to 1 */

--- a/src/portable/nxp/khci/dcd_khci.c
+++ b/src/portable/nxp/khci/dcd_khci.c
@@ -269,8 +269,8 @@ void dcd_init(uint8_t rhport)
 {
   (void) rhport;
 
-  // save crystal-less setting (recovery clock)
-  #ifdef USB_CLK_RECOVER_IRC_EN_IRC_EN
+  // save crystal-less setting (if available)
+  #if defined(FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED) && FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED == 1
   uint32_t clk_recover_irc_en = KHCI->CLK_RECOVER_IRC_EN;
   uint32_t clk_recover_ctrl = KHCI->CLK_RECOVER_CTRL;
   #endif
@@ -278,8 +278,8 @@ void dcd_init(uint8_t rhport)
   KHCI->USBTRC0 |= USB_USBTRC0_USBRESET_MASK;
   while (KHCI->USBTRC0 & USB_USBTRC0_USBRESET_MASK);
 
-  // restore crystal-less setting
-  #ifdef USB_CLK_RECOVER_IRC_EN_IRC_EN
+  // restore crystal-less setting (if available)
+  #if defined(FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED) && FSL_FEATURE_USB_KHCI_IRC48M_MODULE_CLOCK_ENABLED == 1
   KHCI->CLK_RECOVER_IRC_EN = clk_recover_irc_en;
   KHCI->CLK_RECOVER_CTRL  |= clk_recover_ctrl;
   #endif


### PR DESCRIPTION
**Describe the PR**
only save/restore CLK_RECOVER_IRC_EN/CTRL if FSL_FEATURE_USB_KHCI_IRC…48M_MODULE_CLOCK_ENABLED is defined to 1
