### PR TITLE
Fix STM32L4 GPIOD clock enable for variants without GPIOD

### DIFF
--- a/hw/bsp/stm32l4/family.c
+++ b/hw/bsp/stm32l4/family.c
@@ -59,7 +59,9 @@ void board_init(void) {
   __HAL_RCC_GPIOA_CLK_ENABLE();
   __HAL_RCC_GPIOB_CLK_ENABLE();
   __HAL_RCC_GPIOC_CLK_ENABLE();
+#if defined(GPIOD)
   __HAL_RCC_GPIOD_CLK_ENABLE();
+#endif
 #if defined(GPIOE)
   __HAL_RCC_GPIOE_CLK_ENABLE();
 #endif


### PR DESCRIPTION
Fix STM32L4 GPIOD clock enable for variants without GPIOD like the STM32L432.