### PR TITLE
Fix USB FSDEV enumeration on CH32V20x by enabling D+ Pull-up

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -833,7 +833,7 @@ void dcd_int_disable(uint8_t rhport) {
   fsdev_int_disable(rhport);
 }
 
-  #if defined(USB_BCDR_DPPU) || defined(SYSCFG_PMC_USB_PU)
+  #if defined(USB_BCDR_DPPU) || defined(SYSCFG_PMC_USB_PU) || defined(EXTEN_USBD_PU_EN)
 void dcd_connect(uint8_t rhport) {
   fsdev_connect(rhport);
 }


### PR DESCRIPTION
**Describe the PR**
Enable FSDEV D+ pull-up control on CH32V20x by including `EXTEN_USBD_PU_EN` in the dcd_connect/disconnect build guard.

**Additional context**
The FSDEV DCD only defines `dcd_connect()` when `USB_BCDR_DPPU` or `SYSCFG_PMC_USB_PU` are present.  
On CH32V20x those macros are absent, so `dcd_connect()` is empty and the USB pull-up never turns on, leaving the device will never enumerated by PC.
In this patch, add `defined(EXTEN_USBD_PU_EN)` so the CH32V20x functions in `fsdev_ch32.h` will be used.  
`EXTEN_USBD_PU_EN` is CH32V20x-specific and corresponds to the internal D+ pull-up enable.