### PR TITLE
Usbh attach debounce

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -12,7 +12,7 @@
       <configuration PROFILE_NAME="feather_rp2040" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=pico_sdk -DPICO_BOARD=adafruit_feather_rp2040 -DLOG=1" />
       <configuration PROFILE_NAME="feather_rp2040_max3421" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=feather_rp2040_max3421 -DLOG=1" />
       <configuration PROFILE_NAME="metro_rp2040" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=pico_sdk -DPICO_BOARD=adafruit_metro_rp2040 -DLOG=1 -DMAX3421_HOST=1" />
-      <configuration PROFILE_NAME="adafruit_metro_rp2350" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=adafruit_metro_rp2350 -DLOG=1" />
+      <configuration PROFILE_NAME="adafruit_metro_rp2350" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=adafruit_metro_rp2350 -DLOG=1 -DCFLAGS_CLI=&quot;-DCFG_TUH_RPI_PIO_USB=1&quot;" />
       <configuration PROFILE_NAME="adafruit_fruit_jam" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=adafruit_fruit_jam -DLOG=1 -DCFLAGS_CLI=&quot;-DCFG_TUH_RPI_PIO_USB=1&quot;" />
       <configuration PROFILE_NAME="adafruit_feather_esp32_v2" ENABLED="false" TOOLCHAIN_NAME="ESP-IDF" GENERATION_OPTIONS="-DBOARD=adafruit_feather_esp32_v2 -DMAX3421_HOST=1 -DLOG=1">
         <ADDITIONAL_GENERATION_ENVIRONMENT>
@@ -94,7 +94,8 @@
       <configuration PROFILE_NAME="metro m7 1011 sd" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=metro_m7_1011_sd -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1" />
       <configuration PROFILE_NAME="metro_m7_1011" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=metro_m7_1011 -DLOG=1 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="rt1010 evk" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=mimxrt1010_evk -DLOG=1 -DLOGGER=RTT" />
-      <configuration PROFILE_NAME="mimxrt1060_evk" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=mimxrt1060_evk -DLOG=1 -DLOGGER=RTT" />
+      <configuration PROFILE_NAME="mimxrt1060_evk" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=mimxrt1060_evk -DLOG=1" />
+      <configuration PROFILE_NAME="mimxrt1064_evk" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=mimxrt1064_evk" />
       <configuration PROFILE_NAME="rt1170 evkb" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=mimxrt1170_evkb -DLOG=1 -DLOGGER=RTT -DTRACE_ETM=1" />
       <configuration PROFILE_NAME="stm32f072disco" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f072disco -DLOG=0 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="stm32f103_mini_2" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=stm32f103_mini_2 -DLOG=1 -DLOGGGER=RTT" />
@@ -166,7 +167,6 @@
       <configuration PROFILE_NAME="max32650fthr" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=max32650fthr -DLOG=0 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="max32666fthr" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=max32666fthr -DLOG=0 -DLOGGER=RTT" />
       <configuration PROFILE_NAME="max32690evkit" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=max32690evkit -DLOG=1 -DLOGGER=RTT" />
-      <configuration PROFILE_NAME="mimxrt1064_evk" ENABLED="false" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBOARD=mimxrt1064_evk" />
     </configurations>
   </component>
 </project>

--- a/.idea/debugServers/rt1060.xml
+++ b/.idea/debugServers/rt1060.xml
@@ -5,7 +5,7 @@
       <env />
     </debugger>
     <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
-    <console port="2334" type="RTT" />
+    <console port="19021" />
     <target device="MIMXRT1062xxx6A" reset-before="false" />
     <connection extended-remote="false" port="4444" warmup-ms="500" />
     <swo />

--- a/.idea/debugServers/rt1064.xml
+++ b/.idea/debugServers/rt1064.xml
@@ -5,7 +5,7 @@
       <env />
     </debugger>
     <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
-    <console port="2334" type="RTT" />
+    <console port="2334" />
     <target device="MIMXRT1064xxx6A" reset-before="false" />
     <connection extended-remote="false" port="4444" warmup-ms="500" />
     <swo />

--- a/.idea/debugServers/rt1064.xml
+++ b/.idea/debugServers/rt1064.xml
@@ -1,11 +1,11 @@
 <component name="DebugServers">
-  <jlink-debug-target name="rt1064" uniqueID="9602472b-6ce8-4a2d-9636-1c03b5fcd6da">
+  <jlink-debug-target name="rt1064" uniqueID="9602472b-6ce8-4a2d-9636-1c03b5fcd6da" selected="true">
     <debugger version="1">
       <debugger kind="GDB" isBundled="true" />
       <env />
     </debugger>
     <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
-    <console port="2334" />
+    <console port="19021" />
     <target device="MIMXRT1064xxx6A" reset-before="false" />
     <connection extended-remote="false" port="4444" warmup-ms="500" />
     <swo />

--- a/.idea/debugServers/sam21.xml
+++ b/.idea/debugServers/sam21.xml
@@ -5,7 +5,7 @@
       <env />
     </debugger>
     <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
-    <console port="2334" type="RTT" />
+    <console port="19021" />
     <target device="ATSAMD21G18A" reset-before="false" />
     <connection extended-remote="false" port="4444" warmup-ms="500" />
     <swo />

--- a/.idea/debugServers/sam51.xml
+++ b/.idea/debugServers/sam51.xml
@@ -5,7 +5,7 @@
       <env />
     </debugger>
     <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
-    <console port="2334" type="RTT" />
+    <console port="19021" />
     <target device="ATSAMD51J19A" reset-before="false" />
     <connection extended-remote="false" port="4444" warmup-ms="500" />
     <swo />

--- a/.idea/debugServers/stm32f769.xml
+++ b/.idea/debugServers/stm32f769.xml
@@ -1,11 +1,11 @@
 <component name="DebugServers">
-  <jlink-debug-target name="stm32f769" uniqueID="7a47302f-f7e5-434b-b20b-78e95318dd0c" selected="true">
+  <jlink-debug-target name="stm32f769" uniqueID="7a47302f-f7e5-434b-b20b-78e95318dd0c">
     <debugger version="1">
       <debugger kind="GDB" isBundled="true" />
       <env />
     </debugger>
     <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
-    <console port="19021" type="RTT" />
+    <console port="19021" />
     <target device="STM32F769NI" reset-before="false" frequency="16000" />
     <connection extended-remote="false" port="4444" warmup-ms="500" />
     <swo />

--- a/.idea/debugServers/stm32h563.xml
+++ b/.idea/debugServers/stm32h563.xml
@@ -5,7 +5,7 @@
       <env />
     </debugger>
     <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
-    <console port="2334" type="RTT" />
+    <console port="19021" />
     <target device="STM32H562ZI" reset-before="false" frequency="16000" />
     <connection extended-remote="false" port="4444" warmup-ms="500" />
     <swo />

--- a/.idea/debugServers/stm32h743.xml
+++ b/.idea/debugServers/stm32h743.xml
@@ -5,7 +5,7 @@
       <env />
     </debugger>
     <gdbserver exe="/usr/bin/JLinkGDBServerCLExe" />
-    <console port="2334" type="RTT" />
+    <console port="19021" />
     <target device="STM32H743XI" reset-before="false" frequency="16000" />
     <connection extended-remote="false" port="4444" warmup-ms="500" />
     <swo />

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1363,6 +1363,7 @@ enum {                               // USB 2.0 specs 7.1.7 for timing
   ENUM_RESET_ROOT_DELAY_MS = 50,     // T(DRSTr)  minimum 50 ms for reset from root port
   ENUM_RESET_HUB_DELAY_MS = 20,      // T(DRST)   10-20 ms for hub reset
   ENUM_RESET_RECOVERY_DELAY_MS = 10, // T(RSTRCY) minimum 10 ms for reset recovery
+  ENUM_SET_ADDRESS_RECOVERY_DELAY_MS = 2, // USB 2.0 Spec 9.2.6.3 min is 2 ms
 };
 
 enum {
@@ -1573,8 +1574,7 @@ static void process_enumeration(tuh_xfer_t* xfer) {
     }
 
     case ENUM_GET_DEVICE_DESC: {
-      // Allow 2ms for address recovery time, Ref USB Spec 9.2.6.3
-      tusb_time_delay_ms_api(2);
+      tusb_time_delay_ms_api(ENUM_SET_ADDRESS_RECOVERY_DELAY_MS); // set address recovery
 
       const uint8_t new_addr = (uint8_t) tu_le16toh(xfer->setup->wValue);
       usbh_device_t* new_dev = get_device(new_addr);

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -86,6 +86,9 @@ typedef struct {
   uint8_t speed;
 } tuh_bus_info_t;
 
+// backward compatibility for hcd_devtree_info_t, maybe removed in the future
+#define hcd_devtree_info_t tuh_bus_info_t
+#define hcd_devtree_get_info(_daddr, _bus_info) tuh_bus_info_get(_daddr, _bus_info)
 
 // ConfigID for tuh_configure()
 enum {

--- a/src/portable/chipidea/ci_hs/hcd_ci_hs.c
+++ b/src/portable/chipidea/ci_hs/hcd_ci_hs.c
@@ -93,12 +93,6 @@ bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   hcd_reg->USBMODE = USBMODE_CM_HOST;
 #endif
 
-  // FIXME force full speed, still have issue with Highspeed enumeration
-  // probably due to physical connection bouncing when plug/unplug
-  // 1. Have issue when plug/unplug devices, maybe the port is not reset properly
-  // 2. Also does not seems to detect disconnection
-  hcd_reg->PORTSC1 |= PORTSC1_FORCE_FULL_SPEED;
-
   return ehci_init(rhport, (uint32_t) &hcd_reg->CAPLENGTH, (uint32_t) &hcd_reg->USBCMD);
 }
 

--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -107,7 +107,6 @@ typedef struct {
 typedef struct {
   hcd_xfer_t xfer[DWC2_CHANNEL_COUNT_MAX];
   hcd_endpoint_t edpt[CFG_TUH_DWC2_ENDPOINT_MAX];
-  bool attach_debounce; // if true: wait for the debounce delay before issuing new attach events
 } hcd_data_t;
 
 hcd_data_t _hcd_data;
@@ -423,11 +422,6 @@ uint32_t hcd_frame_number(uint8_t rhport) {
 
 // Get the current connect status of roothub port
 bool hcd_port_connect_status(uint8_t rhport) {
-  // this is called from enum_new_device() - after the debouncing delays
-  if (_hcd_data.attach_debounce) {
-    _hcd_data.attach_debounce = false; // allow new attach events again
-  }
-
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
   return dwc2->hprt & HPRT_CONN_STATUS;
 }
@@ -1328,10 +1322,7 @@ static void handle_hprt_irq(uint8_t rhport, bool in_isr) {
     hprt |= HPRT_CONN_DETECT;
 
     if (hprt_bm.conn_status) {
-      if (!_hcd_data.attach_debounce) {
-        _hcd_data.attach_debounce = true; // block new attach events until the debounce delay is over
-        hcd_event_device_attach(rhport, in_isr);
-      }
+      hcd_event_device_attach(rhport, in_isr);
     }
   }
 
@@ -1398,12 +1389,8 @@ void hcd_int_handler(uint8_t rhport, bool in_isr) {
     // Device disconnected
     dwc2->gintsts = GINTSTS_DISCINT;
 
-    // ignore device removal if attach debounce is active
-    // it will evaluate the port status after the debounce delay
-    if (!_hcd_data.attach_debounce) {
-      if (!(dwc2->hprt & HPRT_CONN_STATUS)) {
-        hcd_event_device_remove(rhport, in_isr);
-      }
+    if (!(dwc2->hprt & HPRT_CONN_STATUS)) {
+      hcd_event_device_remove(rhport, in_isr);
     }
   }
 


### PR DESCRIPTION
**Describe the PR**
usbh skip attach/remove event on the same roothub port while in debouncing delay. For hub since we don't poll the interrupt endpoint before debouncing, it should be good enough
remove the old logic detecting duplicated attach event, which should be filtered by the new debouncing.
remove dwc2 debouncing logic (which is now is done at usbh layer)

fix https://github.com/hathach/tinyusb/issues/3073