### PR TITLE
Add full/high speed compile flag for Microchip SAME70 examples

### DIFF
--- a/hw/bsp/same70_xplained/board.mk
+++ b/hw/bsp/same70_xplained/board.mk
@@ -14,6 +14,14 @@ CFLAGS += \
 # suppress following warnings from mcu driver
 CFLAGS += -Wno-error=unused-parameter -Wno-error=cast-align -Wno-error=redundant-decls
 
+SPEED ?= high
+
+ifeq ($(SPEED), high)
+  CFLAGS += -DBOARD_TUD_MAX_SPEED=OPT_MODE_HIGH_SPEED
+else
+  CFLAGS += -DBOARD_TUD_MAX_SPEED=OPT_MODE_FULL_SPEED
+endif
+
 # SAM driver is flooded with -Wcast-qual which slow down complication significantly
 CFLAGS_SKIP += -Wcast-qual
 


### PR DESCRIPTION
Default is still high speed, but setting
SPEED=high|full work as expected.

`make BOARD=same70_xplained SPEED=full`

Tested with examples/device/cdc_msc

```preformatted
lsusb -v

...

  TinyUSB Device:

    Product ID: 0x4003
    Vendor ID: 0xcafe
    Version: 1.00
    Serial Number: 0123456789ABCDEF
    Speed: Up to 12 Mb/s   <------ full speed here
    Manufacturer: TinyUSB
    Location ID: 0x03142130 / 12
    Current Available (mA): 500
    Current Required (mA): 100
    Extra Operating Current (mA): 0
    Media:
      Mass Storage:
        Capacity: 8 KB (8,192 bytes)
        Removable Media: Yes
        BSD Name: disk5
        Logical Unit: 0
        Partition Map Type: Unknown
        S.M.A.R.T. status: Verified
        USB Interface: 2
```
