### PR TITLE
Fix ep_ctrl_mask() corrupting opposite direction's ENDPTCTRL bits

### DIFF
--- a/src/portable/chipidea/ci_hs/dcd_ci_hs.c
+++ b/src/portable/chipidea/ci_hs/dcd_ci_hs.c
@@ -388,7 +388,7 @@ TU_ATTR_ALWAYS_INLINE static inline void ep_ctrl_mask(volatile uint32_t *epctrl,
                                                       uint32_t or_mask) {
   uint32_t value = *epctrl;
   if (and_mask != 0) {
-    value &= (dir == TUSB_DIR_OUT) ? and_mask : (and_mask << 16u);
+    value &= (dir == TUSB_DIR_OUT) ? (and_mask | 0xFFFF0000u) : ((and_mask << 16u) | 0x0000FFFFu);
   }
   if (or_mask != 0) {
     value |= (dir == TUSB_DIR_OUT) ? or_mask : (or_mask << 16u);


### PR DESCRIPTION
**Description:**
ep_ctrl_mask() in the ChipIdea HS DCD driver applies an AND mask incorrectly for the IN direction:
`value &= (and_mask << 16u) `
zeros the entire lower 16 bits (OUT/RX half) of the shared ENDPTCTRL register instead of preserving them.

This is triggered when two endpoints share the same endpoint number but use opposite directions (e.g. EP1 OUT for speaker, EP1 IN for mic). Calling ep_ctrl_clear() on the IN direction, which happens during dcd_edpt_iso_activate(), wipes the OUT direction's type and control bits. The endpoint type silently reverts from Isochronous to Control, causing the controller to drop all incoming isochronous data.

The bug is latent on hosts that only activate one direction at a time (e.g. Windows playing audio without opening the mic). It surfaces on Linux where snd-usb-audio probes all alternate settings on all interfaces, activating both directions and corrupting whichever was configured first.

**Fix:**
Mask each direction independently by preserving the opposite half:
```
// Before:
value &= (dir == TUSB_DIR_OUT) ? and_mask : (and_mask << 16u);
```

```
// After:
value &= (dir == TUSB_DIR_OUT) ? (and_mask | 0xFFFF0000u) : ((and_mask << 16u) | 0x0000FFFFu);
```

Affected platforms: All ChipIdea HS targets (iMXRT, LPC18/43, MCX, RW61X) using bidirectional endpoints with the same endpoint number.