### PR TITLE
send ZLP to terminate packet size aligned transfers

### DIFF
--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -208,7 +208,7 @@ static void ncm_start_tx(void) {
   }
 
   transmit_ntb_t *ntb = &transmit_ntb[ncm_interface.current_ntb];
-  // use actual payload length (non padded), reduces likelyhood of aligning with packet length, requiring fewer ZLP
+  // use actual payload length (non padded), reduces likelihood of aligning with packet length, requiring fewer ZLP
   ndp16_datagram_t * last_dg_info = &ntb->ndp.datagram[ncm_interface.datagram_count-1];
   size_t ntb_length = last_dg_info->wDatagramIndex + last_dg_info->wDatagramLength;
 


### PR DESCRIPTION
**Describe the PR**
add NCM transfer termination by ZLP if necessary.
If NCM transfer aligns with (multiple) USB packet size the transfer has to be terminated with a ZLP.

This PR also lowers the likelihood of needing a ZLP to terminate a transfer.

**Additional context**
The driver implementation increased likelihood for this happening by always sending a multiple of 4 bytes in an NCM transfer, caused by including the padding bytes to the next NCM datagram, this however is not required. So by only sending the actual NCM payload length (without the padding to a next, not appended, NCM datagram) the complete USB transfer is no longer always a multiple of 4 bytes, reducing the likelihood of hitting a multiple of USB packet size. Thus terminating the transfer by short packet instead of requiring an extra ZLP.

#2068 Does mention the ZLP problem as well, but aims to improve performance.
Instead of replacing the driver completely (like #2227 ) this PR aims to just fix this one bug with minimal impact.