### PR TITLE
LPC55: FreeRTOS fix

### DIFF
--- a/examples/device/audio_4_channel_mic_freertos/src/FreeRTOSConfig/FreeRTOSConfig.h
+++ b/examples/device/audio_4_channel_mic_freertos/src/FreeRTOSConfig/FreeRTOSConfig.h
@@ -67,6 +67,7 @@
 #define configENABLE_FPU								        1
 #define configENABLE_TRUSTZONE					        0
 #define configMINIMAL_SECURE_STACK_SIZE					( 1024 )
+#define configRUN_FREERTOS_SECURE_ONLY          1
 
 #define configUSE_PREEMPTION                    1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0

--- a/examples/device/audio_test_freertos/src/FreeRTOSConfig/FreeRTOSConfig.h
+++ b/examples/device/audio_test_freertos/src/FreeRTOSConfig/FreeRTOSConfig.h
@@ -67,6 +67,7 @@
 #define configENABLE_FPU								        1
 #define configENABLE_TRUSTZONE					        0
 #define configMINIMAL_SECURE_STACK_SIZE					( 1024 )
+#define configRUN_FREERTOS_SECURE_ONLY          1
 
 #define configUSE_PREEMPTION                    1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0

--- a/examples/device/cdc_msc_freertos/src/FreeRTOSConfig/FreeRTOSConfig.h
+++ b/examples/device/cdc_msc_freertos/src/FreeRTOSConfig/FreeRTOSConfig.h
@@ -67,6 +67,7 @@
 #define configENABLE_FPU								        1
 #define configENABLE_TRUSTZONE					        0
 #define configMINIMAL_SECURE_STACK_SIZE					( 1024 )
+#define configRUN_FREERTOS_SECURE_ONLY          1
 
 #define configUSE_PREEMPTION                    1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0

--- a/examples/device/hid_composite_freertos/src/FreeRTOSConfig/FreeRTOSConfig.h
+++ b/examples/device/hid_composite_freertos/src/FreeRTOSConfig/FreeRTOSConfig.h
@@ -67,6 +67,7 @@
 #define configENABLE_FPU								        1
 #define configENABLE_TRUSTZONE					        0
 #define configMINIMAL_SECURE_STACK_SIZE					( 1024 )
+#define configRUN_FREERTOS_SECURE_ONLY          1
 
 #define configUSE_PREEMPTION                    1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0

--- a/hw/bsp/lpc55/FreeRTOSConfig/FreeRTOSConfig.h
+++ b/hw/bsp/lpc55/FreeRTOSConfig/FreeRTOSConfig.h
@@ -52,6 +52,7 @@
 #define configENABLE_FPU                        1
 #define configENABLE_TRUSTZONE                  0
 #define configMINIMAL_SECURE_STACK_SIZE         (1024)
+#define configRUN_FREERTOS_SECURE_ONLY          1
 
 #define configUSE_PREEMPTION                    1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0

--- a/hw/bsp/lpc55/family.c
+++ b/hw/bsp/lpc55/family.c
@@ -120,12 +120,17 @@ void board_init(void) {
   // Init 96 MHz clock
   BootClockFROHF96M();
 
+#if CFG_TUSB_OS == OPT_OS_NONE
   // 1ms tick timer
   SysTick_Config(SystemCoreClock / 1000);
 
-#if CFG_TUSB_OS == OPT_OS_FREERTOS
+#elif CFG_TUSB_OS == OPT_OS_FREERTOS
+  // Explicitly disable systick to prevent its ISR runs before scheduler start
+  SysTick->CTRL &= ~1U;
+
   // If freeRTOS is used, IRQ priority is limit by max syscall ( smaller is higher )
   NVIC_SetPriority(USB0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
+  NVIC_SetPriority(USB1_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY );
 #endif
 
   // Init all GPIO ports
@@ -239,6 +244,10 @@ void board_init(void) {
 //  phytx &= ~(USBPHY_TX_D_CAL_MASK | USBPHY_TX_TXCAL45DM_MASK | USBPHY_TX_TXCAL45DP_MASK);
 //  phytx |= USBPHY_TX_D_CAL(0x0C) | USBPHY_TX_TXCAL45DP(0x06) | USBPHY_TX_TXCAL45DM(0x06);
 //  USBPHY->TX = phytx;
+
+    ARM_MPU_SetMemAttr(0, 0x44); // Normal memory, non-cacheable (inner and outer)
+    ARM_MPU_SetRegion(0, ARM_MPU_RBAR(0x40100000, ARM_MPU_SH_NON, 0, 1, 1), ARM_MPU_RLAR(0x40104000, 0));
+    ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk | MPU_CTRL_HFNMIENA_Msk);
 #endif
 }
 


### PR DESCRIPTION
**Describe the PR**
Make LPC55 works with FreeRTOS.

Also add MPU setting to fix potentially USB RAM alignment issue (ref. https://community.nxp.com/t5/LPC-Microcontrollers/USB-and-newlib/m-p/1312833#M45952)