### PR TITLE
ci: carry metrics baseline forward on no-code-change pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,10 +207,13 @@ jobs:
         uses: dawidd6/action-download-artifact@v11
         with:
           workflow: build.yml
+          workflow_conclusion: ''      # any conclusion, matching the PR-side baseline download
+          search_artifacts: true       # scan back past runs that lack the artifact (e.g. earlier no-code pushes)
           branch: ${{ github.ref_name }}
           name: metrics-tinyusb
           path: .
           if_no_artifact_found: warn
+        continue-on-error: true        # best-effort: never make a no-code push red
 
       - name: Re-publish baseline so the latest run keeps it
         if: hashFiles('metrics.json') != ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,33 @@ jobs:
           path: metrics_compare.md
 
   # ---------------------------------------
+  # Keep the metrics baseline available on no-code-change pushes
+  # The code-metrics job only runs (and uploads metrics-tinyusb) when code changed, so a
+  # workflow/docs-only push to master would leave the latest run without a baseline for PRs
+  # to compare against. Carry the previous artifact forward so the baseline is never missing.
+  # ---------------------------------------
+  metrics-carry-forward:
+    needs: [ check-paths ]
+    if: github.event_name == 'push' && needs.check-paths.outputs.code_changed != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download previous metrics baseline from this branch
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow: build.yml
+          branch: ${{ github.ref_name }}
+          name: metrics-tinyusb
+          path: .
+          if_no_artifact_found: warn
+
+      - name: Re-publish baseline so the latest run keeps it
+        if: hashFiles('metrics.json') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: metrics-tinyusb
+          path: metrics.json
+
+  # ---------------------------------------
   # Build Make/CMake on Windows/MacOS
   # ---------------------------------------
   build-os:


### PR DESCRIPTION
## Problem
The `code-metrics` job is gated on `code_changed == 'true'` and only uploads the `metrics-tinyusb` artifact on push. So a **workflow/docs-only push to master** (e.g. #3675 "Remove Sponsor Triage workflow", which touched a workflow file *not* in the code filter) leaves the latest master Build run with **no metrics baseline**.

PRs download the baseline from the *latest* master run (`build.yml` "Download Base Branch Metrics"), so when that run has no artifact the size comparison finds nothing and silently falls back to absolute sizes ("No base metrics found, skipping comparison"). That's why recent PRs show no size diff.

## Fix
Add a small `metrics-carry-forward` job that runs on a **non-code-change push** and re-publishes the previous `metrics-tinyusb` artifact, so the latest master run always carries a usable baseline. Carry-forward runs re-upload too, so the baseline chains across consecutive no-code pushes (bounded only by artifact retention; the compare already degrades gracefully if it ever expires).

No rebuild — it just forwards the existing artifact. Scoped to `github.event_name == 'push'` so it never runs on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)