### PR TITLE
Add tuh_enumeration_cb to intercept enumeration xfers

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -65,6 +65,11 @@ TU_ATTR_WEAK void tuh_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_is
   (void) in_isr;
 }
 
+TU_ATTR_WEAK bool tuh_enumeration_cb(tuh_xfer_t* xfer) {
+  (void) xfer;
+  return false;
+}
+
 TU_ATTR_WEAK bool hcd_dcache_clean(const void* addr, uint32_t data_size) {
   (void) addr; (void) data_size;
   return false;
@@ -1331,6 +1336,11 @@ static void enum_full_complete(void);
 
 // process device enumeration
 static void process_enumeration(tuh_xfer_t* xfer) {
+  // Call callback and skip if returns true
+  if (tuh_enumeration_cb(xfer)) {
+    return;
+  }
+  
   // Retry a few times with transfers in enumeration since device can be unstable when starting up
   enum {
     ATTEMPT_COUNT_MAX = 3,

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -108,6 +108,9 @@ TU_ATTR_WEAK void tuh_umount_cb(uint8_t daddr);
 // Invoked when there is a new usb event, which need to be processed by tuh_task()/tuh_task_ext()
 void tuh_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_isr);
 
+// Invoked when an usb enumeration transfer is completed
+bool tuh_enumeration_cb(tuh_xfer_t* xfer);
+
 //--------------------------------------------------------------------+
 // APPLICATION API
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
Adds tuh_enumeration_cb() to allow reading, modifying or discarding xfers during a device enumeration.

