### PR TITLE
refactor(usbh) improve the usage of bus info

### DIFF
--- a/.idea/debugServers/esp32s2.xml
+++ b/.idea/debugServers/esp32s2.xml
@@ -1,0 +1,14 @@
+<component name="DebugServers">
+  <generic-debug-target name="esp32s2" uniqueID="254eff00-2acf-48fe-b255-1d0c0c9c4a7a">
+    <debugger version="1">
+      <debugger kind="GDB">$USER_HOME$/.espressif/tools/xtensa-esp-elf-gdb/14.2_20240403/xtensa-esp-elf-gdb/bin/xtensa-esp32s2-elf-gdb</debugger>
+      <env />
+    </debugger>
+    <gdbserver exe="$USER_HOME$/.espressif/tools/openocd-esp32/v0.12.0-esp32-20241016/openocd-esp32/bin/openocd" args="-f board/esp32s2-kaluga-1.cfg">
+      <env />
+    </gdbserver>
+    <console port="4444" />
+    <target download-type="NONE" reset-command="monitor reset halt" reset-before="false" />
+    <connection extended-remote="false" remote-string="tcp::3333" warmup-ms="500" />
+  </generic-debug-target>
+</component>

--- a/.idea/debugServers/rp2350.xml
+++ b/.idea/debugServers/rp2350.xml
@@ -1,5 +1,5 @@
 <component name="DebugServers">
-  <generic-debug-target name="rp2350" uniqueID="939fdf16-9c30-4261-8435-3e8df7fd5800" selected="true">
+  <generic-debug-target name="rp2350" uniqueID="939fdf16-9c30-4261-8435-3e8df7fd5800">
     <debugger version="1">
       <debugger kind="GDB" isBundled="true" />
       <env />

--- a/.idea/debugServers/stm32f769.xml
+++ b/.idea/debugServers/stm32f769.xml
@@ -1,0 +1,13 @@
+<component name="DebugServers">
+  <jlink-debug-target name="stm32f769" uniqueID="7a47302f-f7e5-434b-b20b-78e95318dd0c" selected="true">
+    <debugger version="1">
+      <debugger kind="GDB" isBundled="true" />
+      <env />
+    </debugger>
+    <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
+    <console port="19021" type="RTT" />
+    <target device="STM32F769NI" reset-before="false" frequency="16000" />
+    <connection extended-remote="false" port="4444" warmup-ms="500" />
+    <swo />
+  </jlink-debug-target>
+</component>

--- a/.idea/debugServers/stm32h563.xml
+++ b/.idea/debugServers/stm32h563.xml
@@ -1,0 +1,13 @@
+<component name="DebugServers">
+  <jlink-debug-target name="stm32h563" uniqueID="a3e9293d-113b-48b3-b83d-dd4249984abe">
+    <debugger version="1">
+      <debugger kind="GDB" isBundled="true" />
+      <env />
+    </debugger>
+    <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
+    <console port="2334" type="RTT" />
+    <target device="STM32H562ZI" reset-before="false" frequency="16000" />
+    <connection extended-remote="false" port="4444" warmup-ms="500" />
+    <swo />
+  </jlink-debug-target>
+</component>

--- a/.idea/debugServers/stm32h743.xml
+++ b/.idea/debugServers/stm32h743.xml
@@ -1,0 +1,13 @@
+<component name="DebugServers">
+  <jlink-debug-target name="stm32h743" uniqueID="6d6a3ed6-f66d-4f6a-9e70-6aafe5c971d0">
+    <debugger version="1">
+      <debugger kind="GDB" isBundled="true" />
+      <env />
+    </debugger>
+    <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
+    <console port="2334" type="RTT" />
+    <target device="STM32H743XI" reset-before="false" frequency="16000" />
+    <connection extended-remote="false" port="4444" warmup-ms="500" />
+    <swo />
+  </jlink-debug-target>
+</component>

--- a/examples/host/cdc_msc_hid/src/msc_app.c
+++ b/examples/host/cdc_msc_hid/src/msc_app.c
@@ -30,13 +30,11 @@
 //--------------------------------------------------------------------+
 static scsi_inquiry_resp_t inquiry_resp;
 
-bool inquiry_complete_cb(uint8_t dev_addr, tuh_msc_complete_data_t const * cb_data)
-{
+static bool inquiry_complete_cb(uint8_t dev_addr, tuh_msc_complete_data_t const * cb_data) {
   msc_cbw_t const* cbw = cb_data->cbw;
   msc_csw_t const* csw = cb_data->csw;
 
-  if (csw->status != 0)
-  {
+  if (csw->status != 0) {
     printf("Inquiry failed\r\n");
     return false;
   }
@@ -55,16 +53,14 @@ bool inquiry_complete_cb(uint8_t dev_addr, tuh_msc_complete_data_t const * cb_da
 }
 
 //------------- IMPLEMENTATION -------------//
-void tuh_msc_mount_cb(uint8_t dev_addr)
-{
+void tuh_msc_mount_cb(uint8_t dev_addr) {
   printf("A MassStorage device is mounted\r\n");
 
   uint8_t const lun = 0;
   tuh_msc_inquiry(dev_addr, lun, &inquiry_resp, inquiry_complete_cb, 0);
 }
 
-void tuh_msc_umount_cb(uint8_t dev_addr)
-{
+void tuh_msc_umount_cb(uint8_t dev_addr) {
   (void) dev_addr;
   printf("A MassStorage device is unmounted\r\n");
 }

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -90,13 +90,6 @@ typedef struct {
   };
 } hcd_event_t;
 
-typedef struct {
-  uint8_t rhport;
-  uint8_t hub_addr;
-  uint8_t hub_port;
-  uint8_t speed;
-} tuh_bus_info_t;
-
 //--------------------------------------------------------------------+
 // Memory API
 //--------------------------------------------------------------------+
@@ -185,9 +178,6 @@ bool hcd_edpt_clear_stall(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr);
 //--------------------------------------------------------------------+
 // USBH implemented API
 //--------------------------------------------------------------------+
-
-// Get device port information
-extern bool hcd_bus_info_get(uint8_t daddr, tuh_bus_info_t* bus_info);
 
 // Called by HCD to notify stack
 extern void hcd_event_handler(hcd_event_t const* event, bool in_isr);

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -95,7 +95,7 @@ typedef struct {
   uint8_t hub_addr;
   uint8_t hub_port;
   uint8_t speed;
-} hcd_devtree_info_t;
+} tuh_bus_info_t;
 
 //--------------------------------------------------------------------+
 // Memory API
@@ -186,12 +186,8 @@ bool hcd_edpt_clear_stall(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr);
 // USBH implemented API
 //--------------------------------------------------------------------+
 
-// Get device tree information of a device
-// USB device tree can be complicated and manged by USBH, this help HCD to retrieve
-// needed topology info to carry out its work
-extern void hcd_devtree_get_info(uint8_t dev_addr, hcd_devtree_info_t* devtree_info);
-
-//------------- Event API -------------//
+// Get device port information
+extern bool hcd_bus_info_get(uint8_t daddr, tuh_bus_info_t* bus_info);
 
 // Called by HCD to notify stack
 extern void hcd_event_handler(hcd_event_t const* event, bool in_isr);
@@ -239,4 +235,4 @@ void hcd_event_xfer_complete(uint8_t dev_addr, uint8_t ep_addr, uint32_t xferred
  }
 #endif
 
-#endif /* _TUSB_HCD_H_ */
+#endif

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -28,9 +28,9 @@
 
 #if CFG_TUH_ENABLED
 
-#include "host/hcd.h"
+#include "hcd.h"
 #include "tusb.h"
-#include "host/usbh_pvt.h"
+#include "usbh_pvt.h"
 #include "hub.h"
 
 //--------------------------------------------------------------------+
@@ -342,7 +342,7 @@ bool tuh_vid_pid_get(uint8_t dev_addr, uint16_t *vid, uint16_t *pid) {
 
 tusb_speed_t tuh_speed_get(uint8_t daddr) {
   tuh_bus_info_t bus_info;
-  hcd_bus_info_get(daddr, &bus_info);
+  tuh_bus_info_get(daddr, &bus_info);
   return bus_info.speed;
 }
 
@@ -875,7 +875,7 @@ bool tuh_edpt_abort_xfer(uint8_t daddr, uint8_t ep_addr) {
 
 uint8_t usbh_get_rhport(uint8_t daddr) {
   tuh_bus_info_t bus_info;
-  hcd_bus_info_get(daddr, &bus_info);
+  tuh_bus_info_get(daddr, &bus_info);
   return bus_info.rhport;
 }
 
@@ -1013,7 +1013,7 @@ bool usbh_edpt_busy(uint8_t dev_addr, uint8_t ep_addr) {
 // HCD Event Handler
 //--------------------------------------------------------------------+
 
-bool hcd_bus_info_get(uint8_t daddr, tuh_bus_info_t* bus_info) {
+bool tuh_bus_info_get(uint8_t daddr, tuh_bus_info_t* bus_info) {
   usbh_device_t const* dev = get_device(daddr);
   if (dev) {
     *bus_info = dev->bus_info;

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -47,7 +47,6 @@
 // forward declaration
 struct tuh_xfer_s;
 typedef struct tuh_xfer_s tuh_xfer_t;
-
 typedef void (*tuh_xfer_cb_t)(tuh_xfer_t* xfer);
 
 // Note1: layout and order of this will be changed in near future
@@ -79,6 +78,14 @@ typedef struct {
   uint8_t daddr;
   tusb_desc_interface_t desc;
 } tuh_itf_info_t;
+
+typedef struct {
+  uint8_t rhport;
+  uint8_t hub_addr;
+  uint8_t hub_port;
+  uint8_t speed;
+} tuh_bus_info_t;
+
 
 // ConfigID for tuh_configure()
 enum {
@@ -177,6 +184,8 @@ extern void hcd_int_handler(uint8_t rhport, bool in_isr);
 #define _tuh_int_handler_arg0()                   TU_VERIFY_STATIC(false, "tuh_int_handler() must have 1 or 2 arguments")
 #define _tuh_int_handler_arg1(_rhport)            hcd_int_handler(_rhport, true)
 #define _tuh_int_handler_arg2(_rhport, _in_isr)   hcd_int_handler(_rhport, _in_isr)
+
+// 1st argument is rhport (mandatory), 2nd argument in_isr (optional)
 #define tuh_int_handler(...)   TU_FUNC_OPTIONAL_ARG(_tuh_int_handler, __VA_ARGS__)
 
 // Check if roothub port is initialized and active as a host
@@ -213,6 +222,9 @@ TU_ATTR_ALWAYS_INLINE static inline bool tuh_suspended(uint8_t daddr) {
 TU_ATTR_ALWAYS_INLINE static inline bool tuh_ready(uint8_t daddr) {
   return tuh_mounted(daddr) && !tuh_suspended(daddr);
 }
+
+// Get bus information of device
+bool tuh_bus_info_get(uint8_t daddr, tuh_bus_info_t* bus_info);
 
 //--------------------------------------------------------------------+
 // Transfer API

--- a/src/host/usbh_pvt.h
+++ b/src/host/usbh_pvt.h
@@ -63,7 +63,7 @@ usbh_class_driver_t const* usbh_app_driver_get_cb(uint8_t* driver_count) TU_ATTR
 // Call by class driver to tell USBH that it has complete the enumeration
 void usbh_driver_set_config_complete(uint8_t dev_addr, uint8_t itf_num);
 
-uint8_t usbh_get_rhport(uint8_t dev_addr);
+uint8_t usbh_get_rhport(uint8_t daddr);
 
 uint8_t* usbh_get_enum_buf(void);
 

--- a/src/portable/chipidea/ci_hs/hcd_ci_hs.c
+++ b/src/portable/chipidea/ci_hs/hcd_ci_hs.c
@@ -35,6 +35,7 @@
 //--------------------------------------------------------------------+
 #include "common/tusb_common.h"
 #include "host/hcd.h"
+#include "host/usbh.h"
 #include "portable/ehci/ehci_api.h"
 #include "ci_hs_type.h"
 

--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -34,6 +34,7 @@
 #include "osal/osal.h"
 
 #include "host/hcd.h"
+#include "host/usbh.h"
 #include "ehci_api.h"
 #include "ehci.h"
 
@@ -838,7 +839,7 @@ static void qhd_init(ehci_qhd_t *p_qhd, uint8_t dev_addr, tusb_desc_endpoint_t c
   }
 
   tuh_bus_info_t bus_info;
-  hcd_bus_info_get(dev_addr, &bus_info);
+  tuh_bus_info_get(dev_addr, &bus_info);
 
   uint8_t const xfer_type = ep_desc->bmAttributes.xfer;
   uint8_t const interval = ep_desc->bInterval;

--- a/src/portable/ehci/ehci.c
+++ b/src/portable/ehci/ehci.c
@@ -837,8 +837,8 @@ static void qhd_init(ehci_qhd_t *p_qhd, uint8_t dev_addr, tusb_desc_endpoint_t c
     tu_memclr(p_qhd, sizeof(ehci_qhd_t));
   }
 
-  hcd_devtree_info_t devtree_info;
-  hcd_devtree_get_info(dev_addr, &devtree_info);
+  tuh_bus_info_t bus_info;
+  hcd_bus_info_get(dev_addr, &bus_info);
 
   uint8_t const xfer_type = ep_desc->bmAttributes.xfer;
   uint8_t const interval = ep_desc->bInterval;
@@ -846,7 +846,7 @@ static void qhd_init(ehci_qhd_t *p_qhd, uint8_t dev_addr, tusb_desc_endpoint_t c
   p_qhd->dev_addr           = dev_addr;
   p_qhd->fl_inactive_next_xact = 0;
   p_qhd->ep_number          = tu_edpt_number(ep_desc->bEndpointAddress);
-  p_qhd->ep_speed           = devtree_info.speed;
+  p_qhd->ep_speed           = bus_info.speed;
   p_qhd->data_toggle_control= (xfer_type == TUSB_XFER_CONTROL) ? 1 : 0;
   p_qhd->head_list_flag     = (dev_addr == 0) ? 1 : 0; // addr0's endpoint is the static async list head
   p_qhd->max_packet_size    = tu_edpt_packet_size(ep_desc);
@@ -887,8 +887,8 @@ static void qhd_init(ehci_qhd_t *p_qhd, uint8_t dev_addr, tusb_desc_endpoint_t c
     default: break;
   }
 
-  p_qhd->fl_hub_addr  = devtree_info.hub_addr;
-  p_qhd->fl_hub_port  = devtree_info.hub_port;
+  p_qhd->fl_hub_addr  = bus_info.hub_addr;
+  p_qhd->fl_hub_port  = bus_info.hub_port;
   p_qhd->mult         = 1; // TODO not use high bandwidth/park mode yet
 
   //------------- HCD Management Data -------------//

--- a/src/portable/mentor/musb/hcd_musb.c
+++ b/src/portable/mentor/musb/hcd_musb.c
@@ -695,16 +695,16 @@ bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet
   _hcd.pipe0.length    = 8;
   _hcd.pipe0.remaining = 0;
 
-  hcd_devtree_info_t devtree;
-  hcd_devtree_get_info(dev_addr, &devtree);
-  switch (devtree.speed) {
+  tuh_bus_info_t bus_info;
+  hcd_bus_info_get(dev_addr, &bus_info);
+  switch (bus_info.speed) {
     default: return false;
     case TUSB_SPEED_LOW:  USB0->TYPE0 = USB_TYPE0_SPEED_LOW;  break;
     case TUSB_SPEED_FULL: USB0->TYPE0 = USB_TYPE0_SPEED_FULL; break;
     case TUSB_SPEED_HIGH: USB0->TYPE0 = USB_TYPE0_SPEED_HIGH; break;
   }
-  USB0->TXHUBADDR0     = devtree.hub_addr;
-  USB0->TXHUBPORT0     = devtree.hub_port;
+  USB0->TXHUBADDR0     = bus_info.hub_addr;
+  USB0->TXHUBPORT0     = bus_info.hub_port;
   USB0->TXFUNCADDR0    = dev_addr;
   USB0->CSRL0 = USB_CSRL0_TXRDY | USB_CSRL0_SETUP;
   return true;
@@ -744,9 +744,9 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const 
   pipe->remaining = 0;
 
   uint8_t pipe_type = 0;
-  hcd_devtree_info_t devtree;
-  hcd_devtree_get_info(dev_addr, &devtree);
-  switch (devtree.speed) {
+  tuh_bus_info_t bus_info;
+  hcd_bus_info_get(dev_addr, &bus_info);
+  switch (bus_info.speed) {
     default: return false;
     case TUSB_SPEED_LOW:  pipe_type |= USB_TXTYPE1_SPEED_LOW;  break;
     case TUSB_SPEED_FULL: pipe_type |= USB_TXTYPE1_SPEED_FULL; break;
@@ -763,8 +763,8 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const 
   hw_endpoint_t volatile *regs = edpt_regs(pipenum - 1);
   if (dir_tx) {
     fadr->TXFUNCADDR = dev_addr;
-    fadr->TXHUBADDR  = devtree.hub_addr;
-    fadr->TXHUBPORT  = devtree.hub_port;
+    fadr->TXHUBADDR  = bus_info.hub_addr;
+    fadr->TXHUBPORT  = bus_info.hub_port;
     regs->TXMAXP     = mps;
     regs->TXTYPE     = pipe_type | epn;
     regs->TXINTERVAL = ep_desc->bInterval;
@@ -775,8 +775,8 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const 
     USB0->TXIE |= TU_BIT(pipenum);
   } else {
     fadr->RXFUNCADDR = dev_addr;
-    fadr->RXHUBADDR  = devtree.hub_addr;
-    fadr->RXHUBPORT  = devtree.hub_port;
+    fadr->RXHUBADDR  = bus_info.hub_addr;
+    fadr->RXHUBPORT  = bus_info.hub_port;
     regs->RXMAXP     = mps;
     regs->RXTYPE     = pipe_type | epn;
     regs->RXINTERVAL = ep_desc->bInterval;

--- a/src/portable/mentor/musb/hcd_musb.c
+++ b/src/portable/mentor/musb/hcd_musb.c
@@ -36,6 +36,7 @@ _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"");
 #endif
 
 #include "host/hcd.h"
+#include "host/usbh.h"
 
 #include "musb_type.h"
 
@@ -696,7 +697,7 @@ bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet
   _hcd.pipe0.remaining = 0;
 
   tuh_bus_info_t bus_info;
-  hcd_bus_info_get(dev_addr, &bus_info);
+  tuh_bus_info_get(dev_addr, &bus_info);
   switch (bus_info.speed) {
     default: return false;
     case TUSB_SPEED_LOW:  USB0->TYPE0 = USB_TYPE0_SPEED_LOW;  break;
@@ -745,7 +746,7 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const 
 
   uint8_t pipe_type = 0;
   tuh_bus_info_t bus_info;
-  hcd_bus_info_get(dev_addr, &bus_info);
+  tuh_bus_info_get(dev_addr, &bus_info);
   switch (bus_info.speed) {
     default: return false;
     case TUSB_SPEED_LOW:  pipe_type |= USB_TXTYPE1_SPEED_LOW;  break;

--- a/src/portable/nxp/khci/hcd_khci.c
+++ b/src/portable/nxp/khci/hcd_khci.c
@@ -36,6 +36,7 @@
 #endif
 
 #include "host/hcd.h"
+#include "host/usbh.h"
 
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION

--- a/src/portable/nxp/lpc17_40/hcd_lpc17_40.c
+++ b/src/portable/nxp/lpc17_40/hcd_lpc17_40.c
@@ -31,6 +31,7 @@
 
 #include "chip.h"
 #include "host/hcd.h"
+#include "host/usbh.h"
 
 void hcd_int_enable(uint8_t rhport)
 {

--- a/src/portable/ohci/ohci.c
+++ b/src/portable/ohci/ohci.c
@@ -328,13 +328,13 @@ static void ed_init(ohci_ed_t *p_ed, uint8_t dev_addr, uint16_t ep_size, uint8_t
     tu_memclr(p_ed, sizeof(ohci_ed_t));
   }
 
-  hcd_devtree_info_t devtree_info;
-  hcd_devtree_get_info(dev_addr, &devtree_info);
+  tuh_bus_info_t bus_info;
+  hcd_bus_info_get(dev_addr, &bus_info);
 
   p_ed->dev_addr          = dev_addr;
   p_ed->ep_number         = ep_addr & 0x0F;
   p_ed->pid               = (xfer_type == TUSB_XFER_CONTROL) ? PID_FROM_TD : (tu_edpt_dir(ep_addr) ? PID_IN : PID_OUT);
-  p_ed->speed             = devtree_info.speed;
+  p_ed->speed             = bus_info.speed;
   p_ed->is_iso            = (xfer_type == TUSB_XFER_ISOCHRONOUS) ? 1 : 0;
   p_ed->max_packet_size   = ep_size;
 

--- a/src/portable/ohci/ohci.c
+++ b/src/portable/ohci/ohci.c
@@ -38,6 +38,7 @@
 #include "osal/osal.h"
 
 #include "host/hcd.h"
+#include "host/usbh.h"
 #include "ohci.h"
 
 // TODO remove
@@ -329,7 +330,7 @@ static void ed_init(ohci_ed_t *p_ed, uint8_t dev_addr, uint16_t ep_size, uint8_t
   }
 
   tuh_bus_info_t bus_info;
-  hcd_bus_info_get(dev_addr, &bus_info);
+  tuh_bus_info_get(dev_addr, &bus_info);
 
   p_ed->dev_addr          = dev_addr;
   p_ed->ep_number         = ep_addr & 0x0F;

--- a/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
+++ b/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
@@ -115,7 +115,7 @@ void hcd_int_disable(uint8_t rhport) {
 
 bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const *desc_ep) {
   tuh_bus_info_t bus_info;
-  hcd_bus_info_get(dev_addr, &bus_info);
+  tuh_bus_info_get(dev_addr, &bus_info);
   bool const need_pre = (bus_info.hub_addr && bus_info.speed == TUSB_SPEED_LOW);
 
   uint8_t const pio_rhport = RHPORT_PIO(rhport);

--- a/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
+++ b/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
@@ -114,9 +114,9 @@ void hcd_int_disable(uint8_t rhport) {
 //--------------------------------------------------------------------+
 
 bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const *desc_ep) {
-  hcd_devtree_info_t dev_tree;
-  hcd_devtree_get_info(dev_addr, &dev_tree);
-  bool const need_pre = (dev_tree.hub_addr && dev_tree.speed == TUSB_SPEED_LOW);
+  tuh_bus_info_t bus_info;
+  hcd_bus_info_get(dev_addr, &bus_info);
+  bool const need_pre = (bus_info.hub_addr && bus_info.speed == TUSB_SPEED_LOW);
 
   uint8_t const pio_rhport = RHPORT_PIO(rhport);
   return pio_usb_host_endpoint_open(pio_rhport, dev_addr, (uint8_t const *) desc_ep, need_pre);

--- a/src/portable/renesas/rusb2/hcd_rusb2.c
+++ b/src/portable/renesas/rusb2/hcd_rusb2.c
@@ -30,6 +30,7 @@
 #if CFG_TUH_ENABLED && defined(TUP_USBIP_RUSB2)
 
 #include "host/hcd.h"
+#include "host/usbh.h"
 #include "rusb2_type.h"
 
 #if TU_CHECK_MCU(OPT_MCU_RX63X, OPT_MCU_RX65X, OPT_MCU_RX72N)
@@ -663,7 +664,7 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const 
   if (0 == epn) {
     rusb->DCPCTR = RUSB2_PIPE_CTR_PID_NAK;
     tuh_bus_info_t bus_info;
-    hcd_bus_info_get(dev_addr, &bus_info);
+    tuh_bus_info_get(dev_addr, &bus_info);
     uint16_t volatile *devadd = (uint16_t volatile *)(uintptr_t) &rusb->DEVADD[0];
     devadd += dev_addr;
     while (rusb->DCPCTR_b.PBUSY) {}

--- a/src/portable/renesas/rusb2/hcd_rusb2.c
+++ b/src/portable/renesas/rusb2/hcd_rusb2.c
@@ -662,13 +662,13 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_endpoint_t const 
 
   if (0 == epn) {
     rusb->DCPCTR = RUSB2_PIPE_CTR_PID_NAK;
-    hcd_devtree_info_t devtree;
-    hcd_devtree_get_info(dev_addr, &devtree);
+    tuh_bus_info_t bus_info;
+    hcd_bus_info_get(dev_addr, &bus_info);
     uint16_t volatile *devadd = (uint16_t volatile *)(uintptr_t) &rusb->DEVADD[0];
     devadd += dev_addr;
     while (rusb->DCPCTR_b.PBUSY) {}
     rusb->DCPMAXP = (dev_addr << 12) | mps;
-    *devadd = (TUSB_SPEED_FULL == devtree.speed) ? RUSB2_DEVADD_USBSPD_FS : RUSB2_DEVADD_USBSPD_LS;
+    *devadd = (TUSB_SPEED_FULL == bus_info.speed) ? RUSB2_DEVADD_USBSPD_FS : RUSB2_DEVADD_USBSPD_LS;
     _hcd.ctl_mps[dev_addr] = mps;
     return true;
   }

--- a/src/portable/synopsys/dwc2/dwc2_common.c
+++ b/src/portable/synopsys/dwc2/dwc2_common.c
@@ -36,6 +36,7 @@
 
 #if CFG_TUH_ENABLED
 #include "host/hcd.h"
+#include "host/usbh.h"
 #endif
 
 #include "dwc2_common.h"

--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -36,6 +36,7 @@
 #define DWC2_DEBUG    2
 
 #include "host/hcd.h"
+#include "host/usbh.h"
 #include "dwc2_common.h"
 
 // Max number of endpoints application can open, can be larger than DWC2_CHANNEL_COUNT_MAX
@@ -476,7 +477,7 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, const tusb_desc_endpoint_t*
   const tusb_speed_t rh_speed = hprt_speed_get(dwc2);
 
   tuh_bus_info_t bus_info;
-  hcd_bus_info_get(dev_addr, &bus_info);
+  tuh_bus_info_get(dev_addr, &bus_info);
 
   // find a free endpoint
   const uint8_t ep_id = edpt_alloc();

--- a/src/portable/template/hcd_template.c
+++ b/src/portable/template/hcd_template.c
@@ -29,6 +29,7 @@
 #if CFG_TUH_ENABLED && CFG_TUSB_MCU == OPT_MCU_NONE
 
 #include "host/hcd.h"
+#include "host/usbh.h"
 
 //--------------------------------------------------------------------+
 // Controller API


### PR DESCRIPTION
**Describe the PR**
- rename hcd_devtree_info_t to tuh_bus_info_t, hcd_devtree_get_info to hcd_bus_info_get
- streamline bus info to usbh_devies, also replace dev0 (renamed to dev0_bus)
- move usbh ctrl_xfer into usbh_data
- rename and add new API tuh_bus_info_get() for application

close #2357