### PR TITLE
ci: post auto-review findings to the PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,9 @@ jobs:
           # Post/update a single summary comment every run, so a clean review
           # ("no issues found") is still visible instead of posting nothing.
           use_sticky_comment: true
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment makes the code-review command post its findings to the PR.
+          # Without it the command only prints the review to the Actions log.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # TEMPORARY: expose the full Claude transcript in the Actions log for
           # debugging. Revert to remove once done.
           show_full_output: true


### PR DESCRIPTION
## Problem

The **Claude Code Review** workflow (`.github/workflows/claude-code-review.yml`) triggers, runs, and completes successfully — but it never posts a review comment on the PR.

Investigating the run for #3681 ([run 27063670201](https://github.com/hathach/tinyusb/actions/runs/27063670201)) showed the job finished `success` and Claude completed the review, but its final output explained why nothing was posted:

> *"Since `--comment` was not provided, I'll output the final summary here."*

The `/code-review:code-review` command only posts findings to the PR when invoked with **`--comment`**. Without it, the review is printed to the Actions log and the comment-post step logs *"No buffered inline comments"* — so the PR gets no review.

## Fix

Add `--comment` to the command prompt so the auto-review is posted on the PR.

```diff
-          prompt: '/code-review:code-review .../pull/...'
+          prompt: '/code-review:code-review .../pull/... --comment'
```

## Notes

- Scope is one line (plus an explanatory comment); `use_sticky_comment: true` and the rest of the config are unchanged.
- Worth a follow-up check after the first run: confirm a single comment is posted/updated per run rather than a fresh comment on every `synchronize` push. If it turns out noisy, we can revisit the sticky-comment interaction.
- The `show_full_output: true` debug line is still marked TEMPORARY in the file and can be reverted separately once comment posting is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)