### PR TITLE
Fix UAC ctrl buffer alignment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,14 @@ latex
 *.jlink
 *.emSession
 *.ninja*
+*.eww
+*.ewp
+*.ewt
+*.ewd
+*.hex
+cmake_install.cmake
+CMakeCache.txt
+settings/
 .settings/
 .vscode/
 .gdb_history

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -208,15 +208,15 @@ tu_static CFG_TUD_MEM_SECTION struct {
 #endif// CFG_TUD_AUDIO_ENABLE_EP_OUT && (USE_LINEAR_BUFFER || CFG_TUD_AUDIO_ENABLE_DECODING)
 
 // Control buffers
-tu_static uint8_t ctrl_buf_1[CFG_TUD_AUDIO_FUNC_1_CTRL_BUF_SZ];
-
-#if CFG_TUD_AUDIO > 1
-tu_static uint8_t ctrl_buf_2[CFG_TUD_AUDIO_FUNC_2_CTRL_BUF_SZ];
-#endif
-
-#if CFG_TUD_AUDIO > 2
-tu_static uint8_t ctrl_buf_3[CFG_TUD_AUDIO_FUNC_3_CTRL_BUF_SZ];
-#endif
+tu_static CFG_TUD_MEM_SECTION struct {
+  TUD_EPBUF_DEF(buf1, CFG_TUD_AUDIO_FUNC_1_CTRL_BUF_SZ);
+  #if CFG_TUD_AUDIO > 1
+  TUD_EPBUF_DEF(buf2, CFG_TUD_AUDIO_FUNC_2_CTRL_BUF_SZ);
+  #endif
+  #if CFG_TUD_AUDIO > 2
+  TUD_EPBUF_DEF(buf3, CFG_TUD_AUDIO_FUNC_3_CTRL_BUF_SZ);
+  #endif
+} ctrl_buf;
 
 // Active alternate setting of interfaces
 tu_static uint8_t alt_setting_1[CFG_TUD_AUDIO_FUNC_1_N_AS_INT];
@@ -1223,18 +1223,18 @@ void audiod_init(void) {
     // Initialize control buffers
     switch (i) {
       case 0:
-        audio->ctrl_buf = ctrl_buf_1;
+        audio->ctrl_buf = ctrl_buf.buf1;
         audio->ctrl_buf_sz = CFG_TUD_AUDIO_FUNC_1_CTRL_BUF_SZ;
         break;
 #if CFG_TUD_AUDIO > 1 && CFG_TUD_AUDIO_FUNC_2_CTRL_BUF_SZ > 0
       case 1:
-        audio->ctrl_buf = ctrl_buf_2;
+        audio->ctrl_buf = ctrl_buf.buf2;
         audio->ctrl_buf_sz = CFG_TUD_AUDIO_FUNC_2_CTRL_BUF_SZ;
         break;
 #endif
 #if CFG_TUD_AUDIO > 2 && CFG_TUD_AUDIO_FUNC_3_CTRL_BUF_SZ > 0
       case 2:
-        audio->ctrl_buf = ctrl_buf_3;
+        audio->ctrl_buf = ctrl_buf.buf3;
         audio->ctrl_buf_sz = CFG_TUD_AUDIO_FUNC_3_CTRL_BUF_SZ;
         break;
 #endif

--- a/src/portable/nxp/lpc_ip3511/dcd_lpc_ip3511.c
+++ b/src/portable/nxp/lpc_ip3511/dcd_lpc_ip3511.c
@@ -297,7 +297,7 @@ bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
 
   dcd_reg->EPLISTSTART  = (uint32_t) _dcd.ep;
   dcd_reg->DATABUFSTART = tu_align((uint32_t) &_dcd, TU_BIT(22)); // 22-bit alignment
-  dcd_reg->INTSTAT     |= dcd_reg->INTSTAT; // clear all pending interrupt
+  dcd_reg->INTSTAT      = dcd_reg->INTSTAT; // clear all pending interrupt
   dcd_reg->INTEN        = INT_DEVICE_STATUS_MASK;
   dcd_reg->DEVCMDSTAT  |= DEVCMDSTAT_DEVICE_ENABLE_MASK | DEVCMDSTAT_DEVICE_CONNECT_MASK |
                            DEVCMDSTAT_RESET_CHANGE_MASK | DEVCMDSTAT_CONNECT_CHANGE_MASK | DEVCMDSTAT_SUSPEND_CHANGE_MASK;
@@ -563,7 +563,8 @@ void dcd_int_handler(uint8_t rhport)
 
   uint32_t const cmd_stat = dcd_reg->DEVCMDSTAT;
 
-  uint32_t int_status = dcd_reg->INTSTAT & dcd_reg->INTEN;
+  uint32_t int_status = dcd_reg->INTSTAT;
+	int_status &= dcd_reg->INTEN;
   dcd_reg->INTSTAT = int_status; // Acknowledge handled interrupt
 
   if (int_status == 0) return;


### PR DESCRIPTION
**Describe the PR**
Title.

**Additional context**
@hathach Please sync mcux-sdk to 2.15 which moved the delay to between `AHBCLKCTRLSET` and `USBPHY->CTRL_CLR`. 

https://github.com/nxp-mcuxpresso/mcux-sdk/blame/1277588e8c34439fc08c657d3176d8a354853643/devices/LPC55S69/drivers/fsl_clock.c#L2035