### PR TITLE
Fix HID stylus descriptor and hid_composite example

### DIFF
--- a/examples/device/hid_composite/src/main.c
+++ b/examples/device/hid_composite/src/main.c
@@ -195,41 +195,30 @@ static void send_hid_report(uint8_t report_id, uint32_t btn)
       }
     }
     break;
+
+    case REPORT_ID_STYLUS_PEN: {
+      static bool touch_state = false;
+      hid_stylus_report_t report = {
+        .attr = 0,
+        .x = 0,
+        .y = 0
+      };
+
+      if (btn) {
+        report.attr = STYLUS_ATTR_TIP_SWITCH | STYLUS_ATTR_IN_RANGE;
+        report.x = 100;
+        report.y = 100;
+        tud_hid_report(REPORT_ID_STYLUS_PEN, &report, sizeof(report));
+        touch_state = true;
+      } else {
+        report.attr = 0;
+        if (touch_state) tud_hid_report(REPORT_ID_STYLUS_PEN, &report, sizeof(report));
+        touch_state = false;
+      }
+    }
+    break;
     default: break;
   }
-}
-
-/* use this to send stylus touch signal through USB. */
-static void send_stylus_touch(uint16_t x, uint16_t y, bool state)
-{
-  // skip if hid is not ready yet
-  if ( !tud_hid_ready() ) return;
-
-  static bool has_stylus_pen = false;
-
-  hid_stylus_report_t report =
-  {
-    .attr = 0,
-    .x = 0,
-    .y = 0
-  };
-
-  report.x = x;
-  report.y = y;
-
-  if (state)
-  {
-    report.attr = STYLUS_ATTR_TIP_SWITCH | STYLUS_ATTR_IN_RANGE;
-    tud_hid_report(REPORT_ID_STYLUS_PEN, &report, sizeof(report));
-
-    has_stylus_pen = true;
-  }else
-  {
-    report.attr = 0;
-    if (has_stylus_pen) tud_hid_report(REPORT_ID_STYLUS_PEN, &report, sizeof(report));
-    has_stylus_pen = false;
-  }
-
 }
 
 // Every 10ms, we will sent 1 report for each HID profile (keyboard, mouse etc ..)
@@ -239,14 +228,6 @@ void hid_task(void)
   // Poll every 10ms
   const uint32_t interval_ms = 10;
   static uint32_t start_ms = 0;
-  static uint32_t touch_ms = 0;
-  static bool touch_state = false;
-
-  if (board_millis() - touch_ms < 100) {
-    touch_ms = board_millis();
-    send_stylus_touch(0, 0, touch_state = !touch_state);
-    return;
-  }
 
   if ( board_millis() - start_ms < interval_ms) return; // not enough time
   start_ms += interval_ms;

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -267,14 +267,14 @@ void tud_hid_report_failed_cb(uint8_t instance, hid_report_type_t report_type, u
 // Stylus Pen Report Descriptor Template
 #define TUD_HID_REPORT_DESC_STYLUS_PEN(...) \
   HID_USAGE_PAGE ( HID_USAGE_PAGE_DIGITIZER )                     , \
-  HID_USAGE      ( HID_USAGE_DIGITIZER_TOUCH_SCREEN )             , \
+  HID_USAGE      ( HID_USAGE_DIGITIZER_PEN )                      , \
   HID_COLLECTION ( HID_COLLECTION_APPLICATION  )                  , \
     /* Report ID if any */\
     __VA_ARGS__ \
-    HID_USAGE    ( HID_USAGE_DIGITIZER_STYLUS )                   , \
-    HID_COLLECTION ( HID_COLLECTION_PHYSICAL   )                  , \
-      HID_USAGE_PAGE  ( HID_USAGE_DIGITIZER_TIP_SWITCH )          , \
-      HID_USAGE_PAGE  ( HID_USAGE_DIGITIZER_IN_RANGE )            , \
+    HID_USAGE    ( HID_USAGE_DIGITIZER_STYLUS                    ), \
+    HID_COLLECTION ( HID_COLLECTION_PHYSICAL                     ), \
+        HID_USAGE  ( HID_USAGE_DIGITIZER_TIP_SWITCH              ), \
+        HID_USAGE  ( HID_USAGE_DIGITIZER_IN_RANGE                ), \
         HID_LOGICAL_MIN ( 0                                      ), \
         HID_LOGICAL_MAX ( 1                                      ), \
         HID_REPORT_SIZE ( 1                                      ), \


### PR DESCRIPTION
**Describe the PR**

- `HID_USAGE_DIGITIZER_TIP_SWITCH` and `HID_USAGE_DIGITIZER_IN_RANGE` are usage but not page, resulting `Driver Error Code: code 10 "A non constant main item was declaired without a corresponding usage"`  on Windows (MSFT made `declaired` typo)

- `send_stylus_touch` in `hid_task` without waiting for button event is really bad, on Windows it locks the cursor to top left once the USB port is connected.
