### PR TITLE
fix zero wLength request in control request

### DIFF
--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -73,6 +73,10 @@ uint8_t* usbd_get_ctrl_buf(void) {
 
 // Queue ZLP status transaction
 static inline bool status_stage_xact(uint8_t rhport, const tusb_control_request_t* request) {
+  // Always use EDPT_CTRL_IN when control request wLength is zero
+  if (request->wLength==0) {
+    return usbd_edpt_xfer(rhport, EDPT_CTRL_IN, NULL, 0);
+  }
   // Opposite to endpoint in Data Phase
   const uint8_t ep_addr = request->bmRequestType_bit.direction ? EDPT_CTRL_OUT : EDPT_CTRL_IN;
   return usbd_edpt_xfer(rhport, ep_addr, NULL, 0, false);
@@ -157,7 +161,9 @@ bool usbd_control_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result,
   (void) result;
 
   // Endpoint Address is opposite to direction bit, this is Status Stage complete event
-  if (tu_edpt_dir(ep_addr) != _ctrl_xfer.request.bmRequestType_bit.direction) {
+  // Control request with zero wLength and IN direction also is Status Stage complete event
+  if ((tu_edpt_dir(ep_addr) != _ctrl_xfer.request.bmRequestType_bit.direction)
+    ||(_ctrl_xfer.request.wLength==0&&_ctrl_xfer.request.bmRequestType_bit.direction==TUSB_DIR_IN)) {
     TU_ASSERT(0 == xferred_bytes);
 
     // invoke optional dcd hook if available


### PR DESCRIPTION
# Description
In the USB specification, when wLength equals 0, the Status Stage is always IN, rather than being opposite to the direction of the Control Request. Therefore, we modified the logic for determining whether it is the Status Stage, as well as the ACK transmission flow for the Status Stage.