### PR TITLE
[stm32] Wait until the PHYC PLL is stable

### DIFF
--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -78,9 +78,15 @@
 #include "tusb_debug.h"
 
 //--------------------------------------------------------------------+
-// Optional API implemented by application if needed
+// API implemented by application if needed
 // TODO move to a more obvious place/file
 //--------------------------------------------------------------------+
+
+// Get current milliseconds, required by some port/configuration without RTOS
+extern uint32_t tusb_time_millis_api(void);
+
+// Delay in milliseconds, use tusb_time_millis_api() by default. required by some port/configuration with no RTOS
+extern void tusb_time_delay_ms_api(uint32_t ms);
 
 // flush data cache
 TU_ATTR_WEAK extern void tusb_app_dcache_flush(uintptr_t addr, uint32_t data_size);

--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -222,6 +222,10 @@ static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
 
       // Enable PLL internal PHY
       USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL_PLLEN;
+
+      // Wait ~2ms until the PLL is ready (there's no RDY bit to query)
+      uint32_t count = (SystemCoreClock / 1000) * 2;
+      while (count--) __NOP();
       #else
 
       #endif

--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -224,8 +224,7 @@ static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
       USB_HS_PHYC->USB_HS_PHYC_PLL |= USB_HS_PHYC_PLL_PLLEN;
 
       // Wait ~2ms until the PLL is ready (there's no RDY bit to query)
-      uint32_t count = (SystemCoreClock / 1000) * 2;
-      while (count--) __NOP();
+      tusb_time_delay_ms_api(2);
       #else
 
       #endif

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -169,16 +169,6 @@ void tusb_int_handler(uint8_t rhport, bool in_isr);
 
 #endif
 
-//--------------------------------------------------------------------+
-// API Implemented by user
-//--------------------------------------------------------------------+
-
-// Get current milliseconds, required by some port/configuration without RTOS
-uint32_t tusb_time_millis_api(void);
-
-// Delay in milliseconds, use tusb_time_millis_api() by default. required by some port/configuration with no RTOS
-void tusb_time_delay_ms_api(uint32_t ms);
-
 #ifdef __cplusplus
  }
 #endif


### PR DESCRIPTION
**Describe the PR**

Thank you for this awesome project, very enjoyable to work with!

I've been integrating TinyUSB using custom firmware on the STM32F723E-DISCOVERY board and got stuck in `reset_core` when initializing the HS port. Waiting 2ms after PLL enablement fixes this issue.

**Additional context**

The solution for this was already discovered in https://github.com/hathach/tinyusb/issues/2074#issuecomment-2597894247, where the CubeHAL waits 2ms, since there's no USB_HS_PHYC_PLLRDY bit in the USB_HS_PHYC peripheral

Closes #2074.
