### PR TITLE
add set protocol skip feature

### DIFF
--- a/src/class/hid/hid.h
+++ b/src/class/hid/hid.h
@@ -145,7 +145,8 @@ typedef enum
 typedef enum
 {
   HID_PROTOCOL_BOOT = 0,
-  HID_PROTOCOL_REPORT = 1
+  HID_PROTOCOL_REPORT = 1,
+  HID_PROTOCOL_SKIP = 2,
 } hid_protocol_mode_enum_t;
 
 /** @} */

--- a/src/class/hid/hid_host.c
+++ b/src/class/hid/hid_host.c
@@ -625,8 +625,11 @@ static void process_set_config(tuh_xfer_t* xfer) {
     case CONFG_SET_IDLE: {
       // Idle rate = 0 mean only report when there is changes
       const uint16_t idle_rate = 0;
-      const uintptr_t next_state = (p_hid->itf_protocol != HID_ITF_PROTOCOL_NONE)
-                                   ? CONFIG_SET_PROTOCOL : CONFIG_GET_REPORT_DESC;
+      const uintptr_t next_state =
+          (p_hid->itf_protocol != HID_ITF_PROTOCOL_NONE &&
+          _hidh_default_protocol <= HID_PROTOCOL_REPORT)
+              ? CONFIG_SET_PROTOCOL
+              : CONFIG_GET_REPORT_DESC;
       _hidh_set_idle(daddr, itf_num, idle_rate, process_set_config, next_state);
       break;
     }


### PR DESCRIPTION
I have a quirky device that has multiple devices in it's report (gamepad, keyboard, and a mouse).

If i send any set hid protocol message to the device during it's life cycle, it will stall the polls to the gamepad endpoint (which I want to talk to) and prefers the keyboard only.

I need some way to tell tinyusb to skip sending the set protocol command during operation, so this PR allows me to call in my code

`  tuh_hid_set_default_protocol(HID_PROTOCOL_SKIP);`

and during enumeration, the device will not get a protocol message sent to it.

Please let me know if you have any alternative suggestions or tips.