### PR TITLE
Add basic USB CDROM support via USB MSC

### DIFF
--- a/examples/device/cdc_msc/src/msc_disk.c
+++ b/examples/device/cdc_msc/src/msc_disk.c
@@ -269,4 +269,10 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
   return (int32_t) resplen;
 }
 
+msc_scsi_device_type_t tud_msc_scsi_device_type(uint8_t lun)
+{
+  (void)lun;
+  return MSC_SCSI_DEVICE_BLOCK;
+}
+
 #endif

--- a/examples/device/cdc_msc_freertos/src/msc_disk.c
+++ b/examples/device/cdc_msc_freertos/src/msc_disk.c
@@ -269,4 +269,10 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
   return (int32_t) resplen;
 }
 
+msc_scsi_device_type_t tud_msc_scsi_device_type(uint8_t lun)
+{
+  (void)lun;
+  return MSC_SCSI_DEVICE_BLOCK;
+}
+
 #endif

--- a/examples/device/dynamic_configuration/src/msc_disk.c
+++ b/examples/device/dynamic_configuration/src/msc_disk.c
@@ -247,4 +247,10 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
   return resplen;
 }
 
+msc_scsi_device_type_t tud_msc_scsi_device_type(uint8_t lun)
+{
+  (void)lun;
+  return MSC_SCSI_DEVICE_BLOCK;
+}
+
 #endif

--- a/examples/device/msc_dual_lun/src/msc_disk_dual.c
+++ b/examples/device/msc_dual_lun/src/msc_disk_dual.c
@@ -331,4 +331,10 @@ int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, u
   return resplen;
 }
 
+msc_scsi_device_type_t tud_msc_scsi_device_type(uint8_t lun)
+{
+  (void)lun;
+  return MSC_SCSI_DEVICE_BLOCK;
+}
+
 #endif

--- a/src/class/msc/msc.h
+++ b/src/class/msc/msc.h
@@ -78,6 +78,13 @@ typedef enum
   MSC_CSW_STATUS_PHASE_ERROR  ///< MSC_CSW_STATUS_PHASE_ERROR
 }msc_csw_status_t;
 
+/// MassStorage SCSI device type
+typedef enum
+{
+  MSC_SCSI_DEVICE_BLOCK = 0 , ///< USB removable disk
+  MSC_SCSI_DEVICE_CDROM     , ///< USB CDROM
+}msc_scsi_device_type_t;
+
 /// Command Block Wrapper
 typedef struct TU_ATTR_PACKED
 {

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -685,6 +685,12 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
         .additional_length = sizeof(scsi_inquiry_resp_t) - 5,
       };
 
+      if (tud_msc_scsi_device_type(lun) == MSC_SCSI_DEVICE_CDROM)
+      {
+        inquiry_rsp.peripheral_device_type = 0x05;
+        inquiry_rsp.peripheral_qualifier = 0x0;
+      }
+
       // vendor_id, product_id, product_rev is space padded string
       memset(inquiry_rsp.vendor_id  , ' ', sizeof(inquiry_rsp.vendor_id));
       memset(inquiry_rsp.product_id , ' ', sizeof(inquiry_rsp.product_id));

--- a/src/class/msc/msc_device.h
+++ b/src/class/msc/msc_device.h
@@ -149,6 +149,9 @@ TU_ATTR_WEAK void tud_msc_scsi_complete_cb(uint8_t lun, uint8_t const scsi_cmd[1
 // Invoked to check if device is writable as part of SCSI WRITE10
 TU_ATTR_WEAK bool tud_msc_is_writable_cb(uint8_t lun);
 
+// Invoked when INQUIRY received to return the correct SCSI device type.
+msc_scsi_device_type_t tud_msc_scsi_device_type(uint8_t lun);
+
 //--------------------------------------------------------------------+
 // Internal Class Driver API
 //--------------------------------------------------------------------+

--- a/test/fuzz/msc_fuzz.cc
+++ b/test/fuzz/msc_fuzz.cc
@@ -157,6 +157,12 @@ int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16], void *buffer,
 
   return 0;
 }
+
+msc_scsi_device_type_t tud_msc_scsi_device_type(uint8_t lun)
+{
+  (void)lun;
+  return MSC_SCSI_DEVICE_BLOCK;
+}
 }
 
 #endif

--- a/test/unit-test/test/device/msc/test_msc_device.c
+++ b/test/unit-test/test/device/msc/test_msc_device.c
@@ -176,6 +176,12 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
   return resplen;
 }
 
+msc_scsi_device_type_t tud_msc_scsi_device_type(uint8_t lun)
+{
+  return MSC_SCSI_DEVICE_BLOCK;
+}
+
+
 //--------------------------------------------------------------------+
 //
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
USB CDROM support requires that the SCSI INQUIRY command returns a different device type and qualifier. The current API for MSC devices doesn't allow the caller to influence these or appear as any other device type. This PR adds a new API function tud_msc_scsi_device_type(uint8_t lun) that enables expandability of SCSI device types as well as two new commands SCSI_CMD_READ_TOC and SCSI_CMD_READ_DISC_INFO.

In order to appear as a CDROM the caller must:
* Implement tud_msc_scsi_device_type and return MSC_SCSI_DEVICE_CDROM
* Implement SCSI_CMD_READ_TOC in tud_msc_scsi_cb  (this returns the CDROM table of contents)
* Implement SCSI_CMD_READ_DISC_INFO in tud_msc_scsi_cb which returns disc info - in many cases this can be uint8_t[2] = {0}

This is a breaking change if you are currently using MSC and you're getting a compilation error you'll need to add.

```
msc_scsi_device_type_t tud_msc_scsi_device_type(uint8_t lun)
{
  (void) lun;
  return MSC_SCSI_DEVICE_BLOCK;
}
```