### PR TITLE
Fix vendor class reset.

### DIFF
--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -185,6 +185,8 @@ void vendord_reset(uint8_t rhport) {
     tu_memclr(p_itf, ITF_MEM_RESET_SIZE);
     tu_edpt_stream_clear(&p_itf->rx.stream);
     tu_edpt_stream_clear(&p_itf->tx.stream);
+    tu_edpt_stream_close(&p_itf->rx.stream);
+    tu_edpt_stream_close(&p_itf->tx.stream);
   }
 }
 


### PR DESCRIPTION
**Describe the PR**

Resolve:
```
USBD Setup Received 00 09 01 00 00 00 00 00 
  Set Configuration
  Open EP 03 with Size = 64
  Open EP 83 with Size = 64
    Allocated 64 bytes at offset 1152  Queue EP 03 with 31 bytes ...
  MSC opened
  Bind EP 03 to driver id 0
  Bind EP 83 to driver id 0
process_set_config 1049: ASSERT FAILED
``` 
Close #2815