### PR TITLE
Fix ch32v103 hardfault & Add CH32V103C8T6 Bluepill board

### DIFF
--- a/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.cmake
+++ b/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.cmake
@@ -1,0 +1,8 @@
+set(LD_FLASH_SIZE 64K)
+set(LD_RAM_SIZE 20K)
+
+function(update_board TARGET)
+  target_compile_definitions(${TARGET} PUBLIC
+    CFG_EXAMPLE_MSC_DUAL_READONLY
+    )
+endfunction()

--- a/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.h
+++ b/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.h
@@ -1,4 +1,4 @@
-/* Some chinese manufactors use CH32V103C8T6 to make Bluepill boards
+/* Some Chinese manufacturers use CH32V103C8T6 to make Bluepill boards
  */
 /* metadata:
    name: CH32V103C8T6-Bluepill

--- a/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.h
+++ b/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.h
@@ -1,0 +1,27 @@
+/* Some chinese manufactors use CH32V103C8T6 to make Bluepill boards
+ */
+/* metadata:
+   name: CH32V103C8T6-Bluepill
+   url: https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill
+*/
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LED_PORT            GPIOC
+#define LED_PIN             GPIO_Pin_13
+#define LED_STATE_ON        0
+
+#define BUTTON_PORT         GPIOA
+#define BUTTON_PIN          GPIO_Pin_1
+#define BUTTON_STATE_ACTIVE 1
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.mk
+++ b/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.mk
@@ -1,0 +1,5 @@
+CFLAGS += -DCFG_EXAMPLE_MSC_DUAL_READONLY
+
+LDFLAGS += \
+  -Wl,--defsym=__FLASH_SIZE=64K \
+  -Wl,--defsym=__RAM_SIZE=20K \

--- a/hw/bsp/ch32v10x/family.c
+++ b/hw/bsp/ch32v10x/family.c
@@ -92,6 +92,7 @@ void board_init(void) {
 #endif
 
   RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
+  RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC, ENABLE);
 
   EXTEN->EXTEN_CTR |= EXTEN_USBFS_IO_EN;
   uint8_t usb_div;

--- a/hw/bsp/ch32v10x/family.c
+++ b/hw/bsp/ch32v10x/family.c
@@ -69,13 +69,13 @@ uint32_t tusb_time_millis_api(void) {
 // 0x800 CSR register is writable in U-mode
 // according to manual: https://www.wch-ic.com/downloads/QingKeV3_Processor_Manual_PDF.html
 __attribute__((always_inline)) RV_STATIC_INLINE
-void __wch_vendor_enable_irq()
+void __wch_vendor_enable_irq(void)
 {
   __asm volatile ("csrs 0x800, %0" : : "r" (0x88) );
 }
 
 __attribute__((always_inline)) RV_STATIC_INLINE
-void __wch_vendor_disable_irq()
+void __wch_vendor_disable_irq(void)
 {
   __asm volatile ("csrc 0x800, %0" : : "r" (0x88) );
   __asm volatile ("fence.i");
@@ -84,7 +84,7 @@ void __wch_vendor_disable_irq()
 void board_init(void) {
   /* __disable_irq() in CH32V103 EVT attempts to call
    * `csrc mstatus, 0x88` in U-mode, which is allowed ONLY in M-mode.
-   * Disable this to avoid hard-fault. */
+   * Replace this with CSR 0x800 to avoid hard-fault. */
   __wch_vendor_disable_irq();
 
 #if CFG_TUSB_OS == OPT_OS_NONE

--- a/hw/bsp/ch32v10x/family.c
+++ b/hw/bsp/ch32v10x/family.c
@@ -67,7 +67,10 @@ uint32_t tusb_time_millis_api(void) {
 #endif
 
 void board_init(void) {
-  __disable_irq();
+  /* __disable_irq() in CH32V103 EVT attempts to call
+   * `csrc mstatus, 0x88` in U-mode, which is allowed ONLY in M-mode.
+   * Disable this to avoid hard-fault. */
+  //__disable_irq();
 
 #if CFG_TUSB_OS == OPT_OS_NONE
   SysTick_Config(SystemCoreClock / 1000);
@@ -123,7 +126,7 @@ void board_init(void) {
   USART_Init(USART1, &usart);
   USART_Cmd(USART1, ENABLE);
 
-  __enable_irq();
+  //__enable_irq();
 
   board_led_write(true);
 }

--- a/hw/bsp/ch32v10x/family.c
+++ b/hw/bsp/ch32v10x/family.c
@@ -66,11 +66,26 @@ uint32_t tusb_time_millis_api(void) {
 }
 #endif
 
+// 0x800 CSR register is writable in U-mode
+// according to manual: https://www.wch-ic.com/downloads/QingKeV3_Processor_Manual_PDF.html
+__attribute__((always_inline)) RV_STATIC_INLINE
+void __wch_vendor_enable_irq()
+{
+  __asm volatile ("csrs 0x800, %0" : : "r" (0x88) );
+}
+
+__attribute__((always_inline)) RV_STATIC_INLINE
+void __wch_vendor_disable_irq()
+{
+  __asm volatile ("csrc 0x800, %0" : : "r" (0x88) );
+  __asm volatile ("fence.i");
+}
+
 void board_init(void) {
   /* __disable_irq() in CH32V103 EVT attempts to call
    * `csrc mstatus, 0x88` in U-mode, which is allowed ONLY in M-mode.
    * Disable this to avoid hard-fault. */
-  //__disable_irq();
+  __wch_vendor_disable_irq();
 
 #if CFG_TUSB_OS == OPT_OS_NONE
   SysTick_Config(SystemCoreClock / 1000);
@@ -126,7 +141,7 @@ void board_init(void) {
   USART_Init(USART1, &usart);
   USART_Cmd(USART1, ENABLE);
 
-  //__enable_irq();
+  __wch_vendor_enable_irq();
 
   board_led_write(true);
 }


### PR DESCRIPTION
> compile but does not run (no blinky), probably due to compile/linker/startup issue

#2674 has a startup issue in `board_init()` : `__disable_irq()` from CH32V103 EVT calls `csrc mstatus, 0x88` in U-mode (which is only allowed in M-mode)

https://github.com/openwch/ch32v103/blob/f99a84c4c42b6fb676560a9b8b7c737401efe0ad/EVT/EXAM/SRC/Core/core_riscv.h#L144-L155

`__disable_irq()` in CH32V307 EVT (probably also in CH32V203), however, uses vendor-defined CSR 0x800. This CSR is writable in U-mode, according to [QingKeV3 Processor Manual](https://www.wch-ic.com/downloads/QingKeV3_Processor_Manual_PDF.html):

https://github.com/openwch/ch32v307/blob/7e33c66cd91008054d2a37db534b10162d1f0c6e/EVT/EXAM/SRC/Core/core_riscv.h#L141-L145

Now you can see the LED blinking, log outputting from UART(if `LOG=2`), but cdc_msc example is still not working.

```
USBD init on controller 0, speed = Auto
sizeof(usbd_device_t) = 55
sizeof(dcd_event_t) = 12
sizeof(tu_fifo_t) = 12
sizeof(tu_edpt_stream_t) = 24
CDC init
MSC init
sizeof(mscd_interface_t) = 64
USBD Bus Reset : Full Speed

USBD Setup Received 80 06 00 01 00 00 40 00 
  Get Descriptor Device
  Queue EP 80 with 18 bytes ...
USBD Xfer Complete on EP 80 with 18 bytes
  Queue EP 00 with 0 bytes ...

USBD Setup Received 80 06 00 01 00 00 40 00 
  Get Descriptor Device
  Queue EP 80 with 18 bytes ...
USBD Xfer Complete on EP 80 with 18 bytes
  Queue EP 00 with 0 bytes ...

```