### PR TITLE
[HIL] add dual host_info_to_device_cdc support

### DIFF
--- a/hw/bsp/family_support.cmake
+++ b/hw/bsp/family_support.cmake
@@ -463,7 +463,7 @@ function(family_flash_openocd TARGET)
   # note skip verify since it has issue with rp2040
   add_custom_target(${TARGET}-openocd
     DEPENDS ${TARGET}
-    COMMAND ${OPENOCD} ${OPTION_LIST} -c init -c halt -c "program $<TARGET_FILE:${TARGET}> reset" ${OPTION_LIST2} -c exit
+    COMMAND ${OPENOCD} -c "tcl_port disabled" -c "gdb_port disabled" ${OPTION_LIST} -c init -c halt -c "program $<TARGET_FILE:${TARGET}>" -c reset ${OPTION_LIST2} -c exit
     VERBATIM
     )
 endfunction()

--- a/hw/bsp/nrf/boards/feather_nrf52840_express/board.cmake
+++ b/hw/bsp/nrf/boards/feather_nrf52840_express/board.cmake
@@ -2,7 +2,7 @@ set(MCU_VARIANT nrf52840)
 set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/../../linker/nrf52840_s140_v6.ld)
 
 # enable max3421 host driver for this board
-set(MAX3421_HOST 1)
+# set(MAX3421_HOST 1)
 
 function(update_board TARGET)
 endfunction()

--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -42,7 +42,7 @@
 static uart_inst_t *uart_inst;
 #endif
 
-#if CFG_TUH_RPI_PIO_USB || CFG_TUD_RPI_PIO_USB
+#if (CFG_TUH_ENABLED && CFG_TUH_RPI_PIO_USB) || (CFG_TUD_ENABLED && CFG_TUD_RPI_PIO_USB)
 #include "pio_usb.h"
 #endif
 
@@ -126,7 +126,7 @@ void stdio_rtt_init(void) {
 
 void board_init(void)
 {
-#if CFG_TUH_RPI_PIO_USB || CFG_TUD_RPI_PIO_USB
+#if (CFG_TUH_ENABLED && CFG_TUH_RPI_PIO_USB) || (CFG_TUD_ENABLED && CFG_TUD_RPI_PIO_USB)
   // Set the system clock to a multiple of 120mhz for bitbanging USB with pico-usb
   set_sys_clock_khz(120000, true);
 

--- a/hw/bsp/samd5x_e5x/boards/metro_m4_express/board.cmake
+++ b/hw/bsp/samd5x_e5x/boards/metro_m4_express/board.cmake
@@ -3,6 +3,9 @@ set(SAM_FAMILY samd51)
 set(JLINK_DEVICE ATSAMD51J19)
 set(LD_FILE_GNU ${CMAKE_CURRENT_LIST_DIR}/${BOARD}.ld)
 
+# force max3421e for testing with hardware-in-the-loop
+set(MAX3421_HOST 1)
+
 function(update_board TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     __SAMD51J19A__

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -27,6 +27,7 @@
 
 import argparse
 import os
+import re
 import sys
 import time
 import serial
@@ -212,14 +213,39 @@ def flash_uniflash(board, firmware):
 
 
 # -------------------------------------------------------------
-# Tests
+# Tests: dual
 # -------------------------------------------------------------
-def test_board_test(board):
+
+def test_dual_host_info_to_device_cdc(board):
+    uid = board['uid']
+    declared_devs = [f'{d["vid_pid"]}_{d["serial"]}' for d in board['tests']['dual_attached']]
+
+    port = get_serial_dev(uid, 'TinyUSB', "TinyUSB_Device", 0)
+    ser = open_serial_dev(port)
+    # read from cdc, first line should contain vid/pid and serial
+    data = ser.read(1000)
+    lines = data.decode('utf-8').splitlines()
+    enum_dev_sn = []
+    for l in lines:
+        vid_pid_sn = re.search(r'ID ([0-9a-fA-F]+):([0-9a-fA-F]+) SN (\w+)', l)
+        if vid_pid_sn:
+            print(f'\r\n  {l} ', end='')
+            enum_dev_sn.append(f'{vid_pid_sn.group(1)}_{vid_pid_sn.group(2)}_{vid_pid_sn.group(3)}')
+
+    assert(set(declared_devs) == set(enum_dev_sn)), \
+        f'Enumerated devices {enum_dev_sn} not match with declared {declared_devs}'
+    return 0
+
+
+# -------------------------------------------------------------
+# Tests: device
+# -------------------------------------------------------------
+def test_device_board_test(board):
     # Dummy test
     pass
 
 
-def test_cdc_dual_ports(board):
+def test_device_cdc_dual_ports(board):
     uid = board['uid']
     port1 = get_serial_dev(uid, 'TinyUSB', "TinyUSB_Device", 0)
     port2 = get_serial_dev(uid, 'TinyUSB', "TinyUSB_Device", 2)
@@ -241,7 +267,7 @@ def test_cdc_dual_ports(board):
     assert ser2.read(100) == str2.upper(), 'Port2 wrong data'
 
 
-def test_cdc_msc(board):
+def test_device_cdc_msc(board):
     uid = board['uid']
     # Echo test
     port = get_serial_dev(uid, 'TinyUSB', "TinyUSB_Device", 0)
@@ -262,11 +288,11 @@ issue at github.com/hathach/tinyusb"
     assert data == readme, 'MSC wrong data'
 
 
-def test_cdc_msc_freertos(board):
-    test_cdc_msc(board)
+def test_device_cdc_msc_freertos(board):
+    test_device_cdc_msc(board)
 
 
-def test_dfu(board):
+def test_device_dfu(board):
     uid = board['uid']
 
     # Wait device enum
@@ -308,7 +334,7 @@ def test_dfu(board):
     os.remove(f_dfu1)
 
 
-def test_dfu_runtime(board):
+def test_device_dfu_runtime(board):
     uid = board['uid']
 
     # Wait device enum
@@ -325,7 +351,7 @@ def test_dfu_runtime(board):
     assert timeout, 'Device not available'
 
 
-def test_hid_boot_interface(board):
+def test_device_hid_boot_interface(board):
     uid = board['uid']
     kbd = get_hid_dev(uid, 'TinyUSB', 'TinyUSB_Device', 'event-kbd')
     mouse1 = get_hid_dev(uid, 'TinyUSB', 'TinyUSB_Device', 'if01-event-mouse')
@@ -341,7 +367,7 @@ def test_hid_boot_interface(board):
     assert timeout, 'HID device not available'
 
 
-def test_hid_composite_freertos(id):
+def test_device_hid_composite_freertos(id):
     # TODO implement later
     pass
 
@@ -351,13 +377,15 @@ def test_hid_composite_freertos(id):
 # -------------------------------------------------------------
 # all possible tests: board_test is added last to disable board's usb
 all_tests = [
-    'cdc_dual_ports',
-    'cdc_msc',
-    'dfu',
-    'cdc_msc_freertos',  # dont test 2 cdc_msc next to each other, since they have same vid/pid. Can be confused by host
-    'dfu_runtime',
-    'hid_boot_interface',
-    'board_test'
+    'device/cdc_dual_ports',
+    'device/cdc_msc',
+    'device/dfu',
+    'device/cdc_msc_freertos',  # don't test 2 cdc_msc next to each other
+    'device/dfu_runtime',
+    'device/hid_boot_interface',
+
+    'dual/host_info_to_device_cdc',
+    'device/board_test'
 ]
 
 
@@ -366,23 +394,23 @@ def test_board(board):
     flasher = board['flasher'].lower()
 
     # default to all tests
-    if 'tests' in board:
-        test_list = board['tests'] + ['board_test']
-    else:
-        test_list = list(all_tests)
+    test_list = list(all_tests)
 
-    # remove skip_tests
-    if 'tests_skip' in board:
-        for skip in board['tests_skip']:
-            if skip in test_list:
-                test_list.remove(skip)
+    if 'tests' in board:
+        board_tests = board['tests']
+        if 'only' in board_tests:
+            test_list = board_tests['only'] + ['device/board_test']
+        if 'skip' in board_tests:
+            for skip in board_tests['skip']:
+                if skip in test_list:
+                    test_list.remove(skip)
 
     err_count = 0
     for test in test_list:
-        fw_dir = f'cmake-build/cmake-build-{name}/device/{test}'
+        fw_dir = f'cmake-build/cmake-build-{name}/{test}'
         if not os.path.exists(fw_dir):
-            fw_dir = f'examples/cmake-build-{name}/device/{test}'
-        fw_name = f'{fw_dir}/{test}'
+            fw_dir = f'examples/cmake-build-{name}/{test}'
+        fw_name = f'{fw_dir}/{os.path.basename(test)}'
         print(f'{name:30} {test:20} ... ', end='')
 
         if not os.path.exists(fw_dir):
@@ -400,7 +428,7 @@ def test_board(board):
 
         if ret.returncode == 0:
             try:
-                ret = globals()[f'test_{test}'](board)
+                ret = globals()[f'test_{test.replace("/", "_")}'](board)
                 print('OK')
             except Exception as e:
                 err_count += 1
@@ -409,7 +437,6 @@ def test_board(board):
         else:
             err_count += 1
             print('Flash failed')
-
     return err_count
 
 

--- a/test/hil/rpi.json
+++ b/test/hil/rpi.json
@@ -49,6 +49,7 @@
             "flasher_sn": "E6614103E72C1D2F",
             "flasher_args": "-f interface/cmsis-dap.cfg -f target/rp2040.cfg -c \"adapter speed 5000\"",
             "tests": {
+                "skip": ["dual/host_info_to_device_cdc"],
                 "dual_attached": [{"vid_pid": "1a86_55d4", "serial": "52D2002470"}]
             }
         },

--- a/test/hil/rpi.json
+++ b/test/hil/rpi.json
@@ -8,11 +8,18 @@
             "flasher_args": "-device nrf52840_xxaa"
         },
         {
-            "name": "itsybitsy_m4",
-            "uid": "D784B28C5338533335202020FF044726",
+            "name": "metro_m4_express",
+            "uid": "9995AD485337433231202020FF100A34",
             "flasher": "openocd",
-            "flasher_sn": "E6614C311B597D32",
-            "flasher_args": "-f interface/cmsis-dap.cfg -f target/atsame5x.cfg -c \"adapter speed 5000\""
+            "flasher_sn": "E6633861A3978538",
+            "flasher_args": "-f interface/cmsis-dap.cfg -f target/atsame5x.cfg",
+            "tests": {
+                "dual_attached": [
+                    {
+                        "vid_pid": "1a86_55d4", "serial": "52D2002130"
+                    }
+                ]
+            }
         },
         {
             "name": "max32666fthr",
@@ -31,7 +38,9 @@
         {
             "name": "ra4m1_ek",
             "uid": "152E163038303131393346E46F26574B",
-            "tests_skip": ["cdc_msc", "cdc_msc_freertos"],
+            "tests": {
+                "skip": ["device/cdc_msc", "device/cdc_msc_freertos"]
+            },
             "comment": "MSC is slow to enumerated #2602",
             "flasher": "jlink",
             "flasher_sn": "000831174392",
@@ -77,9 +86,9 @@
         {
             "name": "espressif_s3_devkitm",
             "uid": "84F703C084E4",
-            "tests": [
-                "cdc_msc_freertos", "hid_composite_freertos"
-            ],
+            "tests": {
+                "only": ["device/cdc_msc_freertos", "device/hid_composite_freertos"]
+            },
             "flasher": "esptool",
             "flasher_sn": "3ea619acd1cdeb11a0a0b806e93fd3f1",
             "flasher_args": "-b 921600"

--- a/test/hil/rpi.json
+++ b/test/hil/rpi.json
@@ -14,11 +14,7 @@
             "flasher_sn": "E6633861A3978538",
             "flasher_args": "-f interface/cmsis-dap.cfg -f target/atsame5x.cfg",
             "tests": {
-                "dual_attached": [
-                    {
-                        "vid_pid": "1a86_55d4", "serial": "52D2002130"
-                    }
-                ]
+                "dual_attached": [{"vid_pid": "1a86_55d4", "serial": "52D2002130"}]
             }
         },
         {
@@ -51,7 +47,10 @@
             "uid": "E6614C311B764A37",
             "flasher": "openocd",
             "flasher_sn": "E6614103E72C1D2F",
-            "flasher_args": "-f interface/cmsis-dap.cfg -f target/rp2040.cfg -c \"adapter speed 5000\""
+            "flasher_args": "-f interface/cmsis-dap.cfg -f target/rp2040.cfg -c \"adapter speed 5000\"",
+            "tests": {
+                "dual_attached": [{"vid_pid": "1a86_55d4", "serial": "52D2002470"}]
+            }
         },
         {
             "name": "stm32f072disco",


### PR DESCRIPTION
**Describe the PR**
- Add intial host test with host_info_to_device_cdc since it can use tinyusb device without additional usb2uart to verify attached device vid/pid/serial
- replace itsybitsy m4 with metro m4 + max3421e shield for testing host
- add devices to test rp2040 + pio-usb host.