### PR TITLE
Work around for esp32s3 racing/timing issue with macos

### DIFF
--- a/.circleci/config2.yml
+++ b/.circleci/config2.yml
@@ -114,7 +114,7 @@ commands:
           name: Build
           command: |
             if [ << parameters.toolchain >> == esp-idf ]; then
-              docker run --rm -v $PWD:/project -w /project espressif/idf:v5.3.1 python tools/build.py << parameters.family >>
+              docker run --rm -v $PWD:/project -w /project espressif/idf:v5.3.2 python tools/build.py << parameters.family >>
             else
               # Toolchain option default is gcc
               if [ << parameters.toolchain >> == arm-clang ]; then

--- a/.github/actions/setup_toolchain/action.yml
+++ b/.github/actions/setup_toolchain/action.yml
@@ -4,9 +4,6 @@ inputs:
   toolchain:
     description: 'Toolchain name'
     required: true
-  toolchain_version:
-    description: 'Toolchain version'
-    required: false
 
 outputs:
   build_option:
@@ -27,7 +24,6 @@ runs:
       uses: ./.github/actions/setup_toolchain/espressif
       with:
         toolchain: ${{ inputs.toolchain }}
-        toolchain_version: ${{ inputs.toolchain_version }}
 
     - name: Get Toolchain URL
       if: >-

--- a/.github/actions/setup_toolchain/espressif/action.yml
+++ b/.github/actions/setup_toolchain/espressif/action.yml
@@ -6,7 +6,8 @@ inputs:
     required: true
   toolchain_version:
     description: 'Toolchain version'
-    required: true
+    required: false
+    default: 'v5.3.2'
 
 runs:
   using: "composite"
@@ -38,4 +39,10 @@ runs:
       run: |
         du -sh $DOCKER_ESP_IDF
         docker load --input $DOCKER_ESP_IDF
+      shell: bash
+
+    - name: Tag Local Image
+      run: |
+        docker tag espressif/idf:${{ inputs.toolchain_version }} espressif/idf:tinyusb
+        docker images
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, hifiphile]
     env:
       BUILD_ARGS: ${{ join(fromJSON(needs.set-matrix.outputs.json)['arm-iar'], ' ') }}
-      # IAR_LMS_BEARER_TOKEN: ${{ secrets.IAR_LMS_BEARER_TOKEN }}
+      IAR_LMS_BEARER_TOKEN: ${{ secrets.IAR_LMS_BEARER_TOKEN }}
     steps:
       - name: Clean workspace
         run: |

--- a/.github/workflows/build_util.yml
+++ b/.github/workflows/build_util.yml
@@ -41,7 +41,6 @@ jobs:
         uses: ./.github/actions/setup_toolchain
         with:
           toolchain: ${{ inputs.toolchain }}
-          toolchain_version: 'v5.3.1'
 
       - name: Get Dependencies
         uses: ./.github/actions/get_deps
@@ -61,7 +60,7 @@ jobs:
       - name: Build
         run: |
           if [ "${{ inputs.toolchain }}" == "esp-idf" ]; then
-            docker run --rm -v $PWD:/project -w /project espressif/idf:v5.3.1 python tools/build.py ${{ matrix.arg }}
+            docker run --rm -v $PWD:/project -w /project espressif/idf:tinyusb python tools/build.py ${{ matrix.arg }}
           else
             python tools/build.py -s ${{ inputs.build-system }} ${{ steps.setup-toolchain.outputs.build_option }} ${{ steps.set-one-per-family.outputs.build_option }} ${{ matrix.arg }}
           fi

--- a/.github/workflows/hil_test.yml
+++ b/.github/workflows/hil_test.yml
@@ -94,8 +94,8 @@ jobs:
   hil-hfp:
     if: github.repository_owner == 'hathach'
     runs-on: [self-hosted, Linux, X64, hifiphile]
-    #env:
-    #  IAR_LMS_BEARER_TOKEN: ${{ secrets.IAR_LMS_BEARER_TOKEN }}
+    env:
+      IAR_LMS_BEARER_TOKEN: ${{ secrets.IAR_LMS_BEARER_TOKEN }}
     steps:
       - name: Clean workspace
         run: |

--- a/hw/bsp/espressif/boards/family.c
+++ b/hw/bsp/espressif/boards/family.c
@@ -175,19 +175,13 @@ bool usb_init(void) {
     // maybe we can use USB_OTG_MODE_DEFAULT and switch using dwc2 driver
 #if CFG_TUD_ENABLED
     .otg_mode = USB_OTG_MODE_DEVICE,
-    .otg_speed = BOARD_TUD_RHPORT ? USB_PHY_SPEED_HIGH : USB_PHY_SPEED_FULL,
 #elif CFG_TUH_ENABLED
     .otg_mode = USB_OTG_MODE_HOST,
-    .otg_speed= BOARD_TUH_RHPORT ? USB_PHY_SPEED_HIGH : USB_PHY_SPEED_FULL,
 #endif
+    // https://github.com/hathach/tinyusb/issues/2943#issuecomment-2601888322
+    // Set speed to undefined (auto-detect) to avoid timinng/racing issue with S3 with host such as macOS
+    .otg_speed = USB_PHY_SPEED_UNDEFINED,
   };
-
-  // OTG IOs config
-  // const usb_phy_otg_io_conf_t otg_io_conf = USB_PHY_SELF_POWERED_DEVICE(config->vbus_monitor_io);
-  // if (config->self_powered) {
-  //   phy_conf.otg_io_conf = &otg_io_conf;
-  // }
-  // ESP_RETURN_ON_ERROR(usb_new_phy(&phy_conf, &phy_hdl), TAG, "Install USB PHY failed");
 
   usb_new_phy(&phy_conf, &phy_hdl);
 

--- a/src/portable/nxp/khci/dcd_khci.c
+++ b/src/portable/nxp/khci/dcd_khci.c
@@ -565,7 +565,7 @@ void dcd_int_handler(uint8_t rhport)
 
   if (is & USB_ISTAT_SOFTOK_MASK) {
     KHCI->ISTAT = USB_ISTAT_SOFTOK_MASK;
-    dcd_event_bus_signal(rhport, DCD_EVENT_SOF, true);
+    dcd_event_sof(rhport, tu_u16(KHCI->FRMNUMH, KHCI->FRMNUML), true);
   }
 
   if (is & USB_ISTAT_STALL_MASK) {


### PR DESCRIPTION
* Updated the ESP-IDF toolchain version from `v5.3.1` to `v5.3.2`
* Set the USB OTG speed to `USB_PHY_SPEED_UNDEFINED` to avoid esp32-s3 timing/racing issues with certain hosts in `hw/bsp/espressif/boards/family.c`.
* Changed the USB SOF event handling to use `dcd_event_sof` with the frame number in `src/portable/nxp/khci/dcd_khci.c`.
* change hfp ci runner to use IAR token since normal IAR license is expired.