### PR TITLE
Remove redundant header file includes for the hid class

### DIFF
--- a/examples/host/bare_api/src/main.c
+++ b/examples/host/bare_api/src/main.c
@@ -34,6 +34,7 @@
 
 #include "bsp/board_api.h"
 #include "tusb.h"
+#include "class/hid/hid.h"
 
 // English
 #define LANGUAGE_ID 0x0409

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -38,8 +38,6 @@
 #include "osal/osal.h"
 #include "common/tusb_fifo.h"
 
-#include "class/hid/hid.h"
-
 //------------- TypeC -------------//
 #if CFG_TUC_ENABLED
   #include "typec/usbc.h"


### PR DESCRIPTION
**Describe the PR**
```c
  #if CFG_TUD_HID
    #include "class/hid/hid_device.h"
  #endif
```
hid_device.h include hid.h

Remove redundant header file includes for the hid class

**Additional context**
If applicable, add any other context about the PR and/or screenshots here.
