### PR TITLE
at32_fsdev: Fix dcd_int_enable when remapping the USB interrupt

### DIFF
--- a/src/portable/st/stm32_fsdev/fsdev_at32.h
+++ b/src/portable/st/stm32_fsdev/fsdev_at32.h
@@ -175,9 +175,9 @@ void dcd_int_enable(uint8_t rhport) {
   // shared USB/CAN IRQs to separate CAN and USB IRQs.
   // This dynamically checks if this remap is active to enable the right IRQs.
   if (CRM->intmap_bit.usbintmap) {
-    NVIC_DisableIRQ(USBFS_MAPH_IRQn);
-    NVIC_DisableIRQ(USBFS_MAPL_IRQn);
-    NVIC_DisableIRQ(USBFSWakeUp_IRQn);
+    NVIC_EnableIRQ(USBFS_MAPH_IRQn);
+    NVIC_EnableIRQ(USBFS_MAPL_IRQn);
+    NVIC_EnableIRQ(USBFSWakeUp_IRQn);
   } else
   #endif
   {


### PR DESCRIPTION
This patch fixes an issue where USB interrupts were mistakenly disabled instead of enabled when the USB interrupt remap (`usbintmap`) was active.
Previously, the code called `NVIC_DisableIRQ()` for `USBFS_MAPH_IRQn`, `USBFS_MAPL_IRQn`, and `USBFSWakeUp_IRQn`, which prevented USB interrupts from working correctly after remapping.

The fix replaces those calls with `NVIC_EnableIRQ()` to properly enable the corresponding USB interrupts.
