### PR TITLE
examples/device/*_freertos: expand stack size when needed

### DIFF
--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -37,7 +37,7 @@
   #define USBD_STACK_SIZE    (3*configMINIMAL_STACK_SIZE/2) * (CFG_TUSB_DEBUG ? 2 : 1)
 #endif
 
-#define CDC_STACK_SIZE      configMINIMAL_STACK_SIZE
+#define CDC_STACK_SIZE      2*configMINIMAL_STACK_SIZE
 #define BLINKY_STACK_SIZE   configMINIMAL_STACK_SIZE
 
 //--------------------------------------------------------------------+

--- a/examples/device/hid_composite_freertos/src/main.c
+++ b/examples/device/hid_composite_freertos/src/main.c
@@ -53,7 +53,7 @@
   #define USBD_STACK_SIZE    (3*configMINIMAL_STACK_SIZE/2) * (CFG_TUSB_DEBUG ? 2 : 1)
 #endif
 
-#define HID_STACK_SZIE      configMINIMAL_STACK_SIZE
+#define HID_STACK_SZIE      2*configMINIMAL_STACK_SIZE
 
 //--------------------------------------------------------------------+
 // MACRO CONSTANT TYPEDEF PROTYPES

--- a/examples/device/midi_test_freertos/src/main.c
+++ b/examples/device/midi_test_freertos/src/main.c
@@ -48,7 +48,7 @@
 #endif
 
 #define BLINKY_STACK_SIZE   configMINIMAL_STACK_SIZE
-#define MIDI_STACK_SIZE     configMINIMAL_STACK_SIZE
+#define MIDI_STACK_SIZE     2*configMINIMAL_STACK_SIZE
 
 // static task
 #if configSUPPORT_STATIC_ALLOCATION

--- a/examples/host/cdc_msc_hid_freertos/src/main.c
+++ b/examples/host/cdc_msc_hid_freertos/src/main.c
@@ -34,7 +34,7 @@
   #define USBH_STACK_SIZE     4096
 #else
   // Increase stack size when debug log is enabled
-  #define USBH_STACK_SIZE    (3*configMINIMAL_STACK_SIZE/2) * (CFG_TUSB_DEBUG ? 2 : 1)
+  #define USBH_STACK_SIZE    (4*configMINIMAL_STACK_SIZE/2) * (CFG_TUSB_DEBUG ? 2 : 1)
 #endif
 
 


### PR DESCRIPTION
All four of these examples immediately crashed on stack overflow when connected, at least on a FRDM_K64F board.

In 46fd82299040f the default freertos stack size was increased, but _only_ for stm32?  Perhaps either all platform examples need the default increased, rather than increasing the problem task stacks as is done here.
