### PR TITLE
fix rp2 iso transfer with new audio driver

### DIFF
--- a/examples/device/uac2_headset/src/main.c
+++ b/examples/device/uac2_headset/src/main.c
@@ -297,8 +297,9 @@ bool tud_audio_set_itf_close_ep_cb(uint8_t rhport, tusb_control_request_t const 
   uint8_t const itf = tu_u16_low(tu_le16toh(p_request->wIndex));
   uint8_t const alt = tu_u16_low(tu_le16toh(p_request->wValue));
 
-  if (ITF_NUM_AUDIO_STREAMING_SPK == itf && alt == 0)
+  if (ITF_NUM_AUDIO_STREAMING_SPK == itf && alt == 0) {
     blink_interval_ms = BLINK_MOUNTED;
+  }
 
   return true;
 }
@@ -309,8 +310,9 @@ bool tud_audio_set_itf_cb(uint8_t rhport, tusb_control_request_t const *p_reques
   uint8_t const alt = tu_u16_low(tu_le16toh(p_request->wValue));
 
   TU_LOG2("Set interface %d alt %d\r\n", itf, alt);
-  if (ITF_NUM_AUDIO_STREAMING_SPK == itf && alt != 0)
+  if (ITF_NUM_AUDIO_STREAMING_SPK == itf && alt != 0) {
     blink_interval_ms = BLINK_STREAMING;
+  }
 
   // Clear buffer when streaming format is changed
   spk_data_size = 0;

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -190,8 +190,9 @@ static void __tusb_irq_path_func(hw_handle_buff_status)(void) {
       bool done = hw_endpoint_xfer_continue(ep);
       if (done) {
         // Notify
-        dcd_event_xfer_complete(0, ep->ep_addr, ep->xferred_len, XFER_RESULT_SUCCESS, true);
+        const uint16_t xferred_len = ep->xferred_len;
         hw_endpoint_reset_transfer(ep);
+        dcd_event_xfer_complete(0, ep->ep_addr, xferred_len, XFER_RESULT_SUCCESS, true);
       }
       remaining_buffers &= ~bit;
     }


### PR DESCRIPTION
reset state before notify stack. since new audio driver can execute xfer_is()