### PR TITLE
[Do Not Merge] Introduce DWC2_I_WANT_FS_ON_HS_BOARD hack

### DIFF
--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -425,7 +425,7 @@ bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
 #endif
   while ((dwc2->gintsts & GINTSTS_CMOD) != GINTSTS_CMODE_HOST) {}
 
-#if DWC2_I_WANT_FS_ON_HS_BOARD
+#ifdef DWC2_I_WANT_FS_ON_HS_BOARD
   // disable high speed mode
   dwc2->hcfg |= HCFG_FSLS_ONLY;
 #else
@@ -1382,9 +1382,9 @@ static void port0_enable(dwc2_regs_t* dwc2, tusb_speed_t speed) {
     hcfg |= HCFG_FSLS_PHYCLK_SEL_30_60MHZ;
   }
 
-#if DWC2_I_WANT_FS_ON_HS_BOARD
+#ifdef DWC2_I_WANT_FS_ON_HS_BOARD
   // disable high speed mode
-  dwc2->hcfg |= HCFG_FSLS_ONLY;
+  hcfg |= HCFG_FSLS_ONLY;
 #endif
 
   dwc2->hcfg = hcfg;


### PR DESCRIPTION
**Describe the PR**
This is a proof-of-concept patch to support Full-Speed USB on DWC2 on a board with High-Speed ULPI

**Additional context**
I've a stm32h747 board with a high-speed external PHY.
But for testing/reliability purposes I want to limit the speed to Full-Speed.

I tried with:

`#define BOARD_TUH_MAX_SPEED  OPT_MODE_HIGH_SPEED`
`#define CFG_TUH_MAX_SPEED    OPT_MODE_FULL_SPEED`

In my `tusb_config.h`, but with bad results (hang in trying to setup the low-speed phy)

This patch is just a proof-of-concept that it is not too difficult to make that work, In the hope that someone can clean that up :)

