### PR TITLE
Fix 1st nak retry one frame shorter.

### DIFF
--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -748,8 +748,11 @@ static void channel_xfer_in_retry(dwc2_regs_t* dwc2, uint8_t ch_id, uint32_t hci
       const dwc2_channel_tsize_t hctsiz = {.value = channel->hctsiz};
       edpt->next_pid = hctsiz.pid; // save PID
       edpt->uframe_countdown = edpt->uframe_interval - ucount;
-      dwc2->gintsts = GINTSTS_SOF; // SOF flag is probably pending
-      dwc2->gintmsk |= GINTSTS_SOF;
+      // enable SOF interrupt if not already enabled
+      if (!(dwc2->gintmsk & GINTMSK_SOFM)) {
+        dwc2->gintsts = GINTSTS_SOF;
+        dwc2->gintmsk |= GINTMSK_SOFM;
+      }
       // already halted, de-allocate channel (called from DMA isr)
       channel_dealloc(dwc2, ch_id);
     }

--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -748,6 +748,7 @@ static void channel_xfer_in_retry(dwc2_regs_t* dwc2, uint8_t ch_id, uint32_t hci
       const dwc2_channel_tsize_t hctsiz = {.value = channel->hctsiz};
       edpt->next_pid = hctsiz.pid; // save PID
       edpt->uframe_countdown = edpt->uframe_interval - ucount;
+      dwc2->gintsts = GINTSTS_SOF; // SOF flag is probably pending
       dwc2->gintmsk |= GINTSTS_SOF;
       // already halted, de-allocate channel (called from DMA isr)
       channel_dealloc(dwc2, ch_id);


### PR DESCRIPTION
**Describe the PR**
A small fix following #3072.

When we enable SOF interrupt the 1st time it could be already pending but uncleared, in `hcd_int_handler` `gintsts = dwc2->gintsts & gintmsk`, since `gintmsk` is unset yet `gintsts` is also unset, in result SOF flag is not cleared.

Cause SOF fire immediately and retry interval shorter, 2nd poll should happen at 63ms instead.

<img width="479" alt="usbpv_SpP7rHuANO" src="https://github.com/user-attachments/assets/5ac73355-ea75-4cf0-b499-d6af116d31d2" />
