### PR TITLE
bsp/stm32f4: enable flash cache

### DIFF
--- a/hw/bsp/stm32f4/family.c
+++ b/hw/bsp/stm32f4/family.c
@@ -109,6 +109,11 @@ void USARTn_IRQHandler(void) {
 
 void board_init(void) {
   board_clock_init();
+
+  __HAL_FLASH_INSTRUCTION_CACHE_ENABLE();
+  __HAL_FLASH_DATA_CACHE_ENABLE();
+  __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+
   //SystemCoreClockUpdate();
 
   // Enable All GPIOs clocks


### PR DESCRIPTION
Which increase `cdc_msc_throughput` speed from 500kB/s to 900kB/s.

Was wondering why `dcd_event_xfer_complete` takes 4us.