### PR TITLE
fix incorrect MTP xact_len calculation

### DIFF
--- a/src/class/mtp/mtp_device.c
+++ b/src/class/mtp/mtp_device.c
@@ -215,7 +215,7 @@ static bool mtpd_data_xfer(mtp_container_info_t* p_container, uint8_t ep_addr) {
     TU_ASSERT(p_mtp->phase == MTP_PHASE_DATA);
   }
 
-  const uint16_t xact_len = tu_min16((uint16_t) (p_mtp->total_len - p_mtp->xferred_len), CFG_TUD_MTP_EP_BUFSIZE);
+  const uint16_t xact_len = (uint16_t) tu_min32(p_mtp->total_len - p_mtp->xferred_len, CFG_TUD_MTP_EP_BUFSIZE);
   if (xact_len) {
     // already transferred all bytes in header's length. Application make an unnecessary extra call
     TU_VERIFY(usbd_edpt_claim(p_mtp->rhport, ep_addr));


### PR DESCRIPTION
**Describe the PR**

Fixes the calculation of remaining bytes to transfer in MTP device class.

The original code casts the result of subtraction into `uint16_t` before taking the minimum, which will break all transfers with more than 65535 bytes. Only `(filesize & 0xFFFF)` bytes can be transferred before the transfer comes to a halt. This PR has deferred the cast to `uint16_t` after calculating the transfer size in `uint32_t` domain.

This bug is discovered when I'm testing MTP Device with an LittleFS on SPI flash as the backing store, with about 11MiB of free space I copied a lot more data than what was available in the examples and it immediately revealed this issue. After applying this change, the issue was resolved and I can copy megabytes of files into the responder device.

<img width="735" height="608" alt="图片" src="https://github.com/user-attachments/assets/4e05b018-3f12-4cfe-94bf-dbf44b27c72c" />

And file hashes are compared. The file was copied to the responder device on macOS and is copied out from responder device on Windows.

<img width="1866" height="557" alt="mtp-hash-compare" src="https://github.com/user-attachments/assets/bd0fd0c2-d5bc-4e88-a0c5-08ba988e042d" />

**Additional context**

The test project can be found at https://github.com/RigoLigoRLC/esp32s3-tusb-mtp . It uses my own fork of espressif/tinyusb with MTP implementation applied on top of v0.18 branch.
