### PR TITLE
midi device: add cable-aware stream read (tud_midi_n_demux_stream_read)

### DIFF
--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -66,6 +66,13 @@ uint32_t tud_midi_n_available(uint8_t itf, uint8_t cable_num);
 // Read byte stream (legacy)
 uint32_t tud_midi_n_stream_read(uint8_t itf, uint8_t cable_num, void *buffer, uint32_t bufsize);
 
+// Read byte stream with cable demultiplexing: returns the cable number of the
+// data that was read.  Reads from a single cable per call; stops when the next
+// packet belongs to a different cable so the caller can dispatch per-cable.
+// Note: shares internal state with tud_midi_n_stream_read(); do not mix both
+// on the same interface.
+uint32_t tud_midi_n_demux_stream_read(uint8_t itf, uint8_t *p_cable_num, void *buffer, uint32_t bufsize);
+
 // Write byte Stream (legacy)
 uint32_t tud_midi_n_stream_write(uint8_t itf, uint8_t cable_num, const uint8_t *buffer, uint32_t bufsize);
 
@@ -94,6 +101,11 @@ TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_available(void) {
 
 TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_stream_read(void *buffer, uint32_t bufsize) {
   return tud_midi_n_stream_read(0, 0, buffer, bufsize);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t
+tud_midi_demux_stream_read(uint8_t *p_cable_num, void *buffer, uint32_t bufsize) {
+  return tud_midi_n_demux_stream_read(0, p_cable_num, buffer, bufsize);
 }
 
 TU_ATTR_ALWAYS_INLINE static inline uint32_t


### PR DESCRIPTION
## Summary

Implements the `tud_midi_n_demux_stream_read()` function proposed in #1838 — a cable-aware variant of `tud_midi_n_stream_read()` that returns the cable number of the data actually read.

The existing `tud_midi_n_stream_read()` accepts a `cable_num` parameter but ignores it (`(void) cable_num`), silently mixing data from all virtual cables into a single stream. This makes it impossible to build multi-port MIDI devices where each cable maps to a separate DIN jack or logical MIDI port.

### New API

```c
// Multiple interfaces (CFG_TUD_MIDI > 1)
uint32_t tud_midi_n_demux_stream_read(uint8_t itf, uint8_t *p_cable_num,
                                       void *buffer, uint32_t bufsize);

// Single interface convenience wrapper
uint32_t tud_midi_demux_stream_read(uint8_t *p_cable_num,
                                     void *buffer, uint32_t bufsize);
```

Reads MIDI byte-stream data from the RX FIFO. Peeks at each USB-MIDI event packet header before consuming it and **stops when the next packet belongs to a different cable**, allowing callers to dispatch per-cable without losing data. Sets `*p_cable_num` to the cable number of the returned data.

### Usage example

```c
uint8_t cable_num;
uint8_t buf[64];
uint32_t n;

while ((n = tud_midi_demux_stream_read(&cable_num, buf, sizeof(buf))) > 0) {
    // route buf[0..n-1] to the handler for cable_num
    midi_port_feed(cable_num, buf, n);
}
```

### Implementation details

- Follows the API shape proposed by @rppicomidi in #1838
- Mirrors the approach already used by the host-side `tuh_midi_stream_read()`: uses `tu_edpt_stream_peek()` for cable inspection before consuming packets
- CIN-based byte count from USB MIDI 1.0 Table 4-1
- Leftover handling via the existing `midi_driver_stream_t`
- No changes to existing functions — fully additive, backward compatible

### Files changed

- `src/class/midi/midi_device.c` — new `tud_midi_n_demux_stream_read()` function
- `src/class/midi/midi_device.h` — declaration + single-interface wrapper

Closes #1838