### PR TITLE
ci: membrowse fix targets file

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -330,9 +330,9 @@
     },
     {
       "port": "samd5x_e5x",
-      "board": "d5035_01",
+      "board": "metro_m4_express",
       "toolchain": "arm-none-eabi-gcc-14",
-      "ld": "hw/bsp/samd5x_e5x/boards/d5035_01/same51j19a_flash.ld",
+      "ld": "hw/bsp/samd5x_e5x/boards/metro_m4_express/metro_m4_express.ld",
       "example": "cdc_msc"
     },
     {
@@ -414,9 +414,9 @@
     },
     {
       "port": "stm32h7",
-      "board": "daisyseed",
+      "board": "stm32h743eval",
       "toolchain": "arm-none-eabi-gcc-14",
-      "ld": "hw/bsp/stm32h7/boards/daisyseed/stm32h750ibkx_ram.ld",
+      "ld": "hw/bsp/stm32h7/linker/stm32h743xx_flash.ld",
       "example": "cdc_msc"
     },
     {


### PR DESCRIPTION
MemBrowse targets file was misconfigured for 2 targets. It configured targets that are not actually built in the CI.
That caused failing generating and uploading the reports for those targets.
This PR changes the targets to the ones that are actually being built:

- stm32h7: daisyseed -> stm32h743eval
- samd5x_e5x: d5035_01 -> metro_m4_express
