### PR TITLE
Fix premature MTP phase change after short MTP OUT transfer

### DIFF
--- a/src/class/mtp/mtp_device.c
+++ b/src/class/mtp/mtp_device.c
@@ -441,9 +441,19 @@ bool mtpd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
         threshold = CFG_TUD_MTP_EP_BUFSIZE;
       }
 
-      // Check completion: ZLP, short packet, or total length reached
-      const bool is_complete =
-        (xferred_bytes == 0 || xferred_bytes < threshold || p_mtp->xferred_len >= p_mtp->total_len);
+      // Check completion for IN and OUT separately
+      bool is_complete;
+
+      if (is_data_in)
+      {
+        // IN completion: short packet, ZLP, or reaching total_len
+        is_complete = (xferred_bytes == 0 || xferred_bytes < threshold || p_mtp->xferred_len >= p_mtp->total_len);
+      }
+      else
+      {
+        // OUT completion: reaching total_len or ZLP
+        is_complete = (p_mtp->xferred_len >= p_mtp->total_len) || ((xferred_bytes == 0 && p_mtp->xferred_len > 0));
+      }
 
       TU_LOG_DRV("  MTP Data %s CB: xferred_bytes=%lu, xferred_len/total_len=%lu/%lu, is_complete=%d\r\n",
                  is_data_in ? "IN" : "OUT", xferred_bytes, p_mtp->xferred_len, p_mtp->total_len, is_complete ? 1 : 0);


### PR DESCRIPTION
While implementing SendPartialObject to edit files "in place" on MTP I encountered an issue where TinyUSB's MTP class driver prematurely ends the DATA phase.

With a Linux host (libmtp/gvfs-mtp), the container is split into two bulk OUT transfers: one with the container header, then one with the payload. The first transfer is shorter than the endpoint max packet size, which the device incorrectly treated as end-of-transfer and transitioned to RESPONSE before the full container length had been received.

USB device stack should not use a short BULK OUT packet as the trigger for switching from DATA phase to RESPONSE phase. Only receiving amount of bytes indicated by container length or ZLP should be allowed to do this.

My suggested fix:
Leave IN handling unchanged (the device controls those packets so I assume short-packet termination is correct there). For OUT, end the phase only when the declared container length is reached or or ZLP from host is received.