### PR TITLE
ci: bump actions/github-script v7 -> v8 (Node.js 24)

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
       discussions: write
     steps:
       - name: Label New Issue, PR or Discussion
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/sponsor-triage.yml
+++ b/.github/workflows/sponsor-triage.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync sponsor issues to project board
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.SPONSOR_TOKEN }}
           script: |


### PR DESCRIPTION
Node.js 20 actions are deprecated; GitHub will force Node.js 24 starting June 16th, 2026. Bumps `actions/github-script@v7` -> `@v8` (Node.js 24) in the two workflows added in #3670.

- `.github/workflows/labeler.yml`
- `.github/workflows/sponsor-triage.yml`

The script API (`github`, `core`, `github.graphql`) is unchanged between v7 and v8, so no script changes are needed. These were the only workflows in the repo still on `github-script@v7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)