### PR TITLE
Correct endianness handling for big-endian hosts in SETUP packets

### DIFF
--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -409,10 +409,17 @@ typedef struct TU_ATTR_PACKED {
   uint8_t  bEndpointAddress ; // The address of the endpoint
 
   struct TU_ATTR_PACKED {
+#if TU_BYTE_ORDER == TU_BIG_ENDIAN
+    uint8_t       : 2;
+    uint8_t usage : 2;        // Data, Feedback, Implicit feedback
+    uint8_t sync  : 2;        // None, Asynchronous, Adaptive, Synchronous
+    uint8_t xfer  : 2;        // Control, ISO, Bulk, Interrupt
+#else
     uint8_t xfer  : 2;        // Control, ISO, Bulk, Interrupt
     uint8_t sync  : 2;        // None, Asynchronous, Adaptive, Synchronous
     uint8_t usage : 2;        // Data, Feedback, Implicit feedback
     uint8_t       : 2;
+#endif
   } bmAttributes;
 
   uint16_t wMaxPacketSize   ; // Bit 10..0 : max packet size, bit 12..11 additional transaction per highspeed micro-frame
@@ -522,9 +529,15 @@ typedef struct TU_ATTR_PACKED {
 typedef struct TU_ATTR_PACKED {
   union {
     struct TU_ATTR_PACKED {
+#if TU_BYTE_ORDER == TU_BIG_ENDIAN
+      uint8_t direction :  1; ///< Direction type. tusb_dir_t
+      uint8_t type      :  2; ///< Request type tusb_request_type_t.
+      uint8_t recipient :  5; ///< Recipient type tusb_request_recipient_t.
+#else
       uint8_t recipient :  5; ///< Recipient type tusb_request_recipient_t.
       uint8_t type      :  2; ///< Request type tusb_request_type_t.
       uint8_t direction :  1; ///< Direction type. tusb_dir_t
+#endif
     } bmRequestType_bit;
 
     uint8_t bmRequestType;

--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -219,6 +219,11 @@ TU_ATTR_ALWAYS_INLINE static inline void dcd_event_setup_received(uint8_t rhport
   event.rhport = rhport;
   event.event_id = DCD_EVENT_SETUP_RECEIVED;
   (void) memcpy(&event.setup_received, setup, sizeof(tusb_control_request_t));
+  // USB wire format is little-endian. Convert multi-byte fields to host byte order
+  // so the stack always sees correct values regardless of CPU endianness.
+  event.setup_received.wValue  = tu_le16toh(event.setup_received.wValue);
+  event.setup_received.wIndex  = tu_le16toh(event.setup_received.wIndex);
+  event.setup_received.wLength = tu_le16toh(event.setup_received.wLength);
   dcd_event_handler(&event, in_isr);
 }
 


### PR DESCRIPTION
USB wire format is little-endian, but TinyUSB assumed host byte order == little-endian
in two places:
 
1. dcd_event_setup_received() (dcd.h): after memcpy-ing the raw SETUP bytes into
   tusb_control_request_t, wValue/wIndex/wLength were left in wire byte order.
   Fix: apply tu_le16toh() on each field. On LE hosts this is a no-op.
 
2. Bit-field structs (tusb_types.h): GCC on big-endian ARM allocates bit fields
   from the MSB downward, opposite to the USB spec's LSB-first numbering.
   Fix: reverse the field declaration order under TU_BIG_ENDIAN for
   tusb_desc_endpoint_t.bmAttributes and tusb_control_request_t.bmRequestType_bit.
 
Tested on HED CIU98320B (big-endian ARM, full-speed device) with HID keyboard demo:
full enumeration and keystroke transmission verified.