### PR TITLE
fix desc_end in vendord_open()

### DIFF
--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -197,7 +197,7 @@ void vendord_reset(uint8_t rhport) {
 uint16_t vendord_open(uint8_t rhport, const tusb_desc_interface_t* desc_itf, uint16_t max_len) {
   TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == desc_itf->bInterfaceClass, 0);
   const uint8_t* p_desc = tu_desc_next(desc_itf);
-  const uint8_t* desc_end = p_desc + max_len;
+  const uint8_t* desc_end = (uint8_t const*)desc_itf + max_len;
 
   // Find available interface
   vendord_interface_t* p_vendor = NULL;


### PR DESCRIPTION
minor fix on calculation of desc_end in vendord_open( ) for descriptor prasing

**Describe the PR**

fix `desc_end` calculation
In vendor device class, function `vendord_open()`

**Additional context**

In vendor_device.c, original code
https://github.com/hathach/tinyusb/blob/master/src/class/vendor/vendor_device.c
```c
  const uint8_t* p_desc = tu_desc_next(desc_itf);
  const uint8_t* desc_end = p_desc + max_len;
```
`desc_end` is calaulated by `p_desc + max_len` which is `u_desc_next(desc_itf) + max_len` ,
but parameter `max_len` include length of `desc_itf`, 
which make `desc_end` exceed the real end of descriptor by length of `desc_itf `

It won't cause issue since while loop stopped when all endpoints are founded 
But error may occur when trying to peek descriptors after last endpoint 

Since vendor_device is an ideal reference for developing new USB function
I suppose it'll be better to do the minor fix
```c
  const uint8_t* p_desc = tu_desc_next(desc_itf);
  const uint8_t* desc_end = (uint8_t const*)desc_itf + max_len;
```
Encountered this when I try to check if next interface an AlternateSetting of current interface

thanks.
