### PR TITLE
Bug fix for STM32H5 need few cycles for RX PMA descriptor to update

### DIFF
--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -421,7 +421,7 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
 /* Standard AS Isochronous Feedback Endpoint Descriptor(4.10.2.1) */
 #define TUD_AUDIO_DESC_STD_AS_ISO_FB_EP_LEN 7
 #define TUD_AUDIO_DESC_STD_AS_ISO_FB_EP(_ep, _interval) \
-  TUD_AUDIO_DESC_STD_AS_ISO_FB_EP_LEN, TUSB_DESC_ENDPOINT, _ep, (uint8_t) (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_NO_SYNC | TUSB_ISO_EP_ATT_EXPLICIT_FB), U16_TO_U8S_LE(4), _interval
+  TUD_AUDIO_DESC_STD_AS_ISO_FB_EP_LEN, TUSB_DESC_ENDPOINT, _ep, (uint8_t) ((uint8_t)TUSB_XFER_ISOCHRONOUS | (uint8_t)TUSB_ISO_EP_ATT_NO_SYNC | (uint8_t)TUSB_ISO_EP_ATT_EXPLICIT_FB), U16_TO_U8S_LE(4), _interval
 
 // AUDIO simple descriptor (UAC2) for 1 microphone input
 // - 1 Input Terminal, 1 Feature Unit (Mute and Volume Control), 1 Output Terminal, 1 Clock Source

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -296,17 +296,14 @@ TU_ATTR_ALWAYS_INLINE static inline uint32_t pcd_get_ep_rx_cnt(USB_TypeDef * USB
 {
 #ifdef FSDEV_BUS_32BIT
   (void) USBx;
-  volatile uint32_t count = 10;
-  /*
-  WA: few cycles for RX PMA descriptor to update
-  This workaround is ported from stm32h5xx_hal_pcd.h : PCD_GET_EP_RX_CNT H5
-  This code fixes an issue when the code is compiled in GCC with a fast optimization(O2/O3) and device with an high frequency.
-  The function doesn't return the correct value.
-  Issue observed on Windows 10 and stm32h573i_dk and tud_task() scheduled by IT, the device is not migrated the USB device is not visible .
+  /* WA: few cycles for RX PMA descriptor to update, otherwise doesn't return the correct value.
+     Note: required for G0, U5, H5 etc. 
+  This workaround is ported from stm32h5xx_hal_pcd.h and fixes the issue when calling this function fast enough.
+  Reproduced with GCC ast optimization(O2/O3) and stm32h573i_dk with an high frequency. 
+  Observed on Windows 10 where tud_task() is scheduled by interrupt handler.
   */
-  while (count > 0U)
-  {
-    asm("NOP");
+  volatile uint32_t count = 10; // defined as PCD_RX_PMA_CNT in stm32 hal_driver
+  while (count > 0U) {
     count--;
   }
   return (pma32[2*bEpIdx + 1] & 0x03FF0000) >> 16;

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -297,9 +297,9 @@ TU_ATTR_ALWAYS_INLINE static inline uint32_t pcd_get_ep_rx_cnt(USB_TypeDef * USB
 #ifdef FSDEV_BUS_32BIT
   (void) USBx;
   /* WA: few cycles for RX PMA descriptor to update, otherwise doesn't return the correct value.
-     Note: required for G0, U5, H5 etc. 
+     Note: required for G0, U5, H5 etc.
   This workaround is ported from stm32h5xx_hal_pcd.h and fixes the issue when calling this function fast enough.
-  Reproduced with GCC ast optimization(O2/O3) and stm32h573i_dk with an high frequency. 
+  Reproduced with GCC ast optimization(O2/O3) and stm32h573i_dk with an high frequency.
   Observed on Windows 10 where tud_task() is scheduled by interrupt handler.
   */
   volatile uint32_t count = 10; // defined as PCD_RX_PMA_CNT in stm32 hal_driver

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -296,6 +296,19 @@ TU_ATTR_ALWAYS_INLINE static inline uint32_t pcd_get_ep_rx_cnt(USB_TypeDef * USB
 {
 #ifdef FSDEV_BUS_32BIT
   (void) USBx;
+  volatile uint32_t count = 10;
+  /*
+  WA: few cycles for RX PMA descriptor to update
+  This workaround is ported from stm32h5xx_hal_pcd.h : PCD_GET_EP_RX_CNT H5
+  This code fixes an issue when the code is compiled in GCC with a fast optimization(O2/O3) and device with an high frequency.
+  The function doesn't return the correct value.
+  Issue observed on Windows 10 and stm32h573i_dk and tud_task() scheduled by IT, the device is not migrated the USB device is not visible .
+  */
+  while (count > 0U)
+  {
+    asm("NOP");
+    count--;
+  }
   return (pma32[2*bEpIdx + 1] & 0x03FF0000) >> 16;
 #else
   __I uint16_t *regPtr = pcd_ep_rx_cnt_ptr(USBx, bEpIdx);


### PR DESCRIPTION
*dcd_stm32_fsdev.c:  Fix a bug seen with stm32h5xxx when the driver is compiled with CubeIde O1/O2/O3*
patch fixes a bug discovered when I build my application for the speed. The new timing introduces a bug in the function pcd_get_ep_rx_cnt(). 
The function doesn't return the correct value.
After discussion with my colleagues, they told me that this issue is fixed with a workaround. 
This workaround is ported from stm32h5xx_hal_pcd.h : PCD_GET_EP_RX_CNT (ST HAL for H5) 
Issue observed on Windows 10 and stm32h573i_dk and tud_task() scheduled by IT or by a FreeRtos task.  The device is not migrated the USB device is not visible.
I didn’t surrounded the patch by a, ifdef specific to the H5 because I think this issue could be present in various MCU family and is pretty neutral (just a very small delay)

* IAR Warning: Fixed due to an boolean operation between enum (Pa089)*
Just fix painful waring on IAR 9.40.1

