### PR TITLE
Use role TUSB_ROLE_HOST in host stack initialization

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -40,7 +40,7 @@ Minimal Example
 
      // init host stack on roothub port 1 for fullspeed host
      tusb_rhport_init_t host_init = {
-       .role  = TUSB_ROLE_DEVICE,
+       .role  = TUSB_ROLE_HOST,
        .speed = TUSB_SPEED_FULL
      };
      tusb_init(1, &host_init);


### PR DESCRIPTION
It seems that the host instance should be initialized with role TUSB_ROLE_HOST.

I have not, however, tested this and might be wrong about that. Feel free to just close this PR if this is incorrect.