### PR TITLE
Enhance dwc2 dcd

### DIFF
--- a/hw/bsp/family_support.cmake
+++ b/hw/bsp/family_support.cmake
@@ -289,6 +289,11 @@ function(family_add_tinyusb TARGET OPT_MCU RTOS)
       )
   endif ()
 
+  # compile define from command line
+  if(DEFINED CFLAGS_CLI)
+    target_compile_options(${TARGET}-tinyusb PUBLIC ${CFLAGS_CLI})
+  endif()
+
 endfunction()
 
 # Add bin/hex output

--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -538,7 +538,7 @@
   #define TUP_DCD_EDPT_ISO_ALLOC
 #endif
 
-#if defined(TUP_USBIP_DWC2) // && CFG_TUD_DWC2_DMA == 0
+#if defined(TUP_USBIP_DWC2) // && CFG_TUD_DWC2_DMA_ENABLE == 0
   #define TUP_MEM_CONST_ADDR
 #endif
 

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -71,7 +71,7 @@ static bool _sof_en;
 TU_ATTR_ALWAYS_INLINE static inline bool dma_device_enabled(const dwc2_regs_t* dwc2) {
   (void) dwc2;
   // Internal DMA only
-  return CFG_TUD_DWC2_DMA && dwc2->ghwcfg2_bm.arch == GHWCFG2_ARCH_INTERNAL_DMA;
+  return CFG_TUD_DWC2_DMA_ENABLE && dwc2->ghwcfg2_bm.arch == GHWCFG2_ARCH_INTERNAL_DMA;
 }
 
 static void dma_setup_prepare(uint8_t rhport) {
@@ -897,8 +897,6 @@ static void handle_epin_irq(uint8_t rhport) {
   Note: when OTG_MULTI_PROC_INTRPT = 1, Device Each endpoint interrupt deachint/deachmsk/diepeachmsk/doepeachmsk
   are combined to generate dedicated interrupt line for each endpoint.
  */
-
-
 void dcd_int_handler(uint8_t rhport) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
 

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -770,8 +770,6 @@ static void handle_rxflvl_irq(uint8_t rhport) {
 }
 
 static void handle_epout_slave(uint8_t rhport, uint8_t epnum, dwc2_doepint_t doepint_bm) {
-  // dwc2_regs_t* dwc2 = DWC2_REG(rhport);
-
   if (doepint_bm.setup_phase_done) {
     dcd_event_setup_received(rhport, (uint8_t*) _setup_packet, true);
     return;
@@ -882,8 +880,6 @@ static void handle_epout_dma(uint8_t rhport, uint8_t epnum, dwc2_doepint_t doepi
 }
 
 static void handle_epin_dma(uint8_t rhport, uint8_t epnum, dwc2_diepint_t diepint_bm) {
-  // dwc2_regs_t* dwc2 = DWC2_REG(rhport);
-  // dwc2_dep_t* epin = &dwc2->epin[epnum];
   xfer_ctl_t* xfer = XFER_CTL_BASE(epnum, TUSB_DIR_IN);
 
   if (diepint_bm.xfer_complete) {
@@ -921,7 +917,6 @@ static void handle_ep_irq(uint8_t rhport, uint8_t dir) {
 
       epout->intr = intr.value; // Clear interrupt
 
-      // print_doepint(doepint);
       if (is_dma) {
         #if CFG_TUD_DWC2_DMA_ENABLE
         if (dir == TUSB_DIR_IN) {
@@ -1034,12 +1029,6 @@ void dcd_int_handler(uint8_t rhport) {
     // IEPINT bit read-only, clear using DIEPINTn
     handle_ep_irq(rhport, TUSB_DIR_IN);
   }
-
-  //  // Check for Incomplete isochronous IN transfer
-  //  if(int_status & GINTSTS_IISOIXFR) {
-  //    printf("      IISOIXFR!\r\n");
-  ////    TU_LOG(DWC2_DEBUG, "      IISOIXFR!\r\n");
-  //  }
 }
 
 #if CFG_TUD_TEST_MODE

--- a/src/portable/synopsys/dwc2/dwc2_common.c
+++ b/src/portable/synopsys/dwc2/dwc2_common.c
@@ -194,7 +194,7 @@ bool dwc2_core_is_highspeed(dwc2_regs_t* dwc2, tusb_role_t role) {
  * In addition, UTMI+/ULPI can be shared to run at fullspeed mode with 48Mhz
  *
 */
-bool dwc2_core_init(uint8_t rhport, bool is_highspeed) {
+bool dwc2_core_init(uint8_t rhport, bool is_highspeed, bool is_dma) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
 
   // Check Synopsys ID register, failed if controller clock/power is not enabled
@@ -228,6 +228,13 @@ bool dwc2_core_init(uint8_t rhport, bool is_highspeed) {
   dwc2->gintsts = 0xFFFFFFFFU;
   dwc2->gotgint = 0xFFFFFFFFU;
   dwc2->gintmsk = 0;
+
+  if (is_dma) {
+    // DMA seems to be only settable after a core reset, and not possible to switch on-the-fly
+    dwc2->gahbcfg |= GAHBCFG_DMAEN | GAHBCFG_HBSTLEN_2;
+  } else {
+    dwc2->gintmsk |= GINTSTS_RXFLVL;
+  }
 
   return true;
 }

--- a/src/portable/synopsys/dwc2/dwc2_common.h
+++ b/src/portable/synopsys/dwc2/dwc2_common.h
@@ -73,7 +73,7 @@ TU_ATTR_ALWAYS_INLINE static inline dwc2_regs_t* DWC2_REG(uint8_t rhport) {
 }
 
 bool dwc2_core_is_highspeed(dwc2_regs_t* dwc2, tusb_role_t role);
-bool dwc2_core_init(uint8_t rhport, bool is_highspeed);
+bool dwc2_core_init(uint8_t rhport, bool is_highspeed, bool is_dma);
 void dwc2_core_handle_common_irq(uint8_t rhport, bool in_isr);
 
 //--------------------------------------------------------------------+

--- a/src/portable/synopsys/dwc2/dwc2_type.h
+++ b/src/portable/synopsys/dwc2/dwc2_type.h
@@ -537,12 +537,15 @@ typedef struct TU_ATTR_PACKED {
   uint32_t in_rx_txfe          : 1; // 4 IN token received when TxFIFO is empty
   uint32_t in_rx_ep_mismatch   : 1; // 5 IN token received with EP mismatch
   uint32_t in_ep_nak_effective : 1; // 6 IN endpoint NAK effective
-  uint32_t rsv7                : 1; // 7 Reserved
-  uint32_t txfifo_underrun     : 1; // 8 Tx FIFO underrun
+  uint32_t txfifo_empty        : 1; // 7 TX FIFO empty
+  uint32_t txfifo_underrun     : 1; // 8 Tx FIFO under run
   uint32_t bna                 : 1; // 9 Buffer not available
-  uint32_t rsv10_12            : 3; // 10..12 Reserved
+  uint32_t rsv10               : 1; // 10 Reserved
+  uint32_t iso_packet_drop     : 1; // 11 Isochronous OUT packet drop status
+  uint32_t babble_err          : 1; // 12 Babble error
   uint32_t nak                 : 1; // 13 NAK
-  uint32_t rsv14_31            : 18; // 14..31 Reserved
+  uint32_t nyet                : 1; // 14 NYET
+  uint32_t rsv14_31            :17; // 15..31 Reserved
 } dwc2_diepint_t;
 TU_VERIFY_STATIC(sizeof(dwc2_diepint_t) == 4, "incorrect size");
 
@@ -582,7 +585,7 @@ typedef struct TU_ATTR_PACKED {
   uint32_t nak                : 1; // 13 NAK
   uint32_t nyet               : 1; // 14 NYET
   uint32_t setup_packet_rx    : 1; // 15 Setup packet received (Buffer DMA Mode only)
-  uint32_t rsv16_31           :15; // 16..31 Reserved
+  uint32_t rsv16_31           :16; // 16..31 Reserved
 } dwc2_doepint_t;
 TU_VERIFY_STATIC(sizeof(dwc2_doepint_t) == 4, "incorrect size");
 
@@ -604,6 +607,8 @@ typedef struct {
   };
   uint32_t rsv04;
   union {
+    volatile uint32_t intr;
+
     volatile uint32_t diepint;
     volatile dwc2_diepint_t diepint_bm;
 

--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -336,14 +336,8 @@ bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
 
   // Core Initialization
   const bool is_highspeed = dwc2_core_is_highspeed(dwc2, TUSB_ROLE_HOST);
-  TU_ASSERT(dwc2_core_init(rhport, is_highspeed));
-
-  if (dma_host_enabled(dwc2)) {
-    // DMA seems to be only settable after a core reset, and not possible to switch on-the-fly
-    dwc2->gahbcfg |= GAHBCFG_DMAEN | GAHBCFG_HBSTLEN_2;
-  } else {
-    dwc2->gintmsk |= GINTSTS_RXFLVL;
-  }
+  const bool is_dma = dma_host_enabled(dwc2);
+  TU_ASSERT(dwc2_core_init(rhport, is_highspeed, is_dma));
 
   //------------- 3.1 Host Initialization -------------//
 

--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -1116,8 +1116,8 @@ static void handle_channel_irq(uint8_t rhport, bool in_isr) {
       TU_ASSERT(xfer->ep_id < CFG_TUH_DWC2_ENDPOINT_MAX,);
       dwc2_channel_char_t hcchar_bm = channel->hcchar_bm;
 
-      uint32_t hcint = channel->hcint;
-      channel->hcint = hcint;
+      const uint32_t hcint = channel->hcint;
+      channel->hcint = hcint; // clear interrupt
 
       bool is_done;
       if (is_dma) {

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -247,6 +247,10 @@
 // USBIP
 //--------------------------------------------------------------------+
 
+#ifndef CFG_TUD_DWC2_SLAVE_ENABLE
+  #define CFG_TUD_DWC2_SLAVE_ENABLE 1
+#endif
+
 // DWC2 controller: use DMA for data transfer
 // For processors with data cache enabled, USB endpoint buffer region
 // (defined by CFG_TUSB_MEM_SECTION) must be declared as non-cacheable.

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -252,8 +252,8 @@
 // (defined by CFG_TUSB_MEM_SECTION) must be declared as non-cacheable.
 // For example, on Cortex-M7 the MPU region can be configured as normal
 // non-cacheable, with RASR register value: TEX=1 C=0 B=0 S=0.
-#ifndef CFG_TUD_DWC2_DMA
-  #define CFG_TUD_DWC2_DMA 0
+#ifndef CFG_TUD_DWC2_DMA_ENABLE
+  #define CFG_TUD_DWC2_DMA_ENABLE 0
 #endif
 
 // Enable DWC2 Slave mode for host

--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -17,7 +17,7 @@
             "name": "espressif_s3_devkitm",
             "uid": "84F703C084E4",
             "build" : {
-                "flags_on": ["", "CFG_TUD_DWC2_DMA"]
+                "flags_on": ["", "CFG_TUD_DWC2_DMA_ENABLE"]
             },
             "tests": {
                 "only": ["device/cdc_msc_freertos", "device/hid_composite_freertos"]
@@ -130,7 +130,7 @@
             "name": "stm32f723disco",
             "uid": "460029001951373031313335",
             "build" : {
-                "flags_on": ["", "CFG_TUD_DWC2_DMA"]
+                "flags_on": ["", "CFG_TUD_DWC2_DMA_ENABLE"]
             },
             "tests": {
                 "device": true, "host": true, "dual": false,
@@ -146,7 +146,7 @@
             "name": "stm32h743nucleo",
             "uid": "110018000951383432343236",
             "build" : {
-                "flags_on": ["", "CFG_TUD_DWC2_DMA"]
+                "flags_on": ["", "CFG_TUD_DWC2_DMA_ENABLE"]
             },
             "tests": {
                 "device": true, "host": false, "dual": false
@@ -175,7 +175,7 @@
             "name": "stm32f769disco",
             "uid": "21002F000F51363531383437",
             "build" : {
-                "flags_on": ["", "CFG_TUD_DWC2_DMA"]
+                "flags_on": ["", "CFG_TUD_DWC2_DMA_ENABLE"]
             },
             "tests": {
                 "device": true, "host": false, "dual": false


### PR DESCRIPTION
**Describe the PR**
Improve dcd dwc2 driver
- rename CFG_TUD_DWC2_DMA to CFG_TUD_DWC2_DMA_ENABLE, also add CFG_TUD_DWC2_SLAVE_ENABLE
- separate handle_epin/out_slave/dma to make it easier to wrap around CFG_ macro
- generic clean up
- fix cmake build with CFLAGS_CLI not added to tinyusb target (affected DMA HIL option)
