### PR TITLE
Add host OS detection quirk.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ function(add_tinyusb TARGET)
     # common
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tusb.c
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/common/tusb_fifo.c
+    ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/common/tusb_quirk.c
     # device
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/device/usbd.c
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/device/usbd_control.c

--- a/src/common/tusb_quirk.c
+++ b/src/common/tusb_quirk.c
@@ -34,7 +34,7 @@ void tud_quirk_host_os_hint_desc_cb(tusb_desc_type_t desc) {
     desc_req_idx = 0;
   } else if (desc_req_idx < 2 && (desc == TUSB_DESC_CONFIGURATION || desc == TUSB_DESC_BOS || desc == TUSB_DESC_STRING)) {
     // Skip redundant request
-    if (desc_req_idx == 0 || desc_req_idx > 0 && desc_req_buf[desc_req_idx - 1] != desc) {
+    if (desc_req_idx == 0 || (desc_req_idx > 0 && desc_req_buf[desc_req_idx - 1] != desc)) {
       desc_req_buf[desc_req_idx++] = desc;
     }
   }

--- a/src/common/tusb_quirk.c
+++ b/src/common/tusb_quirk.c
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 HiFiPhile
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "tusb_quirk.h"
+
+#if CFG_TUD_QUIRK_HOST_OS_HINT
+static tusb_desc_type_t desc_req_buf[2];
+static int desc_req_idx = 0;
+
+void tud_quirk_host_os_hint_desc_cb(tusb_desc_type_t desc) {
+  if (desc == TUSB_DESC_DEVICE) {
+    desc_req_idx = 0;
+  } else if (desc_req_idx < 2 && (desc == TUSB_DESC_CONFIGURATION || desc == TUSB_DESC_BOS || desc == TUSB_DESC_STRING)) {
+    // Skip redundant request
+    if (desc_req_idx == 0 || desc_req_idx > 0 && desc_req_buf[desc_req_idx - 1] != desc) {
+      desc_req_buf[desc_req_idx++] = desc;
+    }
+  }
+}
+
+// Each OS request descriptors differently:
+// Windows 10 - 11
+//    Device Desc
+//    Config Desc
+//    BOS    Desc
+//    String Desc
+// Linux 5.4 - 6.8
+//    Device Desc
+//    BOS    Desc
+//    Config Desc
+//    String Desc
+// OS X
+//    Device Desc
+//    String Desc
+//    BOS    Desc
+//    Config Desc
+tud_quirk_host_os_t tud_quirk_host_os_hint(void) {
+  if (desc_req_idx < 2) {
+    return TUD_QUIRK_OS_HINT_UNKNOWN;
+  }
+
+  if (desc_req_buf[0] == TUSB_DESC_BOS && desc_req_buf[1] == TUSB_DESC_CONFIGURATION) {
+    return TUD_QUIRK_OS_HINT_LINUX;
+  } else if (desc_req_buf[0] == TUSB_DESC_CONFIGURATION && desc_req_buf[1] == TUSB_DESC_BOS) {
+    return TUD_QUIRK_OS_HINT_WINDOWS;
+  } else if (desc_req_buf[0] == TUSB_DESC_STRING && desc_req_buf[1] == TUSB_DESC_BOS) {
+    return TUD_QUIRK_OS_HINT_OSX;
+  }
+
+  return TUD_QUIRK_OS_HINT_UNKNOWN;
+}
+
+#endif

--- a/src/common/tusb_quirk.c
+++ b/src/common/tusb_quirk.c
@@ -46,7 +46,7 @@ void tud_quirk_host_os_hint_desc_cb(tusb_desc_type_t desc) {
 //    Config Desc
 //    BOS    Desc
 //    String Desc
-// Linux 5.4 - 6.8
+// Linux 4.14 - 6.8
 //    Device Desc
 //    BOS    Desc
 //    Config Desc
@@ -54,8 +54,8 @@ void tud_quirk_host_os_hint_desc_cb(tusb_desc_type_t desc) {
 // OS X
 //    Device Desc
 //    String Desc
-//    BOS    Desc
-//    Config Desc
+//    Config Desc || BOS    Desc
+//    BOS    Desc || Config Desc
 tud_quirk_host_os_t tud_quirk_host_os_hint(void) {
   if (desc_req_idx < 2) {
     return TUD_QUIRK_OS_HINT_UNKNOWN;
@@ -65,7 +65,7 @@ tud_quirk_host_os_t tud_quirk_host_os_hint(void) {
     return TUD_QUIRK_OS_HINT_LINUX;
   } else if (desc_req_buf[0] == TUSB_DESC_CONFIGURATION && desc_req_buf[1] == TUSB_DESC_BOS) {
     return TUD_QUIRK_OS_HINT_WINDOWS;
-  } else if (desc_req_buf[0] == TUSB_DESC_STRING && desc_req_buf[1] == TUSB_DESC_BOS) {
+  } else if (desc_req_buf[0] == TUSB_DESC_STRING && (desc_req_buf[1] == TUSB_DESC_BOS || desc_req_buf[1] == TUSB_DESC_CONFIGURATION)) {
     return TUD_QUIRK_OS_HINT_OSX;
   }
 

--- a/src/common/tusb_quirk.h
+++ b/src/common/tusb_quirk.h
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 HiFiPhile
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_QUIRK_H_
+#define _TUSB_QUIRK_H_
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "common/tusb_common.h"
+
+//===================================== WARNING =========================================
+// These quirks operate out of USB specification in order to workaround specific issues.
+// They may not work on your platform.
+//=======================================================================================
+
+#ifndef CFG_TUD_QUIRK_HOST_OS_HINT
+#define CFG_TUD_QUIRK_HOST_OS_HINT 0
+#endif
+
+// Host OS detection, can be used to adjust configuration to workaround host limits.
+//
+// Prerequisites:
+// - Set USB version to at least 2.01 in Device Descriptor
+// - Has a valid BOS Descriptor, refer to webusb_serial example
+//
+// Attention:
+//   Windows detection result comes out after Configuration Descriptor request,
+//   meaning it will be too late to do descriptor adjustment. It's advised to make
+//   Windows as default configuration and adjust to other OS accordingly.
+#if CFG_TUD_QUIRK_HOST_OS_HINT
+typedef enum {
+  TUD_QUIRK_OS_HINT_UNKNOWN,
+  TUD_QUIRK_OS_HINT_LINUX,
+  TUD_QUIRK_OS_HINT_OSX,
+  TUD_QUIRK_OS_HINT_WINDOWS,
+} tud_quirk_host_os_t;
+
+// Get Host OS type
+tud_quirk_host_os_t tud_quirk_host_os_hint(void);
+
+// Internal callback
+void tud_quirk_host_os_hint_desc_cb(tusb_desc_type_t desc);
+#endif
+
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_QUIRK_H_ */

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -31,6 +31,7 @@
 #include "device/dcd.h"
 #include "tusb.h"
 #include "common/tusb_private.h"
+#include "common/tusb_quirk.h"
 
 #include "device/usbd.h"
 #include "device/usbd_pvt.h"
@@ -966,6 +967,10 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
 {
   tusb_desc_type_t const desc_type = (tusb_desc_type_t) tu_u16_high(p_request->wValue);
   uint8_t const desc_index = tu_u16_low( p_request->wValue );
+
+#if CFG_TUD_QUIRK_HOST_OS_HINT
+  tud_quirk_host_os_hint_desc_cb(desc_type);
+#endif
 
   switch(desc_type)
   {

--- a/src/tinyusb.mk
+++ b/src/tinyusb.mk
@@ -2,6 +2,7 @@
 TINYUSB_SRC_C += \
 	src/tusb.c \
 	src/common/tusb_fifo.c \
+	src/common/tusb_quirk.c \
 	src/device/usbd.c \
 	src/device/usbd_control.c \
 	src/typec/usbc.c \

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -37,6 +37,7 @@
 #include "common/tusb_common.h"
 #include "osal/osal.h"
 #include "common/tusb_fifo.h"
+#include "common/tusb_quirk.h"
 
 //------------- TypeC -------------//
 #if CFG_TUC_ENABLED


### PR DESCRIPTION
**Describe the PR**
Due to the nature of quirk I'm not sure where to put...

This 1st OS detection quirk mainly resolve UAC class issue. Windows and OSX demand different feedback endpoint size for FS as Windows doesn't implement UAC spec correctly (Linux is compatible with both).
So there needs a way to adjust Configuration Descriptor on the fly.

Tested on:
-  Windows 10 - 11
- Linux 3.10 - 6.8
- OS X Ventura - Sonoma