### PR TITLE
Fix HID descriptor parsing of 4‑byte items

### DIFF
--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -662,7 +662,10 @@ uint8_t tuh_hid_parse_report_descriptor(tuh_hid_report_info_t* report_info_arr, 
 
     uint8_t const tag = header.tag;
     uint8_t const type = header.type;
-    uint8_t const size = (header.size == 3) ? 4 : header.size;
+    uint8_t size = header.size;
+    if (size == 3) {
+      size = 4;
+    }
 
     uint8_t const data8 = (size > 0) ? desc_report[0] : 0;
 

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -664,7 +664,7 @@ uint8_t tuh_hid_parse_report_descriptor(tuh_hid_report_info_t* report_info_arr, 
     uint8_t const type = header.type;
     uint8_t size = header.size;
     if (size == 3) {
-      size = 4;
+      size = 4; // HID 1.11 6.2.2.2 3 is 4 bytes
     }
 
     uint8_t const data8 = (size > 0) ? desc_report[0] : 0;

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -662,9 +662,9 @@ uint8_t tuh_hid_parse_report_descriptor(tuh_hid_report_info_t* report_info_arr, 
 
     uint8_t const tag = header.tag;
     uint8_t const type = header.type;
-    uint8_t const size = header.size;
+    uint8_t const size = (header.size == 3) ? 4 : header.size;
 
-    uint8_t const data8 = desc_report[0];
+    uint8_t const data8 = (size > 0) ? desc_report[0] : 0;
 
     TU_LOG(3, "tag = %d, type = %d, size = %d, data = ", tag, type, size);
     for (uint32_t i = 0; i < size; i++) {


### PR DESCRIPTION
## Summary
- fix HID host parser: handle item size value `3` as 4 bytes
- avoid reading descriptor data when no bytes present

------
https://chatgpt.com/codex/tasks/task_e_6868baec4d148331bb2aa023524eb1b3