### PR TITLE
Update dnserver.c: Match dnserv_free signature with fwd-decl

### DIFF
--- a/lib/networking/dnserver.c
+++ b/lib/networking/dnserver.c
@@ -192,7 +192,7 @@ err_t dnserv_init(const ip_addr_t *bind, uint16_t port, dns_query_proc_t qp)
 	return ERR_OK;
 }
 
-void dnserv_free()
+void dnserv_free(void)
 {
 	if (pcb == NULL) return;
 	udp_remove(pcb);


### PR DESCRIPTION
Otherwise, this leads to a compile error (at least on a recent clang version):

```
/src/tinyusb/lib/networking/dnserver.c:195:17: fatal error: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  195 | void dnserv_free()
      |                 ^
      |                  void
1 error generated.
