### PR TITLE
Fix missing protoype warning, change TUD_EPBUF_TYPE_DEF order

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -61,7 +61,7 @@
           </envs>
         </ADDITIONAL_GENERATION_ENVIRONMENT>
       </configuration>
-      <configuration PROFILE_NAME="espressif_p4_function_ev-CFG_TUD_DWC2_DMA_ENABLE" ENABLED="false" GENERATION_DIR="cmake-build-espressif_p4_function_ev-CFG_TUD_DWC2_DMA_ENABLE" TOOLCHAIN_NAME="ESP-IDF" GENERATION_OPTIONS="-DBOARD=espressif_p4_function_ev -DLOG=1 -DCFLAGS_CLI=&quot;-DCFG_TUD_DWC2_DMA_ENABLE=1&quot;">
+      <configuration PROFILE_NAME="espressif_p4_function_ev-DMA" ENABLED="false" TOOLCHAIN_NAME="ESP-IDF" GENERATION_OPTIONS="-DBOARD=espressif_p4_function_ev -DLOG=1 -DCFLAGS_CLI=&quot;-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1&quot;">
         <ADDITIONAL_GENERATION_ENVIRONMENT>
           <envs>
             <env name="ESPBAUD" value="1500000" />
@@ -83,7 +83,7 @@
       <configuration PROFILE_NAME="metro_m4_express" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=metro_m4_express -DLOG=1 -DLOGGER=RTT -DMAX3421_HOST=1" />
       <configuration PROFILE_NAME="itsybitsy_m4" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=itsybitsy_m4" />
       <configuration PROFILE_NAME="same54_xplained" ENABLED="false" GENERATION_OPTIONS="-DBOARD=same54_xplained -DLOG=1 -DLOGGER=RTT" />
-      <configuration PROFILE_NAME="samg55_xplained" ENABLED="false" GENERATION_OPTIONS="-DBOARD=samg55_xplained" />
+      <configuration PROFILE_NAME="samg55_xplained" ENABLED="true" GENERATION_OPTIONS="-DBOARD=samg55_xplained" />
       <configuration PROFILE_NAME="feather_nrf52840_express" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=feather_nrf52840_express -DLOG=1 -DLOGGER=RTT -DMAX3421_HOST=1" />
       <configuration PROFILE_NAME="pca10056" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=pca10056 -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1" />
       <configuration PROFILE_NAME="pca10095" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=pca10095 -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1" />
@@ -100,7 +100,7 @@
       <configuration PROFILE_NAME="stm32f411disco" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f411disco -DLOG=1 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="stm32f412disco" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f412disco -DLOG=1 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="stm32f723disco" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f723disco -DLOG=0" />
-      <configuration PROFILE_NAME="stm32f723disco-CFG_TUD_DWC2_DMA_ENABLE" ENABLED="false" GENERATION_DIR="cmake-build-stm32f723disco-CFG_TUD_DWC2_DMA_ENABLE" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f723disco -DLOG=1 -DLOGGER=RTT -DCFLAGS_CLI=&quot;-DCFG_TUD_DWC2_DMA_ENABLE=1&quot;" />
+      <configuration PROFILE_NAME="stm32f723disco-DMA" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f723disco -DLOG=1 -DLOGGER=RTT -DCFLAGS_CLI=&quot;-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1&quot;" />
       <configuration PROFILE_NAME="stm32f723disco_device1" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f723disco -DLOG=0 -DRHPORT_DEVICE=1" />
       <configuration PROFILE_NAME="stm32f769disco" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f769disco -DLOG=1 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="stm32g0b1nucleo" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32g0b1nucleo" />
@@ -108,7 +108,7 @@
       <configuration PROFILE_NAME="b_g474e_dpow1" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=b_g474e_dpow1 -DLOG=1 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="stm32h563nucleo" ENABLED="false" GENERATION_OPTIONS="-DBOARD=stm32h563nucleo -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1" />
       <configuration PROFILE_NAME="stm32h743eval" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32h743eval -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1" />
-      <configuration PROFILE_NAME="stm32h743eval-CFG_TUD_DWC2_DMA_ENABLE" ENABLED="false" GENERATION_DIR="cmake-build-stm32h743eval-CFG_TUD_DWC2_DMA_ENABLE" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32h743eval -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1 -DCFLAGS_CLI=&quot;-DCFG_TUD_DWC2_DMA_ENABLE=1&quot;" />
+      <configuration PROFILE_NAME="stm32h743eval-DMA" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32h743eval -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1 -DCFLAGS_CLI=&quot;-DCFG_TUD_DWC2_DMA_ENABLE=1&quot;" />
       <configuration PROFILE_NAME="stm32h743eval_host1" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32h743eval -DRHPORT_HOST=1 -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1" />
       <configuration PROFILE_NAME="stm32h743nucleo" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32h743nucleo -DLOG=1" />
       <configuration PROFILE_NAME="stm32l0538disco" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32l0538disco -DLOG=0 -DLOGGER=RTT" />

--- a/examples/build_system/make/toolchain/gcc_common.mk
+++ b/examples/build_system/make/toolchain/gcc_common.mk
@@ -31,6 +31,7 @@ CFLAGS += \
   -Wreturn-type \
   -Wredundant-decls \
 
+#  -Wmissing-prototypes \
 # conversion is too strict for most mcu driver, may be disable sign/int/arith-conversion
 #  -Wconversion
 

--- a/hw/bsp/board.c
+++ b/hw/bsp/board.c
@@ -39,6 +39,9 @@
   #define sys_read    _read
 #endif
 
+int sys_write(int fhdl, const char *buf, size_t count) TU_ATTR_USED;
+int sys_read(int fhdl, char *buf, size_t count) TU_ATTR_USED;
+
 #if defined(LOGGER_RTT)
 // Logging with RTT
 
@@ -46,13 +49,13 @@
 #if !(defined __SES_ARM) && !(defined __SES_RISCV) && !(defined __CROSSWORKS_ARM)
 #include "SEGGER_RTT.h"
 
-TU_ATTR_USED int sys_write(int fhdl, const char *buf, size_t count) {
+int sys_write(int fhdl, const char *buf, size_t count) {
   (void) fhdl;
   SEGGER_RTT_Write(0, (const char *) buf, (int) count);
   return (int) count;
 }
 
-TU_ATTR_USED int sys_read(int fhdl, char *buf, size_t count) {
+int sys_read(int fhdl, char *buf, size_t count) {
   (void) fhdl;
   int rd = (int) SEGGER_RTT_Read(0, buf, count);
   return (rd > 0) ? rd : -1;
@@ -64,7 +67,7 @@ TU_ATTR_USED int sys_read(int fhdl, char *buf, size_t count) {
 // Logging with SWO for ARM Cortex
 #include "board_mcu.h"
 
-TU_ATTR_USED int sys_write (int fhdl, const char *buf, size_t count) {
+int sys_write (int fhdl, const char *buf, size_t count) {
   (void) fhdl;
   uint8_t const* buf8 = (uint8_t const*) buf;
 
@@ -75,7 +78,7 @@ TU_ATTR_USED int sys_write (int fhdl, const char *buf, size_t count) {
   return (int) count;
 }
 
-TU_ATTR_USED int sys_read (int fhdl, char *buf, size_t count) {
+int sys_read (int fhdl, char *buf, size_t count) {
   (void) fhdl;
   (void) buf;
   (void) count;
@@ -85,12 +88,12 @@ TU_ATTR_USED int sys_read (int fhdl, char *buf, size_t count) {
 #else
 
 // Default logging with on-board UART
-TU_ATTR_USED int sys_write (int fhdl, const char *buf, size_t count) {
+int sys_write (int fhdl, const char *buf, size_t count) {
   (void) fhdl;
   return board_uart_write(buf, (int) count);
 }
 
-TU_ATTR_USED int sys_read (int fhdl, char *buf, size_t count) {
+int sys_read (int fhdl, char *buf, size_t count) {
   (void) fhdl;
   int rd = board_uart_read((uint8_t*) buf, (int) count);
   return (rd > 0) ? rd : -1;
@@ -98,12 +101,12 @@ TU_ATTR_USED int sys_read (int fhdl, char *buf, size_t count) {
 
 #endif
 
-//TU_ATTR_USED int _close(int fhdl) {
+//int _close(int fhdl) {
 //  (void) fhdl;
 //  return 0;
 //}
 
-//TU_ATTR_USED int _fstat(int file, struct stat *st) {
+//int _fstat(int file, struct stat *st) {
 //  memset(st, 0, sizeof(*st));
 //  st->st_mode = S_IFCHR;
 //}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ function(add_tinyusb TARGET)
       -Wunused-function
       -Wreturn-type
       -Wredundant-decls
+      -Wmissing-prototypes
       )
   elseif (CMAKE_C_COMPILER_ID STREQUAL "IAR")
 

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -490,13 +490,13 @@ TU_ATTR_WEAK bool tud_audio_feedback_format_correction_cb(uint8_t func_id) {
   (void) func_id;
   return CFG_TUD_AUDIO_ENABLE_FEEDBACK_FORMAT_CORRECTION;
 }
-#endif
 
 TU_ATTR_WEAK TU_ATTR_FAST_FUNC void tud_audio_feedback_interval_isr(uint8_t func_id, uint32_t frame_number, uint8_t interval_shift) {
   (void) func_id;
   (void) frame_number;
   (void) interval_shift;
 }
+#endif
 
 #if CFG_TUD_AUDIO_ENABLE_INTERRUPT_EP
 TU_ATTR_WEAK void tud_audio_int_done_cb(uint8_t rhport) {

--- a/src/class/bth/bth_device.c
+++ b/src/class/bth/bth_device.c
@@ -52,7 +52,7 @@ typedef struct {
 
 typedef struct {
   TUD_EPBUF_DEF(epout_buf, CFG_TUD_BTH_DATA_EPSIZE);
-  TUD_EPBUF_TYPE_DEF(hci_cmd, bt_hci_cmd_t);
+  TUD_EPBUF_TYPE_DEF(bt_hci_cmd_t, hci_cmd);
 } btd_epbuf_t;
 
 //--------------------------------------------------------------------+

--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -118,14 +118,14 @@ typedef struct {
 
 typedef struct {
   struct {
-    TUD_EPBUF_TYPE_DEF(ntb, recv_ntb_t);
+    TUD_EPBUF_TYPE_DEF(recv_ntb_t, ntb);
   } recv[RECV_NTB_N];
 
   struct {
-    TUD_EPBUF_TYPE_DEF(ntb, xmit_ntb_t);
+    TUD_EPBUF_TYPE_DEF(xmit_ntb_t, ntb);
   } xmit[XMIT_NTB_N];
 
-  TUD_EPBUF_TYPE_DEF(epnotif, ncm_notify_t);
+  TUD_EPBUF_TYPE_DEF(ncm_notify_t, epnotif);
 } ncm_epbuf_t;
 
 static ncm_interface_t ncm_interface;

--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -748,7 +748,7 @@ void tud_network_recv_renew(void) {
 /**
  * Same as tud_network_recv_renew() but knows \a rhport
  */
-void tud_network_recv_renew_r(uint8_t rhport) {
+static void tud_network_recv_renew_r(uint8_t rhport) {
   TU_LOG_DRV("tud_network_recv_renew_r(%d)\n", rhport);
 
   ncm_interface.rhport = rhport;

--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -180,7 +180,7 @@ osal_mutex_t usbtmcLock;
 #define criticalEnter() do { (void) osal_mutex_lock(usbtmcLock,OSAL_TIMEOUT_WAIT_FOREVER); } while (0)
 #define criticalLeave() do { (void) osal_mutex_unlock(usbtmcLock); } while (0)
 
-bool atomicChangeState(usbtmcd_state_enum expectedState, usbtmcd_state_enum newState)
+static bool atomicChangeState(usbtmcd_state_enum expectedState, usbtmcd_state_enum newState)
 {
   bool ret = true;
   criticalEnter();

--- a/src/class/video/video_device.h
+++ b/src/class/video/video_device.h
@@ -40,6 +40,8 @@ extern "C" {
 // CFG_TUD_VIDEO > 1
 //--------------------------------------------------------------------+
 
+bool tud_video_n_connected(uint_fast8_t ctl_idx);
+
 /** Return true if streaming
  *
  * @param[in] ctl_idx    Destination control interface index

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -47,7 +47,7 @@
   }
 
 // Declare an endpoint buffer with a type
-#define TUD_EPBUF_TYPE_DEF(_name, _type) \
+#define TUD_EPBUF_TYPE_DEF(_type, _name) \
   union { \
     CFG_TUD_MEM_ALIGN _type _name; \
     uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(sizeof(_type))]; \

--- a/src/portable/dialog/da146xx/dcd_da146xx.c
+++ b/src/portable/dialog/da146xx/dcd_da146xx.c
@@ -896,6 +896,7 @@ TU_ATTR_ALWAYS_INLINE static inline bool is_in_isr(void)
   return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
 }
 
+void tusb_vbus_changed(bool present);
 void tusb_vbus_changed(bool present)
 {
   if (present && !_dcd.vbus_present)

--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -335,7 +335,7 @@ void dcd_edpt_clear_stall (uint8_t rhport, uint8_t ep_addr)
 //--------------------------------------------------------------------+
 // Interrupt Handler
 //--------------------------------------------------------------------+
-void maybe_transfer_complete(void) {
+static void maybe_transfer_complete(void) {
   uint32_t epints = USB->DEVICE.EPINTSMRY.reg;
 
   for (uint8_t epnum = 0; epnum < USB_EPT_NUM; epnum++) {

--- a/src/portable/microchip/samg/dcd_samg.c
+++ b/src/portable/microchip/samg/dcd_samg.c
@@ -52,37 +52,31 @@ typedef struct
 // Endpoint 0-5, each can only be either OUT or In
 xfer_desc_t _dcd_xfer[EP_COUNT];
 
-void xfer_epsize_set(xfer_desc_t* xfer, uint16_t epsize)
-{
+TU_ATTR_ALWAYS_INLINE static inline void xfer_epsize_set(xfer_desc_t* xfer, uint16_t epsize) {
   xfer->epsize = epsize;
 }
 
-void xfer_begin(xfer_desc_t* xfer, uint8_t * buffer, uint16_t total_bytes)
-{
+TU_ATTR_ALWAYS_INLINE static inline void xfer_begin(xfer_desc_t* xfer, uint8_t * buffer, uint16_t total_bytes) {
   xfer->buffer     = buffer;
   // xfer->ff         = NULL; // TODO support dcd_edpt_xfer_fifo API
   xfer->total_len  = total_bytes;
   xfer->actual_len = 0;
 }
 
-void xfer_end(xfer_desc_t* xfer)
-{
+TU_ATTR_ALWAYS_INLINE static inline void xfer_end(xfer_desc_t* xfer) {
   xfer->buffer     = NULL;
   // xfer->ff         = NULL; // TODO support dcd_edpt_xfer_fifo API
   xfer->total_len  = 0;
   xfer->actual_len = 0;
 }
 
-uint16_t xfer_packet_len(xfer_desc_t* xfer)
-{
+TU_ATTR_ALWAYS_INLINE static inline uint16_t xfer_packet_len(xfer_desc_t* xfer) {
   // also cover zero-length packet
   return tu_min16(xfer->total_len - xfer->actual_len, xfer->epsize);
 }
 
-void xfer_packet_done(xfer_desc_t* xfer)
-{
+TU_ATTR_ALWAYS_INLINE static inline void xfer_packet_done(xfer_desc_t* xfer) {
   uint16_t const xact_len = xfer_packet_len(xfer);
-
   xfer->buffer += xact_len;
   xfer->actual_len += xact_len;
 }
@@ -90,19 +84,15 @@ void xfer_packet_done(xfer_desc_t* xfer)
 //------------- Transaction helpers -------------//
 
 // Write data to EP FIFO, return number of written bytes
-static void xact_ep_write(uint8_t epnum, uint8_t* buffer, uint16_t xact_len)
-{
-  for(uint16_t i=0; i<xact_len; i++)
-  {
+static void xact_ep_write(uint8_t epnum, uint8_t* buffer, uint16_t xact_len) {
+  for(uint16_t i=0; i<xact_len; i++) {
     UDP->UDP_FDR[epnum] = (uint32_t) buffer[i];
   }
 }
 
 // Read data from EP FIFO
-static void xact_ep_read(uint8_t epnum, uint8_t* buffer, uint16_t xact_len)
-{
-  for(uint16_t i=0; i<xact_len; i++)
-  {
+static void xact_ep_read(uint8_t epnum, uint8_t* buffer, uint16_t xact_len) {
+  for(uint16_t i=0; i<xact_len; i++) {
     buffer[i] = (uint8_t) UDP->UDP_FDR[epnum];
   }
 }
@@ -112,24 +102,24 @@ static void xact_ep_read(uint8_t epnum, uint8_t* buffer, uint16_t xact_len)
 #define CSR_NO_EFFECT_1_ALL (UDP_CSR_RX_DATA_BK0 | UDP_CSR_RX_DATA_BK1 | UDP_CSR_STALLSENT | UDP_CSR_RXSETUP | UDP_CSR_TXCOMP)
 
 // Per Specs: CSR need synchronization each write
-static inline void csr_write(uint8_t epnum, uint32_t value)
-{
+TU_ATTR_ALWAYS_INLINE static inline void csr_write(uint8_t epnum, uint32_t value) {
   uint32_t const csr = value;
   UDP->UDP_CSR[epnum] = csr;
 
   volatile uint32_t nop_count;
-  for (nop_count = 0; nop_count < 20; nop_count ++) __NOP();
+  for (nop_count = 0; nop_count < 20; nop_count ++) {
+    __NOP();
+  }
 }
 
 // Per Specs: CSR need synchronization each write
-static inline void csr_set(uint8_t epnum, uint32_t mask)
+TU_ATTR_ALWAYS_INLINE static inline void csr_set(uint8_t epnum, uint32_t mask)
 {
   csr_write(epnum, UDP->UDP_CSR[epnum] | CSR_NO_EFFECT_1_ALL | mask);
 }
 
 // Per Specs: CSR need synchronization each write
-static inline void csr_clear(uint8_t epnum, uint32_t mask)
-{
+TU_ATTR_ALWAYS_INLINE static inline void csr_clear(uint8_t epnum, uint32_t mask) {
   csr_write(epnum, (UDP->UDP_CSR[epnum] | CSR_NO_EFFECT_1_ALL) & ~mask);
 }
 

--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -530,7 +530,7 @@ void dcd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr) {
 /*------------------------------------------------------------------*/
 /* Interrupt Handler
  *------------------------------------------------------------------*/
-void bus_reset(void) {
+static void bus_reset(void) {
   // 6.35.6 USB controller automatically disabled all endpoints (except control)
   NRF_USBD->EPOUTEN = 1UL;
   NRF_USBD->EPINEN = 1UL;
@@ -901,6 +901,7 @@ static void hfclk_disable(void) {
 // Therefore this function must be called to handle USB power event by
 // - nrfx_power_usbevt_init() : if Softdevice is not used or enabled
 // - SoftDevice SOC event : if SD is used and enabled
+void tusb_hal_nrf_power_event(uint32_t event);
 void tusb_hal_nrf_power_event(uint32_t event) {
   // Value is chosen to be as same as NRFX_POWER_USB_EVT_* in nrfx_power.h
   enum {

--- a/src/portable/nxp/khci/hcd_khci.c
+++ b/src/portable/nxp/khci/hcd_khci.c
@@ -140,7 +140,7 @@ typedef struct
 CFG_TUH_MEM_SECTION TU_ATTR_ALIGNED(512) static hcd_data_t _hcd;
 //CFG_TUH_MEM_SECTION TU_ATTR_ALIGNED(4) static uint8_t _rx_buf[1024];
 
-int find_pipe(uint8_t dev_addr, uint8_t ep_addr)
+static int find_pipe(uint8_t dev_addr, uint8_t ep_addr)
 {
   /* Find the target pipe */
   int num;

--- a/src/portable/nxp/lpc17_40/hcd_lpc17_40.c
+++ b/src/portable/nxp/lpc17_40/hcd_lpc17_40.c
@@ -30,6 +30,7 @@
     (CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX)
 
 #include "chip.h"
+#include "host/hcd.h"
 
 void hcd_int_enable(uint8_t rhport)
 {

--- a/src/portable/renesas/rusb2/rusb2_common.c
+++ b/src/portable/renesas/rusb2/rusb2_common.c
@@ -45,6 +45,7 @@ rusb2_controller_t rusb2_controller[] = {
 };
 
 // Application API for setting IRQ number. May throw warnings for missing prototypes.
+void tusb_rusb2_set_irqnum(uint8_t rhport, int32_t irqnum);
 void tusb_rusb2_set_irqnum(uint8_t rhport, int32_t irqnum) {
   rusb2_controller[rhport].irqnum = irqnum;
 }


### PR DESCRIPTION
Fix missing protoype warning, add -Wmissing-prototypes to cmake build for tinyusb src

Endpoint Buffer Definitions:

* [`src/common/tusb_types.h`](diffhunk://#diff-05c83118cd4f8865af0380b64c1a1c073534cfc3f19d3bce7caa4904641fb2b8L50-R50): Updated `TUD_EPBUF_TYPE_DEF` macro to switch the order of parameters for better readability and consistency.
