### PR TITLE
Fix musb RXRDY Clearing

### DIFF
--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -230,13 +230,19 @@ static bool handle_xfer_out(uint8_t rhport, uint_fast8_t ep_addr)
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, epnum);
   // TU_LOG1(" RXCSRL%d = %x\r\n", epnum_minus1 + 1, ep_csr->rx_csrl);
 
-  TU_ASSERT(ep_csr->rx_csrl & MUSB_RXCSRL1_RXRDY);
+  //Fail gracefully. Spurious interrupt.
+  if (!(ep_csr->rx_csrl & MUSB_RXCSRL1_RXRDY)) return false;
+
+  void *buf = pipe->buf;
+  if (buf == NULL) {
+    ep_csr->rx_csrl = MUSB_RXCSRL1_FLUSH;
+    return false;
+  }
 
   const unsigned mps = ep_csr->rx_maxp;
   const unsigned rem = pipe->remaining;
   const unsigned vld = ep_csr->rx_count;
   const unsigned len = TU_MIN(TU_MIN(rem, mps), vld);
-  void          *buf = pipe->buf;
   volatile void *fifo_ptr = &musb_regs->fifo[epnum];
   if (len) {
     if (_dcd.pipe_buf_is_fifo[TUSB_DIR_OUT] & TU_BIT(epnum_minus1)) {
@@ -247,11 +253,12 @@ static bool handle_xfer_out(uint8_t rhport, uint_fast8_t ep_addr)
     }
     pipe->remaining = rem - len;
   }
+
+  ep_csr->rx_csrl = 0; /* Always Clear RXRDY bit */
   if ((len < mps) || (rem == len)) {
     pipe->buf = NULL;
     return NULL != buf;
   }
-  ep_csr->rx_csrl = 0; /* Clear RXRDY bit */
   return false;
 }
 


### PR DESCRIPTION
Resolves an issue in the musb `handle_xfer_out` function where not all execution paths cleared the `MUSB_RXCSRL1_RXRDY` bit, causing the RX interface to hang and no longer communicate with the host.

This issue was discovered while using the RNDIS class in a media converter application. When running iperf testing at full speed (10Mbps link) the USB stack was under constant load of packets and eventually would stop receiving new frames from the host PC.  Other USB events and interrupts were still occurring.

It is believed the root cause was the RXRDY bit not being cleared in all data paths of the xfer handler, resulting in the peripheral no longer accepting new frames into the FIFO.  Applying this change allowed continuous operation under these high traffic conditions without lockup.

### Verification Testing
Testing was performed with 2x MAX32690's acting as RNDIS to 10Mbps single pair ethernet media converters, connected to Linux PCs.  Bidirectional iperf was run for 12 hours resulting in each MCU sending and receiving 18M+ packets (~24 GB) in each direction with no driver lock ups of failures.  Prior to these updates, testing would fail within minutes.
