### PR TITLE
add cpuctl and pinctl to tuh_configure() option for max3421

### DIFF
--- a/.github/workflows/build_iar.yml
+++ b/.github/workflows/build_iar.yml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   cmake:
+    if: github.repository_owner == 'hathach'
     runs-on: [self-hosted, Linux, X64, hifiphile]
     strategy:
       fail-fast: false

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -80,12 +80,16 @@ enum {
   TUH_CFGID_MAX3421 = 200,
 };
 
+typedef struct {
+  uint8_t max_nak; // max NAK per endpoint per frame
+  uint8_t cpuctl; // R16: CPU Control Register
+  uint8_t pinctl; // R17: Pin Control Register. FDUPSPI bit is ignored
+} tuh_configure_max3421_t;
+
 typedef union {
   // For TUH_CFGID_RPI_PIO_USB_CONFIGURATION use pio_usb_configuration_t
 
-  struct {
-    uint8_t max_nak;
-  } max3421;
+  tuh_configure_max3421_t max3421;
 } tuh_configure_param_t;
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
Make it possible to configure max3421 interrupt edge/level polarity and pulse width. Default to negative edge 10.6 us