### PR TITLE
dwc2/host: HFIR: Fix timing off-by-one

### DIFF
--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -1242,9 +1242,9 @@ static void port0_enable(dwc2_regs_t* dwc2, tusb_speed_t speed) {
 
   uint32_t hfir = dwc2->hfir & ~HFIR_FRIVL_Msk;
   if (speed == TUSB_SPEED_HIGH) {
-    hfir |= 125*phy_clock;
+    hfir |= 125*phy_clock - 1; // The "- 1" is the correct value. The Synopsys databook was corrected in 3.30a
   } else {
-    hfir |= 1000*phy_clock;
+    hfir |= 1000*phy_clock - 1;
   }
 
   dwc2->hfir = hfir;


### PR DESCRIPTION
**Describe the PR**
HFIR register for SOF timing was programmed with an off-by-one value (it needs a -1 applied).

- This probably comes from a historical error in the Synopsys databook. They corrected it in version 3.30a, according to this comment on a mailinglist: https://lists.infradead.org/pipermail/linux-rpi-kernel/2016-February/003290.html

- Also, the official Linux kernel dwc2 driver (maintained by Synopsys) contains the values with `-1` offset, as can be seen in the `dwc2_calc_frame_interval()` function here:
https://github.com/torvalds/linux/blob/900241a5cc15e6e0709a012051cc72d224cd6a6e/drivers/usb/dwc2/hcd.c#L326

@HiFiPhile @roma-jam 