### PR TITLE
DWC2: fix recurrent suspend ISR without Vbus connected

### DIFF
--- a/hw/bsp/stm32f4/family.c
+++ b/hw/bsp/stm32f4/family.c
@@ -49,6 +49,7 @@ void OTG_HS_IRQHandler(void) {
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM
 //--------------------------------------------------------------------+
+#ifdef UART_DEV
 UART_HandleTypeDef UartHandle = {
     .Instance = UART_DEV,
     .Init = {
@@ -61,6 +62,7 @@ UART_HandleTypeDef UartHandle = {
       .OverSampling = UART_OVERSAMPLING_16
     }
 };
+#endif
 
 void board_init(void) {
   board_clock_init();
@@ -229,7 +231,7 @@ int board_uart_write(void const *buf, int len) {
   HAL_UART_Transmit(&UartHandle, (uint8_t *) (uintptr_t) buf, len, 0xffff);
   return len;
 #else
-  (void) buf; (void) len; (void) UartHandle;
+  (void) buf; (void) len;
   return 0;
 #endif
 }

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -449,7 +449,7 @@ bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   dwc2->dcfg |= DCFG_NZLSOHSK;
 
   // Enable required interrupts
-  dwc2->gintmsk |= GINTMSK_OTGINT | GINTMSK_USBSUSPM | GINTMSK_USBRST | GINTMSK_ENUMDNEM | GINTMSK_WUIM;
+  dwc2->gintmsk |= GINTMSK_OTGINT | GINTMSK_USBRST | GINTMSK_ENUMDNEM | GINTMSK_WUIM;
 
   // TX FIFO empty level for interrupt is complete empty
   uint32_t gahbcfg = dwc2->gahbcfg;
@@ -914,7 +914,7 @@ void dcd_int_handler(uint8_t rhport) {
   if (int_status & GINTSTS_ENUMDNE) {
     // ENUMDNE is the end of reset where speed of the link is detected
     dwc2->gintsts = GINTSTS_ENUMDNE;
-
+    dwc2->gintmsk |= GINTMSK_USBSUSPM;
     tusb_speed_t speed;
     switch ((dwc2->dsts & DSTS_ENUMSPD_Msk) >> DSTS_ENUMSPD_Pos) {
       case DSTS_ENUMSPD_HS:
@@ -939,11 +939,13 @@ void dcd_int_handler(uint8_t rhport) {
 
   if (int_status & GINTSTS_USBSUSP) {
     dwc2->gintsts = GINTSTS_USBSUSP;
+    dwc2->gintmsk &= ~GINTMSK_USBSUSPM;
     dcd_event_bus_signal(rhport, DCD_EVENT_SUSPEND, true);
   }
 
   if (int_status & GINTSTS_WKUINT) {
     dwc2->gintsts = GINTSTS_WKUINT;
+    dwc2->gintmsk |= GINTMSK_USBSUSPM;
     dcd_event_bus_signal(rhport, DCD_EVENT_RESUME, true);
   }
 
@@ -963,6 +965,7 @@ void dcd_int_handler(uint8_t rhport) {
 
   if(int_status & GINTSTS_SOF) {
     dwc2->gintsts = GINTSTS_SOF;
+    dwc2->gintmsk |= GINTMSK_USBSUSPM;
     const uint32_t frame = (dwc2->dsts & DSTS_FNSOF) >> DSTS_FNSOF_Pos;
 
     // Disable SOF interrupt if SOF was not explicitly enabled since SOF was used for remote wakeup detection


### PR DESCRIPTION
**Describe the PR**
Without Vbus connected the suspend ISR is fired every 20ms after the disconnection, which in turn calls `tud_suspend_cb()`

Can be easily reproduced on STM32F4-DISCO with HS pin PB14/PB15.

**Additional context**
It looks like the timing `TDRSMDN` of `Figure J-5 Device-Initiated Remote Wakeup Sequence` in the databook ?