### PR TITLE
FSDEV: Implement dcd_edpt_close_all()

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -459,13 +459,9 @@ static const tusb_desc_endpoint_t ep0IN_desc = {
 
 static void dcd_handle_bus_reset(void)
 {
-  //__IO uint16_t * const epreg = &(EPREG(0));
   USB->DADDR = 0u; // disable USB peripheral by clearing the EF flag
 
   for (uint32_t i = 0; i < STFSDEV_EP_COUNT; i++) {
-    // Clear all EPREG (or maybe this is automatic? I'm not sure)
-    pcd_set_endpoint(USB, i, 0u);
-
     // Clear EP allocation status
     ep_alloc_status[i].ep_num = 0xFF;
     ep_alloc_status[i].ep_type = 0xFF;
@@ -624,7 +620,6 @@ static void dcd_ep_ctr_rx_handler(uint32_t wIstr)
         uint16_t remaining = xfer->total_len - xfer->queued_len;
         uint16_t cnt = tu_min16(remaining, xfer->max_packet_size);
         pcd_set_ep_rx_cnt(USB, EPindex, cnt);
-        pcd_set_ep_rx_cnt(USB, EPindex, remaining);
       }
       pcd_set_ep_rx_status(USB, EPindex, USB_EP_RX_VALID);
     }

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -864,7 +864,19 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const *p_endpoint_desc)
 void dcd_edpt_close_all(uint8_t rhport)
 {
   (void)rhport;
-  // TODO implement dcd_edpt_close_all()
+
+  for (uint32_t i = 1; i < STFSDEV_EP_COUNT; i++) {
+    // Reset endpoint
+    pcd_set_endpoint(USB, i, 0);
+    // Clear EP allocation status
+    ep_alloc_status[i].ep_num = 0xFF;
+    ep_alloc_status[i].ep_type = 0xFF;
+    ep_alloc_status[i].allocated[0] = false;
+    ep_alloc_status[i].allocated[1] = false;
+  }
+
+  // Reset PMA allocation
+  ep_buf_ptr = DCD_STM32_BTABLE_BASE + 8 * MAX_EP_COUNT + 2 * CFG_TUD_ENDPOINT0_SIZE;
 }
 
 /**


### PR DESCRIPTION
**Describe the PR**
Implement dcd_edpt_close_all()

Tested with `net_lwip_webserver` on NUCLEO-G0B1RE , with command:
`
 echo 1 | sudo tee /sys/bus/usb/devices/3-5/bConfigurationValue
 echo 2 | sudo tee /sys/bus/usb/devices/3-5/bConfigurationValue
`
Can't test with L053 as RAM too small.