### PR TITLE
follow up to pr3118, interface also end with IAD. Add more checks

### DIFF
--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -196,8 +196,8 @@ void vendord_reset(uint8_t rhport) {
 
 uint16_t vendord_open(uint8_t rhport, const tusb_desc_interface_t* desc_itf, uint16_t max_len) {
   TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == desc_itf->bInterfaceClass, 0);
-  const uint8_t* p_desc = tu_desc_next(desc_itf);
   const uint8_t* desc_end = (const uint8_t*)desc_itf + max_len;
+  const uint8_t* p_desc = tu_desc_next(desc_itf);
 
   // Find available interface
   vendord_interface_t* p_vendor = NULL;
@@ -210,17 +210,25 @@ uint16_t vendord_open(uint8_t rhport, const tusb_desc_interface_t* desc_itf, uin
   TU_VERIFY(p_vendor, 0);
 
   p_vendor->itf_num = desc_itf->bInterfaceNumber;
-  while (TUSB_DESC_INTERFACE != tu_desc_type(p_desc) && (desc_end - p_desc > 0)) {
-    if (TUSB_DESC_ENDPOINT == tu_desc_type(p_desc)) {
+  while (tu_desc_is_valid(p_desc, desc_end)) {
+    const uint8_t desc_type = tu_desc_type(p_desc);
+    if (desc_type == TUSB_DESC_INTERFACE || desc_type == TUSB_DESC_INTERFACE_ASSOCIATION) {
+      break; // end of this interface
+    } else if (desc_type == TUSB_DESC_ENDPOINT) {
       const tusb_desc_endpoint_t* desc_ep = (const tusb_desc_endpoint_t*) p_desc;
       TU_ASSERT(usbd_edpt_open(rhport, desc_ep));
 
+      // open endpoint stream, skip if already opened
       if (tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN) {
-        tu_edpt_stream_open(&p_vendor->tx.stream, desc_ep);
-        tud_vendor_n_write_flush((uint8_t)(p_vendor - _vendord_itf));
+        if (p_vendor->tx.stream.ep_addr == 0) {
+          tu_edpt_stream_open(&p_vendor->tx.stream, desc_ep);
+          tud_vendor_n_write_flush((uint8_t)(p_vendor - _vendord_itf));
+        }
       } else {
-        tu_edpt_stream_open(&p_vendor->rx.stream, desc_ep);
-        TU_ASSERT(tu_edpt_stream_read_xfer(rhport, &p_vendor->rx.stream) > 0, 0); // prepare for incoming data
+        if (p_vendor->rx.stream.ep_addr == 0) {
+          tu_edpt_stream_open(&p_vendor->rx.stream, desc_ep);
+          TU_ASSERT(tu_edpt_stream_read_xfer(rhport, &p_vendor->rx.stream) > 0, 0); // prepare for incoming data
+        }
       }
     }
 

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -586,6 +586,12 @@ TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_desc_subtype(void const* desc) {
   return ((uint8_t const*) desc)[DESC_OFFSET_SUBTYPE];
 }
 
+TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_desc_is_valid(void const* desc, uint8_t const* desc_end) {
+  const uint8_t* desc8 = (uint8_t const*) desc;
+  return (desc8 < desc_end) && (tu_desc_next(desc) <= desc_end);
+}
+
+
 // find descriptor that match byte1 (type)
 uint8_t const * tu_desc_find(uint8_t const* desc, uint8_t const* end, uint8_t byte1);
 


### PR DESCRIPTION
follow up to #3118, interface also end with IAD. Add more checks

### Additions to USB descriptor utilities:
* [`src/common/tusb_types.h`](diffhunk://#diff-05c83118cd4f8865af0380b64c1a1c073534cfc3f19d3bce7caa4904641fb2b8R589-R594): Added a new static inline function `tu_desc_is_valid` to check if a USB descriptor is valid by ensuring it is within the bounds of `desc` and `desc_end`. This helps improve robustness when working with USB descriptors.
