### PR TITLE
Add tud_midi_n_tx_avaiable interface created for easier flow control

### DIFF
--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -294,6 +294,12 @@ bool tud_midi_n_packet_write (uint8_t itf, const uint8_t packet[4]) {
   return true;
 }
 
+uint32_t tud_midi_n_tx_available(uint8_t itf) {
+  midid_interface_t *p_midi = &_midid_itf[itf];
+  tu_edpt_stream_t  *ep_str = &p_midi->ep_stream.tx;
+  return tu_edpt_stream_write_available(p_midi->rhport, ep_str);
+}
+
 uint32_t tud_midi_n_packet_write_n(uint8_t itf, const uint8_t packets[], uint32_t n_packets) {
   midid_interface_t *p_midi = &_midid_itf[itf];
   tu_edpt_stream_t  *ep_str = &p_midi->ep_stream.tx;

--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -300,6 +300,12 @@ uint32_t tud_midi_n_tx_available(uint8_t itf) {
   return tu_edpt_stream_write_available(p_midi->rhport, ep_str);
 }
 
+uint32_t tud_midi_n_rx_available(uint8_t itf) {
+  midid_interface_t *p_midi = &_midid_itf[itf];
+  tu_edpt_stream_t  *ep_str = &p_midi->ep_stream.rx;
+  return tu_edpt_stream_read_available(ep_str);
+}
+
 uint32_t tud_midi_n_packet_write_n(uint8_t itf, const uint8_t packets[], uint32_t n_packets) {
   midid_interface_t *p_midi = &_midid_itf[itf];
   tu_edpt_stream_t  *ep_str = &p_midi->ep_stream.tx;

--- a/src/class/midi/midi_device.c
+++ b/src/class/midi/midi_device.c
@@ -301,9 +301,7 @@ uint32_t tud_midi_n_tx_available(uint8_t itf) {
 }
 
 uint32_t tud_midi_n_rx_available(uint8_t itf) {
-  midid_interface_t *p_midi = &_midid_itf[itf];
-  tu_edpt_stream_t  *ep_str = &p_midi->ep_stream.rx;
-  return tu_edpt_stream_read_available(ep_str);
+  return tud_midi_n_available(itf, 0);
 }
 
 uint32_t tud_midi_n_packet_write_n(uint8_t itf, const uint8_t packets[], uint32_t n_packets) {

--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -84,6 +84,9 @@ uint32_t tud_midi_n_packet_write_n(uint8_t itf, const uint8_t packets[], uint32_
 // Get the number of bytes available for writing
 uint32_t tud_midi_n_tx_available(uint8_t itf);
 
+// Get the number of bytes available for reading
+uint32_t tud_midi_n_rx_available(uint8_t itf);
+
 //--------------------------------------------------------------------+
 // Application API (Single Interface)
 //--------------------------------------------------------------------+
@@ -122,6 +125,10 @@ TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_packet_write_n(const uint8
 
 TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_tx_available(void) {
   return tud_midi_n_tx_available(0);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_rx_available(void) {
+  return tud_midi_n_rx_available(0);
 }
 
 //--------------------------------------------------------------------+

--- a/src/class/midi/midi_device.h
+++ b/src/class/midi/midi_device.h
@@ -81,6 +81,9 @@ bool tud_midi_n_packet_write(uint8_t itf, const uint8_t packet[4]);
 // Write multiple event packets, return number of written packets
 uint32_t tud_midi_n_packet_write_n(uint8_t itf, const uint8_t packets[], uint32_t n_packets);
 
+// Get the number of bytes available for writing
+uint32_t tud_midi_n_tx_available(uint8_t itf);
+
 //--------------------------------------------------------------------+
 // Application API (Single Interface)
 //--------------------------------------------------------------------+
@@ -115,6 +118,10 @@ TU_ATTR_ALWAYS_INLINE static inline bool tud_midi_packet_write(const uint8_t pac
 
 TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_packet_write_n(const uint8_t packets[], uint32_t n_packets) {
   return tud_midi_n_packet_write_n(0, packets, n_packets);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_tx_available(void) {
+  return tud_midi_n_tx_available(0);
 }
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
Added publicly accessible Tx and Rx available functions to the MIDI class driver. this allow proper flow-control to prevent data loss when using non-peekable tx FIFOs in the application.

## Files changed
- src/class/midi/midi_device.h
- src/class/midi/midi_device.c

## New interfaces
```
uint32_t tud_midi_n_tx_available(uint8_t itf);
uint32_t tud_midi_n_rx_available(uint8_t itf);
```

## New inline functions
```
TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_tx_available(void) {
  return tud_midi_n_tx_available(0);
}

TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_midi_rx_available(void) {
  return tud_midi_n_rx_available(0);
}
```

