### PR TITLE
fixed compiler warning src/tusb.c

### DIFF
--- a/src/tusb.c
+++ b/src/tusb.c
@@ -477,7 +477,7 @@ void tu_print_mem(void const *buf, uint32_t count, uint8_t indent)
   uint8_t const *buf8 = (uint8_t const *) buf;
 
   char format[] = "%00X";
-  format[2] += 2*size;
+  format[2] += (uint8_t) (2*size); // 1 byte = 2 hex digits
 
   const uint8_t item_per_line  = 16 / size;
 


### PR DESCRIPTION
```
../tinyusb/src/tusb.c: In function 'tu_print_mem':
../tinyusb/src/tusb.c:480:16: warning: conversion from 'int' to 'char' may change value [-Wconversion]
  480 |   format[2] += 2*size;
      |                ^
```