### PR TITLE
bsp/h7rs: fix a typo

### DIFF
--- a/hw/bsp/stm32h7rs/family.c
+++ b/hw/bsp/stm32h7rs/family.c
@@ -329,7 +329,7 @@ void board_init(void) {
   HAL_PWREx_EnableUSBVoltageDetector();
   HAL_PWREx_EnableUSBReg();
 
-  __HAL_RCC_USB2_OTG_FS_CLK_ENABLE();
+  __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
 
   // PM14 VUSB, PM10 ID, PM11 DM, PM12 DP
   // Configure DM DP Pins


### PR DESCRIPTION
**Describe the PR**
Fix `__HAL_RCC_USB_OTG_FS_CLK_ENABLE`

Seems HITL failed on F7 & H7 when DMA is enabled, but it's ok on my F723-DISCO...