### PR TITLE
dcd_nrf5x: fix race condition

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -77,18 +77,6 @@
   #endif
 #endif
 
-/** disable interrupts */
-#define DISABLE_IRQ()                \
-    uint32_t prim = __get_PRIMASK(); \
-    __disable_irq();
-
-/** (re)enable interrupts */
-#define ENABLE_IRQ()    \
-    if (!prim)          \
-    {                   \
-      __enable_irq();   \
-    }
-
 /*------------------------------------------------------------------*/
 /* MACRO TYPEDEF CONSTANT ENUM
  *------------------------------------------------------------------*/
@@ -446,15 +434,11 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t* buffer, uint16_t to
   bool const control_status = (epnum == 0 && total_bytes == 0 && dir != tu_edpt_dir(NRF_USBD->BMREQUESTTYPE));
 
   if (control_status) {
-    DISABLE_IRQ();
-
     // Status Phase also requires EasyDMA has to be available as well !!!!
     edpt_dma_start(&NRF_USBD->TASKS_EP0STATUS);
 
     // The nRF doesn't interrupt on status transmit so we queue up a success response.
     dcd_event_xfer_complete(0, ep_addr, 0, XFER_RESULT_SUCCESS, is_in_isr());
-
-    ENABLE_IRQ();
   } else if (dir == TUSB_DIR_OUT) {
     xfer->started = true;
     if (epnum == 0) {


### PR DESCRIPTION
**Describe the PR**
The PR fixes two race conditions in the dcd_nrf5x driver.  The first one fixes a function invocation from edpt_dma_start() which is called also from interrupt context, the second one (DI/EI) is required to protect a code section from interrupts.

**Additional context**
The actual problems (crashes/hangups) appeared during repeated connect / disconnect to a CDC-ACM on the nRF5x.  The above changes fixed the situation.
