### PR TITLE
skip iar build for forked PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
 
   # ---------------------------------------
   # Build IAR on HFP self-hosted
+  # Since IAR Token secret is not passed to forked PR, only build on PR from the same repo
   # ---------------------------------------
   arm-iar:
     if: github.repository_owner == 'hathach' && github.event_name == 'push'

--- a/.github/workflows/hil_test.yml
+++ b/.github/workflows/hil_test.yml
@@ -90,9 +90,10 @@ jobs:
   # ---------------------------------------
   # Hardware in the loop (HIL)
   # self-hosted by HFP, build with IAR toolchain, for attached hardware checkout test/hil/hfp.json
+  # Since IAR Token secret is not passed to forked PR, only build on PR from the same repo
   # ---------------------------------------
   hil-hfp:
-    if: github.repository_owner == 'hathach'
+    if: github.repository_owner == 'hathach' && github.event.pull_request.head.repo.fork == false
     runs-on: [self-hosted, Linux, X64, hifiphile]
     env:
       IAR_LMS_BEARER_TOKEN: ${{ secrets.IAR_LMS_BEARER_TOKEN }}


### PR DESCRIPTION
**Describe the PR**
the old IAR license scheme is expired, the new cloud scheme require IAR token/secret, which  is not passed/sahred to forked PR. Therefore we can only build IAR same repo.  