### PR TITLE
examples cmake: fix gcc flag -mcpu=cortex=m0

### DIFF
--- a/examples/build_system/cmake/cpu/cortex-m0.cmake
+++ b/examples/build_system/cmake/cpu/cortex-m0.cmake
@@ -1,7 +1,7 @@
 if (TOOLCHAIN STREQUAL "gcc")
   set(TOOLCHAIN_COMMON_FLAGS
     -mthumb
-    -mcpu=cortex-m0plus
+    -mcpu=cortex-m0
     -mfloat-abi=soft
     )
   set(FREERTOS_PORT GCC_ARM_CM0 CACHE INTERNAL "")


### PR DESCRIPTION
**Describe the PR**
Possibly a copy-paste error ? `-mcpu=` flag should be cortex-m0 on gcc, like with the other compilers
