### PR TITLE
bsp/imxrt: refresh teensy config

### DIFF
--- a/hw/bsp/imxrt/boards/teensy_40/board/clock_config.c
+++ b/hw/bsp/imxrt/boards/teensy_40/board/clock_config.c
@@ -15,11 +15,11 @@
 
 /* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
 !!GlobalInfo
-product: Clocks v11.0
+product: Clocks v20.0
 processor: MIMXRT1062xxxxA
 package_id: MIMXRT1062DVL6A
 mcu_data: ksdk2_0
-processor_version: 13.0.2
+processor_version: 26.03.10
 board: MIMXRT1060-EVK
  * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
 

--- a/hw/bsp/imxrt/boards/teensy_40/board/clock_config.h
+++ b/hw/bsp/imxrt/boards/teensy_40/board/clock_config.h
@@ -36,56 +36,56 @@ void BOARD_InitBootClocks(void);
 #define BOARD_BOOTCLOCKRUN_CORE_CLOCK             600000000U  /*!< Core clock frequency: 600000000Hz */
 
 /* Clock outputs (values are in Hz): */
-#define BOARD_BOOTCLOCKRUN_AHB_CLK_ROOT               600000000UL
-#define BOARD_BOOTCLOCKRUN_CAN_CLK_ROOT               40000000UL
-#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT         32768UL
-#define BOARD_BOOTCLOCKRUN_CLKO1_CLK                  0UL
-#define BOARD_BOOTCLOCKRUN_CLKO2_CLK                  0UL
-#define BOARD_BOOTCLOCKRUN_CLK_1M                     1000000UL
-#define BOARD_BOOTCLOCKRUN_CLK_24M                    24000000UL
-#define BOARD_BOOTCLOCKRUN_CSI_CLK_ROOT               12000000UL
-#define BOARD_BOOTCLOCKRUN_ENET2_125M_CLK             1200000UL
-#define BOARD_BOOTCLOCKRUN_ENET2_REF_CLK              0UL
-#define BOARD_BOOTCLOCKRUN_ENET2_TX_CLK               0UL
-#define BOARD_BOOTCLOCKRUN_ENET_125M_CLK              2400000UL
-#define BOARD_BOOTCLOCKRUN_ENET_25M_REF_CLK           1200000UL
-#define BOARD_BOOTCLOCKRUN_ENET_REF_CLK               0UL
-#define BOARD_BOOTCLOCKRUN_ENET_TX_CLK                0UL
-#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT           30000000UL
-#define BOARD_BOOTCLOCKRUN_FLEXIO2_CLK_ROOT           30000000UL
-#define BOARD_BOOTCLOCKRUN_FLEXSPI2_CLK_ROOT          130909090UL
-#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT           130909090UL
-#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ      75000000UL
-#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ      75000000UL
-#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT               150000000UL
-#define BOARD_BOOTCLOCKRUN_LCDIF_CLK_ROOT             67500000UL
-#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT             60000000UL
-#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT             105600000UL
-#define BOARD_BOOTCLOCKRUN_LVDS1_CLK                  1200000000UL
-#define BOARD_BOOTCLOCKRUN_MQS_MCLK                   63529411UL
-#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT            75000000UL
-#define BOARD_BOOTCLOCKRUN_PLL7_MAIN_CLK              480000000UL
-#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT              63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1                 63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2                 63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3                 30000000UL
-#define BOARD_BOOTCLOCKRUN_SAI2_CLK_ROOT              63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI2_MCLK1                 63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI2_MCLK2                 0UL
-#define BOARD_BOOTCLOCKRUN_SAI2_MCLK3                 30000000UL
-#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT              63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1                 63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2                 0UL
-#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3                 30000000UL
-#define BOARD_BOOTCLOCKRUN_SEMC_CLK_ROOT              75000000UL
-#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT            30000000UL
-#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT          0UL
-#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT             132000000UL
-#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT              80000000UL
-#define BOARD_BOOTCLOCKRUN_USBPHY1_CLK                480000000UL
-#define BOARD_BOOTCLOCKRUN_USBPHY2_CLK                480000000UL
-#define BOARD_BOOTCLOCKRUN_USDHC1_CLK_ROOT            198000000UL
-#define BOARD_BOOTCLOCKRUN_USDHC2_CLK_ROOT            198000000UL
+#define BOARD_BOOTCLOCKRUN_AHB_CLK_ROOT               600000000UL    /* Clock consumers of AHB_CLK_ROOT output : AIPSTZ1, AIPSTZ2, AIPSTZ3, AIPSTZ4, ARM, FLEXIO3, FLEXSPI, FLEXSPI2, GPIO6, GPIO7, GPIO8, GPIO9 */
+#define BOARD_BOOTCLOCKRUN_CAN_CLK_ROOT               40000000UL     /* Clock consumers of CAN_CLK_ROOT output : CAN1, CAN2, CAN3 */
+#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT         32768UL        /* Clock consumers of CKIL_SYNC_CLK_ROOT output : CSU, EWM, GPT1, GPT2, KPP, PIT, RTWDOG, SNVS, SPDIF, TEMPMON, TSC, USB1, USB2, WDOG1, WDOG2 */
+#define BOARD_BOOTCLOCKRUN_CLKO1_CLK                  0UL            /* Clock consumers of CLKO1_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_CLKO2_CLK                  0UL            /* Clock consumers of CLKO2_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_CLK_1M                     1000000UL      /* Clock consumers of CLK_1M output : EWM, RTWDOG */
+#define BOARD_BOOTCLOCKRUN_CLK_24M                    24000000UL     /* Clock consumers of CLK_24M output : GPT1, GPT2 */
+#define BOARD_BOOTCLOCKRUN_CSI_CLK_ROOT               12000000UL     /* Clock consumers of CSI_CLK_ROOT output : CSI */
+#define BOARD_BOOTCLOCKRUN_ENET2_125M_CLK             1200000UL      /* Clock consumers of ENET2_125M_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_ENET2_REF_CLK              0UL            /* Clock consumers of ENET2_REF_CLK output : ENET2 */
+#define BOARD_BOOTCLOCKRUN_ENET2_TX_CLK               0UL            /* Clock consumers of ENET2_TX_CLK output : ENET2 */
+#define BOARD_BOOTCLOCKRUN_ENET_125M_CLK              2400000UL      /* Clock consumers of ENET_125M_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_ENET_25M_REF_CLK           1200000UL      /* Clock consumers of ENET_25M_REF_CLK output : ENET, ENET2 */
+#define BOARD_BOOTCLOCKRUN_ENET_REF_CLK               0UL            /* Clock consumers of ENET_REF_CLK output : ENET */
+#define BOARD_BOOTCLOCKRUN_ENET_TX_CLK                0UL            /* Clock consumers of ENET_TX_CLK output : ENET */
+#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT           30000000UL     /* Clock consumers of FLEXIO1_CLK_ROOT output : FLEXIO1 */
+#define BOARD_BOOTCLOCKRUN_FLEXIO2_CLK_ROOT           30000000UL     /* Clock consumers of FLEXIO2_CLK_ROOT output : FLEXIO2, FLEXIO3 */
+#define BOARD_BOOTCLOCKRUN_FLEXSPI2_CLK_ROOT          130909090UL    /* Clock consumers of FLEXSPI2_CLK_ROOT output : FLEXSPI2 */
+#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT           130909090UL    /* Clock consumers of FLEXSPI_CLK_ROOT output : FLEXSPI */
+#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ      75000000UL     /* Clock consumers of GPT1_ipg_clk_highfreq output : GPT1 */
+#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ      75000000UL     /* Clock consumers of GPT2_ipg_clk_highfreq output : GPT2 */
+#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT               150000000UL    /* Clock consumers of IPG_CLK_ROOT output : ADC1, ADC2, ADC_ETC, AOI1, AOI2, ARM, BEE, CAN1, CAN2, CAN3, CCM, CMP1, CMP2, CMP3, CMP4, CSI, CSU, DCDC, DCP, DMA0, DMAMUX, ENC1, ENC2, ENC3, ENC4, ENET, ENET2, EWM, FLEXIO1, FLEXIO2, FLEXIO3, FLEXRAM, FLEXSPI, FLEXSPI2, GPC, GPIO1, GPIO10, GPIO2, GPIO3, GPIO4, GPIO5, IOMUXC, KPP, LCDIF, LPI2C1, LPI2C2, LPI2C3, LPI2C4, LPSPI1, LPSPI2, LPSPI3, LPSPI4, LPUART1, LPUART2, LPUART3, LPUART4, LPUART5, LPUART6, LPUART7, LPUART8, NVIC, OCOTP, PMU, PWM1, PWM2, PWM3, PWM4, PXP, ROMC, RTWDOG, SAI1, SAI2, SAI3, SNVS, SPDIF, SRC, TEMPMON, TMR1, TMR2, TMR3, TMR4, TRNG, TSC, USB1, USB2, USDHC1, USDHC2, WDOG1, WDOG2, XBARA1, XBARB2, XBARB3 */
+#define BOARD_BOOTCLOCKRUN_LCDIF_CLK_ROOT             67500000UL     /* Clock consumers of LCDIF_CLK_ROOT output : LCDIF */
+#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT             60000000UL     /* Clock consumers of LPI2C_CLK_ROOT output : LPI2C1, LPI2C2, LPI2C3, LPI2C4 */
+#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT             105600000UL    /* Clock consumers of LPSPI_CLK_ROOT output : LPSPI1, LPSPI2, LPSPI3, LPSPI4 */
+#define BOARD_BOOTCLOCKRUN_LVDS1_CLK                  1200000000UL   /* Clock consumers of LVDS1_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_MQS_MCLK                   63529411UL     /* Clock consumers of MQS_MCLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT            75000000UL     /* Clock consumers of PERCLK_CLK_ROOT output : GPT1, GPT2, PIT */
+#define BOARD_BOOTCLOCKRUN_PLL7_MAIN_CLK              480000000UL    /* Clock consumers of PLL7_MAIN_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT              63529411UL     /* Clock consumers of SAI1_CLK_ROOT output : N/A */
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1                 63529411UL     /* Clock consumers of SAI1_MCLK1 output : SAI1 */
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2                 63529411UL     /* Clock consumers of SAI1_MCLK2 output : SAI1 */
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3                 30000000UL     /* Clock consumers of SAI1_MCLK3 output : SAI1 */
+#define BOARD_BOOTCLOCKRUN_SAI2_CLK_ROOT              63529411UL     /* Clock consumers of SAI2_CLK_ROOT output : N/A */
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK1                 63529411UL     /* Clock consumers of SAI2_MCLK1 output : SAI2 */
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK2                 0UL            /* Clock consumers of SAI2_MCLK2 output : SAI2 */
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK3                 30000000UL     /* Clock consumers of SAI2_MCLK3 output : SAI2 */
+#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT              63529411UL     /* Clock consumers of SAI3_CLK_ROOT output : N/A */
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1                 63529411UL     /* Clock consumers of SAI3_MCLK1 output : SAI3 */
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2                 0UL            /* Clock consumers of SAI3_MCLK2 output : SAI3 */
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3                 30000000UL     /* Clock consumers of SAI3_MCLK3 output : SAI3 */
+#define BOARD_BOOTCLOCKRUN_SEMC_CLK_ROOT              75000000UL     /* Clock consumers of SEMC_CLK_ROOT output : SEMC */
+#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT            30000000UL     /* Clock consumers of SPDIF0_CLK_ROOT output : SPDIF */
+#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT          0UL            /* Clock consumers of SPDIF0_EXTCLK_OUT output : SPDIF */
+#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT             132000000UL    /* Clock consumers of TRACE_CLK_ROOT output : ARM */
+#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT              80000000UL     /* Clock consumers of UART_CLK_ROOT output : LPUART1, LPUART2, LPUART3, LPUART4, LPUART5, LPUART6, LPUART7, LPUART8 */
+#define BOARD_BOOTCLOCKRUN_USBPHY1_CLK                480000000UL    /* Clock consumers of USBPHY1_CLK output : TEMPMON, USB1 */
+#define BOARD_BOOTCLOCKRUN_USBPHY2_CLK                480000000UL    /* Clock consumers of USBPHY2_CLK output : USB2 */
+#define BOARD_BOOTCLOCKRUN_USDHC1_CLK_ROOT            198000000UL    /* Clock consumers of USDHC1_CLK_ROOT output : USDHC1 */
+#define BOARD_BOOTCLOCKRUN_USDHC2_CLK_ROOT            198000000UL    /* Clock consumers of USDHC2_CLK_ROOT output : USDHC2 */
 
 /*! @brief Arm PLL set for BOARD_BootClockRUN configuration.
  */

--- a/hw/bsp/imxrt/boards/teensy_40/board/pin_mux.c
+++ b/hw/bsp/imxrt/boards/teensy_40/board/pin_mux.c
@@ -6,11 +6,11 @@
 /*
  * TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
 !!GlobalInfo
-product: Pins v13.1
+product: Pins v17.0
 processor: MIMXRT1062xxxxA
 package_id: MIMXRT1062DVL6A
 mcu_data: ksdk2_0
-processor_version: 13.0.2
+processor_version: 26.03.10
 board: MIMXRT1060-EVK
 pin_labels:
 - {pin_num: E7, pin_signal: GPIO_B0_01, label: LCDIF_ENABLE, identifier: USER_BUTTON}
@@ -80,16 +80,13 @@ void BOARD_InitPins(void) {
   IOMUXC_SetPinConfig(IOMUXC_GPIO_B0_01_GPIO2_IO01, 0xB0B0U);
 }
 
-
 /*
  * TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
 BOARD_InitDEBUG_UARTPins:
 - options: {callFromInitBoot: 'true', coreID: core0, enableClock: 'true'}
 - pin_list:
-  - {pin_num: K14, peripheral: LPUART1, signal: TX, pin_signal: GPIO_AD_B0_12, software_input_on: Disable, hysteresis_enable: Disable, pull_up_down_config: Pull_Down_100K_Ohm,
-    pull_keeper_select: Keeper, pull_keeper_enable: Enable, open_drain: Disable, speed: MHZ_100, drive_strength: R0_6, slew_rate: Slow}
-  - {pin_num: L14, peripheral: LPUART1, signal: RX, pin_signal: GPIO_AD_B0_13, software_input_on: Disable, hysteresis_enable: Disable, pull_up_down_config: Pull_Down_100K_Ohm,
-    pull_keeper_select: Keeper, pull_keeper_enable: Enable, open_drain: Disable, speed: MHZ_100, drive_strength: R0_6, slew_rate: Slow}
+  - {pin_num: G11, peripheral: LPUART6, signal: RX, pin_signal: GPIO_AD_B0_03, speed: MHZ_50}
+  - {pin_num: M11, peripheral: LPUART6, signal: TX, pin_signal: GPIO_AD_B0_02, speed: MHZ_50}
  * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS ***********
  */
 
@@ -104,10 +101,9 @@ void BOARD_InitDEBUG_UARTPins(void) {
 
   IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_02_LPUART6_TX, 0U);
   IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_03_LPUART6_RX, 0U);
-  IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_02_LPUART6_TX, 0x10B0U);
-  IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_03_LPUART6_RX, 0x10B0U);
+  IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_02_LPUART6_TX, 0x1030U);
+  IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_03_LPUART6_RX, 0x1030U);
 }
-
 
 /*
  * TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
@@ -142,7 +138,6 @@ void BOARD_InitUSDHCPins(void) {
   IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3, 0U);
 }
 
-
 /*
  * TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
 BOARD_InitQSPIPins:
@@ -175,7 +170,6 @@ void BOARD_InitQSPIPins(void) {
   IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B1_10_FLEXSPIA_DATA02, 0U);
   IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B1_11_FLEXSPIA_DATA03, 0U);
 }
-
 /***********************************************************************************************************************
  * EOF
  **********************************************************************************************************************/

--- a/hw/bsp/imxrt/boards/teensy_40/board/pin_mux.h
+++ b/hw/bsp/imxrt/boards/teensy_40/board/pin_mux.h
@@ -47,6 +47,7 @@ void BOARD_InitBootPins(void);
 
 /* Symbols to be used with GPIO driver */
 #define BOARD_INITPINS_USER_LED_GPIO                                       GPIO2   /*!< GPIO peripheral base pointer */
+#define BOARD_INITPINS_USER_LED_INIT_GPIO_VALUE                               0U   /*!< GPIO output initial state */
 #define BOARD_INITPINS_USER_LED_GPIO_PIN                                      3U   /*!< GPIO pin number */
 #define BOARD_INITPINS_USER_LED_GPIO_PIN_MASK                         (1U << 3U)   /*!< GPIO pin mask */
 #define BOARD_INITPINS_USER_LED_PORT                                       GPIO2   /*!< PORT peripheral base pointer */
@@ -72,16 +73,6 @@ void BOARD_InitBootPins(void);
  *
  */
 void BOARD_InitPins(void);
-
-/* GPIO_AD_B0_12 (coord K14), UART1_TXD */
-/* Routed pin properties */
-#define BOARD_INITDEBUG_UARTPINS_UART1_TXD_PERIPHERAL                    LPUART1   /*!< Peripheral name */
-#define BOARD_INITDEBUG_UARTPINS_UART1_TXD_SIGNAL                             TX   /*!< Signal name */
-
-/* GPIO_AD_B0_13 (coord L14), UART1_RXD */
-/* Routed pin properties */
-#define BOARD_INITDEBUG_UARTPINS_UART1_RXD_PERIPHERAL                    LPUART1   /*!< Peripheral name */
-#define BOARD_INITDEBUG_UARTPINS_UART1_RXD_SIGNAL                             RX   /*!< Signal name */
 
 /*!
  * @brief Configures pin routing and optionally pin electrical features.

--- a/hw/bsp/imxrt/boards/teensy_40/teensy40.mex
+++ b/hw/bsp/imxrt/boards/teensy_40/teensy40.mex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding= "UTF-8" ?>
-<configuration name="MIMXRT1060-EVK" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_13 http://mcuxpresso.nxp.com/XSD/mex_configuration_13.xsd" uuid="2174caba-38fe-48d5-8f89-42a23354d23b" version="13" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_13" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<configuration name="MIMXRT1060-EVK" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_19 http://mcuxpresso.nxp.com/XSD/mex_configuration_19.xsd" uuid="2174caba-38fe-48d5-8f89-42a23354d23b" version="19" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <common>
       <processor>MIMXRT1062xxxxA</processor>
       <package>MIMXRT1062DVL6A</package>
@@ -13,19 +13,19 @@
    </common>
    <preferences>
       <validate_boot_init_only>false</validate_boot_init_only>
-      <generate_extended_information>false</generate_extended_information>
       <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
       <update_include_paths>true</update_include_paths>
+      <enable_parallel_routing>true</enable_parallel_routing>
       <generate_registers_defines>false</generate_registers_defines>
    </preferences>
    <tools>
-      <pins name="Pins" version="13.1" enabled="true" update_project_code="true">
+      <pins name="Pins" version="17.0" enabled="true" update_project_code="true">
          <generated_project_files>
             <file path="board/pin_mux.c" update_enabled="true"/>
             <file path="board/pin_mux.h" update_enabled="true"/>
          </generated_project_files>
          <pins_profile>
-            <processor_version>13.0.2</processor_version>
+            <processor_version>26.03.10</processor_version>
             <pin_labels>
                <pin_label pin_num="E7" pin_signal="GPIO_B0_01" label="LCDIF_ENABLE" identifier="USER_BUTTON"/>
                <pin_label pin_num="D8" pin_signal="GPIO_B0_03" label="LCDIF_VSYNC" identifier="USER_LED"/>
@@ -41,7 +41,7 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
-                  <dependency resourceType="Peripheral" resourceId="GPIO2" description="Peripheral GPIO2 is not initialized" problem_level="1" source="Pins:BOARD_InitPins">
+                  <dependency resourceType="Peripheral" resourceId="GPIO2" description="Peripheral GPIO2 signals are routed in the Pins Tool, but the peripheral is not initialized in the Peripherals Tool." problem_level="1" source="Pins:BOARD_InitPins">
                      <feature name="initialized" evaluation="equal">
                         <data>true</data>
                      </feature>
@@ -85,7 +85,7 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
-                  <dependency resourceType="Peripheral" resourceId="LPUART1" description="Peripheral LPUART1 is not initialized" problem_level="1" source="Pins:BOARD_InitDEBUG_UARTPins">
+                  <dependency resourceType="Peripheral" resourceId="LPUART6" description="Peripheral LPUART6 signals are routed in the Pins Tool, but the peripheral is not initialized in the Peripherals Tool." problem_level="1" source="Pins:BOARD_InitDEBUG_UARTPins">
                      <feature name="initialized" evaluation="equal">
                         <data>true</data>
                      </feature>
@@ -102,30 +102,14 @@
                   </dependency>
                </dependencies>
                <pins>
-                  <pin peripheral="LPUART1" signal="TX" pin_num="K14" pin_signal="GPIO_AD_B0_12">
+                  <pin peripheral="LPUART6" signal="RX" pin_num="G11" pin_signal="GPIO_AD_B0_03">
                      <pin_features>
-                        <pin_feature name="software_input_on" value="Disable"/>
-                        <pin_feature name="hysteresis_enable" value="Disable"/>
-                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
-                        <pin_feature name="pull_keeper_select" value="Keeper"/>
-                        <pin_feature name="pull_keeper_enable" value="Enable"/>
-                        <pin_feature name="open_drain" value="Disable"/>
-                        <pin_feature name="speed" value="MHZ_100"/>
-                        <pin_feature name="drive_strength" value="R0_6"/>
-                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
                      </pin_features>
                   </pin>
-                  <pin peripheral="LPUART1" signal="RX" pin_num="L14" pin_signal="GPIO_AD_B0_13">
+                  <pin peripheral="LPUART6" signal="TX" pin_num="M11" pin_signal="GPIO_AD_B0_02">
                      <pin_features>
-                        <pin_feature name="software_input_on" value="Disable"/>
-                        <pin_feature name="hysteresis_enable" value="Disable"/>
-                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
-                        <pin_feature name="pull_keeper_select" value="Keeper"/>
-                        <pin_feature name="pull_keeper_enable" value="Enable"/>
-                        <pin_feature name="open_drain" value="Disable"/>
-                        <pin_feature name="speed" value="MHZ_100"/>
-                        <pin_feature name="drive_strength" value="R0_6"/>
-                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
                      </pin_features>
                   </pin>
                </pins>
@@ -138,7 +122,7 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
-                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 is not initialized" problem_level="1" source="Pins:BOARD_InitUSDHCPins">
+                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 signals are routed in the Pins Tool, but the peripheral is not initialized in the Peripherals Tool." problem_level="1" source="Pins:BOARD_InitUSDHCPins">
                      <feature name="initialized" evaluation="equal">
                         <data>true</data>
                      </feature>
@@ -172,7 +156,7 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
-                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI is not initialized" problem_level="1" source="Pins:BOARD_InitQSPIPins">
+                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI signals are routed in the Pins Tool, but the peripheral is not initialized in the Peripherals Tool." problem_level="1" source="Pins:BOARD_InitQSPIPins">
                      <feature name="initialized" evaluation="equal">
                         <data>true</data>
                      </feature>
@@ -200,13 +184,13 @@
             </function>
          </functions_list>
       </pins>
-      <clocks name="Clocks" version="11.0" enabled="true" update_project_code="true">
+      <clocks name="Clocks" version="20.0" enabled="true" update_project_code="true">
          <generated_project_files>
             <file path="board/clock_config.c" update_enabled="true"/>
             <file path="board/clock_config.h" update_enabled="true"/>
          </generated_project_files>
          <clocks_profile>
-            <processor_version>13.0.2</processor_version>
+            <processor_version>26.03.10</processor_version>
          </clocks_profile>
          <clock_configurations>
             <clock_configuration name="BOARD_BootClockRUN" id_prefix="" prefix_user_defined="false">

--- a/hw/bsp/imxrt/boards/teensy_41/board/clock_config.c
+++ b/hw/bsp/imxrt/boards/teensy_41/board/clock_config.c
@@ -15,11 +15,11 @@
 
 /* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
 !!GlobalInfo
-product: Clocks v11.0
+product: Clocks v20.0
 processor: MIMXRT1062xxxxA
 package_id: MIMXRT1062DVL6A
 mcu_data: ksdk2_0
-processor_version: 13.0.2
+processor_version: 26.03.10
 board: MIMXRT1060-EVK
  * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
 

--- a/hw/bsp/imxrt/boards/teensy_41/board/clock_config.h
+++ b/hw/bsp/imxrt/boards/teensy_41/board/clock_config.h
@@ -36,56 +36,56 @@ void BOARD_InitBootClocks(void);
 #define BOARD_BOOTCLOCKRUN_CORE_CLOCK             600000000U  /*!< Core clock frequency: 600000000Hz */
 
 /* Clock outputs (values are in Hz): */
-#define BOARD_BOOTCLOCKRUN_AHB_CLK_ROOT               600000000UL
-#define BOARD_BOOTCLOCKRUN_CAN_CLK_ROOT               40000000UL
-#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT         32768UL
-#define BOARD_BOOTCLOCKRUN_CLKO1_CLK                  0UL
-#define BOARD_BOOTCLOCKRUN_CLKO2_CLK                  0UL
-#define BOARD_BOOTCLOCKRUN_CLK_1M                     1000000UL
-#define BOARD_BOOTCLOCKRUN_CLK_24M                    24000000UL
-#define BOARD_BOOTCLOCKRUN_CSI_CLK_ROOT               12000000UL
-#define BOARD_BOOTCLOCKRUN_ENET2_125M_CLK             1200000UL
-#define BOARD_BOOTCLOCKRUN_ENET2_REF_CLK              0UL
-#define BOARD_BOOTCLOCKRUN_ENET2_TX_CLK               0UL
-#define BOARD_BOOTCLOCKRUN_ENET_125M_CLK              2400000UL
-#define BOARD_BOOTCLOCKRUN_ENET_25M_REF_CLK           1200000UL
-#define BOARD_BOOTCLOCKRUN_ENET_REF_CLK               0UL
-#define BOARD_BOOTCLOCKRUN_ENET_TX_CLK                0UL
-#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT           30000000UL
-#define BOARD_BOOTCLOCKRUN_FLEXIO2_CLK_ROOT           30000000UL
-#define BOARD_BOOTCLOCKRUN_FLEXSPI2_CLK_ROOT          130909090UL
-#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT           130909090UL
-#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ      75000000UL
-#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ      75000000UL
-#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT               150000000UL
-#define BOARD_BOOTCLOCKRUN_LCDIF_CLK_ROOT             67500000UL
-#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT             60000000UL
-#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT             105600000UL
-#define BOARD_BOOTCLOCKRUN_LVDS1_CLK                  1200000000UL
-#define BOARD_BOOTCLOCKRUN_MQS_MCLK                   63529411UL
-#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT            75000000UL
-#define BOARD_BOOTCLOCKRUN_PLL7_MAIN_CLK              480000000UL
-#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT              63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1                 63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2                 63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3                 30000000UL
-#define BOARD_BOOTCLOCKRUN_SAI2_CLK_ROOT              63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI2_MCLK1                 63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI2_MCLK2                 0UL
-#define BOARD_BOOTCLOCKRUN_SAI2_MCLK3                 30000000UL
-#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT              63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1                 63529411UL
-#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2                 0UL
-#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3                 30000000UL
-#define BOARD_BOOTCLOCKRUN_SEMC_CLK_ROOT              75000000UL
-#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT            30000000UL
-#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT          0UL
-#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT             132000000UL
-#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT              80000000UL
-#define BOARD_BOOTCLOCKRUN_USBPHY1_CLK                480000000UL
-#define BOARD_BOOTCLOCKRUN_USBPHY2_CLK                480000000UL
-#define BOARD_BOOTCLOCKRUN_USDHC1_CLK_ROOT            198000000UL
-#define BOARD_BOOTCLOCKRUN_USDHC2_CLK_ROOT            198000000UL
+#define BOARD_BOOTCLOCKRUN_AHB_CLK_ROOT               600000000UL    /* Clock consumers of AHB_CLK_ROOT output : AIPSTZ1, AIPSTZ2, AIPSTZ3, AIPSTZ4, ARM, FLEXIO3, FLEXSPI, FLEXSPI2, GPIO6, GPIO7, GPIO8, GPIO9 */
+#define BOARD_BOOTCLOCKRUN_CAN_CLK_ROOT               40000000UL     /* Clock consumers of CAN_CLK_ROOT output : CAN1, CAN2, CAN3 */
+#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT         32768UL        /* Clock consumers of CKIL_SYNC_CLK_ROOT output : CSU, EWM, GPT1, GPT2, KPP, PIT, RTWDOG, SNVS, SPDIF, TEMPMON, TSC, USB1, USB2, WDOG1, WDOG2 */
+#define BOARD_BOOTCLOCKRUN_CLKO1_CLK                  0UL            /* Clock consumers of CLKO1_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_CLKO2_CLK                  0UL            /* Clock consumers of CLKO2_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_CLK_1M                     1000000UL      /* Clock consumers of CLK_1M output : EWM, RTWDOG */
+#define BOARD_BOOTCLOCKRUN_CLK_24M                    24000000UL     /* Clock consumers of CLK_24M output : GPT1, GPT2 */
+#define BOARD_BOOTCLOCKRUN_CSI_CLK_ROOT               12000000UL     /* Clock consumers of CSI_CLK_ROOT output : CSI */
+#define BOARD_BOOTCLOCKRUN_ENET2_125M_CLK             1200000UL      /* Clock consumers of ENET2_125M_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_ENET2_REF_CLK              0UL            /* Clock consumers of ENET2_REF_CLK output : ENET2 */
+#define BOARD_BOOTCLOCKRUN_ENET2_TX_CLK               0UL            /* Clock consumers of ENET2_TX_CLK output : ENET2 */
+#define BOARD_BOOTCLOCKRUN_ENET_125M_CLK              2400000UL      /* Clock consumers of ENET_125M_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_ENET_25M_REF_CLK           1200000UL      /* Clock consumers of ENET_25M_REF_CLK output : ENET, ENET2 */
+#define BOARD_BOOTCLOCKRUN_ENET_REF_CLK               0UL            /* Clock consumers of ENET_REF_CLK output : ENET */
+#define BOARD_BOOTCLOCKRUN_ENET_TX_CLK                0UL            /* Clock consumers of ENET_TX_CLK output : ENET */
+#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT           30000000UL     /* Clock consumers of FLEXIO1_CLK_ROOT output : FLEXIO1 */
+#define BOARD_BOOTCLOCKRUN_FLEXIO2_CLK_ROOT           30000000UL     /* Clock consumers of FLEXIO2_CLK_ROOT output : FLEXIO2, FLEXIO3 */
+#define BOARD_BOOTCLOCKRUN_FLEXSPI2_CLK_ROOT          130909090UL    /* Clock consumers of FLEXSPI2_CLK_ROOT output : FLEXSPI2 */
+#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT           130909090UL    /* Clock consumers of FLEXSPI_CLK_ROOT output : FLEXSPI */
+#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ      75000000UL     /* Clock consumers of GPT1_ipg_clk_highfreq output : GPT1 */
+#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ      75000000UL     /* Clock consumers of GPT2_ipg_clk_highfreq output : GPT2 */
+#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT               150000000UL    /* Clock consumers of IPG_CLK_ROOT output : ADC1, ADC2, ADC_ETC, AOI1, AOI2, ARM, BEE, CAN1, CAN2, CAN3, CCM, CMP1, CMP2, CMP3, CMP4, CSI, CSU, DCDC, DCP, DMA0, DMAMUX, ENC1, ENC2, ENC3, ENC4, ENET, ENET2, EWM, FLEXIO1, FLEXIO2, FLEXIO3, FLEXRAM, FLEXSPI, FLEXSPI2, GPC, GPIO1, GPIO10, GPIO2, GPIO3, GPIO4, GPIO5, IOMUXC, KPP, LCDIF, LPI2C1, LPI2C2, LPI2C3, LPI2C4, LPSPI1, LPSPI2, LPSPI3, LPSPI4, LPUART1, LPUART2, LPUART3, LPUART4, LPUART5, LPUART6, LPUART7, LPUART8, NVIC, OCOTP, PMU, PWM1, PWM2, PWM3, PWM4, PXP, ROMC, RTWDOG, SAI1, SAI2, SAI3, SNVS, SPDIF, SRC, TEMPMON, TMR1, TMR2, TMR3, TMR4, TRNG, TSC, USB1, USB2, USDHC1, USDHC2, WDOG1, WDOG2, XBARA1, XBARB2, XBARB3 */
+#define BOARD_BOOTCLOCKRUN_LCDIF_CLK_ROOT             67500000UL     /* Clock consumers of LCDIF_CLK_ROOT output : LCDIF */
+#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT             60000000UL     /* Clock consumers of LPI2C_CLK_ROOT output : LPI2C1, LPI2C2, LPI2C3, LPI2C4 */
+#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT             105600000UL    /* Clock consumers of LPSPI_CLK_ROOT output : LPSPI1, LPSPI2, LPSPI3, LPSPI4 */
+#define BOARD_BOOTCLOCKRUN_LVDS1_CLK                  1200000000UL   /* Clock consumers of LVDS1_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_MQS_MCLK                   63529411UL     /* Clock consumers of MQS_MCLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT            75000000UL     /* Clock consumers of PERCLK_CLK_ROOT output : GPT1, GPT2, PIT */
+#define BOARD_BOOTCLOCKRUN_PLL7_MAIN_CLK              480000000UL    /* Clock consumers of PLL7_MAIN_CLK output : N/A */
+#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT              63529411UL     /* Clock consumers of SAI1_CLK_ROOT output : N/A */
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1                 63529411UL     /* Clock consumers of SAI1_MCLK1 output : SAI1 */
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2                 63529411UL     /* Clock consumers of SAI1_MCLK2 output : SAI1 */
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3                 30000000UL     /* Clock consumers of SAI1_MCLK3 output : SAI1 */
+#define BOARD_BOOTCLOCKRUN_SAI2_CLK_ROOT              63529411UL     /* Clock consumers of SAI2_CLK_ROOT output : N/A */
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK1                 63529411UL     /* Clock consumers of SAI2_MCLK1 output : SAI2 */
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK2                 0UL            /* Clock consumers of SAI2_MCLK2 output : SAI2 */
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK3                 30000000UL     /* Clock consumers of SAI2_MCLK3 output : SAI2 */
+#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT              63529411UL     /* Clock consumers of SAI3_CLK_ROOT output : N/A */
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1                 63529411UL     /* Clock consumers of SAI3_MCLK1 output : SAI3 */
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2                 0UL            /* Clock consumers of SAI3_MCLK2 output : SAI3 */
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3                 30000000UL     /* Clock consumers of SAI3_MCLK3 output : SAI3 */
+#define BOARD_BOOTCLOCKRUN_SEMC_CLK_ROOT              75000000UL     /* Clock consumers of SEMC_CLK_ROOT output : SEMC */
+#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT            30000000UL     /* Clock consumers of SPDIF0_CLK_ROOT output : SPDIF */
+#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT          0UL            /* Clock consumers of SPDIF0_EXTCLK_OUT output : SPDIF */
+#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT             132000000UL    /* Clock consumers of TRACE_CLK_ROOT output : ARM */
+#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT              80000000UL     /* Clock consumers of UART_CLK_ROOT output : LPUART1, LPUART2, LPUART3, LPUART4, LPUART5, LPUART6, LPUART7, LPUART8 */
+#define BOARD_BOOTCLOCKRUN_USBPHY1_CLK                480000000UL    /* Clock consumers of USBPHY1_CLK output : TEMPMON, USB1 */
+#define BOARD_BOOTCLOCKRUN_USBPHY2_CLK                480000000UL    /* Clock consumers of USBPHY2_CLK output : USB2 */
+#define BOARD_BOOTCLOCKRUN_USDHC1_CLK_ROOT            198000000UL    /* Clock consumers of USDHC1_CLK_ROOT output : USDHC1 */
+#define BOARD_BOOTCLOCKRUN_USDHC2_CLK_ROOT            198000000UL    /* Clock consumers of USDHC2_CLK_ROOT output : USDHC2 */
 
 /*! @brief Arm PLL set for BOARD_BootClockRUN configuration.
  */

--- a/hw/bsp/imxrt/boards/teensy_41/board/pin_mux.c
+++ b/hw/bsp/imxrt/boards/teensy_41/board/pin_mux.c
@@ -6,11 +6,11 @@
 /*
  * TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
 !!GlobalInfo
-product: Pins v13.1
+product: Pins v17.0
 processor: MIMXRT1062xxxxA
 package_id: MIMXRT1062DVL6A
 mcu_data: ksdk2_0
-processor_version: 13.0.2
+processor_version: 26.03.10
 board: MIMXRT1060-EVK
 pin_labels:
 - {pin_num: E7, pin_signal: GPIO_B0_01, label: LCDIF_ENABLE, identifier: USER_BUTTON}
@@ -80,16 +80,13 @@ void BOARD_InitPins(void) {
   IOMUXC_SetPinConfig(IOMUXC_GPIO_B0_01_GPIO2_IO01, 0xB0B0U);
 }
 
-
 /*
  * TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
 BOARD_InitDEBUG_UARTPins:
 - options: {callFromInitBoot: 'true', coreID: core0, enableClock: 'true'}
 - pin_list:
-  - {pin_num: K14, peripheral: LPUART1, signal: TX, pin_signal: GPIO_AD_B0_12, software_input_on: Disable, hysteresis_enable: Disable, pull_up_down_config: Pull_Down_100K_Ohm,
-    pull_keeper_select: Keeper, pull_keeper_enable: Enable, open_drain: Disable, speed: MHZ_100, drive_strength: R0_6, slew_rate: Slow}
-  - {pin_num: L14, peripheral: LPUART1, signal: RX, pin_signal: GPIO_AD_B0_13, software_input_on: Disable, hysteresis_enable: Disable, pull_up_down_config: Pull_Down_100K_Ohm,
-    pull_keeper_select: Keeper, pull_keeper_enable: Enable, open_drain: Disable, speed: MHZ_100, drive_strength: R0_6, slew_rate: Slow}
+  - {pin_num: G11, peripheral: LPUART6, signal: RX, pin_signal: GPIO_AD_B0_03, speed: MHZ_50}
+  - {pin_num: M11, peripheral: LPUART6, signal: TX, pin_signal: GPIO_AD_B0_02, speed: MHZ_50}
  * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS ***********
  */
 
@@ -104,10 +101,9 @@ void BOARD_InitDEBUG_UARTPins(void) {
 
   IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_02_LPUART6_TX, 0U);
   IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_03_LPUART6_RX, 0U);
-  IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_02_LPUART6_TX, 0x10B0U);
-  IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_03_LPUART6_RX, 0x10B0U);
+  IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_02_LPUART6_TX, 0x1030U);
+  IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B0_03_LPUART6_RX, 0x1030U);
 }
-
 
 /*
  * TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
@@ -142,7 +138,6 @@ void BOARD_InitUSDHCPins(void) {
   IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3, 0U);
 }
 
-
 /*
  * TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
 BOARD_InitQSPIPins:
@@ -175,7 +170,6 @@ void BOARD_InitQSPIPins(void) {
   IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B1_10_FLEXSPIA_DATA02, 0U);
   IOMUXC_SetPinMux(IOMUXC_GPIO_SD_B1_11_FLEXSPIA_DATA03, 0U);
 }
-
 /***********************************************************************************************************************
  * EOF
  **********************************************************************************************************************/

--- a/hw/bsp/imxrt/boards/teensy_41/board/pin_mux.h
+++ b/hw/bsp/imxrt/boards/teensy_41/board/pin_mux.h
@@ -47,6 +47,7 @@ void BOARD_InitBootPins(void);
 
 /* Symbols to be used with GPIO driver */
 #define BOARD_INITPINS_USER_LED_GPIO                                       GPIO2   /*!< GPIO peripheral base pointer */
+#define BOARD_INITPINS_USER_LED_INIT_GPIO_VALUE                               0U   /*!< GPIO output initial state */
 #define BOARD_INITPINS_USER_LED_GPIO_PIN                                      3U   /*!< GPIO pin number */
 #define BOARD_INITPINS_USER_LED_GPIO_PIN_MASK                         (1U << 3U)   /*!< GPIO pin mask */
 #define BOARD_INITPINS_USER_LED_PORT                                       GPIO2   /*!< PORT peripheral base pointer */
@@ -72,16 +73,6 @@ void BOARD_InitBootPins(void);
  *
  */
 void BOARD_InitPins(void);
-
-/* GPIO_AD_B0_12 (coord K14), UART1_TXD */
-/* Routed pin properties */
-#define BOARD_INITDEBUG_UARTPINS_UART1_TXD_PERIPHERAL                    LPUART1   /*!< Peripheral name */
-#define BOARD_INITDEBUG_UARTPINS_UART1_TXD_SIGNAL                             TX   /*!< Signal name */
-
-/* GPIO_AD_B0_13 (coord L14), UART1_RXD */
-/* Routed pin properties */
-#define BOARD_INITDEBUG_UARTPINS_UART1_RXD_PERIPHERAL                    LPUART1   /*!< Peripheral name */
-#define BOARD_INITDEBUG_UARTPINS_UART1_RXD_SIGNAL                             RX   /*!< Signal name */
 
 /*!
  * @brief Configures pin routing and optionally pin electrical features.

--- a/hw/bsp/imxrt/boards/teensy_41/teensy41.mex
+++ b/hw/bsp/imxrt/boards/teensy_41/teensy41.mex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding= "UTF-8" ?>
-<configuration name="MIMXRT1060-EVK" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_13 http://mcuxpresso.nxp.com/XSD/mex_configuration_13.xsd" uuid="2174caba-38fe-48d5-8f89-42a23354d23b" version="13" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_13" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<configuration name="MIMXRT1060-EVK" xsi:schemaLocation="http://mcuxpresso.nxp.com/XSD/mex_configuration_19 http://mcuxpresso.nxp.com/XSD/mex_configuration_19.xsd" uuid="2174caba-38fe-48d5-8f89-42a23354d23b" version="19" xmlns="http://mcuxpresso.nxp.com/XSD/mex_configuration_19" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <common>
       <processor>MIMXRT1062xxxxA</processor>
       <package>MIMXRT1062DVL6A</package>
@@ -13,19 +13,19 @@
    </common>
    <preferences>
       <validate_boot_init_only>false</validate_boot_init_only>
-      <generate_extended_information>false</generate_extended_information>
       <generate_code_modified_registers_only>false</generate_code_modified_registers_only>
       <update_include_paths>true</update_include_paths>
+      <enable_parallel_routing>true</enable_parallel_routing>
       <generate_registers_defines>false</generate_registers_defines>
    </preferences>
    <tools>
-      <pins name="Pins" version="13.1" enabled="true" update_project_code="true">
+      <pins name="Pins" version="17.0" enabled="true" update_project_code="true">
          <generated_project_files>
             <file path="board/pin_mux.c" update_enabled="true"/>
             <file path="board/pin_mux.h" update_enabled="true"/>
          </generated_project_files>
          <pins_profile>
-            <processor_version>13.0.2</processor_version>
+            <processor_version>26.03.10</processor_version>
             <pin_labels>
                <pin_label pin_num="E7" pin_signal="GPIO_B0_01" label="LCDIF_ENABLE" identifier="USER_BUTTON"/>
                <pin_label pin_num="D8" pin_signal="GPIO_B0_03" label="LCDIF_VSYNC" identifier="USER_LED"/>
@@ -41,7 +41,7 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
-                  <dependency resourceType="Peripheral" resourceId="GPIO2" description="Peripheral GPIO2 is not initialized" problem_level="1" source="Pins:BOARD_InitPins">
+                  <dependency resourceType="Peripheral" resourceId="GPIO2" description="Peripheral GPIO2 signals are routed in the Pins Tool, but the peripheral is not initialized in the Peripherals Tool." problem_level="1" source="Pins:BOARD_InitPins">
                      <feature name="initialized" evaluation="equal">
                         <data>true</data>
                      </feature>
@@ -85,7 +85,7 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
-                  <dependency resourceType="Peripheral" resourceId="LPUART1" description="Peripheral LPUART1 is not initialized" problem_level="1" source="Pins:BOARD_InitDEBUG_UARTPins">
+                  <dependency resourceType="Peripheral" resourceId="LPUART6" description="Peripheral LPUART6 signals are routed in the Pins Tool, but the peripheral is not initialized in the Peripherals Tool." problem_level="1" source="Pins:BOARD_InitDEBUG_UARTPins">
                      <feature name="initialized" evaluation="equal">
                         <data>true</data>
                      </feature>
@@ -102,30 +102,14 @@
                   </dependency>
                </dependencies>
                <pins>
-                  <pin peripheral="LPUART1" signal="TX" pin_num="K14" pin_signal="GPIO_AD_B0_12">
+                  <pin peripheral="LPUART6" signal="RX" pin_num="G11" pin_signal="GPIO_AD_B0_03">
                      <pin_features>
-                        <pin_feature name="software_input_on" value="Disable"/>
-                        <pin_feature name="hysteresis_enable" value="Disable"/>
-                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
-                        <pin_feature name="pull_keeper_select" value="Keeper"/>
-                        <pin_feature name="pull_keeper_enable" value="Enable"/>
-                        <pin_feature name="open_drain" value="Disable"/>
-                        <pin_feature name="speed" value="MHZ_100"/>
-                        <pin_feature name="drive_strength" value="R0_6"/>
-                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
                      </pin_features>
                   </pin>
-                  <pin peripheral="LPUART1" signal="RX" pin_num="L14" pin_signal="GPIO_AD_B0_13">
+                  <pin peripheral="LPUART6" signal="TX" pin_num="M11" pin_signal="GPIO_AD_B0_02">
                      <pin_features>
-                        <pin_feature name="software_input_on" value="Disable"/>
-                        <pin_feature name="hysteresis_enable" value="Disable"/>
-                        <pin_feature name="pull_up_down_config" value="Pull_Down_100K_Ohm"/>
-                        <pin_feature name="pull_keeper_select" value="Keeper"/>
-                        <pin_feature name="pull_keeper_enable" value="Enable"/>
-                        <pin_feature name="open_drain" value="Disable"/>
-                        <pin_feature name="speed" value="MHZ_100"/>
-                        <pin_feature name="drive_strength" value="R0_6"/>
-                        <pin_feature name="slew_rate" value="Slow"/>
+                        <pin_feature name="speed" value="MHZ_50"/>
                      </pin_features>
                   </pin>
                </pins>
@@ -138,7 +122,7 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
-                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 is not initialized" problem_level="1" source="Pins:BOARD_InitUSDHCPins">
+                  <dependency resourceType="Peripheral" resourceId="USDHC1" description="Peripheral USDHC1 signals are routed in the Pins Tool, but the peripheral is not initialized in the Peripherals Tool." problem_level="1" source="Pins:BOARD_InitUSDHCPins">
                      <feature name="initialized" evaluation="equal">
                         <data>true</data>
                      </feature>
@@ -172,7 +156,7 @@
                   <enableClock>true</enableClock>
                </options>
                <dependencies>
-                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI is not initialized" problem_level="1" source="Pins:BOARD_InitQSPIPins">
+                  <dependency resourceType="Peripheral" resourceId="FLEXSPI" description="Peripheral FLEXSPI signals are routed in the Pins Tool, but the peripheral is not initialized in the Peripherals Tool." problem_level="1" source="Pins:BOARD_InitQSPIPins">
                      <feature name="initialized" evaluation="equal">
                         <data>true</data>
                      </feature>
@@ -200,13 +184,13 @@
             </function>
          </functions_list>
       </pins>
-      <clocks name="Clocks" version="11.0" enabled="true" update_project_code="true">
+      <clocks name="Clocks" version="20.0" enabled="true" update_project_code="true">
          <generated_project_files>
             <file path="board/clock_config.c" update_enabled="true"/>
             <file path="board/clock_config.h" update_enabled="true"/>
          </generated_project_files>
          <clocks_profile>
-            <processor_version>13.0.2</processor_version>
+            <processor_version>26.03.10</processor_version>
          </clocks_profile>
          <clock_configurations>
             <clock_configuration name="BOARD_BootClockRUN" id_prefix="" prefix_user_defined="false">


### PR DESCRIPTION
This pull request updates the Teensy 4.0 board support package to use newer MCUXpresso configuration tools and changes the default debug UART from `LPUART1` to `LPUART6`. It also updates the pin and clock configuration files to match these changes and cleans up related code and metadata.
