### PR TITLE
sparkfun_samd21_mini_usb board support

### DIFF
--- a/hw/bsp/samd21/boards/sparkfun_samd21_mini_usb/board.cmake
+++ b/hw/bsp/samd21/boards/sparkfun_samd21_mini_usb/board.cmake
@@ -1,0 +1,9 @@
+set(JLINK_DEVICE ATSAMD21G18)
+set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/${BOARD}.ld)
+
+function(update_board TARGET)
+  target_compile_definitions(${TARGET} PUBLIC
+    __SAMD21G18A__
+    CFG_EXAMPLE_VIDEO_READONLY
+    )
+endfunction()

--- a/hw/bsp/samd21/boards/sparkfun_samd21_mini_usb/board.h
+++ b/hw/bsp/samd21/boards/sparkfun_samd21_mini_usb/board.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2021 Jean Gressmann <jean@0x42.de>
+ * Copyright (c) 2020, Ha Thach (tinyusb.org)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,15 +21,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
+ * This file is part of the TinyUSB stack.
  */
 
-#pragma once
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 // LED
-#define LED_PIN               10 // PA10
+#define LED_PIN               /*PA*/17 /*(D13)*/
 #define LED_STATE_ON          1
+
+// Button
+#define BUTTON_PIN            /*PA*/14 /*(D2)*/
+#define BUTTON_STATE_ACTIVE   0
 
 // UART
 #define UART_SERCOM           0
-#define UART_RX_PIN           7
-#define UART_TX_PIN           6
+#define UART_RX_PIN           /*PA*/11 /*(D0)*/
+#define UART_TX_PIN           /*PA*/10 /*(D1)*/
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* BOARD_H_ */

--- a/hw/bsp/samd21/boards/sparkfun_samd21_mini_usb/board.mk
+++ b/hw/bsp/samd21/boards/sparkfun_samd21_mini_usb/board.mk
@@ -1,0 +1,9 @@
+CFLAGS += -D__SAMD21G18A__ -DCFG_EXAMPLE_VIDEO_READONLY
+
+# All source paths should be relative to the top level.
+LD_FILE = $(BOARD_PATH)/$(BOARD).ld
+
+# For flash-jlink target
+JLINK_DEVICE = ATSAMD21G18
+
+flash: flash-bossac

--- a/hw/bsp/samd21/boards/sparkfun_samd21_mini_usb/sparkfun_samd21_mini_usb.ld
+++ b/hw/bsp/samd21/boards/sparkfun_samd21_mini_usb/sparkfun_samd21_mini_usb.ld
@@ -1,0 +1,146 @@
+/**
+ * \file
+ *
+ * \brief Linker script for running in internal FLASH on the SAMD21G18A
+ *
+ * Copyright (c) 2017 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+  rom      (rx)  : ORIGIN = 0x00000000 + 8K, LENGTH = 0x00040000 - 8K
+  ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000-0x0004 /* 4 bytes used by bootloader to keep data between resets */
+}
+
+/* The stack size used by the application. NOTE: you need to adjust according to your application. */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : DEFINED(__stack_size__) ? __stack_size__ : 0x2000;
+
+ENTRY(Reset_Handler)
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > rom
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+        end = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    . = ALIGN(4);
+    _end = . ;
+}

--- a/hw/bsp/samd21/family.c
+++ b/hw/bsp/samd21/family.c
@@ -172,8 +172,21 @@ uint32_t board_button_read(void) {
 static void uart_init(void)
 {
 #if UART_SERCOM == 0
-  gpio_set_pin_function(PIN_PA06, PINMUX_PA06D_SERCOM0_PAD2);
-  gpio_set_pin_function(PIN_PA07, PINMUX_PA07D_SERCOM0_PAD3);
+  #if UART_TX_PIN == 6
+    gpio_set_pin_function(PIN_PA06, PINMUX_PA06D_SERCOM0_PAD2);
+  #elif UART_TX_PIN == 10
+    gpio_set_pin_function(PIN_PA10, PINMUX_PA10C_SERCOM0_PAD2);
+  #else
+    #error "UART_TX_PIN not supported"
+  #endif
+
+  #if UART_RX_PIN == 7
+    gpio_set_pin_function(PIN_PA07, PINMUX_PA07D_SERCOM0_PAD3);
+  #elif UART_RX_PIN == 11
+    gpio_set_pin_function(PIN_PA11, PINMUX_PA11C_SERCOM0_PAD3);
+  #else
+    #error "UART_RX_PIN not supported"
+#endif
 
   // setup clock (48MHz)
   _pm_enable_bus_clock(PM_BUS_APBC, SERCOM0);
@@ -194,6 +207,7 @@ static void uart_init(void)
     SERCOM_USART_CTRLB_TXEN | /* tx enabled */
     SERCOM_USART_CTRLB_RXEN;  /* rx enabled */
 
+  /* 115200 */
   SERCOM0->USART.BAUD.reg = SERCOM_USART_BAUD_FRAC_FP(0) | SERCOM_USART_BAUD_FRAC_BAUD(26);
 
   SERCOM0->USART.CTRLA.bit.ENABLE = 1; /* activate SERCOM */


### PR DESCRIPTION
Adds support for the [SparkFun SAMD21 Mini Breakout](https://www.sparkfun.com/products/13664)

It has different TX/RX pins for serial, so I had to do some preprocessor shenanigans in `family.c`.
Let me know if there's a better way to do this and I will change it - I'm quite new to TinyUSB.