### PR TITLE
fix(dcd/dwc2): Do not modify FS PHY registers on HS PHY ESP32-P4

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -527,34 +527,38 @@ void dcd_remote_wakeup(uint8_t rhport) {
 }
 
 void dcd_connect(uint8_t rhport) {
-  (void) rhport;
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
 
 #ifdef TUP_USBIP_DWC2_ESP32
-  usb_wrap_otg_conf_reg_t conf = USB_WRAP.otg_conf;
-  conf.pad_pull_override = 0;
-  conf.dp_pullup = 0;
-  conf.dp_pulldown = 0;
-  conf.dm_pullup = 0;
-  conf.dm_pulldown = 0;
-  USB_WRAP.otg_conf = conf;
+  // On ESP32-P4 HS PHY, do not write to USB_WRAP register which belongs to FS PHY
+  if (rhport == 0) {
+    usb_wrap_otg_conf_reg_t conf = USB_WRAP.otg_conf;
+    conf.pad_pull_override = 0;
+    conf.dp_pullup = 0;
+    conf.dp_pulldown = 0;
+    conf.dm_pullup = 0;
+    conf.dm_pulldown = 0;
+    USB_WRAP.otg_conf = conf;
+  }
 #endif
 
   dwc2->dctl &= ~DCTL_SDIS;
 }
 
 void dcd_disconnect(uint8_t rhport) {
-  (void) rhport;
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
 
 #ifdef TUP_USBIP_DWC2_ESP32
-  usb_wrap_otg_conf_reg_t conf = USB_WRAP.otg_conf;
-  conf.pad_pull_override = 1;
-  conf.dp_pullup = 0;
-  conf.dp_pulldown = 1;
-  conf.dm_pullup = 0;
-  conf.dm_pulldown = 1;
-  USB_WRAP.otg_conf = conf;
+  // On ESP32-P4 HS PHY, do not write to USB_WRAP register which belongs to FS PHY
+  if (rhport == 0) {
+    usb_wrap_otg_conf_reg_t conf = USB_WRAP.otg_conf;
+    conf.pad_pull_override = 1;
+    conf.dp_pullup = 0;
+    conf.dp_pulldown = 1;
+    conf.dm_pullup = 0;
+    conf.dm_pulldown = 1;
+    USB_WRAP.otg_conf = conf;
+  }
 #endif
 
   dwc2->dctl |= DCTL_SDIS;


### PR DESCRIPTION
`dcd_connect` and `dcd_disconnect` functions write unconditionally to `USB_WRAP` registers.

However, on ESP32-P4 `USB_WRAP` is associated with Full Speed PHY. Therefore, the code must be check for `rhport` index and write to `USB_WRAP` only if the FullSpeed port is used