### PR TITLE
Add support for STM32H7RSxx

### DIFF
--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -298,6 +298,13 @@
   #define TUP_USBIP_FSDEV_STM32
   #define TUP_DCD_ENDPOINT_MAX    8
 
+#elif TU_CHECK_MCU(OPT_MCU_STM32H7RS)
+  #define TUP_USBIP_DWC2
+  #define TUP_USBIP_DWC2_STM32
+
+  // FS has 6, HS has 9
+  #define TUP_DCD_ENDPOINT_MAX    9
+
 //--------------------------------------------------------------------+
 // Sony
 //--------------------------------------------------------------------+

--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -69,6 +69,14 @@ extern "C" {
     #define OTG_FS_IRQn             OTG_HS_IRQn
   #endif
 
+#elif CFG_TUSB_MCU == OPT_MCU_STM32H7RS
+  #include "stm32h7rsxx.h"
+  #define EP_MAX_FS       6
+  #define EP_FIFO_SIZE_FS 1280
+
+  #define EP_MAX_HS       9
+  #define EP_FIFO_SIZE_HS 4096
+
 #elif CFG_TUSB_MCU == OPT_MCU_STM32F7
   #include "stm32f7xx.h"
   #define EP_MAX_FS       6

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -92,6 +92,7 @@
 #define OPT_MCU_STM32L5           314 ///< ST L5
 #define OPT_MCU_STM32H5           315 ///< ST H5
 #define OPT_MCU_STM32U0           316 ///< ST U0
+#define OPT_MCU_STM32H7RS         317 ///< ST F7RS
 
 // Sony
 #define OPT_MCU_CXD56             400 ///< SONY CXD56


### PR DESCRIPTION
**Describe the PR**
Add (partial) support for the STM32H7RSxx MCUs, see #2816.

**Additional context**

This has been tested with USBCDC through the USB HS peripheral of the STM32H7S3L8 on the chip's Nucleo board. I am presently unable to test the USB FS peripheral on this board, but from what I can see I expect it should work as is. 

Note that this chip also has a UCPD peripheral to control USB C PD, which I have not tried to use. 
