### PR TITLE
skip iar build with forked pr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
 
             BUILDSYSTEM_TOOLCHAIN=(
               "cmake arm-clang"
-              "cmake arm-iar"
               "make aarch64-gcc"
               "make arm-gcc"
               "make msp430-gcc"
@@ -28,6 +27,11 @@ jobs:
               "make rx-gcc"
               "cmake esp-idf"
             )
+
+            # only build IAR if not forked PR, since IAR token is not shared
+            if [ -z $CIRCLE_PR_USERNAME ]; then
+              BUILDSYSTEM_TOOLCHAIN+=("cmake arm-iar")
+            fi
 
             RESOURCE_LARGE='["nrf", "imxrt", "stm32f4", "stm32h7"]'
 


### PR DESCRIPTION
This pull request includes changes to the `.circleci/config.yml` file to modify the build system toolchain configuration. The most important changes include removing the `cmake arm-iar` toolchain from the default list and adding conditional logic to include it only for specific users.

Changes in build system toolchain configuration:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L23): Removed `cmake arm-iar` from the default `BUILDSYSTEM_TOOLCHAIN` list.
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R31-R35): Added conditional logic to include `cmake arm-iar` in the `BUILDSYSTEM_TOOLCHAIN` list only if the pull request is from the user `hathach`.