### PR TITLE
Fix ESP32-SX resume

### DIFF
--- a/src/portable/espressif/esp32sx/dcd_esp32sx.c
+++ b/src/portable/espressif/esp32sx/dcd_esp32sx.c
@@ -207,6 +207,7 @@ void dcd_init(uint8_t rhport)
                  USB_USBRSTMSK_M   |
                  USB_ENUMDONEMSK_M |
                  USB_RESETDETMSK_M |
+                 USB_WKUPINT_M |
                  USB_DISCONNINTMSK_M; // host most only
 
   dcd_connect(rhport);


### PR DESCRIPTION
The interrupt handler pipes through the resume event but the interrupt wasn't enabled in the first place.
