### PR TITLE
Enhance dcd rusb2, support ra2a1 pipe number scheme 

### DIFF
--- a/hw/bsp/ra/boards/ra2a1_ek/board.h
+++ b/hw/bsp/ra/boards/ra2a1_ek/board.h
@@ -31,10 +31,10 @@
 extern "C" {
 #endif
 
-#define LED1          BSP_IO_PORT_01_PIN_06
+#define LED1          BSP_IO_PORT_02_PIN_05
 #define LED_STATE_ON  1
 
-#define SW1                   BSP_IO_PORT_01_PIN_05
+#define SW1                   BSP_IO_PORT_02_PIN_06
 #define BUTTON_STATE_ACTIVE   0
 
 static const ioport_pin_cfg_t board_pin_cfg[] = {

--- a/hw/bsp/ra/family.c
+++ b/hw/bsp/ra/family.c
@@ -64,8 +64,11 @@ BSP_DONT_REMOVE BSP_PLACE_IN_SECTION(BSP_SECTION_APPLICATION_VECTORS)
 const fsp_vector_t g_vector_table[BSP_ICU_VECTOR_MAX_ENTRIES] = {
     [0] = usbfs_interrupt_handler, /* USBFS INT (USBFS interrupt) */
     [1] = usbfs_resume_handler,    /* USBFS RESUME (USBFS resume interrupt) */
+
+#ifndef BSP_MCU_GROUP_RA2A1
     [2] = usbfs_d0fifo_handler,    /* USBFS FIFO 0 (DMA transfer request 0) */
     [3] = usbfs_d1fifo_handler,    /* USBFS FIFO 1 (DMA transfer request 1) */
+#endif
 
 #ifdef BOARD_HAS_USB_HIGHSPEED
     [4] = usbhs_interrupt_handler, /* USBHS INT (USBHS interrupt) */

--- a/hw/bsp/ra/vector_data.h
+++ b/hw/bsp/ra/vector_data.h
@@ -9,8 +9,11 @@ extern "C" {
 /* ISR prototypes */
 void usbfs_interrupt_handler(void);
 void usbfs_resume_handler(void);
+
+#ifndef BSP_MCU_GROUP_RA2A1
 void usbfs_d0fifo_handler(void);
 void usbfs_d1fifo_handler(void);
+#endif
 
 #ifdef BOARD_HAS_USB_HIGHSPEED
 void usbhs_interrupt_handler(void);

--- a/src/portable/renesas/rusb2/dcd_rusb2.c
+++ b/src/portable/renesas/rusb2/dcd_rusb2.c
@@ -1005,7 +1005,6 @@ void dcd_int_handler(uint8_t rhport)
     const unsigned s = rusb->BRDYSTS & m;
     /* clear active bits (don't write 0 to already cleared bits according to the HW manual) */
     rusb->BRDYSTS = ~s;
-
     for (unsigned p = 0; p < PIPE_COUNT; ++p) {
       if (tu_bit_test(s, p)) {
         process_pipe_brdy(rhport, p);

--- a/src/portable/renesas/rusb2/hcd_rusb2.c
+++ b/src/portable/renesas/rusb2/hcd_rusb2.c
@@ -45,6 +45,9 @@
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
 //--------------------------------------------------------------------+
+enum {
+  PIPE_COUNT = 10,
+};
 
 TU_ATTR_PACKED_BEGIN
 TU_ATTR_BIT_FIELD_ORDER_BEGIN
@@ -75,7 +78,7 @@ TU_ATTR_BIT_FIELD_ORDER_END
 typedef struct
 {
   bool         need_reset; /* The device has not been reset after connection. */
-  pipe_state_t pipe[10];
+  pipe_state_t pipe[PIPE_COUNT];
   uint8_t ep[4][2][15];   /* a lookup table for a pipe index from an endpoint address */
   uint8_t      ctl_mps[5]; /* EP0 max packet size for each device */
 } hcd_data_t;
@@ -86,46 +89,30 @@ typedef struct
 static hcd_data_t _hcd;
 
 // TODO merged with DCD
-// Transfer conditions specifiable for each pipe:
+// Transfer conditions specifiable for each pipe for most MCUs
 // - Pipe 0: Control transfer with 64-byte single buffer
-// - Pipes 1 and 2: Bulk isochronous transfer continuous transfer mode with programmable buffer size up
-//   to 2 KB and optional double buffer
-// - Pipes 3 to 5: Bulk transfer continuous transfer mode with programmable buffer size up to 2 KB and
-//   optional double buffer
-// - Pipes 6 to 9: Interrupt transfer with 64-byte single buffer
-enum {
-  PIPE_1ST_BULK = 3,
-  PIPE_1ST_INTERRUPT = 6,
-  PIPE_COUNT = 10,
-};
+// - Pipes 1 and 2: Bulk or ISO
+// - Pipes 3 to 5: Bulk
+// - Pipes 6 to 9: Interrupt
+//
+// Note: for small mcu such as
+// - RA2A1: only pipe 4-7 are available, and no support for ISO
+static unsigned find_pipe(unsigned xfer_type) {
+  const uint8_t pipe_idx_arr[4][2] = {
+      { 0, 0 }, // Control
+      { 1, 2 }, // Isochronous
+      { 1, 5 }, // Bulk
+      { 6, 9 }, // Interrupt
+  };
 
-static unsigned find_pipe(unsigned xfer) {
-  switch ( xfer ) {
-    case TUSB_XFER_ISOCHRONOUS:
-      for (int i = 1; i < PIPE_1ST_BULK; ++i) {
-        if ( 0 == _hcd.pipe[i].ep ) return i;
-      }
-      break;
+  // find backward since only pipe 1, 2 support ISO
+  const uint8_t idx_first = pipe_idx_arr[xfer_type][0];
+  const uint8_t idx_last  = pipe_idx_arr[xfer_type][1];
 
-    case TUSB_XFER_BULK:
-      for (int i = PIPE_1ST_BULK; i < PIPE_1ST_INTERRUPT; ++i) {
-        if ( 0 == _hcd.pipe[i].ep ) return i;
-      }
-      for (int i = 1; i < PIPE_1ST_BULK; ++i) {
-        if ( 0 == _hcd.pipe[i].ep ) return i;
-      }
-      break;
-
-    case TUSB_XFER_INTERRUPT:
-      for (int i = PIPE_1ST_INTERRUPT; i < PIPE_COUNT; ++i) {
-        if ( 0 == _hcd.pipe[i].ep ) return i;
-      }
-      break;
-
-    default:
-      /* No support for control transfer */
-      break;
+  for (int i = idx_last; i >= idx_first; i--) {
+    if (0 == _hcd.pipe[i].ep) return i;
   }
+
   return 0;
 }
 
@@ -718,7 +705,7 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const 
   }
 
   rusb->PIPECFG = cfg;
-  rusb->BRDYSTS = 0x1FFu ^ TU_BIT(num);
+  rusb->BRDYSTS = 0x3FFu ^ TU_BIT(num);
   rusb->NRDYENB |= TU_BIT(num);
   rusb->BRDYENB |= TU_BIT(num);
 
@@ -846,14 +833,10 @@ void hcd_int_handler(uint8_t rhport, bool in_isr) {
     unsigned s = rusb->BRDYSTS & m;
     /* clear active bits (don't write 0 to already cleared bits according to the HW manual) */
     rusb->BRDYSTS = ~s;
-    while (s) {
-#if defined(__CCRX__)
-      const unsigned num = Mod37BitPosition[(-s & s) % 37];
-#else
-      const unsigned num = __builtin_ctz(s);
-#endif
-      process_pipe_brdy(rhport, num);
-      s &= ~TU_BIT(num);
+    for (unsigned p = 0; p < PIPE_COUNT; ++p) {
+      if (tu_bit_test(s, p)) {
+        process_pipe_brdy(rhport, p);
+      }
     }
   }
 }


### PR DESCRIPTION
**Describe the PR**
- Enhance dcd rusb2: 
  - fix mask typo for brdy status with pipe9
  - ~use forloop to remove ctz which is not portable~ keep ctz() since it is better for run time in isr 
- support ra2a1 pipe number scheme  
- fix ra2a1 ek led/button, but usb not enumerated probably bsp/clock setup thing.

Note to myself: while debugging, I notice sometimes somehow the _dcd seems to be clear accidentally, not sure what causes it. Maybe an memory overflow or something.