### PR TITLE
Fix TUH_EPSIZE_BULK_MPS macro

### DIFF
--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -42,7 +42,7 @@
 //--------------------------------------------------------------------+
 
 // Endpoint Bulk size depending on host mx speed
-#define TUH_EPSIZE_BULK_MPS   (TUD_OPT_HIGH_SPEED ? TUSB_EPSIZE_BULK_HS : TUSB_EPSIZE_BULK_FS)
+#define TUH_EPSIZE_BULK_MPS   (TUH_OPT_HIGH_SPEED ? TUSB_EPSIZE_BULK_HS : TUSB_EPSIZE_BULK_FS)
 
 // forward declaration
 struct tuh_xfer_s;


### PR DESCRIPTION
TUH_EPSIZE_BULK_MPS should be set based on TUH_OPT_HIGH_SPEED, not TUD_OPT_HIGH_SPEED

**Describe the PR**

I'm trying to debug tinyusb on a stm32h7 board with a full speed device (TUD) and a high speed host (TUH).
The high speed CDC code doesn't work with small 64-byte buffers.
My code is not yet working, but I think this is an obvious fix.
