### PR TITLE
[host] abort all pending transfer when SET_CONFIGURATION is complete

### DIFF
--- a/examples/host/bare_api/src/tusb_config.h
+++ b/examples/host/bare_api/src/tusb_config.h
@@ -71,7 +71,7 @@
 
 #if CFG_TUSB_MCU == OPT_MCU_RP2040
   // #define CFG_TUH_RPI_PIO_USB   1 // use pio-usb as host controller
-  // #define CFG_TUH_RPI_PIO_USB   1 // use max3421 as host controller
+  // #define CFG_TUH_MAX3421       1 // use max3421 as host controller
 
   // host roothub port is 1 if using either pio-usb or max3421
   #if (defined(CFG_TUH_RPI_PIO_USB) && CFG_TUH_RPI_PIO_USB) || (defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421)

--- a/examples/host/cdc_msc_hid/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid/src/tusb_config.h
@@ -71,7 +71,7 @@
 
 #if CFG_TUSB_MCU == OPT_MCU_RP2040
   // #define CFG_TUH_RPI_PIO_USB   1 // use pio-usb as host controller
-  // #define CFG_TUH_RPI_PIO_USB   1 // use max3421 as host controller
+  // #define CFG_TUH_MAX3421       1 // use max3421 as host controller
 
   // host roothub port is 1 if using either pio-usb or max3421
   #if (defined(CFG_TUH_RPI_PIO_USB) && CFG_TUH_RPI_PIO_USB) || (defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421)

--- a/examples/host/cdc_msc_hid_freertos/src/tusb_config.h
+++ b/examples/host/cdc_msc_hid_freertos/src/tusb_config.h
@@ -76,7 +76,7 @@
 
 #if CFG_TUSB_MCU == OPT_MCU_RP2040
   // #define CFG_TUH_RPI_PIO_USB   1 // use pio-usb as host controller
-  // #define CFG_TUH_RPI_PIO_USB   1 // use max3421 as host controller
+  // #define CFG_TUH_MAX3421       1 // use max3421 as host controller
 
   // host roothub port is 1 if using either pio-usb or max3421
   #if (defined(CFG_TUH_RPI_PIO_USB) && CFG_TUH_RPI_PIO_USB) || (defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421)

--- a/examples/host/hid_controller/src/tusb_config.h
+++ b/examples/host/hid_controller/src/tusb_config.h
@@ -71,7 +71,7 @@
 
 #if CFG_TUSB_MCU == OPT_MCU_RP2040
   // #define CFG_TUH_RPI_PIO_USB   1 // use pio-usb as host controller
-  // #define CFG_TUH_RPI_PIO_USB   1 // use max3421 as host controller
+  // #define CFG_TUH_MAX3421       1 // use max3421 as host controller
 
   // host roothub port is 1 if using either pio-usb or max3421
   #if (defined(CFG_TUH_RPI_PIO_USB) && CFG_TUH_RPI_PIO_USB) || (defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421)

--- a/examples/host/msc_file_explorer/src/tusb_config.h
+++ b/examples/host/msc_file_explorer/src/tusb_config.h
@@ -71,7 +71,7 @@
 
 #if CFG_TUSB_MCU == OPT_MCU_RP2040
   // #define CFG_TUH_RPI_PIO_USB   1 // use pio-usb as host controller
-  // #define CFG_TUH_RPI_PIO_USB   1 // use max3421 as host controller
+  // #define CFG_TUH_MAX3421       1 // use max3421 as host controller
 
   // host roothub port is 1 if using either pio-usb or max3421
   #if (defined(CFG_TUH_RPI_PIO_USB) && CFG_TUH_RPI_PIO_USB) || (defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421)

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -112,8 +112,7 @@ uint8_t const * tu_desc_find3(uint8_t const* desc, uint8_t const* end, uint8_t b
 // Endpoint Helper for both Host and Device stack
 //--------------------------------------------------------------------+
 
-bool tu_edpt_claim(tu_edpt_state_t* ep_state, osal_mutex_t mutex)
-{
+bool tu_edpt_claim(tu_edpt_state_t* ep_state, osal_mutex_t mutex) {
   (void) mutex;
 
   // pre-check to help reducing mutex lock
@@ -122,8 +121,7 @@ bool tu_edpt_claim(tu_edpt_state_t* ep_state, osal_mutex_t mutex)
 
   // can only claim the endpoint if it is not busy and not claimed yet.
   bool const available = (ep_state->busy == 0) && (ep_state->claimed == 0);
-  if (available)
-  {
+  if (available) {
     ep_state->claimed = 1;
   }
 
@@ -132,16 +130,14 @@ bool tu_edpt_claim(tu_edpt_state_t* ep_state, osal_mutex_t mutex)
   return available;
 }
 
-bool tu_edpt_release(tu_edpt_state_t* ep_state, osal_mutex_t mutex)
-{
+bool tu_edpt_release(tu_edpt_state_t* ep_state, osal_mutex_t mutex) {
   (void) mutex;
 
   (void) osal_mutex_lock(mutex, OSAL_TIMEOUT_WAIT_FOREVER);
 
   // can only release the endpoint if it is claimed and not busy
   bool const ret = (ep_state->claimed == 1) && (ep_state->busy == 0);
-  if (ret)
-  {
+  if (ret) {
     ep_state->claimed = 0;
   }
 


### PR DESCRIPTION
**Describe the PR**
- abort all pending transfer when SET_CONFIGURATION is complete
- usbh enumeration: move _parse_configuration_descriptor after SET_CONFIGURATION is successful
- use tu_edpt_release in tuh_edpt_abort_xfer instead of usbh_edpt_release
- rename _xfer_complete -> _control_xfer_complete
- most changes are due to code reformat

fix an issue with circuitpython https://github.com/adafruit/circuitpython/issues/8885