### PR TITLE
add tud_msc_inquiry2_cb() for full inquiry response

### DIFF
--- a/examples/device/cdc_msc/src/msc_disk.c
+++ b/examples/device/cdc_msc/src/msc_disk.c
@@ -116,18 +116,20 @@ uint8_t msc_disk[DISK_BLOCK_NUM][DISK_BLOCK_SIZE] = {
   README_CONTENTS
 };
 
-// Invoked when received SCSI_CMD_INQUIRY
-// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
-void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {
+// Invoked when received SCSI_CMD_INQUIRY, v2 with full inquiry response
+// Some inquiry_resp's fields are already filled with default values, application can update them
+// Return length of inquiry response, typically sizeof(scsi_inquiry_resp_t) (36 bytes), can be longer if included vendor data.
+uint32_t tud_msc_inquiry2_cb(uint8_t lun, scsi_inquiry_resp_t* inquiry_resp) {
   (void) lun;
-
   const char vid[] = "TinyUSB";
   const char pid[] = "Mass Storage";
   const char rev[] = "1.0";
 
-  memcpy(vendor_id, vid, strlen(vid));
-  memcpy(product_id, pid, strlen(pid));
-  memcpy(product_rev, rev, strlen(rev));
+  memcpy(inquiry_resp->vendor_id, vid, strlen(vid));
+  memcpy(inquiry_resp->product_id, pid, strlen(pid));
+  memcpy(inquiry_resp->product_rev, rev, strlen(rev));
+
+  return sizeof(scsi_inquiry_resp_t); // 36 bytes
 }
 
 // Invoked when received Test Unit Ready command.

--- a/examples/device/cdc_msc_freertos/src/msc_disk.c
+++ b/examples/device/cdc_msc_freertos/src/msc_disk.c
@@ -188,16 +188,20 @@ static void io_task(void *params) {
 void msc_disk_init() {}
 #endif
 
-// Invoked when received SCSI_CMD_INQUIRY
-// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
-void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {
+// Invoked when received SCSI_CMD_INQUIRY, v2 with full inquiry response
+// Some inquiry_resp's fields are already filled with default values, application can update them
+// Return length of inquiry response, typically sizeof(scsi_inquiry_resp_t) (36 bytes), can be longer if included vendor data.
+uint32_t tud_msc_inquiry2_cb(uint8_t lun, scsi_inquiry_resp_t* inquiry_resp) {
   (void) lun;
   const char vid[] = "TinyUSB";
   const char pid[] = "Mass Storage";
   const char rev[] = "1.0";
-  memcpy(vendor_id  , vid, strlen(vid));
-  memcpy(product_id , pid, strlen(pid));
-  memcpy(product_rev, rev, strlen(rev));
+
+  memcpy(inquiry_resp->vendor_id, vid, strlen(vid));
+  memcpy(inquiry_resp->product_id, pid, strlen(pid));
+  memcpy(inquiry_resp->product_rev, rev, strlen(rev));
+
+  return sizeof(scsi_inquiry_resp_t); // 36 bytes
 }
 
 // Invoked when received Test Unit Ready command.

--- a/examples/device/dynamic_configuration/src/msc_disk.c
+++ b/examples/device/dynamic_configuration/src/msc_disk.c
@@ -116,19 +116,20 @@ uint8_t msc_disk[DISK_BLOCK_NUM][DISK_BLOCK_SIZE] =
   README_CONTENTS
 };
 
-// Invoked when received SCSI_CMD_INQUIRY
-// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
-void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4])
-{
+// Invoked when received SCSI_CMD_INQUIRY, v2 with full inquiry response
+// Some inquiry_resp's fields are already filled with default values, application can update them
+// Return length of inquiry response, typically sizeof(scsi_inquiry_resp_t) (36 bytes), can be longer if included vendor data.
+uint32_t tud_msc_inquiry2_cb(uint8_t lun, scsi_inquiry_resp_t* inquiry_resp) {
   (void) lun;
-
   const char vid[] = "TinyUSB";
   const char pid[] = "Mass Storage";
   const char rev[] = "1.0";
 
-  memcpy(vendor_id  , vid, strlen(vid));
-  memcpy(product_id , pid, strlen(pid));
-  memcpy(product_rev, rev, strlen(rev));
+  memcpy(inquiry_resp->vendor_id, vid, strlen(vid));
+  memcpy(inquiry_resp->product_id, pid, strlen(pid));
+  memcpy(inquiry_resp->product_rev, rev, strlen(rev));
+
+  return sizeof(scsi_inquiry_resp_t); // 36 bytes
 }
 
 // Invoked when received Test Unit Ready command.

--- a/examples/device/msc_dual_lun/src/msc_disk_dual.c
+++ b/examples/device/msc_dual_lun/src/msc_disk_dual.c
@@ -207,18 +207,20 @@ uint8_t tud_msc_get_maxlun_cb(void) {
   return 2; // dual LUN
 }
 
-// Invoked when received SCSI_CMD_INQUIRY
-// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
-void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]) {
-  (void) lun; // use same ID for both LUNs
-
+// Invoked when received SCSI_CMD_INQUIRY, v2 with full inquiry response
+// Some inquiry_resp's fields are already filled with default values, application can update them
+// Return length of inquiry response, typically sizeof(scsi_inquiry_resp_t) (36 bytes), can be longer if included vendor data.
+uint32_t tud_msc_inquiry2_cb(uint8_t lun, scsi_inquiry_resp_t* inquiry_resp) {
+  (void) lun;
   const char vid[] = "TinyUSB";
   const char pid[] = "Mass Storage";
   const char rev[] = "1.0";
 
-  memcpy(vendor_id  , vid, strlen(vid));
-  memcpy(product_id , pid, strlen(pid));
-  memcpy(product_rev, rev, strlen(rev));
+  memcpy(inquiry_resp->vendor_id, vid, strlen(vid));
+  memcpy(inquiry_resp->product_id, pid, strlen(pid));
+  memcpy(inquiry_resp->product_rev, rev, strlen(rev));
+
+  return sizeof(scsi_inquiry_resp_t); // 36 bytes
 }
 
 // Invoked when received Test Unit Ready command.

--- a/src/class/msc/msc.h
+++ b/src/class/msc/msc.h
@@ -108,8 +108,7 @@ TU_VERIFY_STATIC(sizeof(msc_csw_t) == 13, "size is not correct");
 //--------------------------------------------------------------------+
 
 /// SCSI Command Operation Code
-typedef enum
-{
+typedef enum {
   SCSI_CMD_TEST_UNIT_READY              = 0x00, ///< The SCSI Test Unit Ready command is used to determine if a device is ready to transfer data (read/write), i.e. if a disk has spun up, if a tape is loaded and ready etc. The device does not perform a self-test operation.
   SCSI_CMD_INQUIRY                      = 0x12, ///< The SCSI Inquiry command is used to obtain basic information from a target device.
   SCSI_CMD_MODE_SELECT_6                = 0x15, ///<  provides a means for the application client to specify medium, logical unit, or peripheral device parameters to the device server. Device servers that implement the MODE SELECT(6) command shall also implement the MODE SENSE(6) command. Application clients should issue MODE SENSE(6) prior to each MODE SELECT(6) to determine supported mode pages, page lengths, and other parameters.
@@ -124,8 +123,7 @@ typedef enum
 }scsi_cmd_type_t;
 
 /// SCSI Sense Key
-typedef enum
-{
+typedef enum {
   SCSI_SENSE_NONE            = 0x00, ///< no specific Sense Key. This would be the case for a successful command
   SCSI_SENSE_RECOVERED_ERROR = 0x01, ///< Indicates the last command completed successfully with some recovery action performed by the disc drive.
   SCSI_SENSE_NOT_READY       = 0x02, ///< Indicates the logical unit addressed cannot be accessed.
@@ -140,6 +138,27 @@ typedef enum
   SCSI_SENSE_VOLUME_OVERFLOW = 0x0d, ///< Indicates a buffered peripheral device has reached the end of medium partition and data remains in the buffer that has not been written to the medium.
   SCSI_SENSE_MISCOMPARE      = 0x0e  ///< Indicates that the source data did not match the data read from the medium.
 }scsi_sense_key_type_t;
+
+
+typedef enum {
+  SCSI_PDT_DIRECT_ACCESS = 0x0,
+  SCSI_PDT_SEQUENTIAL_ACCESS = 0x1,
+  SCSI_PDT_PRINTER = 0x2,
+  SCSI_PDT_PROCESSOR = 0x3,
+  SCSI_PDT_WRITE_ONCE = 0x4,
+  SCSI_PDT_CD_DVD = 0x5,
+  SCSI_PDT_SCANNER = 0x6,
+  SCSI_PDT_OPTICAL_DEVICE = 0x7,
+  SCSI_PDT_MEDIUM_CHANGER = 0x8,
+  SCSI_PDT_COMMUNICATIONS = 0x9, // obsolete
+  SCSI_PDT_RAID = 0x0c,
+  SCSI_PDT_ENCLOSURE_SERVICES = 0x0d,
+  SCSI_PDT_SIMPLIFIED_DIRECT_ACCESS = 0x0e,
+  SCSI_PDT_OPTICAL_CARD_READER = 0x0f,
+  SCSI_PDT_BRIDGE = 0x10, ///< Bridge device, e.g. USB to SCSI bridge
+  SCSI_PDT_OBJECT_BASED_STORAGE = 0x11, ///< Object-based storage device
+  SCSI_PDT_AUTOMATION_DRIVE_INTERFACE = 0x12, ///< Automation/Drive Interface (ADI) device
+} scsi_peripheral_device_type_t;
 
 //--------------------------------------------------------------------+
 // SCSI Primary Command (SPC-4)

--- a/src/class/msc/msc_device.h
+++ b/src/class/msc/msc_device.h
@@ -90,9 +90,14 @@ bool tud_msc_async_io_done(int32_t bytes_io, bool in_isr);
 int32_t tud_msc_read10_cb (uint8_t lun, uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
 int32_t tud_msc_write10_cb (uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize);
 
-// Invoked when received SCSI_CMD_INQUIRY
+// Invoked when received SCSI_CMD_INQUIRY, v1, application should use v2 if possible
 // Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
 void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4]);
+
+// Invoked when received SCSI_CMD_INQUIRY, v2 with full inquiry response
+// Some inquiry_resp's fields are already filled with default values, application can update them
+// Return length of inquiry response, typically sizeof(scsi_inquiry_resp_t) (36 bytes), can be longer if included vendor data.
+uint32_t tud_msc_inquiry2_cb(uint8_t lun, scsi_inquiry_resp_t* inquiry_resp);
 
 // Invoked when received Test Unit Ready command.
 // return true allowing host to read/write this LUN e.g SD card inserted

--- a/test/unit-test/test/device/msc/test_msc_device.c
+++ b/test/unit-test/test/device/msc/test_msc_device.c
@@ -94,19 +94,20 @@ enum
 
 uint8_t msc_disk[DISK_BLOCK_NUM][DISK_BLOCK_SIZE];
 
-// Invoked when received SCSI_CMD_INQUIRY
-// Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
-void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4])
-{
+// Invoked when received SCSI_CMD_INQUIRY, v2 with full inquiry response
+// Some inquiry_resp's fields are already filled with default values, application can update them
+// Return length of inquiry response, typically sizeof(scsi_inquiry_resp_t) (36 bytes), can be longer if included vendor data.
+uint32_t tud_msc_inquiry2_cb(uint8_t lun, scsi_inquiry_resp_t* inquiry_resp) {
   (void) lun;
-
   const char vid[] = "TinyUSB";
   const char pid[] = "Mass Storage";
   const char rev[] = "1.0";
 
-  memcpy(vendor_id  , vid, strlen(vid));
-  memcpy(product_id , pid, strlen(pid));
-  memcpy(product_rev, rev, strlen(rev));
+  memcpy(inquiry_resp->vendor_id, vid, strlen(vid));
+  memcpy(inquiry_resp->product_id, pid, strlen(pid));
+  memcpy(inquiry_resp->product_rev, rev, strlen(rev));
+
+  return sizeof(scsi_inquiry_resp_t); // 36 bytes
 }
 
 // Invoked when received Test Unit Ready command.


### PR DESCRIPTION
add v2 for inquriy response callback tud_msc_inquiry2_cb(). When both are implemented, v2 will be used. close #2954 