### PR TITLE
 _open_vc_itf parsing error when vc->std.bNumEndpoints != 0

### DIFF
--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -70,6 +70,13 @@ typedef struct TU_ATTR_PACKED {
   uint8_t bEntityId;
 } tusb_desc_cs_video_entity_itf_t;
 
+typedef struct TU_ATTR_PACKED {
+  uint8_t  bLength;
+  uint8_t  bDescriptorType;
+  uint8_t  bDescriptorSubtype;
+  uint16_t wMaxTransferSize;
+} tusb_desc_cs_video_vc_ep_t;
+
 typedef union {
   struct TU_ATTR_PACKED {
     uint8_t bLength;
@@ -746,6 +753,9 @@ static bool _close_vc_itf(uint8_t rhport, videod_interface_t *self)
   /* The end of the video control interface descriptor. */
   void const *end = _end_of_control_descriptor(vc);
   if (vc->std.bNumEndpoints != 0) {
+    /* Extend end to cover the standard endpoint and class-specific endpoint descriptors
+     * that follow wTotalLength */
+    end = (uint8_t const*)end + sizeof(tusb_desc_endpoint_t) + sizeof(tusb_desc_cs_video_vc_ep_t);
     /* Find the notification endpoint descriptor. */
     cur = _find_desc(cur, end, TUSB_DESC_ENDPOINT);
     TU_ASSERT(cur < end);
@@ -786,6 +796,9 @@ static bool _open_vc_itf(uint8_t rhport, videod_interface_t *self, uint_fast8_t 
   if (vc->std.bNumEndpoints != 0) {
     /* Support for 1 endpoint only. */
     TU_VERIFY(1 == vc->std.bNumEndpoints);
+    /* Extend end to cover the standard endpoint and class-specific endpoint descriptors
+     * that follow wTotalLength */
+    end = (uint8_t const*)end + sizeof(tusb_desc_endpoint_t) + sizeof(tusb_desc_cs_video_vc_ep_t);
     /* Find the notification endpoint descriptor. */
     cur = _find_desc(cur, end, TUSB_DESC_ENDPOINT);
     TU_VERIFY(cur < end);


### PR DESCRIPTION
The Hierarchy and Memory Layout
 Standard Interface Descriptor (VC)
 Video Control Header Descriptor: Contains wTotalLength.
 Video Control Camera Terminal Descriptor
 Video Control Output Terminal Descriptor
 Standard Endpoint Descriptor: The physical interrupt pipe (Length = 7 bytes).
 Class-Specific VC Interrupt Endpoint Descriptor: Additional endpoint metadata (Length = 5 bytes).

fixed _end_of_control_descriptor logic.
wTotalLength does not include Standard Endpoint Descriptor and Class-specific VC Interrupt Endpoint Descriptor,
so fix that _end_of_control_descriptor include Standard Endpoint Descriptor and Class-specific VC Interrupt Endpoint Descriptor. It will also fix _close_vc_itf, _open_vc_itf. _find_desc_entity parsing.