### PR TITLE
ci: don't cancel build on merge to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   HIL_JSON: test/hil/tinyusb.json


### PR DESCRIPTION
Concurrent PRs targeting master could cause the CI flow of the first PR to be cancelled, creating a gap in the MemBrowse report chain. Updated the build job to prevent this going forward.
The report chain is currently intact. 