### PR TITLE
Allow different port and mode for LED on ch32v boards

### DIFF
--- a/hw/bsp/ch32v20x/boards/ch32v203c_r0_1v0/board.h
+++ b/hw/bsp/ch32v20x/boards/ch32v203c_r0_1v0/board.h
@@ -13,6 +13,8 @@ extern "C" {
 #define LED_PORT       GPIOA
 #define LED_PIN        GPIO_Pin_0
 #define LED_STATE_ON   0
+#define LED_CLOCK_EN() RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE)
+#define LED_MODE       GPIO_Mode_Out_OD
 
 #define UART_DEV        USART1
 #define UART_CLOCK_EN() RCC_APB2PeriphClockCmd(RCC_APB2Periph_USART1, ENABLE)

--- a/hw/bsp/ch32v20x/boards/ch32v203g_r0_1v0/board.h
+++ b/hw/bsp/ch32v20x/boards/ch32v203g_r0_1v0/board.h
@@ -13,6 +13,8 @@ extern "C" {
 #define LED_PORT       GPIOA
 #define LED_PIN        GPIO_Pin_0
 #define LED_STATE_ON   0
+#define LED_CLOCK_EN() RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE)
+#define LED_MODE       GPIO_Mode_Out_OD
 
 #define UART_DEV        USART2
 #define UART_CLOCK_EN() RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART2, ENABLE)

--- a/hw/bsp/ch32v20x/boards/nanoch32v203/board.h
+++ b/hw/bsp/ch32v20x/boards/nanoch32v203/board.h
@@ -13,6 +13,8 @@ extern "C" {
 #define LED_PORT       GPIOA
 #define LED_PIN        GPIO_Pin_15
 #define LED_STATE_ON   0
+#define LED_CLOCK_EN() RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE)
+#define LED_MODE       GPIO_Mode_Out_OD
 
 #define UART_DEV        USART1
 #define UART_CLOCK_EN() RCC_APB2PeriphClockCmd(RCC_APB2Periph_USART1, ENABLE)

--- a/hw/bsp/ch32v20x/family.c
+++ b/hw/bsp/ch32v20x/family.c
@@ -96,11 +96,11 @@ void board_init(void) {
   SysTick_Config(SystemCoreClock / 1000);
 #endif
 
-  RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
+  LED_CLOCK_EN();
 
   GPIO_InitTypeDef GPIO_InitStructure = {
     .GPIO_Pin = LED_PIN,
-    .GPIO_Mode = GPIO_Mode_Out_OD,
+    .GPIO_Mode = LED_MODE,
     .GPIO_Speed = GPIO_Speed_10MHz,
   };
   GPIO_Init(LED_PORT, &GPIO_InitStructure);


### PR DESCRIPTION
While there is a define for the port, the clock enable is hardcoded for GPIOA, so setting a different port than GPIOA doesn't work. This fixes it by adding a define for enabling the port clock.

It also adds a define for the pin mode, because not all boards have the LED connected in a way that open drain works with it.
