### PR TITLE
Skip Zephyr and Membrowse comment temporarily

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,0 @@
-**Describe the PR**
-A clear and concise description of what this PR solve.
-
-**Additional context**
-If applicable, add any other context about the PR and/or screenshots here.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,33 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'lib/**'
+      - 'hw/**'
+      - 'tools/build.py'
+      - 'tools/get_deps.py'
+      - '.github/actions/**'
+      - '.github/workflows/build.yml'
+      - '.github/workflows/build_util.yml'
+      - '.github/workflows/ci_set_matrix.py'
   pull_request:
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'lib/**'
+      - 'hw/**'
+      - 'test/hil/**'
+      - 'tools/build.py'
+      - 'tools/get_deps.py'
+      - '.github/actions/**'
+      - '.github/workflows/build.yml'
+      - '.github/workflows/build_util.yml'
+      - '.github/workflows/ci_set_matrix.py'
   release:
     types: [ published ]
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,44 +39,7 @@ env:
   HIL_JSON: test/hil/tinyusb.json
 
 jobs:
-  # Check if code paths changed (skip builds if doc-only)
-  check-paths:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      code_changed: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2  # Needed for push commit comparison
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            code:
-              - 'src/**'
-              - 'examples/**'
-              - 'lib/**'
-              - 'hw/**'
-              - 'test/hil/**'
-              - 'tools/build.py'
-              - 'tools/get_deps.py'
-              - '.github/actions/**'
-              - '.github/workflows/build.yml'
-              - '.github/workflows/build_util.yml'
-              - '.github/workflows/ci_set_matrix.py'
-
   set-matrix:
-    needs: [check-paths]
-    if: |
-      always() && (
-        github.event_name == 'release' ||
-        github.event_name == 'workflow_dispatch' ||
-        needs.check-paths.outputs.code_changed == 'true'
-      )
     runs-on: ubuntu-latest
     outputs:
       json: ${{ steps.set-matrix-json.outputs.matrix }}
@@ -197,8 +184,6 @@ jobs:
   # Build Make/CMake on Windows/MacOS
   # ---------------------------------------
   build-os:
-    needs: [check-paths]
-    if: needs.check-paths.outputs.code_changed == 'true'
     uses: ./.github/workflows/build_util.yml
     strategy:
       fail-fast: false
@@ -215,9 +200,8 @@ jobs:
   # Zephyr
   # ---------------------------------------
   zephyr:
-    needs: [check-paths]
     # skip zephyr build due to failed build, fix later
-    if: false && needs.check-paths.outputs.code_changed == 'true'
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout TinyUSB
@@ -239,10 +223,8 @@ jobs:
   # Run on PR only (hil-tinyusb), hil-hfp only run on non-forked PR
   # ---------------------------------------
   hil-build:
-    needs: [check-paths, set-matrix]
-    if: |
-      github.repository_owner == 'hathach' &&
-      (github.event_name == 'workflow_dispatch' || needs.check-paths.outputs.code_changed == 'true')
+    needs: set-matrix
+    if: github.repository_owner == 'hathach'
     uses: ./.github/workflows/build_util.yml
     strategy:
       fail-fast: false
@@ -261,10 +243,7 @@ jobs:
   # self-hosted on local VM, for attached hardware checkout HIL_JSON
   # ---------------------------------------
   hil-tinyusb:
-    needs: [check-paths, hil-build]
-    if: |
-      github.repository_owner == 'hathach' &&
-      (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || needs.check-paths.outputs.code_changed == 'true')
+    needs: hil-build
     runs-on: [ self-hosted, X64, hathach, hardware-in-the-loop ]
     steps:
       - name: Get Skip Boards from previous run
@@ -304,11 +283,9 @@ jobs:
   # Since IAR Token secret is not passed to forked PR, only build non-forked PR
   # ---------------------------------------
   hil-hfp:
-    needs: [check-paths]
     if: |
       github.repository_owner == 'hathach' &&
-      github.event.pull_request.head.repo.fork == false &&
-      (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || needs.check-paths.outputs.code_changed == 'true')
+      !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
     runs-on: [ self-hosted, Linux, X64, hifiphile ]
     env:
       IAR_LMS_BEARER_TOKEN: ${{ secrets.IAR_LMS_BEARER_TOKEN }}
@@ -348,30 +325,19 @@ jobs:
   # PR: only runs if code changed (doc-only PRs skip entirely)
   # ---------------------------------------
   membrowse:
-    needs: [check-paths, cmake]
-    if: |
-      always() && !cancelled() && (
-        github.event_name == 'push' ||
-        github.event_name == 'release' ||
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' && needs.check-paths.outputs.code_changed == 'true')
-      )
+    needs: cmake
     permissions:
       contents: read
       actions: read
     uses: ./.github/workflows/membrowse-report.yml
     with:
-      code_changed: ${{ needs.check-paths.outputs.code_changed == 'true' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+      code_changed: true
     secrets: inherit
 
   membrowse-comment:
-    needs: [check-paths, membrowse]
-    # skip membrowse comment since it is kind of distracting
-    if: >
-      false &&
-      always() &&
-      github.event_name == 'pull_request' &&
-      needs.check-paths.outputs.code_changed == 'true'
+    needs: membrowse
+    # skip membrowse comment since it is too verbal
+    if: false && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/hw/bsp/family_support.cmake
+++ b/hw/bsp/family_support.cmake
@@ -238,6 +238,7 @@ function(family_add_bloaty TARGET)
     COMMAND ${BLOATY_EXE} ${OPTION_LIST} $<TARGET_FILE:${TARGET}>
     VERBATIM)
 
+  set_property(TARGET ${TARGET}-bloaty PROPERTY FOLDER ${TARGET})
   # post build
   #  add_custom_command(TARGET ${TARGET} POST_BUILD
   #    COMMAND ${BLOATY_EXE} --csv ${OPTION_LIST} $<TARGET_FILE:${TARGET}> > ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_bloaty.csv
@@ -257,6 +258,8 @@ function(family_add_linkermap TARGET)
     COMMAND python ${LINKERMAP_PY} ${OPTION_LIST} $<TARGET_FILE:${TARGET}>.map
     VERBATIM
     )
+
+  set_property(TARGET ${TARGET}-linkermap PROPERTY FOLDER ${TARGET})
 
   # post build
   add_custom_command(TARGET ${TARGET} POST_BUILD
@@ -508,6 +511,8 @@ exit"
     COMMAND ${JLINKEXE} -device ${JLINK_DEVICE} ${OPTION_LIST} -if ${JLINK_IF} -JTAGConf -1,-1 -speed auto -CommandFile $<TARGET_FILE_DIR:${BINARY_TARGET}>/${BINARY_TARGET}.jlink
     VERBATIM
     )
+
+  set_property(TARGET ${NAME_TARGET}-jlink PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -521,6 +526,8 @@ function(family_flash_stlink TARGET)
     DEPENDS ${TARGET}
     COMMAND ${STM32_PROGRAMMER_CLI} --connect port=swd --write $<TARGET_FILE:${TARGET}> --go
     )
+
+  set_property(TARGET ${TARGET}-stlink PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -534,6 +541,8 @@ function(family_flash_stflash TARGET)
     DEPENDS ${TARGET}
     COMMAND ${ST_FLASH} write $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.bin 0x8000000
     )
+
+  set_property(TARGET ${TARGET}-stflash PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -560,6 +569,8 @@ function(family_flash_openocd TARGET)
     COMMAND ${OPENOCD} -c "tcl_port disabled; gdb_port disabled" ${OPTION_LIST} -c "init; halt; program $<TARGET_FILE:${TARGET}>" -c reset ${OPTION_LIST2} -c exit
     VERBATIM
     )
+
+  set_property(TARGET ${TARGET}-openocd PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -621,6 +632,8 @@ function(family_flash_wlink_rs TARGET)
     DEPENDS ${TARGET}
     COMMAND ${WLINK_RS} flash $<TARGET_FILE:${TARGET}>
     )
+
+  set_property(TARGET ${TARGET}-wlink-rs PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -634,6 +647,8 @@ function(family_flash_pyocd TARGET)
     DEPENDS ${TARGET}
     COMMAND ${PYOCD} flash -t ${PYOCD_TARGET} $<TARGET_FILE:${TARGET}>
     )
+
+  set_property(TARGET ${TARGET}-pyocd PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -643,6 +658,7 @@ function(family_flash_uf2 TARGET FAMILY_ID)
     DEPENDS ${TARGET}
     COMMAND python ${UF2CONV_PY} -f ${FAMILY_ID} --deploy $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.uf2
     )
+  set_property(TARGET ${TARGET}-uf2 PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -657,6 +673,8 @@ function(family_flash_teensy TARGET)
     COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${TARGET}> $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.hex
     COMMAND ${TEENSY_CLI} --mcu=${TEENSY_MCU} -w -s $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.hex
     )
+
+  set_property(TARGET ${TARGET}-teensy PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -675,6 +693,8 @@ function(family_flash_nxplink TARGET)
     DEPENDS ${TARGET}
     COMMAND ${LINKSERVER_PATH} flash ${NXPLINK_DEVICE} load $<TARGET_FILE:${TARGET}>
     )
+
+  set_property(TARGET ${TARGET}-nxplink PROPERTY FOLDER ${TARGET})
 endfunction()
 
 
@@ -688,6 +708,8 @@ function(family_flash_dfu_util TARGET OPTION)
     COMMAND ${DFU_UTIL} -R -d ${DFU_UTIL_VID_PID} -a 0 -D $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.bin
     VERBATIM
     )
+
+  set_property(TARGET ${TARGET}-dfu-util PROPERTY FOLDER ${TARGET})
 endfunction()
 
 function(family_flash_msp430flasher TARGET)
@@ -703,6 +725,8 @@ function(family_flash_msp430flasher TARGET)
     COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=${MSP430FLASHER_PARENT_DIR}
             ${MSP430FLASHER} -w $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.hex -z [VCC]
     )
+
+  set_property(TARGET ${TARGET}-msp430flasher PROPERTY FOLDER ${TARGET})
 endfunction()
 
 function(family_flash_uniflash TARGET)
@@ -717,6 +741,8 @@ function(family_flash_uniflash TARGET)
     COMMAND ${DSLITE} ${UNIFLASH_OPTION} -f $<TARGET_FILE_DIR:${TARGET}>/${TARGET}.hex
     VERBATIM
     )
+
+  set_property(TARGET ${TARGET}-uniflash PROPERTY FOLDER ${TARGET})
 endfunction()
 
 #----------------------------------


### PR DESCRIPTION
Summary
- Deleted .github/pull_request_template.md.
- Updated .github/workflows/build.yml:
  - Simplified workflows by removing check-paths job dependencies and code path validation.
  - Adjusted conditions for jobs like hil-build, hil-tinyusb, and hil-hfp.
  - Marked specific workflows (e.g., zephyr) to be skipped explicitly using if: false or similar.
 - Updated family_support.cmake:
  - Added FOLDER properties for various post-build and flashing targets, improving organization and project structure.