### PR TITLE
dwc2/host: clear SOF flag in handle_sof_irq()

### DIFF
--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -1182,6 +1182,7 @@ static void handle_channel_irq(uint8_t rhport, bool in_isr) {
 static bool handle_sof_irq(uint8_t rhport, bool in_isr) {
   (void) in_isr;
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+  dwc2->gintsts = GINTSTS_SOF; // Clear the SOF interrupt flag
 
   bool more_isr = false;
 


### PR DESCRIPTION
**Describe the PR**
The SOF flag was not cleared in the `hcd_int_handler()` ISR or `handle_sof_irq()` function inside of it.
This caused recurring and infinite IRQs in some cases (e.g. when connecting a HUB). 

**Additional context**
See discussion here: https://github.com/hathach/tinyusb/discussions/3062
