### PR TITLE
Fix compiler error with c++ files and -Werror=extra

### DIFF
--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -554,7 +554,7 @@ TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_edpt_number(uint8_t addr) {
 }
 
 TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_edpt_addr(uint8_t num, uint8_t dir) {
-  return (uint8_t) (num | (dir == TUSB_DIR_IN ? TUSB_DIR_IN_MASK : 0u));
+  return (uint8_t) (num | (dir == (uint8_t)TUSB_DIR_IN ? (uint8_t)TUSB_DIR_IN_MASK : 0u));
 }
 
 TU_ATTR_ALWAYS_INLINE static inline uint16_t tu_edpt_packet_size(tusb_desc_endpoint_t const* desc_ep) {


### PR DESCRIPTION
**Describe the PR**
When compiling a c++ file that includes `tusb.h`, I get the following error:

`enumerated and non-enumerated type in conditional expression [-Werror=extra]`

Casting the enum values used for the comparison in `tu_edpt_addr` to `uint8_t` fixes the issue.

**Additional context**
We have `-Werror=extra` enabled on our project.
