### PR TITLE
nrf5x: request HFCLK in USB_EVT_READY to fix post-SoftDevice deadlock

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -1049,6 +1049,12 @@ void tusb_hal_nrf_power_event(uint32_t event) {
         NVIC_EnableIRQ(USBD_IRQn);
       }
 
+      // Ensure HFCLK is requested in the current context. The hfclk_enable() in
+      // USB_EVT_DETECTED may have been pre-SoftDevice. After Softdevice is
+      // enabled, HFXO is physically off again. So any caller that fires
+      // USB_EVT_READY post-SD would hang here.
+      hfclk_enable();
+
       // Wait for HFCLK
       while (!hfclk_running()) {}
 


### PR DESCRIPTION
## Summary

Fix a deadlock in `tusb_hal_nrf_power_event(USB_EVT_READY)` when fired after the SoftDevice has been enabled.

`USB_EVT_DETECTED` runs `hfclk_enable()` which, when SD is not yet enabled, starts HFXO via direct CLOCK register access. After `sd_softdevice_enable()` takes over the CLOCK peripheral, HFXO is physically off again and SD's HFCLK reference count is 0.

If `USB_EVT_READY` is then fired post-SD (e.g. on nRF52 via Bluefruit's `usb_softdevice_post_enable()` when the pre-SD `nrfx_power` READY callback didn't get to run before `nrfx_power` was uninited), the wait loop

```c
while (!hfclk_running()) {}
```

calls `sd_clock_hfclk_is_running()` which returns false forever — deadlock that blocks both USB enumeration and any further app code on the calling thread.

The fix calls `hfclk_enable()` immediately before the wait, so HFCLK is requested in whichever context (SD or direct) is current. `hfclk_enable()` is idempotent.

## Reproduction

Adafruit Feather nRF52840 Express running the `bleuart` example, flashed via JLink (cold start, race-prone). Without the patch the chip wedges in `sd_clock_hfclk_is_running` SVC: no USB enumeration, no BLE advertising. With the patch USB enumerates as `239a:8029` and BLE advertises as `Feather nRF52840 Express`.

## Test plan

- [x] Verified on Feather nRF52840 Express (S140 v6.1.1, FreeRTOS): USB CDC + BLE both working post-fix
- [ ] No-SD nRF52840 sketch (TinyUSB device-only): the added `hfclk_enable()` is idempotent and takes the same direct-register branch as before, so behavior should be unchanged
- [ ] nRF52833 / nRF5340 (if applicable): logic is identical; should be a no-op for paths that already work