### PR TITLE
use usbreset to reset built-in usb 2.0 hub VIA Labs before each test

### DIFF
--- a/.github/workflows/build_esp.yml
+++ b/.github/workflows/build_esp.yml
@@ -86,11 +86,17 @@ jobs:
         # USB bus on rpi4 is not stable, reset it before testing
       - name: Reset USB bus
         run: |
-          for port in $(lspci | grep USB | cut -d' ' -f1); do
-              echo -n "0000:${port}"| sudo tee /sys/bus/pci/drivers/xhci_hcd/unbind;
-              sleep 0.1;
-              echo -n "0000:${port}" | sudo tee /sys/bus/pci/drivers/xhci_hcd/bind;
-          done
+          lsusb
+          lsusb -t
+          # reset VIA Labs 2.0 hub
+          usbreset 001/002
+
+          # legacy code
+          #for port in $(lspci | grep USB | cut -d' ' -f1); do
+          #    echo -n "0000:${port}"| sudo tee /sys/bus/pci/drivers/xhci_hcd/unbind;
+          #    sleep 0.1;
+          #    echo -n "0000:${port}" | sudo tee /sys/bus/pci/drivers/xhci_hcd/bind;
+          #done
 
       - name: Checkout test/hil
         uses: actions/checkout@v4

--- a/.github/workflows/build_esp.yml
+++ b/.github/workflows/build_esp.yml
@@ -89,7 +89,7 @@ jobs:
           lsusb
           lsusb -t
           # reset VIA Labs 2.0 hub
-          usbreset 001/002
+          sudo usbreset 001/002
 
           # legacy code
           #for port in $(lspci | grep USB | cut -d' ' -f1); do

--- a/.github/workflows/cmake_arm.yml
+++ b/.github/workflows/cmake_arm.yml
@@ -141,11 +141,17 @@ jobs:
         # USB bus on rpi4 is not stable, reset it before testing
       - name: Reset USB bus
         run: |
-          for port in $(lspci | grep USB | cut -d' ' -f1); do
-              echo -n "0000:${port}"| sudo tee /sys/bus/pci/drivers/xhci_hcd/unbind;
-              sleep 0.1;
-              echo -n "0000:${port}" | sudo tee /sys/bus/pci/drivers/xhci_hcd/bind;
-          done
+          lsusb
+          lsusb -t
+          # reset VIA Labs 2.0 hub
+          usbreset 001/002
+
+          # legacy code
+          #for port in $(lspci | grep USB | cut -d' ' -f1); do
+          #    echo -n "0000:${port}"| sudo tee /sys/bus/pci/drivers/xhci_hcd/unbind;
+          #    sleep 0.1;
+          #    echo -n "0000:${port}" | sudo tee /sys/bus/pci/drivers/xhci_hcd/bind;
+          #done
 
       - name: Checkout test/hil
         uses: actions/checkout@v4

--- a/.github/workflows/cmake_arm.yml
+++ b/.github/workflows/cmake_arm.yml
@@ -144,7 +144,7 @@ jobs:
           lsusb
           lsusb -t
           # reset VIA Labs 2.0 hub
-          usbreset 001/002
+          sudo usbreset 001/002
 
           # legacy code
           #for port in $(lspci | grep USB | cut -d' ' -f1); do


### PR DESCRIPTION
**Describe the PR**
use usbreset to reset built-in usb 2.0 hub VIA Labs before each test

