### PR TITLE
fix(dwc2/hcd): guard against divide-by-zero when ep_size is 0

### DIFF
--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -293,7 +293,7 @@ TU_ATTR_ALWAYS_INLINE static inline uint8_t edpt_find_opened(uint8_t dev_addr, u
 }
 
 TU_ATTR_ALWAYS_INLINE static inline uint16_t cal_packet_count(uint16_t len, uint16_t ep_size) {
-  if (len == 0) {
+  if (len == 0 || ep_size == 0) {
     return 1;
   } else {
     return tu_div_ceil(len, ep_size);
@@ -523,13 +523,16 @@ bool hcd_edpt_open(uint8_t rhport, uint8_t dev_addr, const tusb_desc_endpoint_t*
   tuh_bus_info_t bus_info;
   tuh_bus_info_get(dev_addr, &bus_info);
 
+  const uint16_t ep_size = tu_edpt_packet_size(desc_ep);
+  TU_ASSERT(ep_size != 0, false); // ep descriptor must have non-zero wMaxPacketSize
+
   // find a free endpoint
   const uint8_t ep_id = edpt_alloc();
   TU_ASSERT(ep_id < CFG_TUH_DWC2_ENDPOINT_MAX);
   hcd_endpoint_t* edpt = &_hcd_data.edpt[ep_id];
 
   dwc2_channel_char_t* hcchar_bm = &edpt->hcchar_bm;
-  hcchar_bm->ep_size         = tu_edpt_packet_size(desc_ep);
+  hcchar_bm->ep_size         = ep_size;
   hcchar_bm->ep_num          = tu_edpt_number(desc_ep->bEndpointAddress);
   hcchar_bm->ep_dir          = tu_edpt_dir(desc_ep->bEndpointAddress);
   hcchar_bm->low_speed_dev   = (bus_info.speed == TUSB_SPEED_LOW) ? 1 : 0;


### PR DESCRIPTION
Fix integer divide-by-zero crash in DWC2 host controller driver during USB host enumeration.

In `cal_packet_count()`, `ep_size` could be 0 if the device descriptor returns `bMaxPacketSize0 = 0` (due to buggy device or DMA cache coherency issues on ESP32), causing an integer divide-by-zero crash.

Two-layer fix:
- In `hcd_edpt_open()`: validate `ep_size != 0` before allocating the endpoint slot, returning false to let enumeration handle the error gracefully.
- In `cal_packet_count()`: guard `ep_size == 0` as a last-resort safety net.

Fixes #3525

Generated with [Claude Code](https://claude.ai/code)