### PR TITLE
dwc2: for esp32 force disconnect/connect using USB_WRAP otg pad override

### DIFF
--- a/.github/actions/setup_toolchain/action.yml
+++ b/.github/actions/setup_toolchain/action.yml
@@ -39,8 +39,6 @@ runs:
         TOOLCHAIN_JSON='{
           "aarch64-gcc": "https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz",
           "arm-clang": "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/LLVMEmbeddedToolchainForArm-17.0.1-Linux-x86_64.tar.xz",
-          "arm-iar": "",
-          "arm-gcc": "",
           "msp430-gcc": "http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/9_2_0_0/export/msp430-gcc-9.2.0.50_linux64.tar.bz2",
           "riscv-gcc": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz",
           "rx-gcc": "http://gcc-renesas.com/downloads/get.php?f=rx/8.3.0.202004-gnurx/gcc-8.3.0.202004-GNURX-ELF.run"

--- a/.github/actions/setup_toolchain/espressif/action.yml
+++ b/.github/actions/setup_toolchain/espressif/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'Toolchain name'
     required: true
   toolchain_version:
-    description: 'Toolchain URL or version'
+    description: 'Toolchain version'
     required: true
 
 runs:

--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -336,6 +336,7 @@
 //--------------------------------------------------------------------+
 #elif TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
   #define TUP_USBIP_DWC2
+  #define TUP_USBIP_DWC2_ESP32
   #define TUP_DCD_ENDPOINT_MAX    6
 
 #elif TU_CHECK_MCU(OPT_MCU_ESP32, OPT_MCU_ESP32C2, OPT_MCU_ESP32C3, OPT_MCU_ESP32C6, OPT_MCU_ESP32H2)

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -43,7 +43,7 @@
 
 #if defined(TUP_USBIP_DWC2_STM32)
   #include "dwc2_stm32.h"
-#elif TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
+#elif defined(TUP_USBIP_DWC2_ESP32)
   #include "dwc2_esp32.h"
 #elif TU_CHECK_MCU(OPT_MCU_GD32VF103)
   #include "dwc2_gd32.h"
@@ -667,12 +667,34 @@ void dcd_remote_wakeup(uint8_t rhport) {
 void dcd_connect(uint8_t rhport) {
   (void) rhport;
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+
+#ifdef TUP_USBIP_DWC2_ESP32
+  usb_wrap_otg_conf_reg_t conf = USB_WRAP.otg_conf;
+  conf.pad_pull_override = 0;
+  conf.dp_pullup = 0;
+  conf.dp_pulldown = 0;
+  conf.dm_pullup = 0;
+  conf.dm_pulldown = 0;
+  USB_WRAP.otg_conf = conf;
+#endif
+
   dwc2->dctl &= ~DCTL_SDIS;
 }
 
 void dcd_disconnect(uint8_t rhport) {
   (void) rhport;
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+
+#ifdef TUP_USBIP_DWC2_ESP32
+  usb_wrap_otg_conf_reg_t conf = USB_WRAP.otg_conf;
+  conf.pad_pull_override = 1;
+  conf.dp_pullup = 0;
+  conf.dp_pulldown = 1;
+  conf.dm_pullup = 0;
+  conf.dm_pulldown = 1;
+  USB_WRAP.otg_conf = conf;
+#endif
+
   dwc2->dctl |= DCTL_SDIS;
 }
 

--- a/src/portable/synopsys/dwc2/dwc2_esp32.h
+++ b/src/portable/synopsys/dwc2/dwc2_esp32.h
@@ -32,60 +32,52 @@
  extern "C" {
 #endif
 
+#include "freertos/task.h"
+
 #include "esp_intr_alloc.h"
 #include "soc/periph_defs.h"
-//#include "soc/usb_periph.h"
-#include "freertos/task.h"
+#include "soc/usb_wrap_struct.h"
 
 #define DWC2_REG_BASE       0x60080000UL
 #define DWC2_EP_MAX         6             // USB_OUT_EP_NUM. TODO ESP32Sx only has 5 tx fifo (5 endpoint IN)
 
-static const dwc2_controller_t _dwc2_controller[] =
-{
+static const dwc2_controller_t _dwc2_controller[] = {
   { .reg_base = DWC2_REG_BASE, .irqnum = 0, .ep_count = DWC2_EP_MAX, .ep_fifo_size = 1024 }
 };
 
 static intr_handle_t usb_ih;
 
-static void dcd_int_handler_wrap(void* arg)
-{
-  (void) arg;
+static void dcd_int_handler_wrap(void* arg) {
+  (void)arg;
   dcd_int_handler(0);
 }
 
-TU_ATTR_ALWAYS_INLINE
-static inline void dwc2_dcd_int_enable (uint8_t rhport)
-{
-  (void) rhport;
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_dcd_int_enable(uint8_t rhport) {
+  (void)rhport;
   esp_intr_alloc(ETS_USB_INTR_SOURCE, ESP_INTR_FLAG_LOWMED, dcd_int_handler_wrap, NULL, &usb_ih);
 }
 
-TU_ATTR_ALWAYS_INLINE
-static inline void dwc2_dcd_int_disable (uint8_t rhport)
-{
-  (void) rhport;
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_dcd_int_disable(uint8_t rhport) {
+  (void)rhport;
   esp_intr_free(usb_ih);
 }
 
-static inline void dwc2_remote_wakeup_delay(void)
-{
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_remote_wakeup_delay(void) {
   vTaskDelay(pdMS_TO_TICKS(1));
 }
 
 // MCU specific PHY init, called BEFORE core reset
-static inline void dwc2_phy_init(dwc2_regs_t * dwc2, uint8_t hs_phy_type)
-{
-  (void) dwc2;
-  (void) hs_phy_type;
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
+  (void)dwc2;
+  (void)hs_phy_type;
 
   // nothing to do
 }
 
 // MCU specific PHY update, it is called AFTER init() and core reset
-static inline void dwc2_phy_update(dwc2_regs_t * dwc2, uint8_t hs_phy_type)
-{
-  (void) dwc2;
-  (void) hs_phy_type;
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_update(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
+  (void)dwc2;
+  (void)hs_phy_type;
 
   // nothing to do
 }
@@ -94,4 +86,4 @@ static inline void dwc2_phy_update(dwc2_regs_t * dwc2, uint8_t hs_phy_type)
 }
 #endif
 
-#endif /* _DWC2_ESP32_H_ */
+#endif


### PR DESCRIPTION
**Describe the PR**
dwc2 for esp32 force disconnect/connect using USB_WRAP otg pad override (DM=DP=0) in addition to dwc2's dctrl. This is required for arduino-esp32, simple DCTL_SDIS isn't able to force re-enumeration on S3 probably due to DM/DP pad on S3 is muxing from USB OTG and JTAG.

help with https://github.com/adafruit/Adafruit_TinyUSB_Arduino/issues/436