### PR TITLE
ci(claude): post sticky summary comment on code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,6 +44,9 @@ jobs:
             actions: read
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          # Post/update a single summary comment every run, so a clean review
+          # ("no issues found") is still visible instead of posting nothing.
+          use_sticky_comment: true
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # TEMPORARY: expose the full Claude transcript in the Actions log for
           # debugging. Revert to remove once done.


### PR DESCRIPTION
## Problem

The Claude auto-review workflow posts **nothing** when a review finds no issues. With `use_sticky_comment` unset, the only output path is inline comments (`post-buffered-inline-comments`), so a clean "no issues found" review buffers zero inline comments and surfaces no comment at all on the PR — making it look like the review failed (see #3666).

## Change

Set `use_sticky_comment: true` so the action posts/updates a single summary comment on every run. Clean reviews are now visible, and re-runs update the same comment instead of stacking new ones (also sidesteps the "Claude already commented → skip" gate).

## Notes

- Must land on `master` to take effect: the action's workflow-validation requires the PR branch's workflow file to match the default branch, so the behavior only kicks in for PRs branched after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)