### PR TITLE
fix(rp2040) set RTOS as cmake cache to fix pico-example build

### DIFF
--- a/hw/bsp/family_support.cmake
+++ b/hw/bsp/family_support.cmake
@@ -12,7 +12,7 @@ set(UF2CONV_PY ${TOP}/tools/uf2/utils/uf2conv.py)
 # RTOS
 #-------------------------------------------------------------
 if (NOT DEFINED RTOS)
-  set(RTOS noos)
+  set(RTOS noos CACHE STRING "RTOS")
 endif ()
 
 #-------------------------------------------------------------


### PR DESCRIPTION
fix #3004 set RTOS as cmake cache to fix pico-example build