### PR TITLE
forward declare board_millis for OPT_OS_CUSTOM

### DIFF
--- a/hw/bsp/board_api.h
+++ b/hw/bsp/board_api.h
@@ -116,6 +116,7 @@ static inline uint32_t board_millis(void) {
 
 #elif CFG_TUSB_OS == OPT_OS_CUSTOM
 // Implement your own board_millis() in any of .c file
+uint32_t board_millis(void);
 
 #else
   #error "board_millis() is not implemented for this OS"


### PR DESCRIPTION
When porting examples to a custom OS the missing forward declaration of board_millis creates problems.
The forward declaration lets custom OS ports use the `board_api.h` for use of `board_usb_get_serial` and implement `board_millis` anywhere if needed with the correct signature.

The CDC examples include the `bsp/board_api.h` in `usb_descriptors.c` for use of `board_usb_get_serial`. `board_api.h` also includes implementation of `board_delay` which uses `board_millis`. But in case of `OPT_OS_CUSTOM` it has not been declared anywhere, so it gets implicitly declared as `int board_millis(void)` which will not link with an implementation using the correct `unsigned int` return type.

