### PR TITLE
Fake unplug devices when a root hub is deinit

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -412,17 +412,10 @@ bool tuh_deinit(uint8_t rhport) {
   // deinit host controller
   hcd_int_disable(rhport);
   hcd_deinit(rhport);
-
   _usbh_controller = TUSB_INDEX_INVALID_8;
 
-  // "unplug" all devices on this rhport
-  for (uint8_t idx = 0; idx < CFG_TUH_DEVICE_MAX + CFG_TUH_HUB; idx++) {
-    usbh_device_t *dev = &_usbh_devices[idx];
-    if (!dev->connected || dev->rhport != rhport) {
-      continue;
-    }
-    process_removing_device(rhport, dev->hub_addr, dev->hub_port);
-  }
+  // "unplug" all devices on this rhport (hub_addr = 0, hub_port = 0)
+  process_removing_device(rhport, 0, 0);
 
   // deinit host stack if no controller is active
   if (!tuh_inited()) {

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -415,6 +415,15 @@ bool tuh_deinit(uint8_t rhport) {
 
   _usbh_controller = TUSB_INDEX_INVALID_8;
 
+  // "unplug" all devices on this rhport
+  for (uint8_t idx = 0; idx < CFG_TUH_DEVICE_MAX + CFG_TUH_HUB; idx++) {
+    usbh_device_t *dev = &_usbh_devices[idx];
+    if (!dev->connected || dev->rhport != rhport) {
+      continue;
+    }
+    process_removing_device(rhport, dev->hub_addr, dev->hub_port);
+  }
+
   // deinit host stack if no controller is active
   if (!tuh_inited()) {
     // Class drivers


### PR DESCRIPTION
This causes the correct "umount" callbacks to occur before deiniting a root hub and its drivers.
