### PR TITLE
fix(dcd/dwc2): Fix reset procedure for versions >=4.20a

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_common.c
+++ b/src/portable/synopsys/dwc2/dwc2_common.c
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ha Thach (tinyusb.org)
+ * Copyright (c) 2024-2025 Ha Thach (tinyusb.org)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,11 +45,14 @@
 //
 //--------------------------------------------------------------------
 static void reset_core(dwc2_regs_t* dwc2) {
+  // load gsnpsid (it is not readable after reset is asserted)
+  uint32_t gsnpsid = dwc2->gsnpsid;
+
   // reset core
   dwc2->grstctl |= GRSTCTL_CSRST;
 
-  if ((dwc2->gsnpsid & DWC2_CORE_REV_MASK) < (DWC2_CORE_REV_4_20a & DWC2_CORE_REV_MASK)) {
-    // prior v42.0 CSRST is self-clearing
+  if ((gsnpsid & DWC2_CORE_REV_MASK) < (DWC2_CORE_REV_4_20a & DWC2_CORE_REV_MASK)) {
+    // prior v4.20a CSRST is self-clearing
     while (dwc2->grstctl & GRSTCTL_CSRST) {}
   } else {
     // From v4.20a CSRST bit is write only, CSRT_DONE (w1c) is introduced for checking.


### PR DESCRIPTION
**Describe the PR**
Fix soft reset procedure for DWC2 version >= 4.20a.

I suspect this code was never tested since none of the supported targets use version >=4.20a.
After `GRSTCTL_CSRST` is set, read from `dwc2->gsnpsid` always returns zero, so it must be read first and reset second.

**Additional context**
ESP32-P4 silicon revision 3 updates DWC2 to version 4.30a
