### PR TITLE
fix correct DWC2_EP_COUNT

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -44,7 +44,7 @@
 #if TU_CHECK_MCU(OPT_MCU_GD32VF103)
   #define DWC2_EP_COUNT(_dwc2)   DWC2_EP_MAX
 #else
-  #define DWC2_EP_COUNT(_dwc2)  ((_dwc2)->ghwcfg2_bm.num_dev_ep)
+  #define DWC2_EP_COUNT(_dwc2)  ((_dwc2)->ghwcfg2_bm.num_dev_ep + 1)
 #endif
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
fix #2900 
This pull request includes a small but important change to the `src/portable/synopsys/dwc2/dcd_dwc2.c` file. The change modifies the macro definition of `DWC2_EP_COUNT` to correctly account for the number of device endpoints by adding 1 to the existing count.

* [`src/portable/synopsys/dwc2/dcd_dwc2.c`](diffhunk://#diff-1f2490fb8ceeb23801391e207e1972f09dd6a7fbbe431154211cc1896dc363a0L47-R47): Changed the `DWC2_EP_COUNT` macro to add 1 to the number of device endpoints.