### PR TITLE
dcd_nrf5x: fix race condition

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -441,11 +441,11 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t* buffer, uint16_t to
   bool const control_status = (epnum == 0 && total_bytes == 0 && dir != tu_edpt_dir(NRF_USBD->BMREQUESTTYPE));
 
   if (control_status) {
-    // Status Phase also requires EasyDMA has to be available as well !!!!
-    edpt_dma_start(&NRF_USBD->TASKS_EP0STATUS);
-
     // The nRF doesn't interrupt on status transmit so we queue up a success response.
     dcd_event_xfer_complete(0, ep_addr, 0, XFER_RESULT_SUCCESS, is_in_isr());
+
+    // Status Phase also requires EasyDMA has to be available as well !!!!
+    edpt_dma_start(&NRF_USBD->TASKS_EP0STATUS);
   } else if (dir == TUSB_DIR_OUT) {
     xfer->started = true;
     if (epnum == 0) {


### PR DESCRIPTION
**Describe the PR**
Order of calls in dcd_nrf5x.c in dcd_edpt_xfer was wrong,  Wrong order led to a race condition which happened rarely.

**Additional context**
There was a lengthy discussion in #2778.

Thanks to @kasjer for his support solving this.  He is also responsible for explanation what happened: https://github.com/hathach/tinyusb/issues/2778#issuecomment-2317336403

Closes #2778
Closes #2240
