### PR TITLE
Use EP0 buffer directly if it's large enough 

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -430,7 +430,7 @@ static inline uint8_t* get_ctrl_buffer(void) {
   #if CFG_TUD_AUDIO_CTRL_BUF_SZ > CFG_TUD_ENDPOINT0_BUFSIZE
   return ctrl_buf;
   #else
-  return _usbd_ctrl_epbuf.buf;
+  return usbd_get_ctrl_buf();
   #endif
 }
 

--- a/src/class/dfu/dfu_device.c
+++ b/src/class/dfu/dfu_device.c
@@ -75,7 +75,7 @@ static inline uint8_t* get_xfer_buffer(void) {
   #if CFG_TUD_DFU_XFER_BUFSIZE > CFG_TUD_ENDPOINT0_BUFSIZE
   return _transfer_buf;
   #else
-  return _usbd_ctrl_epbuf.buf;
+  return usbd_get_ctrl_buf();
   #endif
 }
 

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -59,7 +59,13 @@ typedef struct {
 
 static usbd_control_xfer_t _ctrl_xfer;
 
-CFG_TUD_MEM_SECTION usbd_ctrl_epbuf_t _usbd_ctrl_epbuf;
+CFG_TUD_MEM_SECTION static struct {
+  TUD_EPBUF_DEF(buf, CFG_TUD_ENDPOINT0_BUFSIZE);
+} _ctrl_epbuf;
+
+uint8_t* usbd_get_ctrl_buf(void) {
+  return _ctrl_epbuf.buf;
+}
 
 //--------------------------------------------------------------------+
 // Application API
@@ -91,12 +97,12 @@ static bool data_stage_xact(uint8_t rhport) {
 
   if (_ctrl_xfer.request.bmRequestType_bit.direction == TUSB_DIR_IN) {
     ep_addr = EDPT_CTRL_IN;
-    if (0u != xact_len && _ctrl_xfer.buffer != _usbd_ctrl_epbuf.buf) {
-      TU_VERIFY(0 == tu_memcpy_s(_usbd_ctrl_epbuf.buf, CFG_TUD_ENDPOINT0_BUFSIZE, _ctrl_xfer.buffer, xact_len));
+    if (0u != xact_len && _ctrl_xfer.buffer != _ctrl_epbuf.buf) {
+      TU_VERIFY(0 == tu_memcpy_s(_ctrl_epbuf.buf, CFG_TUD_ENDPOINT0_BUFSIZE, _ctrl_xfer.buffer, xact_len));
     }
   }
 
-  return usbd_edpt_xfer(rhport, ep_addr, xact_len ? _usbd_ctrl_epbuf.buf : NULL, xact_len, false);
+  return usbd_edpt_xfer(rhport, ep_addr, xact_len ? _ctrl_epbuf.buf : NULL, xact_len, false);
 }
 
 // Transmit data to/from the control endpoint.
@@ -167,8 +173,8 @@ bool usbd_control_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result,
 
   if (_ctrl_xfer.request.bmRequestType_bit.direction == TUSB_DIR_OUT) {
     TU_VERIFY(_ctrl_xfer.buffer);
-    if (_ctrl_xfer.buffer != _usbd_ctrl_epbuf.buf) {
-      memcpy(_ctrl_xfer.buffer, _usbd_ctrl_epbuf.buf, xferred_bytes);
+    if (_ctrl_xfer.buffer != _ctrl_epbuf.buf) {
+      memcpy(_ctrl_xfer.buffer, _ctrl_epbuf.buf, xferred_bytes);
     }
     TU_LOG_MEM(CFG_TUD_LOG_LEVEL, _ctrl_xfer.buffer, xferred_bytes, 2);
   }

--- a/src/device/usbd_pvt.h
+++ b/src/device/usbd_pvt.h
@@ -72,11 +72,7 @@ void usbd_int_set(bool enabled);
 void usbd_spin_lock(bool in_isr);
 void usbd_spin_unlock(bool in_isr);
 
-typedef struct {
-  TUD_EPBUF_DEF(buf, CFG_TUD_ENDPOINT0_BUFSIZE);
-} usbd_ctrl_epbuf_t;
-
-extern usbd_ctrl_epbuf_t _usbd_ctrl_epbuf;
+uint8_t* usbd_get_ctrl_buf(void);
 
 //--------------------------------------------------------------------+
 // USBD Endpoint API


### PR DESCRIPTION
This pull request improves how control transfer buffers are managed for both the Audio and DFU device classes. The main enhancement is to allow the use of the endpoint 0 buffer for control transfers when it is large enough, falling back to a dedicated buffer only when necessary.
