### PR TITLE
hcd_edpt_abort_xfer implemented for rp2040

### DIFF
--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -535,10 +535,12 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t *b
 
 bool hcd_edpt_abort_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr) {
   (void) rhport;
-  (void) dev_addr;
-  (void) ep_addr;
-  // TODO not implemented yet
-  return false;
+  struct hw_endpoint *ep = get_dev_ep(dev_addr, ep_addr);
+  if (!ep || !ep->active) return true;
+  *hwbuf_ctrl_reg_host(ep) = 0;
+  hw_endpoint_reset_transfer(ep);
+  ep->next_pid = 0;
+  return true;
 }
 
 bool hcd_setup_send(uint8_t rhport, uint8_t dev_addr, uint8_t const setup_packet[8])


### PR DESCRIPTION
I use a custom msc_host modified to support CBI and removable media. This hcd_edpt_abort_xfer is needed when a SCSI command times out. I was able to verify this abort works by ejecting a 3.5" floppy disk during IO and forcing a real hardware timeout.

The msc_host and app used for testing:
https://github.com/picocomputer/rp6502/blob/main/src/ria/usb/msc_host.c
https://github.com/picocomputer/rp6502/blob/main/src/ria/usb/msc.c
