### PR TITLE
Fix AT32F405xx missing USB HS definition

### DIFF
--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -601,6 +601,15 @@
   #define TUP_USBIP_DWC2_AT32
   #define TUP_DCD_ENDPOINT_MAX    8
 
+  // AT32F405xx has on-chip HS PHY
+  #if defined(AT32F405CBT7) || defined(AT32F405CBU7) ||     \
+      defined(AT32F405CCT7) || defined(AT32F405CCU7) ||     \
+      defined(AT32F405KBU7_4) || defined(AT32F405KCU7_4) || \
+      defined(AT32F405RBT7_7) || defined(AT32F405RBT7) ||   \
+      defined(AT32F405RCT7_7) || defined(AT32F405RCT7)
+    #define TUP_RHPORT_HIGHSPEED  1 // Port0: FS, Port1: HS
+  #endif
+
 #elif TU_CHECK_MCU(OPT_MCU_AT32F425)
   #define TUP_USBIP_DWC2
   #define TUP_USBIP_DWC2_AT32


### PR DESCRIPTION
**Describe the PR**
Fix #3198 by defining `TUP_RHPORT_HIGHSPEED` when the MCU is a variant of AT32F405xx.
