### PR TITLE
Fix(host) enumeration with 8bitdo devices

### DIFF
--- a/examples/host/cdc_msc_hid/src/hid_app.c
+++ b/examples/host/cdc_msc_hid/src/hid_app.c
@@ -39,18 +39,16 @@
 static uint8_t const keycode2ascii[128][2] =  { HID_KEYCODE_TO_ASCII };
 
 // Each HID instance can has multiple reports
-static struct
-{
+static struct {
   uint8_t report_count;
   tuh_hid_report_info_t report_info[MAX_REPORT];
-}hid_info[CFG_TUH_HID];
+} hid_info[CFG_TUH_HID];
 
 static void process_kbd_report(hid_keyboard_report_t const *report);
 static void process_mouse_report(hid_mouse_report_t const * report);
 static void process_generic_report(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len);
 
-void hid_app_task(void)
-{
+void hid_app_task(void) {
   // nothing to do
 }
 
@@ -63,64 +61,57 @@ void hid_app_task(void)
 // can be used to parse common/simple enough descriptor.
 // Note: if report descriptor length > CFG_TUH_ENUMERATION_BUFSIZE, it will be skipped
 // therefore report_desc = NULL, desc_len = 0
-void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len)
-{
+void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const *desc_report, uint16_t desc_len) {
   printf("HID device address = %d, instance = %d is mounted\r\n", dev_addr, instance);
 
   // Interface protocol (hid_interface_protocol_enum_t)
-  const char* protocol_str[] = { "None", "Keyboard", "Mouse" };
+  const char *protocol_str[] = {"None", "Keyboard", "Mouse"};
   uint8_t const itf_protocol = tuh_hid_interface_protocol(dev_addr, instance);
 
   printf("HID Interface Protocol = %s\r\n", protocol_str[itf_protocol]);
 
   // By default host stack will use activate boot protocol on supported interface.
   // Therefore for this simple example, we only need to parse generic report descriptor (with built-in parser)
-  if ( itf_protocol == HID_ITF_PROTOCOL_NONE )
-  {
+  if (itf_protocol == HID_ITF_PROTOCOL_NONE) {
     hid_info[instance].report_count = tuh_hid_parse_report_descriptor(hid_info[instance].report_info, MAX_REPORT, desc_report, desc_len);
     printf("HID has %u reports \r\n", hid_info[instance].report_count);
   }
 
   // request to receive report
   // tuh_hid_report_received_cb() will be invoked when report is available
-  if ( !tuh_hid_receive_report(dev_addr, instance) )
-  {
+  if (!tuh_hid_receive_report(dev_addr, instance)) {
     printf("Error: cannot request to receive report\r\n");
   }
 }
 
 // Invoked when device with hid interface is un-mounted
-void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance)
-{
+void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
   printf("HID device address = %d, instance = %d is unmounted\r\n", dev_addr, instance);
 }
 
 // Invoked when received report from device via interrupt endpoint
-void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len)
-{
+void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t const *report, uint16_t len) {
   uint8_t const itf_protocol = tuh_hid_interface_protocol(dev_addr, instance);
 
-  switch (itf_protocol)
-  {
+  switch (itf_protocol) {
     case HID_ITF_PROTOCOL_KEYBOARD:
       TU_LOG2("HID receive boot keyboard report\r\n");
-      process_kbd_report( (hid_keyboard_report_t const*) report );
-    break;
+      process_kbd_report((hid_keyboard_report_t const *) report);
+      break;
 
     case HID_ITF_PROTOCOL_MOUSE:
       TU_LOG2("HID receive boot mouse report\r\n");
-      process_mouse_report( (hid_mouse_report_t const*) report );
-    break;
+      process_mouse_report((hid_mouse_report_t const *) report);
+      break;
 
     default:
       // Generic report requires matching ReportID and contents with previous parsed report info
       process_generic_report(dev_addr, instance, report, len);
-    break;
+      break;
   }
 
   // continue to request to receive report
-  if ( !tuh_hid_receive_report(dev_addr, instance) )
-  {
+  if (!tuh_hid_receive_report(dev_addr, instance)) {
     printf("Error: cannot request to receive report\r\n");
   }
 }
@@ -231,29 +222,24 @@ static void process_mouse_report(hid_mouse_report_t const * report)
 //--------------------------------------------------------------------+
 // Generic Report
 //--------------------------------------------------------------------+
-static void process_generic_report(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len)
-{
+static void process_generic_report(uint8_t dev_addr, uint8_t instance, uint8_t const *report, uint16_t len) {
   (void) dev_addr;
   (void) len;
 
   uint8_t const rpt_count = hid_info[instance].report_count;
-  tuh_hid_report_info_t* rpt_info_arr = hid_info[instance].report_info;
-  tuh_hid_report_info_t* rpt_info = NULL;
+  tuh_hid_report_info_t *rpt_info_arr = hid_info[instance].report_info;
+  tuh_hid_report_info_t *rpt_info = NULL;
 
-  if ( rpt_count == 1 && rpt_info_arr[0].report_id == 0)
-  {
+  if (rpt_count == 1 && rpt_info_arr[0].report_id == 0) {
     // Simple report without report ID as 1st byte
     rpt_info = &rpt_info_arr[0];
-  }else
-  {
+  } else {
     // Composite report, 1st byte is report ID, data starts from 2nd byte
     uint8_t const rpt_id = report[0];
 
     // Find report id in the array
-    for(uint8_t i=0; i<rpt_count; i++)
-    {
-      if (rpt_id == rpt_info_arr[i].report_id )
-      {
+    for (uint8_t i = 0; i < rpt_count; i++) {
+      if (rpt_id == rpt_info_arr[i].report_id) {
         rpt_info = &rpt_info_arr[i];
         break;
       }
@@ -263,8 +249,7 @@ static void process_generic_report(uint8_t dev_addr, uint8_t instance, uint8_t c
     len--;
   }
 
-  if (!rpt_info)
-  {
+  if (!rpt_info) {
     printf("Couldn't find report info !\r\n");
     return;
   }
@@ -276,23 +261,22 @@ static void process_generic_report(uint8_t dev_addr, uint8_t instance, uint8_t c
   // - Consumer Control (Media Key) : Consumer, Consumer Control
   // - System Control (Power key)   : Desktop, System Control
   // - Generic (vendor)             : 0xFFxx, xx
-  if ( rpt_info->usage_page == HID_USAGE_PAGE_DESKTOP )
-  {
-    switch (rpt_info->usage)
-    {
+  if (rpt_info->usage_page == HID_USAGE_PAGE_DESKTOP) {
+    switch (rpt_info->usage) {
       case HID_USAGE_DESKTOP_KEYBOARD:
         TU_LOG1("HID receive keyboard report\r\n");
         // Assume keyboard follow boot report layout
-        process_kbd_report( (hid_keyboard_report_t const*) report );
-      break;
+        process_kbd_report((hid_keyboard_report_t const *) report);
+        break;
 
       case HID_USAGE_DESKTOP_MOUSE:
         TU_LOG1("HID receive mouse report\r\n");
         // Assume mouse follow boot report layout
-        process_mouse_report( (hid_mouse_report_t const*) report );
-      break;
+        process_mouse_report((hid_mouse_report_t const *) report);
+        break;
 
-      default: break;
+      default:
+        break;
     }
   }
 }

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -462,7 +462,7 @@ TU_VERIFY_STATIC( sizeof(tusb_desc_interface_assoc_t) == 8, "size is not correct
 typedef struct TU_ATTR_PACKED {
   uint8_t  bLength         ; ///< Size of this descriptor in bytes
   uint8_t  bDescriptorType ; ///< Descriptor Type
-  uint16_t unicode_string[];
+  uint16_t utf16le[];
 } tusb_desc_string_t;
 
 // USB Binary Device Object Store (BOS)

--- a/src/host/hub.c
+++ b/src/host/hub.c
@@ -46,7 +46,7 @@ typedef struct {
 
   // from hub descriptor
   uint8_t bNbrPorts;
-  uint8_t bPwrOn2PwrGood; // port power on to good, in 2ms unit
+  uint8_t bPwrOn2PwrGood_2ms; // port power on to good, in 2ms unit
   // uint16_t wHubCharacteristics;
 
   hub_port_status_response_t port_status;
@@ -279,7 +279,7 @@ static void config_set_port_power (tuh_xfer_t* xfer) {
   // only use number of ports in hub descriptor
   hub_desc_cs_t const* desc_hub = (hub_desc_cs_t const*) p_epbuf->ctrl_buf;
   p_hub->bNbrPorts = desc_hub->bNbrPorts;
-  p_hub->bPwrOn2PwrGood = desc_hub->bPwrOn2PwrGood;
+  p_hub->bPwrOn2PwrGood_2ms = desc_hub->bPwrOn2PwrGood;
 
   // May need to GET_STATUS
 
@@ -301,7 +301,6 @@ static void config_port_power_complete (tuh_xfer_t* xfer) {
       TU_MESS_FAILED();
       TU_BREAKPOINT();
     }
-    // delay bPwrOn2PwrGood * 2 ms before set configuration complete
     usbh_driver_set_config_complete(daddr, p_hub->itf_num);
   } else {
     // power next port

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -265,6 +265,13 @@ bool tuh_descriptor_get_hid_report(uint8_t daddr, uint8_t itf_num, uint8_t desc_
 bool tuh_descriptor_get_string(uint8_t daddr, uint8_t index, uint16_t language_id, void* buffer, uint16_t len,
                                tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
+// Get language id string descriptor (control transfer)
+TU_ATTR_ALWAYS_INLINE static inline
+bool tuh_descriptor_get_string_langid(uint8_t daddr, void* buffer, uint16_t len,
+                               tuh_xfer_cb_t complete_cb, uintptr_t user_data) {
+  return tuh_descriptor_get_string(daddr, 0, 0, buffer, len, complete_cb, user_data);
+}
+
 // Get manufacturer string descriptor (control transfer)
 // true on success, false if there is on-going control transfer or incorrect parameters
 bool tuh_descriptor_get_manufacturer_string(uint8_t daddr, uint16_t language_id, void* buffer, uint16_t len,
@@ -303,6 +310,12 @@ uint8_t tuh_descriptor_get_hid_report_sync(uint8_t daddr, uint8_t itf_num, uint8
 // Sync (blocking) version of tuh_descriptor_get_string()
 // return transfer result
 uint8_t tuh_descriptor_get_string_sync(uint8_t daddr, uint8_t index, uint16_t language_id, void* buffer, uint16_t len);
+
+// Sync (blocking) version of tuh_descriptor_get_string_langid()
+TU_ATTR_ALWAYS_INLINE static inline
+uint8_t tuh_descriptor_get_string_langid_sync(uint8_t daddr, void* buffer, uint16_t len) {
+  return tuh_descriptor_get_string_sync(daddr, 0, 0, buffer, len);
+}
 
 // Sync (blocking) version of tuh_descriptor_get_manufacturer_string()
 // return transfer result

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -110,7 +110,7 @@ void __tusb_irq_path_func(_hw_endpoint_buffer_control_update32)(struct hw_endpoi
       *ep->buffer_control = value & ~USB_BUF_CTRL_AVAIL;
       // 4.1.2.5.1 Con-current access: 12 cycles (should be good for 48*12Mhz = 576Mhz) after write to buffer control
       // Don't need delay in host mode as host is in charge
-      if ( !is_host_mode()) {
+      if (!is_host_mode()) {
         busy_wait_at_least_cycles(12);
       }
     }


### PR DESCRIPTION
**Describe the PR**
- fix(hcd_rp2040) assert/panic endpoint already active: when a device reset while having on-going control transfer
- featuer(host) always get language id, manufacturer, product and serial string. Which is required by some device such as 8bitdo. Should fix #2163 
- add tuh_descriptor_get_string_langid() API 

@tannewt please try to see if this works with your 8bitdo gamepad

PS: IAR build failed due to server maintanence