### PR TITLE
simplify dwc2 test mode

### DIFF
--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -195,7 +195,6 @@
 #elif TU_CHECK_MCU(OPT_MCU_STM32F4)
   #define TUP_USBIP_DWC2
   #define TUP_USBIP_DWC2_STM32
-  #define TUP_USBIP_DWC2_TEST_MODE
 
   // For most mcu, FS has 4, HS has 6. TODO 446/469/479 HS has 9
   #define TUP_DCD_ENDPOINT_MAX    6
@@ -210,7 +209,6 @@
   // MCU with on-chip HS Phy
   #if defined(STM32F723xx) || defined(STM32F730xx) || defined(STM32F733xx)
     #define TUP_RHPORT_HIGHSPEED  1 // Port0: FS, Port1: HS
-    #define TUP_USBIP_DWC2_TEST_MODE
   #endif
 
 #elif TU_CHECK_MCU(OPT_MCU_STM32H7)
@@ -285,7 +283,6 @@
         defined(STM32U5F7xx) || defined(STM32U5F9xx) || defined(STM32U5G7xx) || defined(STM32U5G9xx)
       #define TUP_DCD_ENDPOINT_MAX  9
       #define TUP_RHPORT_HIGHSPEED  1
-      #define TUP_USBIP_DWC2_TEST_MODE
     #else
       #define TUP_DCD_ENDPOINT_MAX  6
     #endif

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -214,6 +214,15 @@ enum {
 
 #define TUSB_DESC_CONFIG_POWER_MA(x)  ((x)/2)
 
+// USB 2.0 Spec Table 9-7: Test Mode Selectors
+typedef enum {
+  TUSB_FEATURE_TEST_J = 1,
+  TUSB_FEATURE_TEST_K,
+  TUSB_FEATURE_TEST_SE0_NAK,
+  TUSB_FEATURE_TEST_PACKET,
+  TUSB_FEATURE_TEST_FORCE_ENABLE,
+} tusb_feature_test_mode_t;
+
 //--------------------------------------------------------------------+
 //
 //--------------------------------------------------------------------+

--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -89,14 +89,6 @@ typedef struct TU_ATTR_ALIGNED(4) {
   };
 } dcd_event_t;
 
-typedef enum {
-  TEST_J = 1,
-  TEST_K,
-  TEST_SE0_NAK,
-  TEST_PACKET,
-  TEST_FORCE_ENABLE,
-} test_mode_t;
-
 //TU_VERIFY_STATIC(sizeof(dcd_event_t) <= 12, "size is not correct");
 
 //--------------------------------------------------------------------+
@@ -150,11 +142,8 @@ void dcd_disconnect(uint8_t rhport);
 void dcd_sof_enable(uint8_t rhport, bool en);
 
 #if CFG_TUD_TEST_MODE
-// Check if the test mode is supported, returns true is test mode selector is supported
-bool dcd_check_test_mode_support(test_mode_t test_selector) TU_ATTR_WEAK;
-
 // Put device into a test mode (needs power cycle to quit)
-void dcd_enter_test_mode(uint8_t rhport, test_mode_t test_selector) TU_ATTR_WEAK;
+void dcd_enter_test_mode(uint8_t rhport, tusb_feature_test_mode_t test_selector);
 #endif
 //--------------------------------------------------------------------+
 // Endpoint API

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -1195,25 +1195,13 @@ void dcd_int_handler(uint8_t rhport) {
   //  }
 }
 
-#if defined(TUP_USBIP_DWC2_TEST_MODE) && CFG_TUD_TEST_MODE
-
-bool dcd_check_test_mode_support(test_mode_t test_selector) {
-  // Check if test mode selector is unsupported
-  if (TEST_FORCE_ENABLE < test_selector || TEST_J > test_selector) {
-    return false;
-  }
-
-  return true;
-}
-
-void dcd_enter_test_mode(uint8_t rhport, test_mode_t test_selector) {
-  // Get port address...
+#if CFG_TUD_TEST_MODE
+void dcd_enter_test_mode(uint8_t rhport, tusb_feature_test_mode_t test_selector) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
 
   // Enable the test mode
-  dwc2->dctl = (dwc2->dctl & ~DCTL_TCTL_Msk) | (test_selector << DCTL_TCTL_Pos);
+  dwc2->dctl = (dwc2->dctl & ~DCTL_TCTL_Msk) | (((uint8_t) test_selector) << DCTL_TCTL_Pos);
 }
-
-#endif /* TUP_USBIP_DWC2_TEST_MODE && CFG_TUD_TEST_MODE */
+#endif
 
 #endif

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -381,7 +381,7 @@
   #error "CFG_TUD_ENDPPOINT_MAX must be less than or equal to TUP_DCD_ENDPOINT_MAX"
 #endif
 
-// USB 2.0 compliance test mode support
+// USB 2.0 7.1.20: compliance test mode support
 #ifndef CFG_TUD_TEST_MODE
   #define CFG_TUD_TEST_MODE       0
 #endif


### PR DESCRIPTION
**Describe the PR**
follow up to #2416
- all dwc2 ip seems to support test mode in both fs/hs -> remove TUP_USBIP_DWC2_TEST_MODE
- remove dcd_check_test_mode_support(), all should be supported
- move enum tusb_feature_test_mode_t to tusb_types.h
