### PR TITLE
Jules1

### DIFF
--- a/hw/bsp/ch32x035/boards/ch32x035_default/board.c
+++ b/hw/bsp/ch32x035/boards/ch32x035_default/board.c
@@ -1,0 +1,32 @@
+#include "bsp/board_api.h"
+#include "board.h"
+
+// This is a placeholder board C file. Please implement me!
+// #error "This is a placeholder board C file. Please implement me!"
+
+void board_init(void) {
+  // TODO: board_clock_init();
+  // TODO: board_uart_init();
+}
+
+void board_led_write(int state) {
+  (void)state;
+}
+
+uint32_t board_button_read(void) {
+  return 0;
+}
+
+int board_uart_read(uint8_t* buf, int len) {
+  (void)buf; (void)len;
+  return 0;
+}
+
+int board_uart_write(void const * buf, int len) {
+  (void)buf; (void)len;
+  return 0;
+}
+
+uint32_t board_millis(void) {
+  return 0;
+}

--- a/hw/bsp/ch32x035/boards/ch32x035_default/board.cmake
+++ b/hw/bsp/ch32x035/boards/ch32x035_default/board.cmake
@@ -1,0 +1,2 @@
+# Placeholder board.cmake
+# error("This is a placeholder board.cmake. Please implement me for your board!")

--- a/hw/bsp/ch32x035/boards/ch32x035_default/board.h
+++ b/hw/bsp/ch32x035/boards/ch32x035_default/board.h
@@ -1,0 +1,34 @@
+#ifndef BOARD_H_
+#define BOARD_H_
+
+// This is a placeholder board header. Please edit me!
+// #error "This is a placeholder board header. Please edit me!"
+
+// TODO: Include actual CH32X035 SDK header if available
+// #include "ch32x035.h"
+
+// Example GPIO for LED
+// #define LED_PORT              GPIOA
+// #define LED_PIN               GPIO_PIN_5
+// #define LED_STATE_ON          1
+
+// Example GPIO for Button
+// #define BUTTON_PORT           GPIOC
+// #define BUTTON_PIN            GPIO_PIN_13
+// #define BUTTON_STATE_ACTIVE   0
+
+// Example UART for logs
+// #define UART_DEV              USART1
+// #define UART_TX_PORT          GPIOA
+// #define UART_TX_PIN           GPIO_PIN_9
+// #define UART_RX_PORT          GPIOA
+// #define UART_RX_PIN           GPIO_PIN_10
+
+void board_init(void);
+void board_led_write(int state);
+uint32_t board_button_read(void);
+int board_uart_read(uint8_t* buf, int len);
+int board_uart_write(void const * buf, int len);
+uint32_t board_millis(void);
+
+#endif // BOARD_H_

--- a/hw/bsp/ch32x035/boards/ch32x035_default/board.mk
+++ b/hw/bsp/ch32x035/boards/ch32x035_default/board.mk
@@ -1,0 +1,2 @@
+# Placeholder board.mk
+# $(error This is a placeholder board.mk. Please implement me for your board!)

--- a/hw/bsp/ch32x035/family.c
+++ b/hw/bsp/ch32x035/family.c
@@ -1,0 +1,205 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Greg Davill
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+/* metadata:
+   manufacturer: WCH
+*/
+
+#include "stdio.h"
+
+// https://github.com/openwch/ch32x035/pull/90  // TODO: Update this link if necessary
+// https://github.com/openwch/ch32v20x/pull/12 // TODO: Update this link if necessary, or remove if not relevant
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#endif
+
+#include "debug_uart.h" // Assuming this is still relevant for ch32x035
+#include "ch32x035.h"   // Replaced ch32v30x.h
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include "bsp/board_api.h"
+#include "board.h"
+
+//--------------------------------------------------------------------+
+// Forward USB interrupt events to TinyUSB IRQ Handler
+//--------------------------------------------------------------------+
+
+// TODO maybe having FS as port0, HS as port1 // This comment is kept as it might still be relevant
+
+__attribute__((interrupt)) void USBHS_IRQHandler(void) { // Name kept, specific to WCH USB IP
+  #if CFG_TUD_WCH_USBIP_USBHS
+  tud_int_handler(0);
+  #endif
+}
+
+__attribute__((interrupt)) void OTG_FS_IRQHandler(void) { // Name kept, specific to WCH USB IP
+  #if CFG_TUD_WCH_USBIP_USBFS
+  tud_int_handler(0);
+  #endif
+}
+
+//--------------------------------------------------------------------+
+// MACRO TYPEDEF CONSTANT ENUM
+//--------------------------------------------------------------------+
+
+uint32_t SysTick_Config(uint32_t ticks) {
+  NVIC_EnableIRQ(SysTicK_IRQn); // Generic CMSIS/RISC-V define
+  SysTick->CTLR = 0;
+  SysTick->SR = 0;
+  SysTick->CNT = 0;
+  SysTick->CMP = ticks - 1;
+  SysTick->CTLR = 0xF;
+  return 0;
+}
+
+void board_init(void) {
+
+  /* Disable interrupts during init */
+  __disable_irq();
+
+#if CFG_TUSB_OS == OPT_OS_NONE
+  SysTick_Config(SystemCoreClock / 1000);
+#endif
+
+  usart_printf_init(CFG_BOARD_UART_BAUDRATE);
+
+#ifdef CH32X035_D8C // Replaced CH32V30x_D8C - Check if this define is appropriate for ch32x035
+  // ch32x035: Highspeed USB (If applicable, verify specifics for ch32x035)
+  // The following RCC configurations are specific to CH32V30x's USBHS.
+  // These will likely need to be adapted or removed for CH32X035 based on its datasheet.
+  // For now, they are commented out or left as placeholders.
+  // RCC_USBCLK48MConfig(RCC_USBCLK48MCLKSource_USBPHY);
+  // RCC_USBHSPLLCLKConfig(RCC_HSBHSPLLCLKSource_HSE);
+  // RCC_USBHSConfig(RCC_USBPLL_Div2);
+  // RCC_USBHSPLLCKREFCLKConfig(RCC_USBHSPLLCKREFCLK_4M);
+  // RCC_USBHSPHYPLLALIVEcmd(ENABLE);
+  // RCC_AHBPeriphClockCmd(RCC_AHBPeriph_USBHS, ENABLE);
+  #warning "USB Highspeed peripheral configuration for CH32X035 needs verification."
+#endif
+
+  // Fullspeed USB
+  // Verify SystemCoreClock and corresponding RCC_OTGFSCLKSource divisors for CH32X035
+  uint8_t otg_div;
+  switch (SystemCoreClock) {
+    case 48000000:  otg_div = RCC_OTGFSCLKSource_PLLCLK_Div1; break;
+    case 96000000:  otg_div = RCC_OTGFSCLKSource_PLLCLK_Div2; break;
+    case 144000000: otg_div = RCC_OTGFSCLKSource_PLLCLK_Div3; break; // Check max clock for ch32x035
+    default: TU_ASSERT(0,); break; // Ensure SystemCoreClock is valid for ch32x035
+  }
+  RCC_OTGFSCLKConfig(otg_div); // Verify this function and its parameters for ch32x035
+  RCC_AHBPeriphClockCmd(RCC_AHBPeriph_OTG_FS, ENABLE); // Verify this for ch32x035
+
+  GPIO_InitTypeDef GPIO_InitStructure = {0};
+
+  // LED
+  // Ensure LED_CLOCK_EN, LED_PIN, LED_PORT are correctly defined for the ch32x035 board
+  LED_CLOCK_EN();
+  GPIO_InitStructure.GPIO_Pin = LED_PIN;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_OD;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+  GPIO_Init(LED_PORT, &GPIO_InitStructure);
+
+  // Button
+  // Ensure BUTTON_CLOCK_EN, BUTTON_PIN, BUTTON_PORT are correctly defined for the ch32x035 board
+  BUTTON_CLOCK_EN();
+  GPIO_InitStructure.GPIO_Pin = BUTTON_PIN;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPU;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+  GPIO_Init(BUTTON_PORT, &GPIO_InitStructure);
+
+  /* Enable interrupts globally */
+  __enable_irq();
+
+  board_delay(2);
+}
+
+#if CFG_TUSB_OS == OPT_OS_NONE
+volatile uint32_t system_ticks = 0;
+
+__attribute__((interrupt)) void SysTick_Handler(void) { // Generic SysTick Handler
+  SysTick->SR = 0;
+  system_ticks++;
+}
+
+uint32_t board_millis(void) {
+  return system_ticks;
+}
+
+#endif
+
+//--------------------------------------------------------------------+
+// Board porting API
+//--------------------------------------------------------------------+
+
+void board_led_write(bool state) {
+  // Ensure LED_PORT, LED_PIN are correct for ch32x035
+  GPIO_WriteBit(LED_PORT, LED_PIN, state);
+}
+
+uint32_t board_button_read(void) {
+  // Ensure BUTTON_PORT, BUTTON_PIN, BUTTON_STATE_ACTIVE are correct for ch32x035
+  return BUTTON_STATE_ACTIVE == GPIO_ReadInputDataBit(BUTTON_PORT, BUTTON_PIN);
+}
+
+int board_uart_read(uint8_t* buf, int len) {
+  (void) buf;
+  (void) len;
+  // TODO: Implement UART read for ch32x035 if necessary
+  return 0;
+}
+
+int board_uart_write(void const* buf, int len) {
+  int txsize = len;
+  const char* bufc = (const char*) buf;
+  while (txsize--) {
+    uart_write(*bufc++); // Ensure uart_write is compatible with ch32x035
+  }
+  uart_sync(); // Ensure uart_sync is compatible with ch32x035
+  return len;
+}
+
+#ifdef USE_FULL_ASSERT
+/**
+ * @brief  Reports the name of the source file and the source line number
+ *         where the assert_param error has occurred.
+ * @param  file: pointer to the source file name
+ * @param  line: assert_param error line source number
+ * @retval None
+ */
+void assert_failed(char* file, uint32_t line) {
+  /* USER CODE BEGIN 6 */
+  /* User can add his own implementation to report the file name and line
+     number,
+     tex: printf("Wrong parameters value: file %s on line %d\r\n", file, line)
+   */
+  /* USER CODE END 6 */
+}
+#endif /* USE_FULL_ASSERT */

--- a/hw/bsp/ch32x035/family.mk
+++ b/hw/bsp/ch32x035/family.mk
@@ -1,0 +1,68 @@
+# https://www.embecosm.com/resources/tool-chain-downloads/#riscv-stable
+#CROSS_COMPILE ?= riscv32-unknown-elf-
+
+# Toolchain from https://nucleisys.com/download.php
+#CROSS_COMPILE ?= riscv-nuclei-elf-
+
+# Toolchain from https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack
+CROSS_COMPILE ?= riscv-none-elf-
+
+CH32_FAMILY = ch32x035
+SDK_DIR = hw/mcu/wch/ch32x035 # Replaced ch32v307
+SDK_SRC_DIR = $(SDK_DIR)/EVT/EXAM/SRC
+
+include $(TOP)/$(BOARD_PATH)/board.mk
+CPU_CORE ?= rv32imac-ilp32 # Assuming CPU core remains the same, verify if ch32x035 has a different core/extensions
+
+# default to use high speed port, unless specified in board.mk or command line
+# TODO: Verify if ch32x035 has USBHS, and if this SPEED variable is still applicable.
+# For now, keeping logic, but it might need adjustment.
+SPEED ?= high
+
+CFLAGS += \
+	-flto \
+	-msmall-data-limit=8 \
+	-mno-save-restore \
+	-fmessage-length=0 \
+	-fsigned-char \
+	-DCFG_TUSB_MCU=OPT_MCU_CH32X035 # Replaced OPT_MCU_CH32V307
+
+# https://github.com/openwch/ch32v307/pull/90  // TODO: Update this link if a ch32x035 equivalent exists
+CFLAGS += -Wno-error=strict-prototypes
+
+ifeq ($(SPEED),high)
+  $(info "Using USBHS driver for HighSpeed mode")
+  CFLAGS += -DCFG_TUD_WCH_USBIP_USBHS=1 # Keep if USBHS is relevant for ch32x035
+else
+  $(info "Using USBFS driver for FullSpeed mode")
+  CFLAGS += -DCFG_TUD_WCH_USBIP_USBFS=1 # Keep if USBFS is relevant for ch32x035
+endif
+
+LDFLAGS_GCC += \
+	-nostdlib -nostartfiles \
+  --specs=nosys.specs --specs=nano.specs \
+
+SRC_C += \
+	src/portable/wch/dcd_ch32_usbhs.c \
+	src/portable/wch/dcd_ch32_usbfs.c \
+	$(SDK_SRC_DIR)/Core/core_riscv.c \
+	$(SDK_SRC_DIR)/Peripheral/src/${CH32_FAMILY}_gpio.c \
+	$(SDK_SRC_DIR)/Peripheral/src/${CH32_FAMILY}_misc.c \
+	$(SDK_SRC_DIR)/Peripheral/src/${CH32_FAMILY}_rcc.c \
+	$(SDK_SRC_DIR)/Peripheral/src/${CH32_FAMILY}_usart.c
+# TODO: Verify peripheral driver names for ch32x035. They might differ from ch32v30x.
+
+SRC_S += \
+	$(SDK_SRC_DIR)/Startup/startup_${CH32_FAMILY}_D8C.S # Verify startup file name for ch32x035. _D8C might be specific.
+
+INC += \
+	$(TOP)/$(BOARD_PATH) \
+	$(TOP)/$(SDK_SRC_DIR)/Core \
+	$(TOP)/$(SDK_SRC_DIR)/Peripheral/inc
+# TODO: Verify include paths for ch32x035 SDK structure.
+
+# For freeRTOS port source
+FREERTOS_PORTABLE_SRC = $(FREERTOS_PORTABLE_PATH)/RISC-V
+
+OPENOCD_WCH_OPTION=-f $(TOP)/$(FAMILY_PATH)/wch-riscv.cfg # TODO: Verify if ch32x035 uses a different openocd cfg.
+flash: flash-openocd-wch

--- a/hw/bsp/ch32x035/linker/ch32x035.ld
+++ b/hw/bsp/ch32x035/linker/ch32x035.ld
@@ -1,0 +1,89 @@
+/*
+ * Placeholder linker script for CH32X035 (likely ARM Cortex-M0/M0+)
+ * Please verify and update FLASH and RAM origins and lengths.
+ * #error "This is a placeholder linker script. Please verify memory regions and sections!"
+ */
+
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 62K /* TODO: Adjust X035 actual flash size (e.g. 62K for CH32X035F8P6) */
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 10K /* TODO: Adjust X035 actual RAM size (e.g. 10K for CH32X035F8P6) */
+}
+
+_estack = ORIGIN(RAM) + LENGTH(RAM); /* End of RAM */
+
+SECTIONS
+{
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb */
+    *(.glue_7t)        /* glue thumb to arm */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  _sidata = LOADADDR(.data);
+
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  .bss :
+  {
+    . = ALIGN(4);
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + MIN(_Min_Heap_Size, 0); /* Reserve space for heap if Minimal Heap Size is defined */
+    . = . + _Min_Stack_Size; /* Reserve space for stack */
+    . = ALIGN(8);
+  } >RAM
+}
+
+/* Define default heap and stack sizes if not provided by user */
+/* These are minimal values for a basic TinyUSB example. Adjust as needed. */
+_Min_Heap_Size = 0x100 ; /* Minimal Heap Size e.g. 256 bytes */
+_Min_Stack_Size = 0x200 ; /* Minimal Stack Size e.g. 512 bytes */

--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -478,6 +478,12 @@
 //--------------------------------------------------------------------+
 // WCH
 //--------------------------------------------------------------------+
+#elif TU_CHECK_MCU(OPT_MCU_CH32X035)
+  #define TUP_USBIP_WCH_USBFS
+  #if !defined(CFG_TUD_WCH_USBIP_USBFS)
+  #define CFG_TUD_WCH_USBIP_USBFS 1
+  #endif
+  #define TUP_DCD_ENDPOINT_MAX    8
 #elif TU_CHECK_MCU(OPT_MCU_CH32F20X)
   #define TUP_USBIP_WCH_USBHS
   #define TUP_USBIP_WCH_USBFS

--- a/src/portable/wch/ch32x035_usbfs_reg.h
+++ b/src/portable/wch/ch32x035_usbfs_reg.h
@@ -1,0 +1,166 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Matthew Tran
+ * Copyright (c) 2024 hathach
+ * Copyright (c) 2024 TinyUSB Community (for CH32X035 modifications)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+// TODO: This is a SKELETON header file for CH32X035 USB Full-Speed (USBFS) peripheral registers.
+// It needs to be populated with actual register definitions, base addresses, and bit fields
+// specific to the CH32X035 series, based on its official reference manual.
+// The existing definitions below are largely from other CH32 series (like V103, V307)
+// and MUST BE VERIFIED AND UPDATED.
+
+#ifndef USB_CH32X035_USBFS_REG_H
+#define USB_CH32X035_USBFS_REG_H
+
+// TODO: Remove or verify these GCC pragmas if not needed or if causing issues with chosen compiler for CH32X035
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#endif
+
+// TODO: CH32X035 - Define the USBOTG_FS_TypeDef structure according to the CH32X035 reference manual.
+// The structure below is an example from CH32V103 and is likely DIFFERENT for CH32X035.
+/*
+typedef struct
+{
+  __IO uint8_t  BASE_CTRL;
+  __IO uint8_t  UDEV_CTRL;
+  __IO uint8_t  INT_EN;
+  __IO uint8_t  DEV_ADDR;
+  __IO uint8_t  Reserve0;
+  __IO uint8_t  MIS_ST;
+  __IO uint8_t  INT_FG;
+  __IO uint8_t  INT_ST;
+  __IO uint32_t RX_LEN;
+  __IO uint8_t  UEP4_1_MOD;
+  __IO uint8_t  UEP2_3_MOD;
+  __IO uint8_t  UEP5_6_MOD;
+  __IO uint8_t  UEP7_MOD;
+  __IO uint32_t UEP0_DMA;
+  __IO uint32_t UEP1_DMA;
+  // ... other endpoint DMA registers ...
+  __IO uint32_t UEP7_DMA;
+  __IO uint16_t UEP0_TX_LEN;
+  __IO uint8_t  UEP0_TX_CTRL;
+  __IO uint8_t  UEP0_RX_CTRL;
+  // ... other endpoint TX/RX control and length registers ...
+  __IO uint16_t UEP7_TX_LEN;
+  __IO uint8_t  UEP7_TX_CTRL;
+  __IO uint8_t  UEP7_RX_CTRL;
+  __IO uint32_t Reserve1;
+  __IO uint32_t OTG_CR;     // May not exist or be different in CH32X035
+  __IO uint32_t OTG_SR;     // May not exist or be different in CH32X035
+} USBOTG_FS_TypeDef;
+*/
+
+// TODO: CH32X035 - Define the correct base address for the USBFS peripheral.
+// The address 0x40023400 is from CH32V103 and is LIKELY INCORRECT for CH32X035.
+// #define USBOTG_FS ((USBOTG_FS_TypeDef *) 0x40023400_CH32X035_USBFS_BASE_ADDRESS_TODO)
+
+
+// TODO: Verify ALL register bit definitions below for CH32X035. These are generic names
+// but their values or existence might differ.
+
+// CTRL Register Bits
+#define USBFS_CTRL_DMA_EN    (1 << 0) // TODO: Verify bit position and meaning
+#define USBFS_CTRL_CLR_ALL   (1 << 1) // TODO: Verify bit position and meaning
+#define USBFS_CTRL_RESET_SIE (1 << 2) // TODO: Verify bit position and meaning
+#define USBFS_CTRL_INT_BUSY  (1 << 3) // TODO: Verify bit position and meaning
+#define USBFS_CTRL_SYS_CTRL  (1 << 4) // TODO: Verify bit position and meaning (e.g., UC_HOST_MODE in some WCH chips)
+#define USBFS_CTRL_DEV_PUEN  (1 << 5) // TODO: Verify bit position and meaning (pull-up enable)
+#define USBFS_CTRL_LOW_SPEED (1 << 6) // TODO: Verify bit position and meaning
+#define USBFS_CTRL_HOST_MODE (1 << 7) // TODO: Verify bit position and meaning (may be part of SYS_CTRL)
+
+// INT_EN Register Bits (Interrupt Enable)
+#define USBFS_INT_EN_BUS_RST  (1 << 0) // TODO: Verify bit position (for device mode: reset)
+#define USBFS_INT_EN_DETECT   (1 << 0) // TODO: Verify bit position (for host mode: connect/disconnect)
+#define USBFS_INT_EN_TRANSFER (1 << 1) // TODO: Verify bit position (transfer complete)
+#define USBFS_INT_EN_SUSPEND  (1 << 2) // TODO: Verify bit position (suspend event)
+#define USBFS_INT_EN_HST_SOF  (1 << 3) // TODO: Verify bit position (for host mode: SOF sent)
+#define USBFS_INT_EN_FIFO_OV  (1 << 4) // TODO: Verify bit position (FIFO overflow)
+#define USBFS_INT_EN_DEV_NAK  (1 << 6) // TODO: Verify bit position (for device mode: NAK sent)
+#define USBFS_INT_EN_DEV_SOF  (1 << 7) // TODO: Verify bit position (for device mode: SOF received)
+
+// INT_FG Register Bits (Interrupt Flag)
+#define USBFS_INT_FG_BUS_RST  (1 << 0) // TODO: Verify bit position
+#define USBFS_INT_FG_DETECT   (1 << 0) // TODO: Verify bit position
+#define USBFS_INT_FG_TRANSFER (1 << 1) // TODO: Verify bit position
+#define USBFS_INT_FG_SUSPEND  (1 << 2) // TODO: Verify bit position
+#define USBFS_INT_FG_HST_SOF  (1 << 3) // TODO: Verify bit position
+#define USBFS_INT_FG_FIFO_OV  (1 << 4) // TODO: Verify bit position
+#define USBFS_INT_FG_SIE_FREE (1 << 5) // TODO: Verify bit position (CH32V10x specific?)
+#define USBFS_INT_FG_TOG_OK   (1 << 6) // TODO: Verify bit position (Toggle OK - CH32V10x specific?)
+#define USBFS_INT_FG_IS_NAK   (1 << 7) // TODO: Verify bit position (NAK transaction flag)
+
+// INT_ST Register Bits (Interrupt Status)
+#define USBFS_INT_ST_MASK_UIS_ENDP(x)  (((x) >> 0) & 0x0F) // TODO: Verify mask and shift for endpoint number
+#define USBFS_INT_ST_MASK_UIS_TOKEN(x) (((x) >> 4) & 0x03) // TODO: Verify mask and shift for token PID
+
+// UDEV_CTRL Register Bits (USB Device Control)
+#define USBFS_UDEV_CTRL_PORT_EN   (1 << 0) // TODO: Verify bit position (USB port enable)
+#define USBFS_UDEV_CTRL_GP_BIT    (1 << 1) // TODO: Verify bit position (General purpose bit, CH32V10x specific?)
+#define USBFS_UDEV_CTRL_LOW_SPEED (1 << 2) // TODO: Verify bit position (Force low speed)
+#define USBFS_UDEV_CTRL_DM_PIN    (1 << 4) // TODO: Verify bit position (DM pin status)
+#define USBFS_UDEV_CTRL_DP_PIN    (1 << 5) // TODO: Verify bit position (DP pin status)
+#define USBFS_UDEV_CTRL_PD_DIS    (1 << 7) // TODO: Verify bit position (Pull-down disable, often means pull-up enable for D+)
+
+
+// Endpoint TX_CTRL Register Bits
+#define USBFS_EP_T_RES_MASK (3 << 0) // TODO: Verify mask for transaction response
+#define USBFS_EP_T_TOG      (1 << 2) // TODO: Verify bit for current toggle status (read-only?)
+#define USBFS_EP_T_AUTO_TOG (1 << 3) // TODO: Verify bit for hardware auto toggle
+
+#define USBFS_EP_T_RES_ACK   (0 << 0) // TODO: Verify value for ACK
+#define USBFS_EP_T_RES_NYET  (1 << 0) // TODO: Verify value for NYET
+#define USBFS_EP_T_RES_NAK   (2 << 0) // TODO: Verify value for NAK
+#define USBFS_EP_T_RES_STALL (3 << 0) // TODO: Verify value for STALL
+
+// Endpoint RX_CTRL Register Bits
+#define USBFS_EP_R_RES_MASK (3 << 0) // TODO: Verify mask for transaction response
+#define USBFS_EP_R_TOG      (1 << 2) // TODO: Verify bit for current toggle status (read-only?)
+#define USBFS_EP_R_AUTO_TOG (1 << 3) // TODO: Verify bit for hardware auto toggle
+
+#define USBFS_EP_R_RES_ACK   (0 << 0) // TODO: Verify value for ACK
+#define USBFS_EP_R_RES_NYET  (1 << 0) // TODO: Verify value for NYET (usually not for RX)
+#define USBFS_EP_R_RES_NAK   (2 << 0) // TODO: Verify value for NAK
+#define USBFS_EP_R_RES_STALL (3 << 0) // TODO: Verify value for STALL
+
+// Token PID values (These are standard USB PIDs, likely unchanged)
+#define PID_OUT   0
+#define PID_SOF   1
+#define PID_IN    2
+#define PID_SETUP 3
+
+// TODO: Add any other CH32X035 specific registers or bit fields.
+// For example, endpoint configuration registers (UEPn_CONFIG),
+// endpoint buffer DMA address registers (UEPn_DMA),
+// endpoint max packet size registers, etc.
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#endif // USB_CH32X035_USBFS_REG_H

--- a/src/portable/wch/dcd_ch32x035.c
+++ b/src/portable/wch/dcd_ch32x035.c
@@ -1,0 +1,394 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Matthew Tran
+ * Copyright (c) 2024 hathach
+ * Copyright (c) 2024 TinyUSB Community (for CH32X035 modifications)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+// TODO: This is a skeleton driver for CH32X035 based on dcd_ch32_usbfs.c.
+// It requires significant updates for CH32X035-specific USB peripheral registers,
+// interrupt handling, and overall USB IP behavior.
+// Verify all register names, bit fields, and addresses against the CH32X035 reference manual.
+
+#include "tusb_option.h"
+
+#if CFG_TUD_ENABLED && defined(TUP_USBIP_WCH_CH32X035) && CFG_TUD_WCH_USBIP_CH32X035
+
+#include "device/dcd.h"
+#include "ch32x035_usbfs_reg.h" // TODO: Create and populate this header with CH32X035 USBFS registers
+
+/* private defines */
+#define EP_MAX (8) // TODO: Verify max endpoints for CH32X035
+
+// TODO: Update these register access macros for CH32X035
+#define EP_DMA(ep)     ((&USBOTG_FS->UEP0_DMA)[ep])
+#define EP_TX_LEN(ep)  ((&USBOTG_FS->UEP0_TX_LEN)[2 * ep])
+#define EP_TX_CTRL(ep) ((&USBOTG_FS->UEP0_TX_CTRL)[4 * ep])
+#define EP_RX_CTRL(ep) ((&USBOTG_FS->UEP0_RX_CTRL)[4 * ep])
+
+/* private data */
+struct usb_xfer {
+  bool valid;
+  uint8_t* buffer;
+  size_t len;
+  size_t processed_len;
+  size_t max_size;
+};
+
+static struct {
+  bool ep0_tog;
+  bool isochronous[EP_MAX];
+  struct usb_xfer xfer[EP_MAX][2];
+  TU_ATTR_ALIGNED(4) uint8_t buffer[EP_MAX][2][64]; // TODO: Verify EP buffer needs, especially for ISO
+  TU_ATTR_ALIGNED(4) struct {
+    // OUT transfers >64 bytes will overwrite queued IN data!
+    // TODO: This EP3 buffer handling is specific to the original driver, review for CH32X035
+    uint8_t out[64];
+    uint8_t in[1023];
+    uint8_t pad;
+  } ep3_buffer;
+} data;
+
+/* private helpers */
+// TODO: Review and adapt all logic in update_in and update_out for CH32X035 specifics
+static void update_in(uint8_t rhport, uint8_t ep, bool force) {
+  struct usb_xfer* xfer = &data.xfer[ep][TUSB_DIR_IN];
+  if (xfer->valid) {
+    if (force || xfer->len) {
+      size_t len = TU_MIN(xfer->max_size, xfer->len);
+      if (ep == 0) {
+        memcpy(data.buffer[ep][TUSB_DIR_OUT], xfer->buffer, len); // ep0 uses same chunk
+      } else if (ep == 3) { // TODO: EP3 specific logic, review
+        memcpy(data.ep3_buffer.in, xfer->buffer, len);
+      } else {
+        memcpy(data.buffer[ep][TUSB_DIR_IN], xfer->buffer, len);
+      }
+      xfer->buffer += len;
+      xfer->len -= len;
+      xfer->processed_len += len;
+
+      EP_TX_LEN(ep) = len;
+      if (ep == 0) {
+        EP_TX_CTRL(0) = USBFS_EP_T_RES_ACK | (data.ep0_tog ? USBFS_EP_T_TOG : 0); // TODO: Verify CH32X035 registers
+        data.ep0_tog = !data.ep0_tog;
+      } else if (data.isochronous[ep]) {
+        EP_TX_CTRL(ep) = (EP_TX_CTRL(ep) & ~(USBFS_EP_T_RES_MASK)) | USBFS_EP_T_RES_NYET; // TODO: Verify CH32X035 registers
+      } else {
+        EP_TX_CTRL(ep) = (EP_TX_CTRL(ep) & ~(USBFS_EP_T_RES_MASK)) | USBFS_EP_T_RES_ACK; // TODO: Verify CH32X035 registers
+      }
+    } else {
+      xfer->valid = false;
+      EP_TX_CTRL(ep) = (EP_TX_CTRL(ep) & ~(USBFS_EP_T_RES_MASK)) | USBFS_EP_T_RES_NAK; // TODO: Verify CH32X035 registers
+      dcd_event_xfer_complete(
+          rhport, ep | TUSB_DIR_IN_MASK, xfer->processed_len,
+          XFER_RESULT_SUCCESS, true);
+    }
+  }
+}
+
+static void update_out(uint8_t rhport, uint8_t ep, size_t rx_len) {
+  struct usb_xfer* xfer = &data.xfer[ep][TUSB_DIR_OUT];
+  if (xfer->valid) {
+    size_t len = TU_MIN(xfer->max_size, TU_MIN(xfer->len, rx_len));
+    if (ep == 3) { // TODO: EP3 specific logic, review
+      memcpy(xfer->buffer, data.ep3_buffer.out, len);
+    } else {
+      memcpy(xfer->buffer, data.buffer[ep][TUSB_DIR_OUT], len);
+    }
+    xfer->buffer += len;
+    xfer->len -= len;
+    xfer->processed_len += len;
+
+    if (xfer->len == 0 || len < xfer->max_size) {
+      xfer->valid = false;
+      dcd_event_xfer_complete(rhport, ep, xfer->processed_len, XFER_RESULT_SUCCESS, true);
+    }
+
+    if (ep == 0) {
+      EP_RX_CTRL(0) = USBFS_EP_R_RES_ACK; // TODO: Verify CH32X035 registers
+    }
+  }
+}
+
+/* public functions */
+// TODO: THIS ENTIRE FUNCTION NEEDS CH32X035 SPECIFIC IMPLEMENTATION
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  (void) rh_init;
+  // TODO: CH32X035: Initialize USB peripheral registers
+  // TODO: CH32X035: Configure PLLs, clocks for USB
+  // TODO: CH32X035: Enable USB interrupts
+  // TODO: CH32X035: Setup EP0 buffers and control registers
+
+  // Example from dcd_ch32_usbfs.c (NEEDS COMPLETE REPLACEMENT FOR CH32X035)
+  // USBOTG_FS->BASE_CTRL = USBFS_CTRL_SYS_CTRL | USBFS_CTRL_INT_BUSY | USBFS_CTRL_DMA_EN;
+  // USBOTG_FS->UDEV_CTRL = USBFS_UDEV_CTRL_PD_DIS | USBFS_UDEV_CTRL_PORT_EN;
+  // USBOTG_FS->DEV_ADDR = 0x00;
+  //
+  // USBOTG_FS->INT_FG = 0xFF;
+  // USBOTG_FS->INT_EN = USBFS_INT_EN_BUS_RST | USBFS_INT_EN_TRANSFER | USBFS_INT_EN_SUSPEND;
+  //
+  // EP_DMA(0) = (uint32_t) &data.buffer[0][0];
+  // EP_TX_LEN(0) = 0;
+  // EP_TX_CTRL(0) = USBFS_EP_T_RES_NAK;
+  // EP_RX_CTRL(0) = USBFS_EP_R_RES_ACK;
+  //
+  // USBOTG_FS->UEP4_1_MOD = 0xCC;
+  // USBOTG_FS->UEP2_3_MOD = 0xCC;
+  // USBOTG_FS->UEP5_6_MOD = 0xCC;
+  // USBOTG_FS->UEP7_MOD = 0x0C;
+  //
+  // for (uint8_t ep = 1; ep < EP_MAX; ep++) {
+  //   EP_DMA(ep) = (uint32_t) &data.buffer[ep][0];
+  //   EP_TX_LEN(ep) = 0;
+  //   EP_TX_CTRL(ep) = USBFS_EP_T_AUTO_TOG | USBFS_EP_T_RES_NAK;
+  //   EP_RX_CTRL(ep) = USBFS_EP_R_AUTO_TOG | USBFS_EP_R_RES_NAK;
+  // }
+  // EP_DMA(3) = (uint32_t) &data.ep3_buffer.out[0]; // TODO: EP3 specific
+
+  TU_LOG_DCD("CH32X035 DCD Init: TODO - Implement CH32X035 specific initialization\r\n");
+
+  dcd_connect(rhport); // This might be generic enough, but review
+
+  return true;
+}
+
+// TODO: THIS ENTIRE FUNCTION NEEDS CH32X035 SPECIFIC IMPLEMENTATION
+void dcd_int_handler(uint8_t rhport) {
+  (void) rhport;
+  // TODO: CH32X035: Read interrupt flags
+  // TODO: CH32X035: Handle different USB events (Reset, Suspend, Transfer complete, Setup)
+  // TODO: CH32X035: Call appropriate dcd_event_...() functions
+  // TODO: CH32X035: Clear interrupt flags
+
+  // Example from dcd_ch32_usbfs.c (NEEDS COMPLETE REPLACEMENT FOR CH32X035)
+  // uint8_t status = USBOTG_FS->INT_FG;
+  // if (status & USBFS_INT_FG_TRANSFER) {
+  //   uint8_t ep = USBFS_INT_ST_MASK_UIS_ENDP(USBOTG_FS->INT_ST);
+  //   uint8_t token = USBFS_INT_ST_MASK_UIS_TOKEN(USBOTG_FS->INT_ST);
+  //
+  //   switch (token) {
+  //     case PID_OUT: {
+  //       uint16_t rx_len = USBOTG_FS->RX_LEN;
+  //       update_out(rhport, ep, rx_len);
+  //       break;
+  //     }
+  //
+  //     case PID_IN:
+  //       update_in(rhport, ep, false);
+  //       break;
+  //
+  //     case PID_SETUP:
+  //       EP_TX_CTRL(0) = USBFS_EP_T_RES_NAK;
+  //       EP_RX_CTRL(0) = USBFS_EP_R_RES_ACK;
+  //
+  //       data.ep0_tog = true;
+  //       dcd_event_setup_received(rhport, &data.buffer[0][TUSB_DIR_OUT][0], true);
+  //       break;
+  //   }
+  //
+  //   USBOTG_FS->INT_FG = USBFS_INT_FG_TRANSFER;
+  // } else if (status & USBFS_INT_FG_BUS_RST) {
+  //   data.ep0_tog = true;
+  //   data.xfer[0][TUSB_DIR_OUT].max_size = 64;
+  //   data.xfer[0][TUSB_DIR_IN].max_size = 64;
+  //
+  //   dcd_event_bus_reset(rhport, (USBOTG_FS->UDEV_CTRL & USBFS_UDEV_CTRL_LOW_SPEED) ? TUSB_SPEED_LOW : TUSB_SPEED_FULL, true);
+  //
+  //   USBOTG_FS->DEV_ADDR = 0x00;
+  //   EP_RX_CTRL(0) = USBFS_EP_R_RES_ACK;
+  //
+  //   USBOTG_FS->INT_FG = USBFS_INT_FG_BUS_RST;
+  // } else if (status & USBFS_INT_FG_SUSPEND) {
+  //   dcd_event_t event = {.rhport = rhport, .event_id = DCD_EVENT_SUSPEND};
+  //   dcd_event_handler(&event, true);
+  //   USBOTG_FS->INT_FG = USBFS_INT_FG_SUSPEND;
+  // }
+}
+
+void dcd_int_enable(uint8_t rhport) {
+  (void) rhport;
+  // TODO: CH32X035: Enable the correct USB interrupt in the NVIC/PLIC
+  // Example: NVIC_EnableIRQ(USBHD_IRQn); // This IRQn is likely different for CH32X035 USBFS
+  TU_LOG_DCD("CH32X035 DCD Int Enable: TODO - Verify IRQn for CH32X035 USBFS\r\n");
+}
+
+void dcd_int_disable(uint8_t rhport) {
+  (void) rhport;
+  // TODO: CH32X035: Disable the correct USB interrupt in the NVIC/PLIC
+  // Example: NVIC_DisableIRQ(USBHD_IRQn); // This IRQn is likely different for CH32X035 USBFS
+  TU_LOG_DCD("CH32X035 DCD Int Disable: TODO - Verify IRQn for CH32X035 USBFS\r\n");
+}
+
+void dcd_set_address(uint8_t rhport, uint8_t dev_addr) {
+  (void) dev_addr;
+  // TODO: CH32X035: Implement setting device address AFTER status phase of SET_ADDRESS.
+  // This function is called before the status phase. Address is set in `dcd_edpt0_status_complete`.
+  dcd_edpt_xfer(rhport, 0x80, NULL, 0); // zlp status response
+}
+
+void dcd_remote_wakeup(uint8_t rhport) {
+  (void) rhport;
+  // TODO: CH32X035: Implement remote wakeup if supported.
+}
+
+// TODO: Review connect/disconnect logic for CH32X035 specifics (e.g., pull-up resistors)
+void dcd_connect(uint8_t rhport) {
+  (void) rhport;
+  // Example: USBOTG_FS->BASE_CTRL |= USBFS_CTRL_DEV_PUEN; // TODO: Verify CH32X035 register
+  TU_LOG_DCD("CH32X035 DCD Connect: TODO - Verify pull-up enable for CH32X035\r\n");
+}
+
+void dcd_disconnect(uint8_t rhport) {
+  (void) rhport;
+  // Example: USBOTG_FS->BASE_CTRL &= ~USBFS_CTRL_DEV_PUEN; // TODO: Verify CH32X035 register
+  TU_LOG_DCD("CH32X035 DCD Disconnect: TODO - Verify pull-up disable for CH32X035\r\n");
+}
+
+void dcd_sof_enable(uint8_t rhport, bool en) {
+  (void) rhport;
+  (void) en;
+  // TODO: CH32X035: Implement SOF enable/disable if needed.
+}
+
+// TODO: Review for CH32X035 specifics
+void dcd_edpt0_status_complete(uint8_t rhport, tusb_control_request_t const* request) {
+  (void) rhport;
+  if (request->bmRequestType_bit.recipient == TUSB_REQ_RCPT_DEVICE &&
+      request->bmRequestType_bit.type == TUSB_REQ_TYPE_STANDARD &&
+      request->bRequest == TUSB_REQ_SET_ADDRESS) {
+    // USBOTG_FS->DEV_ADDR = (uint8_t) request->wValue; // TODO: Verify CH32X035 register
+    TU_LOG_DCD("CH32X035 DCD Set Address: %d (TODO: Verify register write)\r\n", request->wValue);
+  }
+  // EP_TX_CTRL(0) = USBFS_EP_T_RES_NAK; // TODO: Verify CH32X035 registers
+  // EP_RX_CTRL(0) = USBFS_EP_R_RES_ACK; // TODO: Verify CH32X035 registers
+}
+
+// TODO: Review for CH32X035 specifics, especially EP configuration registers
+bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const* desc_ep) {
+  (void) rhport;
+  uint8_t ep = tu_edpt_number(desc_ep->bEndpointAddress);
+  uint8_t dir = tu_edpt_dir(desc_ep->bEndpointAddress);
+  TU_ASSERT(ep < EP_MAX);
+
+  data.isochronous[ep] = desc_ep->bmAttributes.xfer == TUSB_XFER_ISOCHRONOUS;
+  data.xfer[ep][dir].max_size = tu_edpt_packet_size(desc_ep);
+
+  // TODO: CH32X035: Configure endpoint registers (type, buffer address, etc.)
+  // if (ep != 0) {
+  //   if (dir == TUSB_DIR_OUT) {
+  //     if (data.isochronous[ep]) {
+  //       EP_RX_CTRL(ep) = USBFS_EP_R_AUTO_TOG | USBFS_EP_R_RES_NYET; // TODO: Verify CH32X035 registers
+  //     } else {
+  //       EP_RX_CTRL(ep) = USBFS_EP_R_AUTO_TOG | USBFS_EP_R_RES_ACK; // TODO: Verify CH32X035 registers
+  //     }
+  //   } else {
+  //     EP_TX_LEN(ep) = 0; // TODO: Verify CH32X035 registers
+  //     EP_TX_CTRL(ep) = USBFS_EP_T_AUTO_TOG | USBFS_EP_T_RES_NAK; // TODO: Verify CH32X035 registers
+  //   }
+  // }
+  TU_LOG_DCD("CH32X035 DCD EP Open %02X: TODO - Implement EP config\r\n", desc_ep->bEndpointAddress);
+  return true;
+}
+
+void dcd_edpt_close_all(uint8_t rhport) {
+  (void) rhport;
+  // TODO: CH32X035: Implement if necessary, disable all non-EP0 endpoints.
+}
+
+void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr) {
+  (void) rhport;
+  (void) ep_addr;
+  // TODO: CH32X035: Implement if necessary, disable specific endpoint.
+}
+
+// TODO: Review for CH32X035 specifics
+bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t* buffer, uint16_t total_bytes) {
+  (void) rhport;
+  uint8_t ep = tu_edpt_number(ep_addr);
+  uint8_t dir = tu_edpt_dir(ep_addr);
+
+  struct usb_xfer* xfer = &data.xfer[ep][dir];
+  dcd_int_disable(rhport); // TODO: Ensure this disabling/enabling is correct for CH32X035
+  xfer->valid = true;
+  xfer->buffer = buffer;
+  xfer->len = total_bytes;
+  xfer->processed_len = 0;
+  dcd_int_enable(rhport);
+
+  if (dir == TUSB_DIR_IN) {
+    update_in(rhport, ep, true); // TODO: Ensure update_in is CH32X035 correct
+  } else {
+    // For OUT transfers, hardware should be ready to receive.
+    // If using DMA, setup DMA here. Otherwise, reception is likely interrupt-driven in dcd_int_handler.
+    // EP_RX_CTRL(ep) might need to be set to ACK if not already.
+    TU_LOG_DCD("CH32X035 DCD EP Xfer %02X: TODO - Review OUT transfer setup\r\n", ep_addr);
+  }
+  return true;
+}
+
+// TODO: Review for CH32X035 specifics
+void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
+  (void) rhport;
+  uint8_t ep = tu_edpt_number(ep_addr);
+  uint8_t dir = tu_edpt_dir(ep_addr);
+  // if (ep == 0) {
+  //   if (dir == TUSB_DIR_OUT) {
+  //     EP_RX_CTRL(0) = USBFS_EP_R_RES_STALL; // TODO: Verify CH32X035 registers
+  //   } else {
+  //     EP_TX_LEN(0) = 0; // TODO: Verify CH32X035 registers
+  //     EP_TX_CTRL(0) = USBFS_EP_T_RES_STALL; // TODO: Verify CH32X035 registers
+  //   }
+  // } else {
+  //   if (dir == TUSB_DIR_OUT) {
+  //     EP_RX_CTRL(ep) = (EP_RX_CTRL(ep) & ~USBFS_EP_R_RES_MASK) | USBFS_EP_R_RES_STALL; // TODO: Verify CH32X035 registers
+  //   } else {
+  //     EP_TX_CTRL(ep) = (EP_TX_CTRL(ep) & ~USBFS_EP_T_RES_MASK) | USBFS_EP_T_RES_STALL; // TODO: Verify CH32X035 registers
+  //   }
+  // }
+  TU_LOG_DCD("CH32X035 DCD EP Stall %02X: TODO - Implement EP stall\r\n", ep_addr);
+}
+
+// TODO: Review for CH32X035 specifics
+void dcd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr) {
+  (void) rhport;
+  uint8_t ep = tu_edpt_number(ep_addr);
+  uint8_t dir = tu_edpt_dir(ep_addr);
+  // if (ep == 0) {
+  //   // For EP0, setup stage will clear stall, or specific clear command.
+  //   // The original driver only cleared stall for OUT direction on EP0 here.
+  //   if (dir == TUSB_DIR_OUT) {
+  //     EP_RX_CTRL(0) = USBFS_EP_R_RES_ACK; // TODO: Verify CH32X035 registers
+  //   }
+  // } else {
+  //   if (dir == TUSB_DIR_OUT) {
+  //     // Reset toggle bit as well
+  //     EP_RX_CTRL(ep) = (EP_RX_CTRL(ep) & ~(USBFS_EP_R_RES_MASK | USBFS_EP_R_TOG)) | USBFS_EP_R_RES_ACK; // TODO: Verify CH32X035 registers
+  //   } else {
+  //     EP_TX_CTRL(ep) = (EP_TX_CTRL(ep) & ~(USBFS_EP_T_RES_MASK | USBFS_EP_T_TOG)) | USBFS_EP_T_RES_NAK; // TODO: Verify CH32X035 registers
+  //   }
+  // }
+  TU_LOG_DCD("CH32X035 DCD EP Clear Stall %02X: TODO - Implement EP clear stall\r\n", ep_addr);
+}
+
+#endif // CFG_TUD_ENABLED && defined(TUP_USBIP_WCH_CH32X035) && CFG_TUD_WCH_USBIP_CH32X035

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -188,6 +188,7 @@
 #define OPT_MCU_CH32F20X         2210 ///< WCH CH32F20x
 #define OPT_MCU_CH32V20X         2220 ///< WCH CH32V20X
 #define OPT_MCU_CH32V103         2230 ///< WCH CH32V103
+#define OPT_MCU_CH32X035         2240 ///< WCH CH32X035
 
 // NXP LPC MCX
 #define OPT_MCU_MCXN9            2300  ///< NXP MCX N9 Series


### PR DESCRIPTION
I've added initial support for the WCH CH32X035 MCU to the TinyUSB library.

Here's a summary of the key changes:

1.  **Core TinyUSB Modifications:**
    *   I added `OPT_MCU_CH32X035` to `src/tusb_option.h`.
    *   I added CH32X035-specific definitions (e.g., `TUP_USBIP_WCH_USBFS`,
        `TUP_DCD_ENDPOINT_MAX`) to `src/common/tusb_mcu.h`.
    *   I created a skeleton register header `src/portable/wch/ch32x035_usbfs_reg.h`.
        You'll need to manually populate this file with CH32X035 register
        definitions from the official PDF reference manual.

2.  **Device Controller Driver (DCD):**
    *   I created a placeholder DCD implementation at
        `src/portable/wch/dcd_ch32x035.c`. This file contains the
        basic DCD function structures and requires you to fully implement
        the USB peripheral interactions.

3.  **Board Support Package (BSP) Placeholders:**
    *   I established the family directory `hw/bsp/ch32x035/` with
        `family.c` and `family.mk`.
    *   I created a default board template directory:
        `hw/bsp/ch32x035/boards/ch32x035_default/`.
        This includes placeholder files: `board.h`, `board.c`,
        `board.cmake`, and `board.mk`.
    *   I added a generic ARM Cortex-M linker script placeholder:
        `hw/bsp/ch32x035/linker/ch32x035.ld`. This script
        needs to be updated with CH32X035-specific memory sizes and
        regions.

**Further Work & Considerations for you:**

*   The DCD (`dcd_ch32x035.c`) needs to be fully implemented.
*   The USB register header (`ch32x035_usbfs_reg.h`) needs to be populated.
*   The linker script (`ch32x035.ld`) needs to be verified and updated with
    accurate memory information for CH32X035 devices.
*   Board-specific configurations in `hw/bsp/ch32x035/boards/` need to be
    developed for actual hardware.
*   Your feedback suggested renaming the default board directory from
    `ch32x035_default` to `ch32x035g_r0_1v2`. I can address this
    in a follow-up.
*   The build system (CMake/Makefiles) at the example/application level
    will need to be updated to correctly include and compile the new
    DCD and BSP files when `CFG_TUSB_MCU=OPT_MCU_CH32X035`.

**Describe the PR**
A clear and concise description of what this PR solve.

**Additional context**
If applicable, add any other context about the PR and/or screenshots here.
