### PR TITLE
bump up pio-usb to 0.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
               "make arm-gcc"
               "make msp430-gcc"
               "make riscv-gcc"
-              # "make rx-gcc" llvm-gcc-renesas.com seems to be down
+              "make rx-gcc"
               "cmake esp-idf"
             )
 

--- a/.circleci/config2.yml
+++ b/.circleci/config2.yml
@@ -42,6 +42,10 @@ commands:
               if [[ << parameters.toolchain >> == rx-gcc ]]; then
                 mv toolchain.tar.gz toolchain.run
                 chmod +x toolchain.run
+                # rx-gcc is i386 binary
+                sudo dpkg --add-architecture i386
+                sudo apt update
+                sudo apt install libc6:i386 libncurses5:i386 libstdc++6:i386
                 ./toolchain.run -p ~/cache/<< parameters.toolchain >>/gnurx -y
               else
                 tar -C ~/cache/<< parameters.toolchain >> -xaf toolchain.tar.gz

--- a/.circleci/config2.yml
+++ b/.circleci/config2.yml
@@ -42,10 +42,6 @@ commands:
               if [[ << parameters.toolchain >> == rx-gcc ]]; then
                 mv toolchain.tar.gz toolchain.run
                 chmod +x toolchain.run
-                # rx-gcc is i386 binary
-                sudo dpkg --add-architecture i386
-                sudo apt update
-                sudo apt install libc6:i386 libncurses5:i386 libstdc++6:i386
                 ./toolchain.run -p ~/cache/<< parameters.toolchain >>/gnurx -y
               else
                 tar -C ~/cache/<< parameters.toolchain >> -xaf toolchain.tar.gz
@@ -90,6 +86,13 @@ commands:
               NINJA_URL=https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
               wget $NINJA_URL -O ninja-linux.zip
               unzip ninja-linux.zip -d ~/bin
+            fi
+
+            # rx-gcc is 32-bit binary
+            if [[ << parameters.toolchain >> == rx-gcc ]]; then
+              sudo dpkg --add-architecture i386
+              sudo apt update
+              sudo apt install libc6:i386 libstdc++6:i386 zlib1g:i386
             fi
 
             # Install Pico SDK

--- a/.github/workflows/hil_test.yml
+++ b/.github/workflows/hil_test.yml
@@ -21,51 +21,53 @@ env:
   HIL_JSON: test/hil/rpi.json
 
 jobs:
-  # ---------------------------------------
-  # Build Non Espressif
-  # ---------------------------------------
-  build:
-    if: github.repository_owner == 'hathach'
+  set-matrix:
     runs-on: ubuntu-latest
     outputs:
-      BOARDS_LIST: ${{ steps.parse_hil_json.outputs.BOARDS_LIST }}
+      json: ${{ steps.set-matrix-json.outputs.matrix }}
     steps:
       - name: Checkout TinyUSB
         uses: actions/checkout@v4
 
-      - name: Parse HIL json
-        id: parse_hil_json
+      - name: Generate matrix json
+        id: set-matrix-json
         run: |
-          sudo apt install -y jq
+          MATRIX_JSON=$(jq -c '{ "arm-gcc": [.boards[] | select(.flasher != "esptool" and .flasher != "openocd_wch") | .name] }' ${{ env.HIL_JSON }})
+          echo "matrix=$MATRIX_JSON"
+          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
 
-          # Non-Espresif boards
-          BOARDS_LIST=$(jq -r '.boards[] | select(.flasher != "esptool") | "-b " + .name' ${{ env.HIL_JSON }} | tr '\n' ' ')
-          echo "BOARDS_LIST=$BOARDS_LIST"
-          echo "BOARDS_LIST=$BOARDS_LIST" >> $GITHUB_ENV
-          echo "BOARDS_LIST=$BOARDS_LIST" >> $GITHUB_OUTPUT
+  # ---------------------------------------
+  # Build arm-gcc
+  # ---------------------------------------
+  build:
+    if: github.repository_owner == 'hathach'
+    needs: set-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ${{ fromJSON(needs.set-matrix.outputs.json)['arm-gcc'] }}
+    steps:
+      - name: Checkout TinyUSB
+        uses: actions/checkout@v4
 
       - name: Setup arm-gcc toolchain
         uses: ./.github/actions/setup_toolchain
         with:
           toolchain: 'arm-gcc'
 
-      - name: Setup risv-gcc toolchain
-        uses: ./.github/actions/setup_toolchain
-        with:
-          toolchain: 'riscv-gcc'
-
       - name: Get Dependencies
         uses: ./.github/actions/get_deps
         with:
-          arg: ${{ env.BOARDS_LIST }}
+          arg: -b${{ matrix.board }}
 
       - name: Build
-        run: python tools/build.py $BOARDS_LIST
+        run: python tools/build.py -b${{ matrix.board }}
 
       - name: Upload Artifacts for Hardware Testing
         uses: actions/upload-artifact@v4
         with:
-          name: hil_rpi
+          name: ${{ matrix.board }}
           path: |
             cmake-build/cmake-build-*/*/*/*.elf
             cmake-build/cmake-build-*/*/*/*.bin
@@ -76,11 +78,8 @@ jobs:
   # ---------------------------------------
   hil-rpi:
     if: github.repository_owner == 'hathach'
-    needs:
-      - build
+    needs: build
     runs-on: [self-hosted, ARM64, rpi, hardware-in-the-loop]
-    env:
-      BOARDS_LIST: "${{ needs.build-esp.outputs.BOARDS_LIST }} ${{ needs.build.outputs.BOARDS_LIST }}"
     steps:
       - name: Clean workspace
         run: |
@@ -107,9 +106,4 @@ jobs:
           merge-multiple: true
 
       - name: Test on actual hardware
-        run: |
-          echo "BOARDS_LIST=$BOARDS_LIST"
-          echo "::group::{cmake-build contents}"
-          tree cmake-build
-          echo "::endgroup::"
-          python3 test/hil/hil_test.py $BOARDS_LIST ${{ env.HIL_JSON }}
+        run: python3 test/hil/hil_test.py ${{ env.HIL_JSON }}

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -39,6 +39,9 @@ import fs
 
 ENUM_TIMEOUT = 30
 
+STATUS_OK = "\033[32mOK\033[0m"
+STATUS_FAILED = "\033[31mFailed\033[0m"
+STATUS_SKIPPED = "\033[33mSkipped\033[0m"
 
 # get usb serial by id
 def get_serial_dev(id, vendor_str, product_str, ifnum):
@@ -411,7 +414,7 @@ def test_board(board):
         if not os.path.exists(fw_dir):
             fw_dir = f'examples/cmake-build-{name}/{test}'
         fw_name = f'{fw_dir}/{os.path.basename(test)}'
-        print(f'{name:30} {test:20} ... ', end='')
+        print(f'{name:25} {test:30} ... ', end='')
 
         if not os.path.exists(fw_dir):
             print('Skip')
@@ -432,11 +435,11 @@ def test_board(board):
                 print('OK')
             except Exception as e:
                 err_count += 1
-                print('Failed')
+                print(STATUS_FAILED)
                 print(f'  {e}')
         else:
             err_count += 1
-            print('Flash failed')
+            print(f'Flash {STATUS_FAILED}')
     return err_count
 
 
@@ -463,10 +466,13 @@ def main():
     else:
         config_boards = [e for e in config['boards'] if e['name'] in boards]
 
-    err_count_list = []
     with Pool(processes=os.cpu_count()) as pool:
-        err_count_list = pool.map(test_board, config_boards)
-    err_count = sum(err_count_list)
+        err_count = sum(pool.map(test_board, config_boards))
+
+    print()
+    print("-" * 30)
+    print(f'Total failed: {err_count}')
+    print("-" * 30)
     sys.exit(err_count)
 
 

--- a/test/hil/rpi.json
+++ b/test/hil/rpi.json
@@ -49,7 +49,6 @@
             "flasher_sn": "E6614103E72C1D2F",
             "flasher_args": "-f interface/cmsis-dap.cfg -f target/rp2040.cfg -c \"adapter speed 5000\"",
             "tests": {
-                "skip": ["dual/host_info_to_device_cdc"],
                 "dual_attached": [{"vid_pid": "1a86_55d4", "serial": "52D2002470"}]
             }
         },

--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -58,7 +58,7 @@ deps_optional = {
                             '144f1eb7ea8c06512e12f12b27383601c0272410',
                             'kinetis_k kinetis_k32l2 kinetis_kl lpc51 lpc54 lpc55 mcx imxrt'],
     'hw/mcu/raspberry_pi/Pico-PIO-USB': ['https://github.com/sekigon-gonnoc/Pico-PIO-USB.git',
-                                         '7902e9fa8ed4a271d8d1d5e7e50516c2292b7bc2',
+                                         'fe9133fc513b82cc3dc62c67cb51f2339cf29ef7',
                                          'rp2040'],
     'hw/mcu/renesas/fsp': ['https://github.com/renesas/fsp.git',
                            'd52e5a6a59b7c638da860c2bb309b6e78e752ff8',


### PR DESCRIPTION
**Describe the PR**
- bump up pio-usb to 0.6.1 which fix serious buffer overflow
- enable dual hil test for pico
- enable circleci rx-gcc build

