### PR TITLE
dcd/dwc2: fix suspend interrupt indefinitely disabled on AT32F405

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -1054,6 +1054,8 @@ void dcd_int_handler(uint8_t rhport) {
   if (gintsts & GINTSTS_ENUMDNE) {
     // ENUMDNE is the end of reset where speed of the link is detected
     dwc2->gintsts = GINTSTS_ENUMDNE;
+    // There may be a pending suspend event, so we clear it first
+    dwc2->gintsts = GINTSTS_USBSUSP;
     dwc2->gintmsk |= GINTMSK_USBSUSPM;
     handle_enum_done(rhport);
   }

--- a/src/portable/synopsys/dwc2/dwc2_at32.h
+++ b/src/portable/synopsys/dwc2/dwc2_at32.h
@@ -64,58 +64,59 @@
 #endif
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
- static const dwc2_controller_t _dwc2_controller[] = {
-{.reg_base = DWC2_OTG1_REG_BASE, .irqnum = OTG1_IRQn, .ep_count = DWC2_EP_MAX, .ep_fifo_size = OTG1_FIFO_SIZE},
+static const dwc2_controller_t _dwc2_controller[] = {
+    {.reg_base = DWC2_OTG1_REG_BASE, .irqnum = OTG1_IRQn, .ep_count = DWC2_EP_MAX, .ep_fifo_size = OTG1_FIFO_SIZE},
 #if defined DWC2_OTG2_REG_BASE
-  {.reg_base = DWC2_OTG2_REG_BASE, .irqnum = OTG2_IRQn, .ep_count = DWC2_EP_MAX, .ep_fifo_size = OTG2_FIFO_SIZE}
+    {.reg_base = DWC2_OTG2_REG_BASE, .irqnum = OTG2_IRQn, .ep_count = DWC2_EP_MAX, .ep_fifo_size = OTG2_FIFO_SIZE}
 #endif
- };
+};
 
- TU_ATTR_ALWAYS_INLINE static inline void dwc2_int_set(uint8_t rhport, tusb_role_t role, bool enabled) {
-   (void) role;
-   const IRQn_Type irqn = (IRQn_Type) _dwc2_controller[rhport].irqnum;
-   if (enabled) {
-     NVIC_EnableIRQ(irqn);
-   } else {
-     NVIC_DisableIRQ(irqn);
-   }
- }
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_int_set(uint8_t rhport, tusb_role_t role, bool enabled) {
+  (void) role;
+  const IRQn_Type irqn = (IRQn_Type) _dwc2_controller[rhport].irqnum;
+  if (enabled) {
+    NVIC_EnableIRQ(irqn);
+  } else {
+    NVIC_DisableIRQ(irqn);
+  }
+}
 
- TU_ATTR_ALWAYS_INLINE static inline void dwc2_dcd_int_enable(uint8_t rhport) { NVIC_EnableIRQ(_dwc2_controller[rhport].irqnum);
- }
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_dcd_int_enable(uint8_t rhport) {
+  NVIC_EnableIRQ(_dwc2_controller[rhport].irqnum);
+}
 
- TU_ATTR_ALWAYS_INLINE static inline void dwc2_dcd_int_disable(uint8_t rhport) {
-   NVIC_DisableIRQ(_dwc2_controller[rhport].irqnum);
- }
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_dcd_int_disable(uint8_t rhport) {
+  NVIC_DisableIRQ(_dwc2_controller[rhport].irqnum);
+}
 
- TU_ATTR_ALWAYS_INLINE static inline void dwc2_remote_wakeup_delay(void) {
-   // try to delay for 1 ms
-   uint32_t count = system_core_clock / 1000;
-   while (count--) __asm volatile("nop");
- }
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_remote_wakeup_delay(void) {
+  // try to delay for 1 ms
+  uint32_t count = system_core_clock / 1000;
+  while (count--) __asm volatile("nop");
+}
 
- // MCU specific PHY init, called BEFORE core reset
- TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_init(dwc2_regs_t *dwc2, uint8_t hs_phy_type) {
-   (void) dwc2;
-   // Enable on-chip HS PHY
-   if (hs_phy_type == GHWCFG2_HSPHY_UTMI || hs_phy_type == GHWCFG2_HSPHY_UTMI_ULPI) {
-   } else if (hs_phy_type == GHWCFG2_HSPHY_NOT_SUPPORTED) {
-   }
- }
+// MCU specific PHY init, called BEFORE core reset
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_init(dwc2_regs_t *dwc2, uint8_t hs_phy_type) {
+  (void) dwc2;
+  // Enable on-chip HS PHY
+  if (hs_phy_type == GHWCFG2_HSPHY_UTMI || hs_phy_type == GHWCFG2_HSPHY_UTMI_ULPI) {
+  } else if (hs_phy_type == GHWCFG2_HSPHY_NOT_SUPPORTED) {
+  }
+}
 
- // MCU specific PHY update, it is called AFTER init() and core reset
- TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_update(dwc2_regs_t *dwc2, uint8_t hs_phy_type) {
-   (void) dwc2;
-   (void) hs_phy_type;
+// MCU specific PHY update, it is called AFTER init() and core reset
+TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_update(dwc2_regs_t *dwc2, uint8_t hs_phy_type) {
+  (void) dwc2;
+  (void) hs_phy_type;
 
-   dwc2->stm32_gccfg |= STM32_GCCFG_PWRDWN | STM32_GCCFG_DCDEN | STM32_GCCFG_PDEN;
- }
+  dwc2->stm32_gccfg |= STM32_GCCFG_PWRDWN | STM32_GCCFG_DCDEN | STM32_GCCFG_PDEN;
+}
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* DWC2_GD32_H_ */
+#endif /* DWC2_AT32_H_ */


### PR DESCRIPTION
**Describe the PR**
Fix #3315 by only process SUSPEND event if the device is connected. Tested locally to confirm that `_usb_dev` state is as intended when the bus is suspended and resume. We probably don't need to repeat this change for RESUME event since enabling suspend interrupt during initialization should have no side effect.

Closes #3315
