### PR TITLE
src/class/hid/hid_host.c: fix logging calls for epbuf

### DIFF
--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -410,7 +410,7 @@ bool tuh_hid_send_report(uint8_t daddr, uint8_t idx, uint8_t report_id, const vo
     ++len; // 1 more byte for report_id
   }
 
-  TU_LOG3_MEM(p_hid->epout_buf, len, 2);
+  TU_LOG3_MEM(epbuf->epout, len, 2);
 
   if (!usbh_edpt_xfer(daddr, p_hid->ep_out, epbuf->epout, len)) {
     usbh_edpt_release(daddr, p_hid->ep_out);
@@ -445,7 +445,7 @@ bool hidh_xfer_cb(uint8_t daddr, uint8_t ep_addr, xfer_result_t result, uint32_t
 
   if (dir == TUSB_DIR_IN) {
     TU_LOG_DRV("  Get Report callback (%u, %u)\r\n", daddr, idx);
-    TU_LOG3_MEM(p_hid->epin_buf, xferred_bytes, 2);
+    TU_LOG3_MEM(epbuf->epin, xferred_bytes, 2);
     tuh_hid_report_received_cb(daddr, idx, epbuf->epin, (uint16_t) xferred_bytes);
   } else {
     if (tuh_hid_report_sent_cb) {


### PR DESCRIPTION
Some logging calls were referring to `hidh_interface_t` fields that no longer existed, causing compiler errors when logging was enabled.

I am not sure if my changes are correct: please check. But the file now compiles when logging is enabled.