### PR TITLE
usbh: Set interface recipient should be interface

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1113,7 +1113,7 @@ bool tuh_interface_set(uint8_t daddr, uint8_t itf_num, uint8_t itf_alt,
   TU_LOG_USBH("Set Interface %u Alternate %u\r\n", itf_num, itf_alt);
   tusb_control_request_t const request = {
       .bmRequestType_bit = {
-          .recipient = TUSB_REQ_RCPT_DEVICE,
+          .recipient = TUSB_REQ_RCPT_INTERFACE,
           .type      = TUSB_REQ_TYPE_STANDARD,
           .direction = TUSB_DIR_OUT
       },


### PR DESCRIPTION
**Describe the PR**
Probably just a simple typo. The recipient for tuh_interface_set() should be `TUSB_REQ_RCPT_INTERFACE` instead of `TUSB_REQ_RCPT_DEVICE`.

**Additional context**
![image](https://github.com/hathach/tinyusb/assets/21236406/3b113ae8-a2e5-48e2-8a23-5fcea944668c)
