### PR TITLE
Declare interrupt handler functions for ESP32 DWC2

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_esp32.h
+++ b/src/portable/synopsys/dwc2/dwc2_esp32.h
@@ -87,11 +87,13 @@ static void dwc2_int_handler_wrap(void* arg) {
   const tusb_role_t role = (tusb_role_t) tu_u16_high((uint16_t)(uintptr_t)arg);
 #if CFG_TUD_ENABLED
   if (role == TUSB_ROLE_DEVICE) {
+    void dcd_int_handler(uint8_t rhport);
     dcd_int_handler(rhport);
   }
 #endif
 #if CFG_TUH_ENABLED && !CFG_TUH_MAX3421
   if (role == TUSB_ROLE_HOST) {
+    void hcd_int_handler(uint8_t rhport, bool in_isr);
     hcd_int_handler(rhport, true);
   }
 #endif


### PR DESCRIPTION
When both host and device are enabled at the same time, this function is compiled twice, once for host and once for device, but the device `dcd_int_handler` is not declared when compiling host and the opposite for when compiling device. This PR only adds the declarations so that the function can compile in both cases.

Device `dcd_dwc2.c`
```
tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c
In file included from tinyusb/src/portable/synopsys/dwc2/dwc2_common.h:43,
                 from tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c:43:
tinyusb/src/portable/synopsys/dwc2/dwc2_esp32.h: In function 'dwc2_int_handler_wrap':
tinyusb/src/portable/synopsys/dwc2/dwc2_esp32.h:95:5: error: implicit declaration of function 'hcd_int_handler'; did you mean 'dcd_int_handler'? [-Wimplicit-function-declaration]
   95 |     hcd_int_handler(rhport, true);
      |     ^~~~~~~~~~~~~~~
      |     dcd_int_handler
```

Host `hcd_dwc2.c`
```
tinyusb/src/portable/synopsys/dwc2/hcd_dwc2.c
In file included from tinyusb/src/portable/synopsys/dwc2/dwc2_common.h:43,
                 from tinyusb/src/portable/synopsys/dwc2/hcd_dwc2.c:40:
tinyusb/src/portable/synopsys/dwc2/dwc2_esp32.h: In function 'dwc2_int_handler_wrap':
tinyusb/src/portable/synopsys/dwc2/dwc2_esp32.h:90:5: error: implicit declaration of function 'dcd_int_handler'; did you mean 'hcd_int_handler'? [-Wimplicit-function-declaration]
   90 |     dcd_int_handler(rhport);
      |     ^~~~~~~~~~~~~~~
      |     hcd_int_handler
```
