### PR TITLE
Fixed broken deps on a fresh clone

### DIFF
--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -243,11 +243,13 @@ def get_a_dep(d):
         p.mkdir(parents=True)
         run_cmd(f"{git_cmd} init")
         run_cmd(f"{git_cmd} remote add origin {url}")
+        head = None
+    else:
+        # Check if commit is already fetched
+        result = run_cmd(f"{git_cmd} rev-parse HEAD")
+        head = result.stdout.decode("utf-8").splitlines()[0]
+        run_cmd(f"{git_cmd} reset --hard")
 
-    # Check if commit is already fetched
-    result = run_cmd(f"{git_cmd} rev-parse HEAD")
-    head = result.stdout.decode("utf-8").splitlines()[0]
-    run_cmd(f"{git_cmd} reset --hard")
     if commit != head:
         run_cmd(f"{git_cmd} fetch --depth 1 origin {commit}")
         run_cmd(f"{git_cmd} checkout FETCH_HEAD")


### PR DESCRIPTION
@hathach 

I was preparing to do work on the nxp/mcx bsps to add more boards and noticed some of the dependencies could not be fetched on a fresh clone:

I found that the get_deps script from tinyuf2 solves the issue

Everything worked ok on my test cases (mcx, lpc55 and lpc43) once this fix was in place.

Error before the patch:

```
C:\ELI\tinyusb_dev\tinyusb-dev\tools> .\get_deps.py mcx
cloning lib/FreeRTOS-Kernel with https://github.com/FreeRTOS/FreeRTOS-Kernel.git
cloning tools/uf2 with https://github.com/microsoft/uf2.git
cloning hw/mcu/nxp/mcux-sdk with https://github.com/hathach/mcux-sdk.git
cloning lib/lwip with https://github.com/lwip-tcpip/lwip.git
cloning lib/CMSIS_5 with https://github.com/ARM-software/CMSIS_5.git
Command Error: git -C C:\ELI\tinyusb_dev\tinyusb-dev\hw\mcu\nxp\mcux-sdk rev-parse HEAD
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
HEAD

Command Error: git -C C:\ELI\tinyusb_dev\tinyusb-dev\tools\uf2 rev-parse HEAD
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
HEAD
Command Error: git -C C:\ELI\tinyusb_dev\tinyusb-dev\lib\FreeRTOS-Kernel rev-parse HEAD
Command Error: git -C C:\ELI\tinyusb_dev\tinyusb-dev\lib\lwip rev-parse HEAD

Command Error: git -C C:\ELI\tinyusb_dev\tinyusb-dev\lib\CMSIS_5 rev-parse HEAD
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
HEAD
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
HEAD
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
HEAD
```
