### PR TITLE
Fix erroneous documentation of TU_ASSERT/TU_VERIFY

### DIFF
--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -53,11 +53,11 @@
  * The difference in behavior is that ASSERT triggers a breakpoint while
  * verify does not.
  *
- *   #define TU_VERIFY(cond)                  if(cond) return false;
- *   #define TU_VERIFY(cond,ret)              if(cond) return ret;
+ *   #define TU_VERIFY(cond)                  if (!cond) return false;
+ *   #define TU_VERIFY(cond,ret)              if (!cond) return ret;
  *
- *   #define TU_ASSERT(cond)                  if(cond) {TU_MESS_FAILED(); TU_BREAKPOINT(), return false;}
- *   #define TU_ASSERT(cond,ret)              if(cond) {TU_MESS_FAILED(); TU_BREAKPOINT(), return ret;}
+ *   #define TU_ASSERT(cond)                  if (!cond) {TU_MESS_FAILED(); TU_BREAKPOINT(), return false;}
+ *   #define TU_ASSERT(cond,ret)              if (!cond) {TU_MESS_FAILED(); TU_BREAKPOINT(), return ret;}
  *------------------------------------------------------------------*/
 
 #ifdef __cplusplus


### PR DESCRIPTION
**Describe the PR**
Fixes a logical error in the header file documentation of `TU_ASSERT` and `TU_VERIFY`.