### PR TITLE
RP2040 tweaks

### DIFF
--- a/examples/device/net_lwip_webserver/CMakeLists.txt
+++ b/examples/device/net_lwip_webserver/CMakeLists.txt
@@ -5,7 +5,14 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../../hw/bsp/family_support.cmake)
 # gets PROJECT name for the example (e.g. <BOARD>-<DIR_NAME>)
 family_get_project_name(PROJECT ${CMAKE_CURRENT_LIST_DIR})
 
+# Prefer the tinyusb lwip
 set(LWIP ${TOP}/lib/lwip)
+
+# If we can't find one from tinyusb then check cmake var before giving up
+if (NOT EXISTS ${LWIP}/src)
+  set(LWIP ${TINYUSB_LWIP_PATH})
+endif()
+
 if (NOT EXISTS ${LWIP}/src)
   family_example_missing_dependency(${PROJECT} "lib/lwip")
   return()

--- a/examples/host/cdc_msc_hid/src/hid_app.c
+++ b/examples/host/cdc_msc_hid/src/hid_app.c
@@ -235,6 +235,7 @@ static void process_mouse_report(hid_mouse_report_t const * report)
 static void process_generic_report(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len)
 {
   (void) dev_addr;
+  (void) len;
 
   uint8_t const rpt_count = hid_info[instance].report_count;
   tuh_hid_report_info_t* rpt_info_arr = hid_info[instance].report_info;

--- a/examples/host/hid_controller/src/hid_app.c
+++ b/examples/host/hid_controller/src/hid_app.c
@@ -253,6 +253,7 @@ bool diff_report(sony_ds4_report_t const* rpt1, sony_ds4_report_t const* rpt2)
 
 void process_sony_ds4(uint8_t const* report, uint16_t len)
 {
+  (void)len;
   const char* dpad_str[] = { "N", "NE", "E", "SE", "S", "SW", "W", "NW", "none" };
 
   // previous report used to compare for changes

--- a/hw/bsp/family_support.cmake
+++ b/hw/bsp/family_support.cmake
@@ -69,6 +69,10 @@ if (NOT FAMILY STREQUAL rp2040)
   endif()
 endif()
 
+if (NOT NO_WARN_RWX_SEGMENTS_SUPPORTED)
+  set(NO_WARN_RWX_SEGMENTS_SUPPORTED 1)
+endif()
+
 set(WARNING_FLAGS_GNU
   -Wall
   -Wextra
@@ -210,7 +214,7 @@ function(family_configure_common TARGET RTOS)
   # Generate linker map file
   if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_link_options(${TARGET} PUBLIC "LINKER:-Map=$<TARGET_FILE:${TARGET}>.map")
-    if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
+    if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0 AND NO_WARN_RWX_SEGMENTS_SUPPORTED)
       target_link_options(${TARGET} PUBLIC "LINKER:--no-warn-rwx-segments")
     endif ()
  elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
@@ -360,7 +364,7 @@ function(family_add_default_example_warnings TARGET)
     )
 
   if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
+    if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0 AND NO_WARN_RWX_SEGMENTS_SUPPORTED)
       target_link_options(${TARGET} PUBLIC "LINKER:--no-warn-rwx-segments")
     endif()
 

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -657,7 +657,9 @@ uint8_t tuh_hid_parse_report_descriptor(tuh_hid_report_info_t* report_info_arr, 
     uint8_t const data8 = desc_report[0];
 
     TU_LOG(3, "tag = %d, type = %d, size = %d, data = ", tag, type, size);
-    for (uint32_t i = 0; i < size; i++) TU_LOG(3, "%02X ", desc_report[i]);
+    for (uint32_t i = 0; i < size; i++) {
+      TU_LOG(3, "%02X ", desc_report[i]);
+    }
     TU_LOG(3, "\r\n");
 
     switch (type) {

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -75,7 +75,6 @@ void rp2040_usb_init(void) {
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 #endif
-  memset(usb_hw, 0, sizeof(*usb_hw));
   memset(usb_dpram, 0, sizeof(*usb_dpram));
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -53,6 +53,14 @@ TU_ATTR_ALWAYS_INLINE static inline bool is_host_mode(void) {
 //--------------------------------------------------------------------+
 // Implementation
 //--------------------------------------------------------------------+
+// Provide own byte by byte memcpy as not all copies are aligned
+static void unaligned_memcpy(void *dst, const void *src, size_t n) {
+  uint8_t *dst_byte = (uint8_t*)dst;
+  const uint8_t *src_byte = (const uint8_t*)src;
+  while (n--) {
+    *dst_byte++ = *src_byte++;
+  }
+}
 
 void rp2040_usb_init(void) {
   // Reset usb controller
@@ -125,7 +133,7 @@ static uint32_t __tusb_irq_path_func(prepare_ep_buffer)(struct hw_endpoint* ep, 
 
   if (!ep->rx) {
     // Copy data from user buffer to hw buffer
-    memcpy(ep->hw_data_buf + buf_id * 64, ep->user_buf, buflen);
+    unaligned_memcpy(ep->hw_data_buf + buf_id * 64, ep->user_buf, buflen);
     ep->user_buf += buflen;
 
     // Mark as full
@@ -230,7 +238,7 @@ static uint16_t __tusb_irq_path_func(sync_ep_buffer)(struct hw_endpoint* ep, uin
     // we have received AFTER we have copied it to the user buffer at the appropriate offset
     assert(buf_ctrl & USB_BUF_CTRL_FULL);
 
-    memcpy(ep->user_buf, ep->hw_data_buf + buf_id * 64, xferred_bytes);
+    unaligned_memcpy(ep->user_buf, ep->hw_data_buf + buf_id * 64, xferred_bytes);
     ep->xferred_len = (uint16_t) (ep->xferred_len + xferred_bytes);
     ep->user_buf += xferred_bytes;
   }

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -398,7 +398,7 @@ static void dump_str_line(uint8_t const* buf, uint16_t count) {
   tu_printf("  |");
   // each line is 16 bytes
   for (uint16_t i = 0; i < count; i++) {
-    const char ch = buf[i];
+    int ch = buf[i];
     tu_printf("%c", isprint(ch) ? ch : '.');
   }
   tu_printf("|\r\n");


### PR DESCRIPTION
RP2040 tweaks:
- Compiler warning fixes
- allow pico-sdk LWIP to be used if TinyUSB one does not exist
- Use custom memcpy in RP2040 code
- Don't clear registers when not needed as hardware reset already does it