### PR TITLE
Add new CDC device callback on driver reset

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -299,6 +299,7 @@ void cdcd_reset(uint8_t rhport) {
       tu_fifo_clear(&p_cdc->tx_ff);
     }
     tu_fifo_set_overwritable(&p_cdc->tx_ff, _cdcd_cfg.tx_overwritabe_if_not_connected);
+    if (tud_cdc_reset_cb) tud_cdc_reset_cb(i);
   }
 }
 

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -219,6 +219,9 @@ TU_ATTR_WEAK void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* p
 //                          device will send a break until another SendBreak request is received with value 0000h.
 TU_ATTR_WEAK void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms);
 
+// Invoked when the driver is reset.
+TU_ATTR_WEAK void tud_cdc_reset_cb(uint8_t itf);
+
 //--------------------------------------------------------------------+
 // INTERNAL USBD-CLASS DRIVER API
 //--------------------------------------------------------------------+


### PR DESCRIPTION
This adds tud_cdc_reset_cb(), which can be implemented to receive notifications when the CDC driver is reset.

**Additional context**
My application use a writer thread that goes to sleep when the the TX fifo is full, and is woken up by the tud_cdc_tx_complete_cb()  callback. However, if there is a usb reset, then it gets hung since any pending writes are discarded. It would be useful to have a callback so that the writer thread can also wake up when there has been a usb reset.
