### PR TITLE
Fix RP2040 isochronous endpoint reset panic and send silent frames in uac2_headset to avoid noise

### DIFF
--- a/examples/device/uac2_headset/src/main.c
+++ b/examples/device/uac2_headset/src/main.c
@@ -80,6 +80,8 @@ int16_t volume[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1];// +1 for master channel 
 int32_t mic_buf[CFG_TUD_AUDIO_FUNC_1_EP_IN_SW_BUF_SZ / 4];
 // Buffer for speaker data
 int32_t spk_buf[CFG_TUD_AUDIO_FUNC_1_EP_OUT_SW_BUF_SZ / 4];
+// Buffer for silent data
+int32_t silent_buf[CFG_TUD_AUDIO_FUNC_1_EP_OUT_SW_BUF_SZ / 4];
 // Speaker data size received in the last frame
 int spk_data_size;
 // Resolution per format
@@ -363,7 +365,9 @@ void audio_task(void) {
       tud_audio_write((uint8_t *) mic_buf, (uint16_t) (spk_data_size / 2));
       spk_data_size = 0;
     }
-  }
+  } else {
+    tud_audio_write((uint8_t *)silent_buf, sizeof(silent_buf));
+   }
 }
 
 void audio_control_task(void) {

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -191,7 +191,9 @@ static void __tusb_irq_path_func(hw_handle_buff_status)(void) {
       if (done) {
         // Notify
         dcd_event_xfer_complete(0, ep->ep_addr, ep->xferred_len, XFER_RESULT_SUCCESS, true);
-        hw_endpoint_reset_transfer(ep);
+        if (ep->transfer_type != TUSB_XFER_ISOCHRONOUS) {
+          hw_endpoint_reset_transfer(ep);
+        }
       }
       remaining_buffers &= ~bit;
     }


### PR DESCRIPTION
Fix #3177
This PR contains small but critical fixes for the RP2040, and the `uac2_headset` example.

1. `src/portable/raspberrypi/rp2040/dcd_rp2040.c` – suppress unnecessary resets on ISO endpoints  
  Skips `hw_endpoint_reset_transfer()` when the endpoint is isochronous. Prevents redundant EP resets that could stall ISO streams and trigger the `Can't continue xfer on inactive ep 81` panic.
2. `examples/device/uac2_headset/src/main.c` – always transmit a silent frame when no OUT data arrives  
  Adds a zero‑filled `silent_buf` and writes it whenever `tud_audio_read()` returns 0.
  Ensures an IN packet is sent every SOF, eliminating noise caused by host‑side underruns.

Both fixes improve audio stability on RP2040 devices running TinyUSB.