### PR TITLE
Fix typo in CDC stack size constant

### DIFF
--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -88,7 +88,7 @@ int main(void) {
 #else
   xTaskCreate(led_blinking_task, "blinky", BLINKY_STACK_SIZE, NULL, 1, NULL);
   xTaskCreate(usb_device_task, "usbd", USBD_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, NULL);
-  xTaskCreate(cdc_task, "cdc", CDC_STACK_SZIE, NULL, configMAX_PRIORITIES - 2, NULL);
+  xTaskCreate(cdc_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES - 2, NULL);
 #endif
 
 #ifndef ESP_PLATFORM

--- a/examples/host/cdc_msc_hid_freertos/src/cdc_app.c
+++ b/examples/host/cdc_msc_hid_freertos/src/cdc_app.c
@@ -29,16 +29,16 @@
 #include "app.h"
 
 #ifdef ESP_PLATFORM
-  #define CDC_STACK_SZIE      2048
+  #define CDC_STACK_SIZE      2048
 #else
-  #define CDC_STACK_SZIE     (3*configMINIMAL_STACK_SIZE/2)
+  #define CDC_STACK_SIZE     (3*configMINIMAL_STACK_SIZE/2)
 #endif
 
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
 //--------------------------------------------------------------------+
 #if configSUPPORT_STATIC_ALLOCATION
-StackType_t  cdc_stack[CDC_STACK_SZIE];
+StackType_t  cdc_stack[CDC_STACK_SIZE];
 StaticTask_t cdc_taskdef;
 #endif
 
@@ -46,9 +46,9 @@ static void cdc_app_task(void* param);
 
 void cdc_app_init(void) {
   #if configSUPPORT_STATIC_ALLOCATION
-  (void) xTaskCreateStatic(cdc_app_task, "cdc", CDC_STACK_SZIE, NULL, configMAX_PRIORITIES-2, cdc_stack, &cdc_taskdef);
+  (void) xTaskCreateStatic(cdc_app_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES-2, cdc_stack, &cdc_taskdef);
   #else
-  (void) xTaskCreate(cdc_app_task, "cdc", CDC_STACK_SZIE, NULL, configMAX_PRIORITIES-2, NULL);
+  (void) xTaskCreate(cdc_app_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES-2, NULL);
   #endif
 }
 


### PR DESCRIPTION
This pull request corrects a typo in the `xTaskCreate` call for the CDC task in the FreeRTOS example. The macro `CDC_STACK_SIZE` was misspelled and is now corrected, ensuring the example to build. 
