### PR TITLE
remove double semicolon since ISO C not allow it

### DIFF
--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -78,7 +78,7 @@ typedef struct
 // _int_set is not used with an RTOS
 #define OSAL_QUEUE_DEF(_int_set, _name, _depth, _type) \
   static _type _name##_##buf[_depth];\
-  osal_queue_def_t _name = { .depth = _depth, .item_sz = sizeof(_type), .buf = _name##_##buf, _OSAL_Q_NAME(_name) };
+  osal_queue_def_t _name = { .depth = _depth, .item_sz = sizeof(_type), .buf = _name##_##buf, _OSAL_Q_NAME(_name) }
 
 //--------------------------------------------------------------------+
 // TASK API

--- a/src/typec/tcd.h
+++ b/src/typec/tcd.h
@@ -63,7 +63,7 @@ typedef struct TU_ATTR_PACKED {
     } xfer_complete;
   };
 
-} tcd_event_t;;
+} tcd_event_t;
 
 //--------------------------------------------------------------------+
 //


### PR DESCRIPTION

**Describe the PR**

ISO C does not allow extra ';' outside of a function [-Werror=pedantic]