### PR TITLE
tinyusb.mk: Remove duplicate usbc.c entry.

### DIFF
--- a/src/tinyusb.mk
+++ b/src/tinyusb.mk
@@ -26,4 +26,3 @@ TINYUSB_SRC_C += \
   src/class/midi/midi_host.c \
   src/class/msc/msc_host.c \
   src/class/vendor/vendor_host.c \
-  src/typec/usbc.c \


### PR DESCRIPTION
`src/typec/usbc.c` is listed twice in `tinyusb.mk`, once in the device sources block and again at the end of the host sources block. This was likely introduced when host sources were appended in 6b8933cfe. Removing the duplicate.