### PR TITLE
host/dwc2: cleanup transfer on device close

### DIFF
--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -448,6 +448,7 @@ void hcd_device_close(uint8_t rhport, uint8_t dev_addr) {
     hcd_endpoint_t* edpt = &_hcd_data.edpt[i];
     if (edpt->hcchar_bm.enable && edpt->hcchar_bm.dev_addr == dev_addr) {
       tu_memclr(edpt, sizeof(hcd_endpoint_t));
+      tu_memclr(&_hcd_data.xfer[i], sizeof(hcd_xfer_t));
     }
   }
 }


### PR DESCRIPTION
**Describe the PR**
Fix xfer complete event of previous enumeration mess with next enumeration.

```
[1:1] Get Descriptor: 80 06 03 03 09 04 00 01 
on EP 00 with 8 bytes: OK
on EP 80 with 40 bytes: OK
[1:1] Control data:
  0000:  28 03 4D 00 61 00 73 00 73 00 20 00 53 00 74 00  |(.M.a.s.s. .S.t.|
  0010:  6F 00 72 00 61 00 67 00 65 00 20 00 44 00 65 00  |o.r.a.g.e. .D.e.|
  0020:  76 00 69 00 63 00 65 00                          |v.i.c.e.|
[1:0:0] USBH DEVICE REMOVED
[1:0:0] unplugged address = 1
Device removed, address = 1
[1:] USBH Device Attach
High Speed
[1:0] Open EP0 with Size = 8
Get 8 byte of Device Descriptor
[1:0] Get Descriptor: 80 06 00 01 00 00 08 00 
on EP 00 with 8 bytes: OK
on EP 00 with 8 bytes: OK
[1:0] Control data:
  0000:  12 01 00 02 00 00 00 40                          |.......@|
on EP 80 with 8 bytes: OK

Set Address = 1
[1:0] Set Address: 00 05 01 00 00 00 00 00 
on EP 00 with 0 bytes: OK
on EP 00 with 8 bytes: OK

[1:1] Open EP0 with Size = 64
Get Device Descriptor
[1:1] Get Descriptor: 80 06 00 01 00 00 12 00 
on EP 80 with 8 bytes: OK
hcd_edpt_xfer 655: ASSERT FAILED
```