### PR TITLE
change hil s3 baudarte

### DIFF
--- a/test/hil/rpi.json
+++ b/test/hil/rpi.json
@@ -29,7 +29,7 @@
             ],
             "flasher": "esptool",
             "flasher_sn": "3ea619acd1cdeb11a0a0b806e93fd3f1",
-            "flasher_args": "-b 1500000"
+            "flasher_args": "-b 921600"
         },
         {
             "name": "metro_m7_1011",


### PR DESCRIPTION
**Describe the PR**
lower flashing baudrate for hil s3, since it seems to have stable issue with pi5 + cp2102

```
[378571.099339] usb 1-2.1.2: device descriptor read/8, error -71
[378571.234364] usb 1-2.1.2: device descriptor read/8, error -71
[378571.345366] usb 1-2.1-port2: unable to enumerate USB device
[378571.942508] cp210x ttyUSB0: failed to get comm status: -71
[378571.944417] cp210x ttyUSB0: failed set request 0x7 status: -71
[378571.946412] cp210x ttyUSB0: failed set request 0x12 status: -71
[378571.948422] cp210x ttyUSB0: failed set request 0x0 status: -71
[378573.059447] cp210x ttyUSB0: failed set request 0x0 status: -71
[378573.059456] cp210x ttyUSB0: cp210x_open - Unable to enable UART
[378574.175498] cp210x ttyUSB0: failed set request 0x0 status: -71
[378574.175506] cp210x ttyUSB0: cp210x_open - Unable to enable UART
pi@pi5b:~/actions-runner/_work/tinyusb/tinyusb $ minicom /dev/ttyUSB0 
```