### PR TITLE
Add option to make CDC TX buffer persistent.

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -295,7 +295,9 @@ void cdcd_reset(uint8_t rhport)
 
     tu_memclr(p_cdc, ITF_MEM_RESET_SIZE);
     tu_fifo_clear(&p_cdc->rx_ff);
+    #if !CFG_TUD_CDC_PERSISTENT_TX_BUFF
     tu_fifo_clear(&p_cdc->tx_ff);
+    #endif
     tu_fifo_set_overwritable(&p_cdc->tx_ff, true);
   }
 }

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -41,6 +41,12 @@
   #define CFG_TUD_CDC_EP_BUFSIZE    (TUD_OPT_HIGH_SPEED ? 512 : 64)
 #endif
 
+// By default the TX fifo buffer is cleared on connect / bus reset.
+// Enable this to persist any data in the fifo instead.
+#ifndef CFG_TUD_CDC_PERSISTENT_TX_BUFF
+  #define CFG_TUD_CDC_PERSISTENT_TX_BUFF    (0)
+#endif
+
 #ifdef __cplusplus
  extern "C" {
 #endif


### PR DESCRIPTION
**Describe the PR**
This MR provides a build configuration define that allows an application to prevent clearing of the CDC TX fifo buffer on port setup / reset.

```
#define CFG_TUD_CDC_PERSISTENT_TX_BUFF (1)
```
The default if it's not set or set to 0 is the same as current production code.

This means that an application can write data to the CDC port before the USB is connected and available, eg logging data right from application startup. This buffered data will then be flushed down the CDC port on the next write or `tud_cdc_write_flush();` after the CDC is connected.

**Additional context**
Related information: https://github.com/hathach/tinyusb/discussions/2595

I'm hoping to add this to support a feature used in micropython. There, the stm port is using the STM usb stack, not TinyUSB. It has a feature where data "sent" to usb CDC at startup is buffered (in the usb stack), before USB is init / connected. Then when USB is connected, data previously buffered is flushed down the line to the client. 

In practice, this buffered content consists of a "startup banner" like:
```
PS C:\Users\anl> mpremote
Connected to MicroPython at COM21
Use Ctrl-] or Ctrl-x to exit this shell

MicroPython v1.23.0-preview.329.gf0f3c92b2f.dirty on 2024-05-08; PCA10059 with NRF52840
Type "help()" for more information.
>>>
```

This feature has been there for years and is quite popular, I really want to replicate this feature on TinyUSB to use across all ports, eventually replacing the STM usb stack with TinyUSB for consistency with all other micropython ports.
