### PR TITLE
Fix some race conditions

### DIFF
--- a/hw/bsp/stm32f7/family.mk
+++ b/hw/bsp/stm32f7/family.mk
@@ -24,6 +24,7 @@ ifeq ($(PORT), 1)
     $(info "Using OTG_HS in FullSpeed mode")
   endif
 else
+  CFLAGS += -DBOARD_TUD_MAX_SPEED=OPT_MODE_FULL_SPEED
   $(info "Using OTG_FS")
 endif
 

--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -81,8 +81,7 @@ typedef struct {
 CFG_TUD_MEM_SECTION static cdcd_interface_t _cdcd_itf[CFG_TUD_CDC];
 static tud_cdc_configure_fifo_t _cdcd_fifo_cfg;
 
-static bool _prep_out_transaction (cdcd_interface_t* p_cdc, bool itf_open)
-{
+static bool _prep_out_transaction (cdcd_interface_t* p_cdc, bool itf_open) {
   uint8_t const rhport = 0;
 
   // Skip if usb is not ready yet

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -61,6 +61,9 @@ bool tud_cdc_configure_fifo(tud_cdc_configure_fifo_t const* cfg);
 // Application API (Multiple Ports) i.e. CFG_TUD_CDC > 1
 //--------------------------------------------------------------------+
 
+// Check if interface is ready
+bool tud_cdc_n_ready(uint8_t itf);
+
 // Check if terminal is connected to this port
 bool tud_cdc_n_connected(uint8_t itf);
 
@@ -116,6 +119,11 @@ bool tud_cdc_n_write_clear(uint8_t itf);
 //--------------------------------------------------------------------+
 // Application API (Single Port)
 //--------------------------------------------------------------------+
+
+TU_ATTR_ALWAYS_INLINE static inline bool tud_cdc_ready(void) {
+  return tud_cdc_n_ready(0);
+}
+
 TU_ATTR_ALWAYS_INLINE static inline bool tud_cdc_connected(void) {
   return tud_cdc_n_connected(0);
 }

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -56,8 +56,8 @@
  *   #define TU_VERIFY(cond)                  if(cond) return false;
  *   #define TU_VERIFY(cond,ret)              if(cond) return ret;
  *
- *   #define TU_ASSERT(cond)                  if(cond) {_MESS_FAILED(); TU_BREAKPOINT(), return false;}
- *   #define TU_ASSERT(cond,ret)              if(cond) {_MESS_FAILED(); TU_BREAKPOINT(), return ret;}
+ *   #define TU_ASSERT(cond)                  if(cond) {TU_MESS_FAILED(); TU_BREAKPOINT(), return false;}
+ *   #define TU_ASSERT(cond,ret)              if(cond) {TU_MESS_FAILED(); TU_BREAKPOINT(), return ret;}
  *------------------------------------------------------------------*/
 
 #ifdef __cplusplus
@@ -70,9 +70,9 @@
 
 #if CFG_TUSB_DEBUG
   #include <stdio.h>
-  #define _MESS_FAILED()    tu_printf("%s %d: ASSERT FAILED\r\n", __func__, __LINE__)
+  #define TU_MESS_FAILED()    tu_printf("%s %d: ASSERT FAILED\r\n", __func__, __LINE__)
 #else
-  #define _MESS_FAILED() do {} while (0)
+  #define TU_MESS_FAILED() do {} while (0)
 #endif
 
 // Halt CPU (breakpoint) when hitting error, only apply for Cortex M3, M4, M7, M33. M55
@@ -119,7 +119,7 @@
  *------------------------------------------------------------------*/
 #define TU_ASSERT_DEFINE(_cond, _ret)                                 \
   do {                                                                \
-    if ( !(_cond) ) { _MESS_FAILED(); TU_BREAKPOINT(); return _ret; } \
+    if ( !(_cond) ) { TU_MESS_FAILED(); TU_BREAKPOINT(); return _ret; } \
   } while(0)
 
 #define TU_ASSERT_1ARGS(_cond)         TU_ASSERT_DEFINE(_cond, false)

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -747,17 +747,23 @@ static bool process_control_request(uint8_t rhport, tusb_control_request_t const
               _usbd_dev.speed = speed; // restore speed
             }
 
+            _usbd_dev.cfg_num = cfg_num;
+
             // Handle the new configuration and execute the corresponding callback
             if ( cfg_num ) {
               // switch to new configuration if not zero
-              TU_ASSERT( process_set_config(rhport, cfg_num) );
+              if (!process_set_config(rhport, cfg_num)) {
+                TU_MESS_FAILED();
+                TU_BREAKPOINT();
+                _usbd_dev.cfg_num = 0;
+                return false;
+              }
               if ( tud_mount_cb ) tud_mount_cb();
             } else {
               if ( tud_umount_cb ) tud_umount_cb();
             }
           }
 
-          _usbd_dev.cfg_num = cfg_num;
           tud_control_status(rhport, p_request);
         }
         break;

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -495,15 +495,16 @@ bool tud_deinit(uint8_t rhport) {
 }
 
 static void configuration_reset(uint8_t rhport) {
+  // Clear mounted status first to ensure tud_ready() return false before driver clean up.
+  tu_varclr(&_usbd_dev);
+  memset(_usbd_dev.itf2drv, DRVID_INVALID, sizeof(_usbd_dev.itf2drv)); // invalid mapping
+  memset(_usbd_dev.ep2drv, DRVID_INVALID, sizeof(_usbd_dev.ep2drv)); // invalid mapping
+
   for (uint8_t i = 0; i < TOTAL_DRIVER_COUNT; i++) {
     usbd_class_driver_t const* driver = get_driver(i);
     TU_ASSERT(driver,);
     driver->reset(rhport);
   }
-
-  tu_varclr(&_usbd_dev);
-  memset(_usbd_dev.itf2drv, DRVID_INVALID, sizeof(_usbd_dev.itf2drv)); // invalid mapping
-  memset(_usbd_dev.ep2drv, DRVID_INVALID, sizeof(_usbd_dev.ep2drv)); // invalid mapping
 }
 
 static void usbd_reset(uint8_t rhport) {

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -495,19 +495,15 @@ bool tud_deinit(uint8_t rhport) {
 }
 
 static void configuration_reset(uint8_t rhport) {
-  // Save setup_count for restore
-  uint8_t setup_count =  _usbd_dev.setup_count;
-  // Clear mounted status first to ensure tud_ready() return false before driver clean up.
-  tu_varclr(&_usbd_dev);
-  memset(_usbd_dev.itf2drv, DRVID_INVALID, sizeof(_usbd_dev.itf2drv)); // invalid mapping
-  memset(_usbd_dev.ep2drv, DRVID_INVALID, sizeof(_usbd_dev.ep2drv)); // invalid mapping
-  _usbd_dev.setup_count = setup_count;
-
   for (uint8_t i = 0; i < TOTAL_DRIVER_COUNT; i++) {
     usbd_class_driver_t const* driver = get_driver(i);
     TU_ASSERT(driver,);
     driver->reset(rhport);
   }
+
+  tu_varclr(&_usbd_dev);
+  memset(_usbd_dev.itf2drv, DRVID_INVALID, sizeof(_usbd_dev.itf2drv)); // invalid mapping
+  memset(_usbd_dev.ep2drv, DRVID_INVALID, sizeof(_usbd_dev.ep2drv)); // invalid mapping
 }
 
 static void usbd_reset(uint8_t rhport) {

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -495,10 +495,13 @@ bool tud_deinit(uint8_t rhport) {
 }
 
 static void configuration_reset(uint8_t rhport) {
+  // Save setup_count for restore
+  uint8_t setup_count =  _usbd_dev.setup_count;
   // Clear mounted status first to ensure tud_ready() return false before driver clean up.
   tu_varclr(&_usbd_dev);
   memset(_usbd_dev.itf2drv, DRVID_INVALID, sizeof(_usbd_dev.itf2drv)); // invalid mapping
   memset(_usbd_dev.ep2drv, DRVID_INVALID, sizeof(_usbd_dev.ep2drv)); // invalid mapping
+  _usbd_dev.setup_count = setup_count;
 
   for (uint8_t i = 0; i < TOTAL_DRIVER_COUNT; i++) {
     usbd_class_driver_t const* driver = get_driver(i);


### PR DESCRIPTION
**Describe the PR**
- In cdc_device if read* functions called before tud_ready() transfer will be queued to EP0 cause strange issues.
- Clear _usbd_dev first to ensure tud_ready() return false before driver clean up.
- Introduced by #2492, if both `DCD_EVENT_BUS_RESET` and `DCD_EVENT_SETUP_RECEIVED` are in the event queue, `setup_count` is cleared in bus reset, result `_usbd_dev.setup_count--` underflow. I think the best fix would be clear the queue on bus reset.
- Fix STM32F7 FS port build using HS define.