### PR TITLE
hil flash itsybitsy m4 with picoprobe

### DIFF
--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -114,11 +114,10 @@ def read_disk_file(id, fname):
 # Flashing firmware
 # -------------------------------------------------------------
 def run_cmd(cmd):
-    # print(cmd)
+    #print(cmd)
     r = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    title = 'command error'
     if r.returncode != 0:
-        # print build output if failed
+        title = 'command error'
         if os.getenv('CI'):
             print(f"::group::{title}")
             print(r.stdout.decode("utf-8"))
@@ -156,23 +155,23 @@ def flash_esptool(board, firmware):
     return ret
 
 
-def doublereset_with_rpi_gpio(board):
+def doublereset_with_rpi_gpio(pin):
     # Off = 0 = Reset
-    led = gpiozero.LED(board["flasher_reset_pin"])
+    nrst = gpiozero.LED(pin)
 
-    led.off()
+    nrst.off()
     time.sleep(0.1)
-    led.on()
+    nrst.on()
     time.sleep(0.1)
-    led.off()
+    nrst.off()
     time.sleep(0.1)
-    led.on()
+    nrst.on()
 
 
 def flash_bossac(board, firmware):
     # double reset to enter bootloader
     if platform.machine() == 'aarch64':
-        doublereset_with_rpi_gpio(board)
+        doublereset_with_rpi_gpio(board["flasher_reset_pin"])
 
     port = get_serial_dev(board["uid"], board["flashser_vendor"], board["flasher_product"], 0)
     timeout = ENUM_TIMEOUT
@@ -367,7 +366,10 @@ def main():
                     test_list.remove(skip)
 
         for test in test_list:
-            fw_name = f'cmake-build/cmake-build-{name}/device/{test}/{test}'
+            fw_dir = f'cmake-build/cmake-build-{name}/device/{test}'
+            if not os.path.exists(fw_dir):
+                fw_dir = f'examples/cmake-build-{name}/device/{test}'
+            fw_name = f'{fw_dir}/{test}'
             print(f'  {test} ...', end='')
 
             # flash firmware. It may fail randomly, retry a few times

--- a/test/hil/rpi.json
+++ b/test/hil/rpi.json
@@ -17,11 +17,9 @@
         {
             "name": "itsybitsy_m4",
             "uid": "D784B28C5338533335202020FF044726",
-            "flasher": "bossac",
-            "flashser_vendor": "Adafruit Industries",
-            "flasher_product": "ItsyBitsy M4 Express",
-            "flasher_reset_pin": "2",
-            "flasher_args": "--offset 0x4000"
+            "flasher": "openocd",
+            "flasher_sn": "E6614C311B597D32",
+            "flasher_args": "-f interface/cmsis-dap.cfg -f target/atsame5x.cfg -c \"adapter speed 5000\""
         },
         {
             "name": "espressif_s3_devkitm",


### PR DESCRIPTION
**Describe the PR**
hil flash itsybitsy m4 with picoprobe which is faster and more stable then using bossaac bootloader
