### PR TITLE
Added support for SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL

### DIFF
--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -685,6 +685,24 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
       }
     break;
 
+    case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
+      resplen = 0;
+
+      if (tud_msc_prevent_allow_medium_removal_cb)
+      {
+         scsi_prevent_allow_medium_removal_t const * prevent_allow = (scsi_prevent_allow_medium_removal_t const *) scsi_cmd;
+        if ( !tud_msc_prevent_allow_medium_removal_cb(lun, prevent_allow->prohibit_removal, prevent_allow->control) )
+        {
+          // Failed status response
+          resplen = - 1;
+
+          // set default sense if not set by callback
+          if ( p_msc->sense_key == 0 ) set_sense_medium_not_present(lun);
+        }
+      }
+    break;
+
+
     case SCSI_CMD_READ_CAPACITY_10:
     {
       uint32_t block_count;

--- a/src/class/msc/msc_device.h
+++ b/src/class/msc/msc_device.h
@@ -131,6 +131,9 @@ TU_ATTR_WEAK uint8_t tud_msc_get_maxlun_cb(void);
 // - Start = 1 : active mode, if load_eject = 1 : load disk storage
 TU_ATTR_WEAK bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject);
 
+//Invoked when we receive the Prevent / Allow Medium Removal command
+TU_ATTR_WEAK bool tud_msc_prevent_allow_medium_removal_cb(uint8_t lun, uint8_t prohibit_removal, uint8_t control);
+
 // Invoked when received REQUEST_SENSE
 TU_ATTR_WEAK int32_t tud_msc_request_sense_cb(uint8_t lun, void* buffer, uint16_t bufsize);
 


### PR DESCRIPTION
This adds support for SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL via a callback function tud_msc_prevent_allow_medium_removal_cb, very similar to the handling of SCSI_CMD_START_STOP_UNIT.

Properly handling the Prevent / Allow Medium Removal command clears up a "Failed to eject device" error on Linux.