### PR TITLE
ch32_usbhs: fix endpoint stall length index and clear-stall response

### DIFF
--- a/src/portable/wch/dcd_ch32_usbhs.c
+++ b/src/portable/wch/dcd_ch32_usbhs.c
@@ -354,7 +354,7 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
   if (dir == TUSB_DIR_OUT) {
     EP_RX_CTRL(ep_num) = USBHS_EP_R_RES_STALL;
   } else {
-    EP_TX_LEN(0)       = 0;
+    EP_TX_LEN(ep_num) = 0;
     EP_TX_CTRL(ep_num) = USBHS_EP_T_RES_STALL;
   }
 }


### PR DESCRIPTION
Was debugging a ch32v305 firmware and claude pointed this out.

Fix issue in the stall handling:

- dcd_edpt_stall() for an IN endpoint cleared EP_TX_LEN(0) instead of EP_TX_LEN(ep_num), clobbering endpoint 0's transmit length register when stalling any other IN endpoint.