### PR TITLE
make sure transfers to device after reset/before setup are ignored

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -623,6 +623,10 @@ void tud_task_ext(uint32_t timeout_ms, bool in_isr) {
         break;
 
       case DCD_EVENT_XFER_COMPLETE: {
+        if(!_usbd_dev.connected) {
+           TU_LOG_USBD("Skipped unexpected transfer\r\n");
+           break;
+        }
         // Invoke the class callback associated with the endpoint address
         uint8_t const ep_addr = event.xfer_complete.ep_addr;
         uint8_t const epnum = tu_edpt_number(ep_addr);


### PR DESCRIPTION
Fixes #2322

**Describe the PR**
In cases of bus reset, there can be pending transfers in the queue. Or a defective host just sends transfers without a proper setup. In both cases this lead to null pointer access after driver lookup(or assert if debug is enabled).   
This small check fixes this.

**Additional context**
I checked the throughput on my STM32U5 base MSC device and could not see a performance hit. Though I am limited at around 256KB/s read speed anyway. I have seen pending transfer after reset with a Win10 host and the linked issue is from Linux, so the problem seems to be universal.
Another option would be to clear the queue on bus reset, but this doesn't fix unexpected transfers and also needs a bit of research to make it work on all supported operating systems.