### PR TITLE
fix ld symbols extraction

### DIFF
--- a/hw/bsp/family_support.cmake
+++ b/hw/bsp/family_support.cmake
@@ -310,7 +310,7 @@ while [ -n \"$pending_ld_scripts\" ]; do \
 done; \
 ld_scripts=\"$(echo \"$all_ld_scripts\" | xargs)\"")
     set(MEMBROWSE_LD_DEFS_CMD
-      "ld_symbols=\"$(${CMAKE_MAKE_PROGRAM} -C ${CMAKE_BINARY_DIR} -t commands ${TARGET} | grep -oP '(?<=-Wl,--defsym=)[^[:space:]]+' | xargs)\"; \
+      "ld_symbols=\"$(${CMAKE_MAKE_PROGRAM} -C ${CMAKE_BINARY_DIR} -t commands ${TARGET} | grep -oP '(?<=--defsym=)[^[:space:]]+' | xargs)\"; \
 ld_defs=\"\"; \
 for symbol in $ld_symbols; do \
   ld_defs=\"$ld_defs --def $symbol\"; \


### PR DESCRIPTION
 Fixed --defsym symbol extraction for HPMicro targets. The previous regex (?<=-Wl,--defsym=) assumed symbols were always passed with the -Wl, GCC wrapper
  prefix, but HPMicro's toolchain passes --defsym= directly. Changed the lookbehind to (?<=--defsym=) so it matches both cases.