### PR TITLE
fix(dcd_dwc2): Fix EP IN counters assignment and usage

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -539,7 +539,7 @@ void dcd_edpt_close_all(uint8_t rhport) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
   uint8_t const ep_count = _dwc2_controller[rhport].ep_count;
 
-  _dcd_data.allocated_epin_count = 1;
+  _dcd_data.allocated_epin_count = 0;
 
   // Disable non-control interrupt
   dwc2->daintmsk = (1 << DAINTMSK_OEPM_Pos) | (1 << DAINTMSK_IEPM_Pos);
@@ -646,7 +646,7 @@ static void handle_bus_reset(uint8_t rhport) {
   tu_memclr(xfer_status, sizeof(xfer_status));
 
   _dcd_data.sof_en = false;
-  _dcd_data.allocated_epin_count = 1;
+  _dcd_data.allocated_epin_count = 0;
 
   // 1. NAK for all OUT endpoints
   for (uint8_t n = 0; n < ep_count; n++) {

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -192,8 +192,8 @@ static bool dfifo_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t packet_size) {
     }
   } else {
     // Check IN endpoints concurrently active limit
-    if(_dwc2_controller->ep_in_count) {
-      TU_ASSERT(_dcd_data.allocated_epin_count < _dwc2_controller->ep_in_count);
+    if(dwc2_controller->ep_in_count) {
+      TU_ASSERT(_dcd_data.allocated_epin_count < dwc2_controller->ep_in_count);
       _dcd_data.allocated_epin_count++;
     }
 


### PR DESCRIPTION
### Requirements
This PR contain two small fixes, which are crucial for using device configuration with fully load EP amount. 
ESP32S2/S3 and ESP32P4.

### Description

1.  Flushing `_dcd_data.allocated_epin_count` to zero while: 
    - `dcd_edpt_close_all()` as we will allocate FIFO for EP0 later in `dfifo_device_init(rhport);`
    -  `handle_bus_reset(uint8_t rhport)` as we will allocate FIFO for EP0 later in `dfifo_device_init(rhport);`
2. Fix the usage of counters for `TU_ASSERT`. When we use `_dwc2_controller` instead of `dwc2_controller` we request the `ep_in_count` member value from the first member, which is FS. This is important, when we run on HS PHY. 

### Related
- Cherry-picked from https://github.com/espressif/tinyusb/pull/41
