### PR TITLE
Supports full-speed host with an high-speed PHY (DWC2)

### DIFF
--- a/src/portable/synopsys/dwc2/dwc2_common.c
+++ b/src/portable/synopsys/dwc2/dwc2_common.c
@@ -187,7 +187,7 @@ bool dwc2_core_is_highspeed(dwc2_regs_t* dwc2, tusb_role_t role) {
   }
 #endif
 #if CFG_TUH_ENABLED
-  if (role == TUSB_ROLE_HOST && !TUH_OPT_HIGH_SPEED) {
+  if (role == TUSB_ROLE_HOST && !TUH_OPT_PHY_SPEED) {
     return false;
   }
 #endif

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -448,12 +448,19 @@
   #define CFG_TUH_MAX_SPEED   (TUH_RHPORT_MODE & OPT_MODE_SPEED_MASK)
 #endif
 
+#ifndef CFG_TUH_PHY_SPEED
+  // fallback to use CFG_TUH_MAX_SPEED
+  #define CFG_TUH_PHY_SPEED   CFG_TUH_MAX_SPEED
+#endif
+
 // For backward compatible
 #define TUSB_OPT_HOST_ENABLED   CFG_TUH_ENABLED
 
 // highspeed support indicator
 #define TUH_OPT_HIGH_SPEED    (CFG_TUH_MAX_SPEED ? (CFG_TUH_MAX_SPEED & OPT_MODE_HIGH_SPEED) : TUP_RHPORT_HIGHSPEED)
 
+// hardware phy speed (might be different than TUH_OPT_HIGH_SPEED in special cases)
+#define TUH_OPT_PHY_SPEED     (CFG_TUH_PHY_SPEED ? (CFG_TUH_PHY_SPEED & OPT_MODE_HIGH_SPEED) : TUP_RHPORT_HIGHSPEED)
 
 //--------------------------------------------------------------------+
 // TODO move later


### PR DESCRIPTION
**Describe the PR**
This patch allows configuring a Full-Speed USB host with DWC2 on a board wired with a High-Speed ULPI PHY

**Additional context**
This implements #3450 proof-of-concept in a proper way (I hope).

It introduces an optional `CFG_TUH_PHY_SPEED` configuration option, which specify the PHY configuration and can be different (higher than) CFG_TUH_MAX_SPEED

For example, this works on a stm32h747 board with external ULPI:

```
#define CFG_TUH_MAX_SPEED		OPT_MODE_FULL_SPEED
#define CFG_TUH_PHY_SPEED		OPT_MODE_HIGH_SPEED
```

The effect of this configuration is to set the `HCFG_FSLS_ONLY` bit on the DWC2 controller at the right place.