### PR TITLE
usbh: Add set address recovery time

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1421,6 +1421,9 @@ static void process_enumeration(tuh_xfer_t* xfer) {
       break;
 
     case ENUM_GET_DEVICE_DESC: {
+      // Allow 2ms for address recovery time, Ref USB Spec 9.2.6.3
+      osal_task_delay(2);
+
       uint8_t const new_addr = (uint8_t) tu_le16toh(xfer->setup->wValue);
 
       usbh_device_t* new_dev = get_device(new_addr);


### PR DESCRIPTION
**Describe the PR**
Will close https://github.com/hathach/tinyusb/issues/2673

**Additional context**
Ref USB Spec 9.2.6.3
After successful completion of the Status stage, the device is allowed a SetAddress() recovery interval of
2 ms. At the end of this interval, the device must be able to accept Setup packets addressed to the new
address. Also, at the end of the recovery interval, the device must not respond to tokens sent to the old
address (unless, of course, the old and new address is the same).
