### PR TITLE
synopsys/dwc2_esp32: Add header for vTaskDelay.

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_esp32.h
+++ b/src/portable/synopsys/dwc2/dwc2_esp32.h
@@ -35,6 +35,7 @@
 #include "esp_intr_alloc.h"
 #include "soc/periph_defs.h"
 //#include "soc/usb_periph.h"
+#include "freertos/task.h"
 
 #define DWC2_REG_BASE       0x60080000UL
 #define DWC2_EP_MAX         6             // USB_OUT_EP_NUM. TODO ESP32Sx only has 5 tx fifo (5 endpoint IN)


### PR DESCRIPTION
**Describe the PR**
When compiling the `synopsys/dwc2` for ESP32-S2 I found it to fail using IDF v5.0.4 with:
```
In file included from /tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c:47:
/tinyusb/src/portable/synopsys/dwc2/dwc2_esp32.h: In function 'dwc2_remote_wakeup_delay':
/tinyusb/src/portable/synopsys/dwc2/dwc2_esp32.h:71:3: error: implicit declaration of function 'vTaskDelay' [-Werror=implicit-function-declaration]
   71 |   vTaskDelay(pdMS_TO_TICKS(1));
      |   ^~~~~~~~~~
cc1: some warnings being treated as errors
```

**Additional context**
I didn't run into this problem initially when using a different IDF version, it must have this imported indirectly in a different header (or this warning/error disabled by default)  however it seems sensible to include the header that defines `vTaskDelay` directly.
