### PR TITLE
Fixing alignemnt issue

### DIFF
--- a/src/portable/chipidea/ci_hs/dcd_ci_hs.c
+++ b/src/portable/chipidea/ci_hs/dcd_ci_hs.c
@@ -330,7 +330,7 @@ void dcd_sof_enable(uint8_t rhport, bool en) {
 //--------------------------------------------------------------------+
 
 static void qtd_init(dcd_qtd_t *p_qtd, void *data_ptr, uint16_t total_bytes) {
-  dcd_dcache_clean_invalidate((uint32_t *)tu_align((uint32_t)data_ptr, 4), total_bytes);
+  dcd_dcache_clean_invalidate((uint32_t *)tu_align((uint32_t)data_ptr, 32), total_bytes);
 
   tu_memclr(p_qtd, sizeof(dcd_qtd_t));
 


### PR DESCRIPTION
The function `qtd_init()` begins with:

```c
static void qtd_init(dcd_qtd_t *p_qtd, void *data_ptr, uint16_t total_bytes) {
  dcd_dcache_clean_invalidate((uint32_t *)tu_align((uint32_t)data_ptr, 4), total_bytes);
```

4 byte aligned pointer is passed to `dcd_dcache_clean_invalidate()` that in turn call `imxrt_dcache_clean_invalidate()`

```c
TU_ATTR_ALWAYS_INLINE static inline bool imxrt_dcache_clean_invalidate(void const* addr, uint32_t data_size) {
  const uintptr_t addr32 = (uintptr_t) addr;
  if (imxrt_is_cache_mem(addr32)) {
    TU_ASSERT(tu_is_aligned32(addr32));
    data_size = round_up_to_cache_line_size(data_size);
    SCB_CleanInvalidateDCache_by_Addr((uint32_t *) addr32, (int32_t) data_size);
  }
  return true;
}
```

the assert check that `addr` is 32 byte aligned, but it is only 4 byte aligned in the caller function `qtd_init()`
