### PR TITLE
Usbh improve hub

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -6,9 +6,9 @@
       <configuration PROFILE_NAME="raspberrypi_zero2" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=raspberrypi_zero2 -DLOG=1" />
       <configuration PROFILE_NAME="raspberrypi_cm4" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=raspberrypi_cm4 -DLOG=1" />
       <configuration PROFILE_NAME="raspberry_pi_pico" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=raspberry_pi_pico -DLOG=1" />
-      <configuration PROFILE_NAME="raspberry_pi_pico2" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=raspberry_pi_pico2 -DLOG=1" />
-      <configuration PROFILE_NAME="raspberry_pi_pico2_riscv" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=raspberry_pi_pico2_riscv -DLOG=1" />
       <configuration PROFILE_NAME="raspberry_pi_pico-pio_host" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=raspberry_pi_pico -DLOG=1 -DCFLAGS_CLI=&quot;-DCFG_TUH_RPI_PIO_USB=1&quot;" />
+      <configuration PROFILE_NAME="raspberry_pi_pico2" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=raspberry_pi_pico2 -DLOG=1" />
+      <configuration PROFILE_NAME="raspberry_pi_pico2-pio_host" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=raspberry_pi_pico2 -DLOG=1 -DCFLAGS_CLI=&quot;-DCFG_TUH_RPI_PIO_USB=1&quot;" />
       <configuration PROFILE_NAME="feather_rp2040" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=pico_sdk -DPICO_BOARD=adafruit_feather_rp2040 -DLOG=1" />
       <configuration PROFILE_NAME="feather_rp2040_max3421" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=feather_rp2040_max3421 -DLOG=1" />
       <configuration PROFILE_NAME="metro_rp2040" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=pico_sdk -DPICO_BOARD=adafruit_metro_rp2040 -DLOG=1 -DMAX3421_HOST=1" />

--- a/src/host/hub.h
+++ b/src/host/hub.h
@@ -170,8 +170,12 @@ bool hub_port_set_feature(uint8_t hub_addr, uint8_t hub_port, uint8_t feature,
                           tuh_xfer_cb_t complete_cb, uintptr_t user_data);
 
 // Get port status
+// If hub_port != 0, resp is ignored. hub_port_get_status_local() can be used to retrieve the status
 bool hub_port_get_status(uint8_t hub_addr, uint8_t hub_port, void *resp,
                          tuh_xfer_cb_t complete_cb, uintptr_t user_data);
+
+// Get port status from local cache. This does not send a request to the device
+bool hub_port_get_status_local(uint8_t hub_addr, uint8_t hub_port, hub_port_status_response_t* resp);
 
 // Get status from Interrupt endpoint
 bool hub_edpt_status_xfer(uint8_t daddr);
@@ -188,7 +192,7 @@ bool hub_port_clear_reset_change(uint8_t hub_addr, uint8_t hub_port, tuh_xfer_cb
   return hub_port_clear_feature(hub_addr, hub_port, HUB_FEATURE_PORT_RESET_CHANGE, complete_cb, user_data);
 }
 
-// Get Hub status
+// Get Hub status (port = 0)
 TU_ATTR_ALWAYS_INLINE static inline
 bool hub_get_status(uint8_t hub_addr, void* resp, tuh_xfer_cb_t complete_cb, uintptr_t user_data) {
   return hub_port_get_status(hub_addr, 0, resp, complete_cb, user_data);
@@ -205,7 +209,7 @@ bool hub_clear_feature(uint8_t hub_addr, uint8_t feature, tuh_xfer_cb_t complete
 bool hub_init       (void);
 bool hub_deinit     (void);
 bool hub_open       (uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *itf_desc, uint16_t max_len);
-bool hub_set_config (uint8_t dev_addr, uint8_t itf_num);
+bool hub_set_config (uint8_t daddr, uint8_t itf_num);
 bool hub_xfer_cb    (uint8_t daddr, uint8_t ep_addr, xfer_result_t event, uint32_t xferred_bytes);
 void hub_close      (uint8_t dev_addr);
 

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1546,7 +1546,7 @@ static void process_enumeration(tuh_xfer_t* xfer) {
       TU_ASSERT(new_addr != 0,);
 
       usbh_device_t* new_dev = get_device(new_addr);
-      new_dev->bus_info = _usbh_data.dev0_bus;
+      new_dev->bus_info = *dev0_bus;
       new_dev->connected = 1;
       new_dev->ep0_size = desc_device->bMaxPacketSize0;
 
@@ -1564,7 +1564,7 @@ static void process_enumeration(tuh_xfer_t* xfer) {
       new_dev->addressed = 1;
       _usbh_data.enumerating_daddr = new_addr;
 
-      hcd_device_close(_usbh_data.dev0_bus.rhport, 0); // close dev0_bus
+      hcd_device_close(dev0_bus->rhport, 0); // close dev0
 
       TU_ASSERT(usbh_edpt_control_open(new_addr, new_dev->ep0_size),); // open new control endpoint
 

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -250,6 +250,10 @@ bool tuh_edpt_close(uint8_t daddr, uint8_t ep_addr);
 // Return true if a queued transfer is aborted, false if there is no transfer to abort
 bool tuh_edpt_abort_xfer(uint8_t daddr, uint8_t ep_addr);
 
+// Set Address (control transfer)
+bool tuh_address_set(uint8_t daddr, uint8_t new_addr,
+                     tuh_xfer_cb_t complete_cb, uintptr_t user_data);
+
 // Set Configuration (control transfer)
 // config_num = 0 will un-configure device. Note: config_num = config_descriptor_index + 1
 // true on success, false if there is on-going control transfer or incorrect parameters


### PR DESCRIPTION
**Describe the PR**

- refactor hub driver and move port reset on connection change to usbh.
- hub: add hub_port_get_status_local(), ignore resp in hub_port_get_status(pot != 0)
- usbh properly deboucning with hub/rootport accordingly to usb specs, also add 10ms of reset recovery
- change debouncing delay from 200ms to 150ms (min is 100ms)

![image](https://github.com/user-attachments/assets/3b98f7c6-b94e-4f2d-9a37-c72bc4552e8d)

This pull request introduces several updates to improve USB host functionality, enhance clarity in the codebase, and add new features. Key changes include the addition of callback interception for port status handling, the introduction of local status retrieval, and various refactorings for consistency and maintainability.

### USB Host Enhancements:
* Added a callback interception mechanism in `hub_port_get_status` to save port status locally before invoking the user callback. This allows for efficient status handling without requiring the user to process raw responses. (`src/host/hub.c`, [[1]](diffhunk://#diff-244f488fd0ad2eb44851a81fc57d806156cfc347d2419e695ecd3a1f1b74ba1eR151-R163) [[2]](diffhunk://#diff-244f488fd0ad2eb44851a81fc57d806156cfc347d2419e695ecd3a1f1b74ba1eR187-R209)
* Introduced a new function, `hub_port_get_status_local`, to retrieve port status from a local cache instead of sending a request to the device. (`src/host/hub.c`, [[1]](diffhunk://#diff-244f488fd0ad2eb44851a81fc57d806156cfc347d2419e695ecd3a1f1b74ba1eR187-R209); `src/host/hub.h`, [[2]](diffhunk://#diff-d5dc8d4d1aa6ed3ac4e677a91daa4f35c76f8d4f31ec209348afef5402a8e091R173-R179)

### Refactoring and Code Simplification:
* Replaced `dev_addr` with `daddr` across multiple functions for consistency with existing naming conventions. (`src/host/hub.c`, [[1]](diffhunk://#diff-244f488fd0ad2eb44851a81fc57d806156cfc347d2419e695ecd3a1f1b74ba1eL241-R277) [[2]](diffhunk://#diff-244f488fd0ad2eb44851a81fc57d806156cfc347d2419e695ecd3a1f1b74ba1eL260-R293); `src/host/hub.h`, [[3]](diffhunk://#diff-d5dc8d4d1aa6ed3ac4e677a91daa4f35c76f8d4f31ec209348afef5402a8e091L208-R212)
* Refactored the `process_new_status` function to consolidate and streamline the handling of hub and port status changes, replacing multiple redundant functions. (`src/host/hub.c`, [[1]](diffhunk://#diff-244f488fd0ad2eb44851a81fc57d806156cfc347d2419e695ecd3a1f1b74ba1eL315-R356) [[2]](diffhunk://#diff-244f488fd0ad2eb44851a81fc57d806156cfc347d2419e695ecd3a1f1b74ba1eL361-L471)

### Descriptor and Device Information Updates:
* Renamed fields in `usbh_device_t` for clarity, including changing `vid`/`pid` to `idVendor`/`idProduct` and other descriptor fields to match USB specification naming. (`src/host/usbh.c`, [[1]](diffhunk://#diff-11e4ea75aae99e53e4714db0b752f48deebbcf6d7ad0077293bc6ab26e5ec924L108-R112) [[2]](diffhunk://#diff-11e4ea75aae99e53e4714db0b752f48deebbcf6d7ad0077293bc6ab26e5ec924L334-R335) [[3]](diffhunk://#diff-11e4ea75aae99e53e4714db0b752f48deebbcf6d7ad0077293bc6ab26e5ec924L1097-R1112)
* Added a new function, `tuh_address_set`, to support setting a new USB device address via a standard control transfer. (`src/host/usbh.c`, [src/host/usbh.cR1143-R1169](diffhunk://#diff-11e4ea75aae99e53e4714db0b752f48deebbcf6d7ad0077293bc6ab26e5ec924R1143-R1169))

### Miscellaneous Improvements:
* Updated comments and inline documentation to clarify the behavior of key functions, such as `hub_port_get_status`. (`src/host/hub.h`, [[1]](diffhunk://#diff-d5dc8d4d1aa6ed3ac4e677a91daa4f35c76f8d4f31ec209348afef5402a8e091R173-R179) [[2]](diffhunk://#diff-d5dc8d4d1aa6ed3ac4e677a91daa4f35c76f8d4f31ec209348afef5402a8e091L191-R195)
* Removed unused or redundant code, such as the `_usbh_data.enumerating_daddr` reset in `tuh_task_ext`. (`src/host/usbh.c`, [src/host/usbh.cL539](diffhunk://#diff-11e4ea75aae99e53e4714db0b752f48deebbcf6d7ad0077293bc6ab26e5ec924L539))