### PR TITLE
change(usbd): Changed return value to true for weak dcd_deinit() (quick fix)

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -86,7 +86,7 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
 
 TU_ATTR_WEAK bool dcd_deinit(uint8_t rhport) {
   (void) rhport;
-  return false;
+  return true;
 }
 
 TU_ATTR_WEAK void dcd_connect(uint8_t rhport) {


### PR DESCRIPTION
## Description

During the recent update (https://github.com/hathach/tinyusb/pull/3326)

`dcd_deinit(rhport);` -> `TU_VERIFY(dcd_deinit(rhport));`

the assertion fails for the ports, where `dcd_deinit()` isn't implemented yet. 

## Changes

This PR introduces a quick fix by changing the default return value from `false` to `true` in the WEAK function, allowing the assert to pass.


The same way, as we have it for: 
```
TU_ATTR_WEAK bool dcd_dcache_clean(const void* addr, uint32_t data_size) {
  (void) addr; (void) data_size;
  return true;
}

TU_ATTR_WEAK bool dcd_dcache_invalidate(const void* addr, uint32_t data_size) {
  (void) addr; (void) data_size;
  return true;
}

TU_ATTR_WEAK bool dcd_dcache_clean_invalidate(const void* addr, uint32_t data_size) {
  (void) addr; (void) data_size;
  return true;
}
```

### Context 

The real implementation may vary,  but for dcd_dwc2 (for example), this might still be not implemented, as we re-configure the controller fully during the following `dcd_init()`. 
