### PR TITLE
Changes required for new SDK 3.2.0

### DIFF
--- a/src/portable/sony/cxd56/dcd_cxd56.c
+++ b/src/portable/sony/cxd56/dcd_cxd56.c
@@ -103,19 +103,23 @@ static int _dcd_bind(FAR struct usbdevclass_driver_s *driver, FAR struct usbdev_
   usbdcd_driver.ep[0] = dev->ep0;
 
   #ifdef EP_ALLOCREQ
+  // SDK v2
   usbdcd_driver.req[0] = EP_ALLOCREQ(usbdcd_driver.ep[0]);
-  if (usbdcd_driver.req[0] != NULL)
-  {
+  if (usbdcd_driver.req[0] != NULL) {
     usbdcd_driver.req[0]->len = 64;
     usbdcd_driver.req[0]->buf = EP_ALLOCBUFFER(usbdcd_driver.ep[0], 64);
-    if (!usbdcd_driver.req[0]->buf)
-    {
+    if (!usbdcd_driver.req[0]->buf) {
       EP_FREEREQ(usbdcd_driver.ep[0], usbdcd_driver.req[0]);
       usbdcd_driver.req[0] = NULL;
+      return ENOMEM;
     }
   }
   #else
-  usbdcd_driver.req[0] = usbdev_allocreq(usbdcd_driver.ep[0],64);
+  // SDK v3
+  usbdcd_driver.req[0] = usbdev_allocreq(usbdcd_driver.ep[0], 64);
+  if (usbdcd_driver.req[0] == NULL) {
+    return ENOMEM;
+  }
   #endif
 
   usbdcd_driver.req[0]->callback = usbdcd_ep0incomplete;
@@ -301,17 +305,17 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const *p_endpoint_desc)
   usbdcd_driver.req[epnum] = NULL;
 
   #ifdef EP_ALLOCREQ
+  // sdk v2
   usbdcd_driver.req[epnum] = EP_ALLOCREQ(usbdcd_driver.ep[epnum]);
-  if (usbdcd_driver.req[epnum] != NULL)
-  {
+  if (usbdcd_driver.req[epnum] != NULL) {
     usbdcd_driver.req[epnum]->len = ep_mps;
   }
-  else
   #else
+  // sdk v3
   usbdcd_driver.req[epnum] = usbdev_allocreq(usbdcd_driver.ep[epnum], ep_mps);
-  if(usbdcd_driver.req[epnum] == NULL)
   #endif
-  {
+
+  if(usbdcd_driver.req[epnum] == NULL) {
     return false;
   }
 

--- a/src/portable/sony/cxd56/dcd_cxd56.c
+++ b/src/portable/sony/cxd56/dcd_cxd56.c
@@ -39,6 +39,25 @@
 #define CXD56_SETUP_QUEUE_DEPTH (4)
 #define CXD56_MAX_DATA_OUT_SIZE (64)
 
+/* Allocate/free I/O requests.
+ * Should not be called from interrupt processing!
+ */
+
+#define EP_ALLOCREQ(ep)            (ep)->ops->allocreq(ep)
+#define EP_FREEREQ(ep,req)         (ep)->ops->freereq(ep,req)
+
+/* Allocate/free an I/O buffer.
+ * Should not be called from interrupt processing!
+ */
+
+#ifdef CONFIG_USBDEV_DMA
+#  define EP_ALLOCBUFFER(ep,nb)    (ep)->ops->allocbuffer(ep,nb)
+#  define EP_FREEBUFFER(ep,buf)    (ep)->ops->freebuffer(ep,buf)
+#else
+#  define EP_ALLOCBUFFER(ep,nb)    kmm_malloc(nb)
+#  define EP_FREEBUFFER(ep,buf)    kmm_free(buf)
+#endif
+
 OSAL_QUEUE_DEF(usbd_int_set, _setup_queue_def, CXD56_SETUP_QUEUE_DEPTH, struct usb_ctrlreq_s);
 
 struct usbdcd_driver_s


### PR DESCRIPTION
 - Define EP_ALLOCREQ
 - Define EP_FREEREQ
 - Define EP_ALLOCBUFFER
 - Define EP_FREEBUFFER

Those were previously defined in spresense-exported-sdk, but now have been removed.
