### PR TITLE
Defines TUP_RHPORT_HIGHSPEED for OPT_MCU_STM32H7

### DIFF
--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -216,6 +216,7 @@
   #define TUP_USBIP_DWC2_STM32
 
   #define TUP_DCD_ENDPOINT_MAX    9
+  #define TUP_RHPORT_HIGHSPEED  1 // Port0: FS, Port1: HS
 
 #elif TU_CHECK_MCU(OPT_MCU_STM32H5)
   #define TUP_USBIP_FSDEV


### PR DESCRIPTION
**Describe the PR**
Adds a necessary define for `OPT_MCU_STM32H7`

**Additional context**
I'm attempting to get tusb running on the [STM32H7B3I-DK](https://www.st.com/en/evaluation-tools/stm32h7b3i-dk.html). While this doesn't totally solve my issues, I did notice that without this `#define`, if I had

```c
// tusb_config.h
#define CFG_TUD_MAX_SPEED OPT_MODE_DEFAULT_SPEED ///< Default (max) speed supported by MCU
```

Then I would wind up with `TUD_OPT_HIGH_SPEED == 0`

https://github.com/hathach/tinyusb/blob/8b1e40c3e2447de5b4a86bbcdcc0344946a4793d/src/tusb_option.h#L302

which would ultimately cause `phy_fs_init` to be called:

https://github.com/hathach/tinyusb/blob/8b1e40c3e2447de5b4a86bbcdcc0344946a4793d/src/portable/synopsys/dwc2/dcd_dwc2.c#L664-L668

Unfortunately I don't have any of the supported h7 boards to double check this against, however so long as they support both FS/HS I believe this change is correct for them. There also seems to still be a major bug in getting things to work with my h7b3i board, so I will keep this as a draft for now until someone has a chance to test it with the boards that it should work properly for.