### PR TITLE
fix(esp): Remove deprecated include

### DIFF
--- a/hw/bsp/espressif/boards/family.c
+++ b/hw/bsp/espressif/boards/family.c
@@ -162,7 +162,6 @@ int board_getchar(void) {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 
 #include "esp_private/usb_phy.h"
-#include "soc/usb_pins.h"
 
 static usb_phy_handle_t phy_hdl;
 


### PR DESCRIPTION
**Describe the PR**
soc/usb_pins.h header will be deprecated in IDF v6.0. It is not needed nor used in current tinyusb

**Additional context**

