### PR TITLE
add(usbh.c): LOG1 debug message when no address available for hub

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1841,6 +1841,12 @@ static uint8_t enum_get_new_address(bool is_hub) {
     }
   }
 
+#if CFG_TUH_HUB
+  if ( is_hub ) {
+    TU_LOG1("All addresses are occupied, try to increase CFG_TUH_HUB value.\r\n");
+  }
+#endif // CFG_TUH_HUB
+
   return 0; // invalid address
 }
 


### PR DESCRIPTION
## Description 

When new device was attached (to root port or downstream port), it goes through the enumeration process. After getting the 8 bytes of the Device Descriptor, the enumeration process calculates a new value for the device address, based on the current implementation: 

```
static uint8_t enum_get_new_address(bool is_hub) {
  uint8_t start;
  uint8_t end;

  if ( is_hub ) {
    start = CFG_TUH_DEVICE_MAX;
    end   = start + CFG_TUH_HUB;
  }else {
    start = 0;
    end   = start + CFG_TUH_DEVICE_MAX;
  }

  for (uint8_t idx = start; idx < end; idx++) {
    if (0 == _usbh_devices[idx].connected) {
      return (idx + 1);
    }
  }

  return 0; // invalid address
}
```

When we have config from the example: 

```
// only hub class is enabled
#define CFG_TUH_HUB                 1

// max device support (excluding hub device): 1 hub typically has 4 ports
#define CFG_TUH_DEVICE_MAX          (3*CFG_TUH_HUB + 1)
```

It is not that obvious (sorry if I missed that somewhere) that to support nesting hubs (means one attached in the another) we need to increase the `CFG_TUH_HUB` value.


## Changes
This PR adds explicit `TU_LOG1()` message, when `CFG_TUH_HUB` is enabled and we are about to return from the function (means unable to assign device address). 
