### PR TITLE
hid: fix report_id extraction for interrupt OUT transfers

### DIFF
--- a/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.cmake
+++ b/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.cmake
@@ -1,0 +1,8 @@
+set(LD_FLASH_SIZE 64K)
+set(LD_RAM_SIZE 20K)
+
+function(update_board TARGET)
+  target_compile_definitions(${TARGET} PUBLIC
+    CFG_EXAMPLE_MSC_DUAL_READONLY
+    )
+endfunction()

--- a/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.h
+++ b/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.h
@@ -1,0 +1,27 @@
+/* Some Chinese manufacturers use CH32V103C8T6 to make Bluepill boards
+ */
+/* metadata:
+   name: CH32V103C8T6-Bluepill
+   url: https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill
+*/
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LED_PORT            GPIOC
+#define LED_PIN             GPIO_Pin_13
+#define LED_STATE_ON        0
+
+#define BUTTON_PORT         GPIOA
+#define BUTTON_PIN          GPIO_Pin_1
+#define BUTTON_STATE_ACTIVE 1
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.mk
+++ b/hw/bsp/ch32v10x/boards/ch32v103c_bluepill/board.mk
@@ -1,0 +1,5 @@
+CFLAGS += -DCFG_EXAMPLE_MSC_DUAL_READONLY
+
+LDFLAGS += \
+  -Wl,--defsym=__FLASH_SIZE=64K \
+  -Wl,--defsym=__RAM_SIZE=20K \

--- a/hw/bsp/ch32v10x/family.c
+++ b/hw/bsp/ch32v10x/family.c
@@ -66,14 +66,33 @@ uint32_t tusb_time_millis_api(void) {
 }
 #endif
 
+// 0x800 CSR register is writable in U-mode
+// according to manual: https://www.wch-ic.com/downloads/QingKeV3_Processor_Manual_PDF.html
+__attribute__((always_inline)) RV_STATIC_INLINE
+void __wch_vendor_enable_irq(void)
+{
+  __asm volatile ("csrs 0x800, %0" : : "r" (0x88) );
+}
+
+__attribute__((always_inline)) RV_STATIC_INLINE
+void __wch_vendor_disable_irq(void)
+{
+  __asm volatile ("csrc 0x800, %0" : : "r" (0x88) );
+  __asm volatile ("fence.i");
+}
+
 void board_init(void) {
-  __disable_irq();
+  /* __disable_irq() in CH32V103 EVT attempts to call
+   * `csrc mstatus, 0x88` in U-mode, which is allowed ONLY in M-mode.
+   * Replace this with CSR 0x800 to avoid hard-fault. */
+  __wch_vendor_disable_irq();
 
 #if CFG_TUSB_OS == OPT_OS_NONE
   SysTick_Config(SystemCoreClock / 1000);
 #endif
 
   RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
+  RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC, ENABLE);
 
   EXTEN->EXTEN_CTR |= EXTEN_USBFS_IO_EN;
   uint8_t usb_div;
@@ -123,7 +142,7 @@ void board_init(void) {
   USART_Init(USART1, &usart);
   USART_Cmd(USART1, ENABLE);
 
-  __enable_irq();
+  __wch_vendor_enable_irq();
 
   board_led_write(true);
 }


### PR DESCRIPTION
## Problem

In `hidd_xfer_cb()`, when an output report is received via interrupt 
OUT endpoint, `tud_hid_set_report_cb()` is always called with 
`report_id=0`.

Per HID spec section 8.2, when a device uses report IDs, the first 
byte of an interrupt OUT transfer is the report ID followed by the 
report data. This is already handled correctly in the SET_REPORT 
control path but was missing for interrupt OUT transfers.

## Fix

Extract report_id from the first byte of the output buffer when 
non-zero and buffer length > 1, consistent with how the control 
path handles report IDs.

## Testing

Built hid_composite example for stm32f411blackpill successfully.

Fixes #2929