### PR TITLE
fix(bsp/rp2040): use MAX3421_SPI in spi_write_read_blocking

### DIFF
--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -368,7 +368,7 @@ bool tuh_max3421_spi_xfer_api(uint8_t rhport, uint8_t const* tx_buf, uint8_t* rx
   }else if (rx_buf == NULL) {
     ret = spi_write_blocking(MAX3421_SPI, tx_buf, xfer_bytes);
   }else {
-    ret = spi_write_read_blocking(spi0, tx_buf, rx_buf, xfer_bytes);
+    ret = spi_write_read_blocking(MAX3421_SPI, tx_buf, rx_buf, xfer_bytes);
   }
 
   return ret == (int) xfer_bytes;


### PR DESCRIPTION
The write+read path in `tuh_max3421_spi_xfer_api()` hardcodes `spi0` instead of `MAX3421_SPI`. The read-only and write-only branches are fine — just this one got missed.

Causes a hang on any board using `spi1` for the MAX3421E (e.g. Feather RP2040 USB Host with a MAX3421E FeatherWing on SPI1). `spi_write_read_blocking()` blocks forever since `spi0` was never initialized.

One-line fix, consistent with the other two branches right above it.