### PR TITLE
Fix compiler warning in hid_boot_interface example

### DIFF
--- a/examples/device/hid_boot_interface/src/main.c
+++ b/examples/device/hid_boot_interface/src/main.c
@@ -161,8 +161,8 @@ void hid_task(void)
       {
         uint8_t const report_id   = 0;
         uint8_t const button_mask = 0;
-        uint8_t const vertical    = 0;
-        uint8_t const horizontal  = 0;
+        int8_t  const vertical    = 0;
+        int8_t  const horizontal  = 0;
         int8_t  const delta       = 5;
 
         tud_hid_n_mouse_report(ITF_NUM_MOUSE, report_id, button_mask, delta, delta, vertical, horizontal);


### PR DESCRIPTION
This fixes
```
tinyusb/examples/device/hid_boot_interface/src/main.c:168:85: error: conversion to 'int8_t' {aka 'signed char'} from 'uint8_t' {aka 'unsigned char'} may change the sign of the result [-Werror=sign-conversion]
  168 |         tud_hid_n_mouse_report(ITF_NUM_MOUSE, report_id, button_mask, delta, delta, vertical, horizontal);
      |                                                                                     ^~~~~~~~
```
and
```
tinyusb/examples/device/hid_boot_interface/src/main.c:168:95: error: conversion to 'int8_t' {aka 'signed char'} from 'uint8_t' {aka 'unsigned char'} may change the sign of the result [-Werror=sign-conversion]
  168 |         tud_hid_n_mouse_report(ITF_NUM_MOUSE, report_id, button_mask, delta, delta, vertical, horizontal);
      |                                                                                               ^~~~~~~~~~
```