### PR TITLE
ensure board_uart_write return -1 on default

### DIFF
--- a/hw/bsp/at32f402_405/family.c
+++ b/hw/bsp/at32f402_405/family.c
@@ -220,7 +220,7 @@ int board_uart_write(void const *buf, int len)
   #else
     (void) buf;
     (void) len;
-    return 0;
+    return -1;
   #endif
 }
 

--- a/hw/bsp/at32f403a_407/family.c
+++ b/hw/bsp/at32f403a_407/family.c
@@ -238,7 +238,7 @@ int board_uart_write(void const *buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/at32f413/family.c
+++ b/hw/bsp/at32f413/family.c
@@ -238,7 +238,7 @@ int board_uart_write(void const *buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/at32f415/family.c
+++ b/hw/bsp/at32f415/family.c
@@ -212,7 +212,7 @@ int board_uart_write(void const *buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/at32f423/family.c
+++ b/hw/bsp/at32f423/family.c
@@ -239,7 +239,7 @@ int board_uart_write(void const *buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/at32f425/family.c
+++ b/hw/bsp/at32f425/family.c
@@ -220,7 +220,7 @@ int board_uart_write(void const *buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/at32f435_437/family.c
+++ b/hw/bsp/at32f435_437/family.c
@@ -265,7 +265,7 @@ int board_uart_write(void const *buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/at32f45x/family.c
+++ b/hw/bsp/at32f45x/family.c
@@ -216,7 +216,7 @@ int board_uart_write(void const *buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/board.c
+++ b/hw/bsp/board.c
@@ -171,7 +171,7 @@ int board_getchar(void) {
 }
 
 int board_putchar(int c) {
-  if (board_uart_write((const char *)&c, 1)) {
+  if (board_uart_write((const char *)&c, 1) > 0) {
     return c;
   } else {
     return -1;

--- a/hw/bsp/ch32v20x/family.c
+++ b/hw/bsp/ch32v20x/family.c
@@ -220,6 +220,6 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }

--- a/hw/bsp/ft9xx/family.c
+++ b/hw/bsp/ft9xx/family.c
@@ -221,8 +221,8 @@ int board_uart_read(uint8_t *buf, int len)
 // Send characters to UART
 int board_uart_write(void const *buf, int len)
 {
-    int count = 0;
 #ifdef BOARD_UART
+    int count = 0;
     uint8_t const *p = (uint8_t const *) buf;
     while (count < len) {
         if (BOARD_UART->LSR_ICR_XON2 & MASK_UART_LSR_THRE) {

--- a/hw/bsp/ft9xx/family.c
+++ b/hw/bsp/ft9xx/family.c
@@ -232,10 +232,11 @@ int board_uart_write(void const *buf, int len)
             break;
         }
     }
+    return count;
 #else
     (void) buf; (void) len;
+    return -1;
 #endif
-    return count;
 }
 
 // Get current milliseconds

--- a/hw/bsp/gd32vf103/family.c
+++ b/hw/bsp/gd32vf103/family.c
@@ -174,7 +174,7 @@ int board_uart_write(void const* buf, int len) {
 #else
   (void)buf;
   (void)len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/kinetis_k/family.c
+++ b/hw/bsp/kinetis_k/family.c
@@ -140,7 +140,7 @@ int board_uart_write(void const *buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/mm32/family.c
+++ b/hw/bsp/mm32/family.c
@@ -167,7 +167,7 @@ int board_uart_write(void const* buf, int len) {
   #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
   #endif
 }
 

--- a/hw/bsp/pic32mz/family.c
+++ b/hw/bsp/pic32mz/family.c
@@ -102,7 +102,9 @@ TU_ATTR_WEAK int board_uart_read(uint8_t * buf, int len)
 TU_ATTR_WEAK int board_uart_write(void const * buf, int len)
 {
   (void) buf;
-  return len;
+  (void) len;
+
+  return -1;
 }
 
 #if CFG_TUSB_OS  == OPT_OS_NONE

--- a/hw/bsp/rp2040/family.c
+++ b/hw/bsp/rp2040/family.c
@@ -282,7 +282,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32c0/family.c
+++ b/hw/bsp/stm32c0/family.c
@@ -193,7 +193,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32f0/family.c
+++ b/hw/bsp/stm32f0/family.c
@@ -206,7 +206,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32f1/family.c
+++ b/hw/bsp/stm32f1/family.c
@@ -246,7 +246,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32f2/family.c
+++ b/hw/bsp/stm32f2/family.c
@@ -210,7 +210,7 @@ int board_uart_write(void const* buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32f3/family.c
+++ b/hw/bsp/stm32f3/family.c
@@ -222,7 +222,7 @@ int board_uart_write(void const* buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32f4/family.c
+++ b/hw/bsp/stm32f4/family.c
@@ -295,7 +295,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32f7/family.c
+++ b/hw/bsp/stm32f7/family.c
@@ -357,7 +357,7 @@ int board_uart_write(const void *buf, int len) {
 #else
   (void)buf;
   (void)len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32g0/family.c
+++ b/hw/bsp/stm32g0/family.c
@@ -206,7 +206,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32g4/family.c
+++ b/hw/bsp/stm32g4/family.c
@@ -236,7 +236,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32h5/family.c
+++ b/hw/bsp/stm32h5/family.c
@@ -238,7 +238,7 @@ int board_uart_write(void const* buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32h7/family.c
+++ b/hw/bsp/stm32h7/family.c
@@ -328,7 +328,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32h7rs/family.c
+++ b/hw/bsp/stm32h7rs/family.c
@@ -490,7 +490,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32l0/family.c
+++ b/hw/bsp/stm32l0/family.c
@@ -176,7 +176,7 @@ int board_uart_write(void const* buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32l4/family.c
+++ b/hw/bsp/stm32l4/family.c
@@ -264,7 +264,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32n6/family.c
+++ b/hw/bsp/stm32n6/family.c
@@ -388,7 +388,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32u0/family.c
+++ b/hw/bsp/stm32u0/family.c
@@ -199,7 +199,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32u5/family.c
+++ b/hw/bsp/stm32u5/family.c
@@ -304,7 +304,7 @@ int board_uart_write(void const *buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/stm32wb/family.c
+++ b/hw/bsp/stm32wb/family.c
@@ -196,7 +196,7 @@ int board_uart_write(void const* buf, int len) {
   return count;
 #else
   (void) buf; (void) len;
-  return 0;
+  return -1;
 #endif
 }
 

--- a/hw/bsp/xmc4000/family.c
+++ b/hw/bsp/xmc4000/family.c
@@ -150,7 +150,7 @@ int board_uart_write(void const* buf, int len) {
 #else
   (void) buf;
   (void) len;
-  return 0;
+  return -1;
 #endif
 }
 


### PR DESCRIPTION
to fix sys_write blocking if no UART is defined