### PR TITLE
limit fifo read size to ep_bufsize regardless ep_buf is used or not

### DIFF
--- a/src/tusb.c
+++ b/src/tusb.c
@@ -485,9 +485,7 @@ uint32_t tu_edpt_stream_read_xfer(tu_edpt_stream_t *s) {
     if (available >= s->mps) {
       // multiple of packet size limit by ep bufsize
       uint16_t count = (uint16_t) (available & ~(s->mps - 1));
-      if (s->ep_buf != NULL) {
-        count = tu_min16(count, s->ep_bufsize);
-      }
+      count = tu_min16(count, s->ep_bufsize);
       TU_ASSERT(stream_xfer(s, count), 0);
       return count;
     } else {


### PR DESCRIPTION
**Describe the PR**
I've added `if (s->ep_buf != NULL) {` during the fixup but it will break receiving behavior when the host can't send ZLP. With this `if` added setting`CFG_TUD_CDC_EP_BUFSIZE` will no longer have effect on devices using HWFIFO.

Related to #2287 