### PR TITLE
Fix osal_spin_unlock for mynewt

### DIFF
--- a/src/osal/osal_mynewt.h
+++ b/src/osal/osal_mynewt.h
@@ -63,7 +63,7 @@ TU_ATTR_ALWAYS_INLINE static inline void osal_spin_unlock(osal_spinlock_t *ctx, 
   if (!TUP_MCU_MULTIPLE_CORE && in_isr) {
     return; // single core MCU does not need to lock in ISR
   }
-  OS_ENTER_CRITICAL(*ctx);
+  OS_EXIT_CRITICAL(*ctx);
 }
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the PR**
Mynewt version for osal_spin_unlock() called
OS_ENTER_CRITICAL instead of OS_EXIT_CRITICAL.
Implementations for other OS's showed intentions behind change.

**Additional context**

