### PR TITLE
Extend callback information

### DIFF
--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -204,6 +204,9 @@ TU_ATTR_WEAK void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts);
 TU_ATTR_WEAK void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* p_line_coding);
 
 // Invoked when received send break
+// \param[in]  itf  interface for which send break was received.
+// \param[in]  duration_ms  the length of time, in milliseconds, of the break signal. If a value of FFFFh, then the
+//                          device will send a break until another SendBreak request is received with value 0000h.
 TU_ATTR_WEAK void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms);
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
I noticed getting `0xFFFF` as duration_ms value which according to [CDC1.2_WMC1.1_012011](https://usb.org/sites/default/files/CDC1.2_WMC1.1_012011.zip) PSTN120.pdf is described as in doxygen info I've putted.

It took me some time to figure this out so I thought lets extend the callback header, since I do not see much of this kind of documentation I'm not sure what is the usual approach, please advice if different is expected.
