### PR TITLE
Fix hwfifo PMA pointer advance on ring buffer wrap

### DIFF
--- a/src/common/tusb_fifo.c
+++ b/src/common/tusb_fifo.c
@@ -280,7 +280,7 @@ static void hwff_push_n(const tu_fifo_t *f, const void *app_buf, uint16_t n, uin
     const uint32_t odd_mask    = data_stride - 1;
     uint16_t       lin_even    = lin_bytes & ~odd_mask;
     tu_hwfifo_read(hwfifo, ff_buf, lin_even, access_mode);
-    HWFIFO_ADDR_NEXT_N(hwfifo, const, lin_even);
+    HWFIFO_ADDR_NEXT_N(hwfifo, const, (lin_even / data_stride) * CFG_TUSB_FIFO_HWFIFO_ADDR_STRIDE);
     ff_buf += lin_even;
 
     // There could be odd 1 byte (16bit) or 1-3 bytes (32bit) before the wrap-around boundary
@@ -337,7 +337,7 @@ static void hwff_pull_n(const tu_fifo_t *f, void *app_buf, uint16_t n, uint16_t 
     const uint32_t odd_mask    = data_stride - 1;
     uint16_t       lin_even    = lin_bytes & ~odd_mask;
     tu_hwfifo_write(hwfifo, ff_buf, lin_even, access_mode);
-    HWFIFO_ADDR_NEXT_N(hwfifo, , lin_even);
+    HWFIFO_ADDR_NEXT_N(hwfifo, , (lin_even / data_stride) * CFG_TUSB_FIFO_HWFIFO_ADDR_STRIDE);
     ff_buf += lin_even;
 
     // There could be odd 1 byte (16bit) or 1-3 bytes (32bit) before the wrap-around boundary


### PR DESCRIPTION
In hwff_push_n() and hwff_pull_n(), the HWFIFO_ADDR_NEXT_N call after processing the linear part of a wrap-around read/write used the data byte count (lin_even) as the address stride increment. On STM32 FSDEV PMA, data_stride=2 and addr_stride=4, so the pointer must advance by (lin_even / data_stride) * addr_stride bytes, not lin_even bytes.

Fixes: 74e59e433 ("fix hwfifo pull/push n with address stride > 0")