### PR TITLE
usbh enum get string descriptor length first

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
   # cmake is built by circle-ci. Due to IAR limit capacity, only build oe per family
   # ---------------------------------------
   arm-iar:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    if: github.event_name == 'push' && github.repository_owner == 'hathach'
     needs: set-matrix
     uses: ./.github/workflows/build_util.yml
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           - 'msp430-gcc'
           - 'riscv-gcc'
           - 'rx-gcc'
-          - 'esp-idf' # build-system is ignored
+          - 'esp-idf'
     with:
       build-system: 'make'
       toolchain: ${{ matrix.toolchain }}
@@ -115,7 +115,8 @@ jobs:
   # cmake is built by circle-ci. Due to IAR limit capacity, only build oe per family
   # ---------------------------------------
   arm-iar:
-    if: github.event_name == 'push' && github.repository_owner == 'hathach'
+    if: false # disable for now since we got reach capacity limit too often
+    #if: github.event_name == 'push' && github.repository_owner == 'hathach'
     needs: set-matrix
     uses: ./.github/workflows/build_util.yml
     secrets: inherit

--- a/.github/workflows/ci_set_matrix.py
+++ b/.github/workflows/ci_set_matrix.py
@@ -44,9 +44,10 @@ family_list = {
     "stm32l0 stm32l4": ["arm-gcc", "arm-clang", "arm-iar"],
     "stm32u5 stm32wb": ["arm-gcc", "arm-clang", "arm-iar"],
     "xmc4000": ["arm-gcc"],
-    "-bespressif_kaluga_1": ["esp-idf"],
-    "-bespressif_s3_devkitm": ["esp-idf"],
-    "-bespressif_p4_function_ev": ["esp-idf"],
+    "-bespressif_s2_devkitc": ["esp-idf"],
+    # S3, P4 will be built by hil test
+    # "-bespressif_s3_devkitm": ["esp-idf"],
+    # "-bespressif_p4_function_ev": ["esp-idf"],
 }
 
 

--- a/hw/bsp/espressif/boards/espressif_s2_devkitc/board.h
+++ b/hw/bsp/espressif/boards/espressif_s2_devkitc/board.h
@@ -36,12 +36,18 @@
  extern "C" {
 #endif
 
-// Note: On the production version (v1.2) WS2812 is connected to GPIO 18,
-// however earlier revision v1.1 WS2812 is connected to GPIO 17
 #define NEOPIXEL_PIN          18
 
 #define BUTTON_PIN            0
 #define BUTTON_STATE_ACTIVE   0
+
+// SPI for USB host shield
+#define MAX3421_SPI_HOST  SPI2_HOST
+#define MAX3421_SCK_PIN  36
+#define MAX3421_MOSI_PIN 35
+#define MAX3421_MISO_PIN 37
+#define MAX3421_CS_PIN   15
+#define MAX3421_INTR_PIN 14
 
 #ifdef __cplusplus
  }

--- a/hw/bsp/espressif/boards/espressif_s3_devkitc/board.h
+++ b/hw/bsp/espressif/boards/espressif_s3_devkitc/board.h
@@ -36,7 +36,7 @@
  extern "C" {
 #endif
 
-#define NEOPIXEL_PIN          48
+#define NEOPIXEL_PIN          38
 
 #define BUTTON_PIN            0
 #define BUTTON_STATE_ACTIVE   0

--- a/hw/bsp/espressif/family.cmake
+++ b/hw/bsp/espressif/family.cmake
@@ -34,6 +34,6 @@ endif ()
 set(EXTRA_COMPONENT_DIRS "src" "${CMAKE_CURRENT_LIST_DIR}/boards" "${CMAKE_CURRENT_LIST_DIR}/components")
 
 # set SDKCONFIG for each IDF Target
-set(SDKCONFIG ${CMAKE_SOURCE_DIR}/sdkconfig.${IDF_TARGET})
+set(SDKCONFIG ${CMAKE_BINARY_DIR}/sdkconfig)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/src/common/tusb_debug.h
+++ b/src/common/tusb_debug.h
@@ -108,15 +108,13 @@ typedef struct {
 } tu_lookup_table_t;
 
 static inline const char* tu_lookup_find(tu_lookup_table_t const* p_table, uint32_t key) {
-  tu_static char not_found[11];
-
   for(uint16_t i=0; i<p_table->count; i++) {
-    if (p_table->items[i].key == key) return p_table->items[i].data;
+    if (p_table->items[i].key == key) { return p_table->items[i].data; }
   }
 
   // not found return the key value in hex
+  static char not_found[11];
   snprintf(not_found, sizeof(not_found), "0x%08lX", (unsigned long) key);
-
   return not_found;
 }
 


### PR DESCRIPTION
**Describe the PR**
- usbh enumeration for string descriptor (langid, manufacturer product, serila): always get the first 2 bytes to determine the length first. otherwise, some device may have buffer overflow.
- fix neopixel for s3 devkitc
- disable iar ci due to capacity limit