### PR TITLE
Fix the error that occurs when executing make on Windows

### DIFF
--- a/examples/build_system/make/toolchain/arm_gcc.mk
+++ b/examples/build_system/make/toolchain/arm_gcc.mk
@@ -74,6 +74,8 @@ LDFLAGS += -Wl,--print-memory-usage
 endif
 
 # from version 12
-ifeq ($(shell expr $(CC_VERSION_MAJOR) \>= 12),1)
+ifeq ($(strip $(if $(CMDEXE),\
+               $(shell if $(CC_VERSION_MAJOR) geq 12 (echo 1) else (echo 0)),\
+               $(shell expr $(CC_VERSION_MAJOR) \>= 12))), 1)
 LDFLAGS += -Wl,--no-warn-rwx-segment
 endif


### PR DESCRIPTION
**Describe the PR**
Fix the following error when executing "make" on command prompt in Windows 11, which has no `sh.exe` on `PATH`.
```console
C:\tinyusb\examples\device\video_capture>make BOARD=frdm_kl25z
process_begin: CreateProcess(NULL, expr 13 >= 12, ...) failed.
C:/tinyusb/examples/build_system/make/toolchain/arm_gcc.mk:77: pipe: Bad file descriptor
```