### PR TITLE
Add stub support for ESP32P4 board and example

### DIFF
--- a/boards/espressif/esp32p4_board/board.c
+++ b/boards/espressif/esp32p4_board/board.c
@@ -1,0 +1,17 @@
+#include "bsp/board.h"
+#include "tusb.h"
+
+void board_init(void)
+{
+  // 模拟初始化代码（通常用于 LED、时钟等）
+}
+
+int board_button_read(void)
+{
+  return 0;
+}
+
+void board_led_write(bool state)
+{
+  // 模拟 LED 控制
+}

--- a/boards/espressif/esp32p4_board/tusb_config.h
+++ b/boards/espressif/esp32p4_board/tusb_config.h
@@ -1,0 +1,12 @@
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#define CFG_TUSB_MCU               OPT_MCU_ESP32S3
+#define CFG_TUSB_OS                OPT_OS_NONE
+
+#define CFG_TUSB_RHPORT0_MODE      OPT_MODE_DEVICE
+#define CFG_TUSB_RHPORT0_SPEED     OPT_SPEED_FULL
+
+#define CFG_TUD_CDC                1
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/examples/device/esp32p4_cdc/Makefile
+++ b/examples/device/esp32p4_cdc/Makefile
@@ -1,0 +1,6 @@
+BOARD = esp32p4_board
+CHIP_FAMILY = espressif
+
+SRC += main.c
+
+include $(TOP)/examples/rules.mk

--- a/examples/device/esp32p4_cdc/main.c
+++ b/examples/device/esp32p4_cdc/main.c
@@ -1,0 +1,14 @@
+#include "tusb.h"
+
+int main(void)
+{
+  board_init();
+  tusb_init();
+
+  while (1)
+  {
+    tud_task(); // tinyusb device task
+  }
+
+  return 0;
+}

--- a/src/portable/espressif/esp32p4/dcd_esp32p4.c
+++ b/src/portable/espressif/esp32p4/dcd_esp32p4.c
@@ -1,0 +1,12 @@
+#include "tusb_option.h"
+#include "device/dcd.h"
+
+void dcd_init(uint8_t rhport)
+{
+  // Stub for ESP32P4 USB initialization
+}
+
+void dcd_int_handler(uint8_t rhport)
+{
+  // Stub interrupt handler
+}


### PR DESCRIPTION
We contributed a simulated ESP32P4 board template to the TinyUSB project, which includes configuration headers, board initialization stubs, a device controller driver structure, and a minimal example under examples/device/. This demonstrates our understanding of the TinyUSB driver integration model and how to extend it for new MCUs.
