### PR TITLE
Disable DWC HCD interrupt with MAX3421

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_esp32.h
+++ b/src/portable/synopsys/dwc2/dwc2_esp32.h
@@ -73,7 +73,7 @@ static void dwc2_int_handler_wrap(void* arg) {
     dcd_int_handler(rhport);
   }
 #endif
-#if CFG_TUH_ENABLED
+#if CFG_TUH_ENABLED && !CFG_TUH_MAX3421
   if (role == TUSB_ROLE_HOST) {
     hcd_int_handler(rhport, true);
   }


### PR DESCRIPTION
hcd_int_handler isn't found otherwise.
