### PR TITLE
Fix in multiple example codes, wrong descriptor device qualifier length.

### DIFF
--- a/examples/device/audio_test_multi_rate/src/usb_descriptors.c
+++ b/examples/device/audio_test_multi_rate/src/usb_descriptors.c
@@ -120,7 +120,7 @@ TU_VERIFY_STATIC(sizeof(desc2_uac2_configuration) == CONFIG_UAC2_TOTAL_LEN, "Inc
 // device qualifier is mostly similar to device descriptor since we don't change configuration based on speed
 tusb_desc_device_qualifier_t const desc_device_qualifier = {
   .bLength            = sizeof(tusb_desc_device_qualifier_t),
-  .bDescriptorType    = TUSB_DESC_DEVICE,
+  .bDescriptorType    = TUSB_DESC_DEVICE_QUALIFIER,
   .bcdUSB             = 0x0200,
 
   .bDeviceClass       = TUSB_CLASS_MISC,

--- a/examples/device/cdc_dual_ports/src/usb_descriptors.c
+++ b/examples/device/cdc_dual_ports/src/usb_descriptors.c
@@ -154,7 +154,7 @@ static uint8_t const desc_hs_configuration[] = {
 // device qualifier is mostly similar to device descriptor since we don't change configuration based on speed
 static tusb_desc_device_qualifier_t const desc_device_qualifier = {
   .bLength            = sizeof(tusb_desc_device_qualifier_t),
-  .bDescriptorType    = TUSB_DESC_DEVICE,
+  .bDescriptorType    = TUSB_DESC_DEVICE_QUALIFIER,
   .bcdUSB             = USB_BCD,
 
   .bDeviceClass       = TUSB_CLASS_MISC,

--- a/examples/device/uac2_speaker_fb/src/usb_descriptors.c
+++ b/examples/device/uac2_speaker_fb/src/usb_descriptors.c
@@ -175,7 +175,7 @@ TU_VERIFY_STATIC(sizeof(desc_uac2_configuration) == CONFIG_UAC2_TOTAL_LEN, "Inco
 // device qualifier is mostly similar to device descriptor since we don't change configuration based on speed
 tusb_desc_device_qualifier_t const desc_device_qualifier = {
   .bLength            = sizeof(tusb_desc_device_qualifier_t),
-  .bDescriptorType    = TUSB_DESC_DEVICE,
+  .bDescriptorType    = TUSB_DESC_DEVICE_QUALIFIER,
   .bcdUSB             = 0x0200,
 
   .bDeviceClass       = TUSB_CLASS_MISC,

--- a/examples/device/video_capture/src/usb_descriptors.c
+++ b/examples/device/video_capture/src/usb_descriptors.c
@@ -386,7 +386,7 @@ static uint8_t * get_hs_configuration_desc(void) {
 // device qualifier is mostly similar to device descriptor since we don't change configuration based on speed
 static tusb_desc_device_qualifier_t const desc_device_qualifier = {
     .bLength            = sizeof(tusb_desc_device_qualifier_t),
-    .bDescriptorType    = TUSB_DESC_DEVICE,
+    .bDescriptorType    = TUSB_DESC_DEVICE_QUALIFIER,
     .bcdUSB             = USB_BCD,
 
     .bDeviceClass       = TUSB_CLASS_MISC,

--- a/examples/device/video_capture_2ch/src/usb_descriptors.c
+++ b/examples/device/video_capture_2ch/src/usb_descriptors.c
@@ -553,7 +553,7 @@ static uint8_t * get_hs_configuration_desc(void) {
 // device qualifier is mostly similar to device descriptor since we don't change configuration based on speed
 static tusb_desc_device_qualifier_t const desc_device_qualifier = {
     .bLength            = sizeof(tusb_desc_device_qualifier_t),
-    .bDescriptorType    = TUSB_DESC_DEVICE,
+    .bDescriptorType    = TUSB_DESC_DEVICE_QUALIFIER,
     .bcdUSB             = USB_BCD,
 
     .bDeviceClass       = TUSB_CLASS_MISC,


### PR DESCRIPTION
I'm not quite sure if it's actually wrong. I found that in five example codes the size of `tusb_desc_device_t` is taken for the `tusb_desc_device_qualifier_t` length field. In multiple other example codes the size of the actual struct `tusb_desc_device_qualifier_t` is taken instead.
But as I said, I'm not sure if it has some other background. 
