### PR TITLE
cdc_host: fix undeclared 'idx' when only LINE_CONTROL_ON_ENUM is defined

### DIFF
--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -839,7 +839,7 @@ static bool set_line_state_on_enum(cdch_interface_t *p_cdc, tuh_xfer_t *xfer) {
     ENUM_SET_LINE_CONTROL,
     ENUM_SET_LINE_COMPLETE,
   };
-  #ifdef CFG_TUH_CDC_LINE_CODING_ON_ENUM
+  #if defined(CFG_TUH_CDC_LINE_CODING_ON_ENUM) || defined(CFG_TUH_CDC_LINE_CONTROL_ON_ENUM)
   const uint8_t idx = get_idx_by_ptr(p_cdc);
   #endif
   const uintptr_t state = xfer->user_data;


### PR DESCRIPTION
A small compile fix in the CDC host on-enum line-state handling.

If you build the CDC host with `CFG_TUH_CDC_LINE_CONTROL_ON_ENUM` set but `CFG_TUH_CDC_LINE_CODING_ON_ENUM` unset, it doesn't compile. `set_line_state_on_enum()` declares `idx` only under `CFG_TUH_CDC_LINE_CODING_ON_ENUM`, but it's also used in the `ENUM_SET_LINE_CONTROL` case (guarded by `CFG_TUH_CDC_LINE_CONTROL_ON_ENUM`), so `idx` is left undeclared in that branch.

I ran into it while looking at turning on `CFG_TUH_CDC_LINE_CONTROL_ON_ENUM` for a host to assert DTR/RTS on enumerate without forcing a fixed line coding, which seems like a pretty reasonable combination but currently won't build.

Fix just guards the declaration under either macro:

```c
#if defined(CFG_TUH_CDC_LINE_CODING_ON_ENUM) || defined(CFG_TUH_CDC_LINE_CONTROL_ON_ENUM)
  const uint8_t idx = get_idx_by_ptr(p_cdc);
#endif
```

Testing: compile only so far. Built the CDC host class with all four combinations of the two macros (neither, coding only, control only, both); control-only failed before this change and builds after. Haven't runtime-tested the control-only enum path.
