### PR TITLE
use existing overloadable Pico SDK section macro instead of creating a custom one

### DIFF
--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -442,7 +442,7 @@
   #define TUP_DCD_ENDPOINT_MAX    16
   #define TUP_MCU_MULTIPLE_CORE   1
 
-  #define TU_ATTR_FAST_FUNC       __attribute__((section(".time_critical.tinyusb")))
+  #define TU_ATTR_FAST_FUNC       __not_in_flash("tinyusb")
 
 //--------------------------------------------------------------------+
 // Silabs


### PR DESCRIPTION
The present ./src/common/tusb_mcu.h forces a particular TU_ATTR_FAST_FUNC to assign a particular section name (specific to the Pico SDK linker files).

Given there is already a __not_in_flash() macro with the same section name in Pico SDK, it would be desirable to use the existing capabilities instead creating yet more.  Also, the existing __not_in_flash() macro allows for overloading for custom builds, unlike the existing RP2040/RP2350 specific TU_ATTR_FAST_FUNC in tusb_mcu.h
