### PR TITLE
Introduce CFG_TUSB_DEBUG_BREAKPOINT hook

### DIFF
--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -73,9 +73,10 @@
   #define TU_MESS_FAILED() do {} while (0)
 #endif
 
- // Custom defined application function
+// Custom defined application function
 #ifdef CFG_TUSB_DEBUG_BREAKPOINT
-#define TU_BREAKPOINT() do { void CFG_TUSB_DEBUG_BREAKPOINT(void); CFG_TUSB_DEBUG_BREAKPOINT(); } while (0)
+  extern void CFG_TUSB_DEBUG_BREAKPOINT(void);
+  #define TU_BREAKPOINT() CFG_TUSB_DEBUG_BREAKPOINT()
 
 // Halt CPU (breakpoint) when hitting error, only apply for Cortex M3, M4, M7, M33. M55
 #elif defined(__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__) || defined(__ARM_ARCH_8_1M_MAIN__) || \


### PR DESCRIPTION
**Describe the PR**
Add a hook to define an external function that will be called when `TU_BREAKPOINT` is hit.

**Additional context**

Like `CFG_TUSB_DEBUG_PRINTF`, if `CFG_TUSB_DEBUG_BREAKPOINT` is defined, a function of that name will be called instead of the predefined platform-dependent code.

This external function could for example print "TU_BREAKPOINT", and/or allows the user to define a "real" breakpoint on that function when debugging.

The immediate need for me is that the default code for stm32h7:

`  #define TU_BREAKPOINT() do {                                                                              \
    volatile uint32_t* ARM_CM_DHCSR =  ((volatile uint32_t*) 0xE000EDF0UL); /* Cortex M CoreDebug->DHCSR */ \
    if (0u != ((*ARM_CM_DHCSR) & 1UL)) { __asm("BKPT #0\n"); } /* Only halt mcu if debugger is attached */   \
  } while(0)
` 

Is very smart, but unfortunately STM32CubeIDE with STlinkV3 hang on the above code when the breakpoint is hit in a debugging session (this is a ST bug, not a tinyusb bug)