### PR TITLE
HIL: replace build.flags_on with named build variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -397,7 +397,15 @@ jobs:
         run: python3 tools/get_deps.py $BUILD_ARGS
 
       - name: Build
-        run: python3 tools/build.py --toolchain iar $BUILD_ARGS
+        run: |
+          # Each variant carries its own --build-name/--cflag, which are global to a
+          # single build.py invocation — so build one matrix entry at a time rather
+          # than joining them (joining would leak a variant's flags onto every board).
+          readarray -t ENTRIES < <(python test/hil/hil_ci_set_matrix.py test/hil/hfp.json | jq -r '.["arm-gcc"][]')
+          for entry in "${ENTRIES[@]}"; do
+            echo "+ tools/build.py --toolchain iar $entry"
+            python3 tools/build.py --toolchain iar $entry
+          done
 
       - name: Test on actual hardware (hardware in the loop)
         run: |

--- a/examples/device/board_test/src/main.c
+++ b/examples/device/board_test/src/main.c
@@ -64,7 +64,6 @@ int main(void) {
     vTaskDelay(portMAX_DELAY);
     #endif
   }
-  // no return: the loop never exits (an unreachable return trips IAR's Pe111)
 }
 
 #else

--- a/examples/device/board_test/src/main.c
+++ b/examples/device/board_test/src/main.c
@@ -57,8 +57,17 @@ void tusb_time_delay_ms_api(uint32_t ms) {
 // CI_BUILD (defined for all CI builds, see hw/bsp/family_support.cmake) skips the
 // blink/echo loop below: after HIL tests, this firmware is flashed to park the
 // board in a quiet, low-power idle state (no USB, LED, or UART activity).
-#ifndef CI_BUILD
+#ifdef CI_BUILD
+int main(void) {
+  while (1) {
+    #if defined(ESP_PLATFORM)
+    vTaskDelay(portMAX_DELAY);
+    #endif
+  }
+  return 0;
+}
 
+#else
 // Task parameter type: ULONG for ThreadX, void* for FreeRTOS and noos
 #if CFG_TUSB_OS == OPT_OS_THREADX
   #define RTOS_PARAM ULONG
@@ -112,46 +121,21 @@ static void board_test_loop(RTOS_PARAM param) {
   }
 }
 
-#endif // CI_BUILD
-
 int main(void) {
-#ifdef CI_BUILD
-  // Park the board in a quiet idle loop. board_init() is intentionally skipped:
-  // no clocks, peripherals, USB, LED, or UART are brought up, so the MCU just
-  // idles after CI flashes this over a board's previous test firmware.
-  // Deliberately a busy spin, NOT wfe/wfi: on some MCUs (i.MX RT1064, MAX32666)
-  // sleeping gates the debug clocks, and since this image is the boot image the
-  // board comes back unflashable — SWD attach and connect-under-reset both fail,
-  // surviving power cycles until the chip is manually recovered.
-  while (1) {
-    #if defined(ESP_PLATFORM)
-    vTaskDelay(portMAX_DELAY); // ESP runs FreeRTOS: yield this task indefinitely
-    #endif
-  }
-  // no return: the loop never exits (an unreachable return trips IAR's Pe111)
-#else
   board_init();
   board_led_write(true);
 
-  #if CFG_TUSB_OS == OPT_OS_FREERTOS
+#if CFG_TUSB_OS == OPT_OS_FREERTOS
   freertos_init();
-  #elif CFG_TUSB_OS == OPT_OS_THREADX
+#elif CFG_TUSB_OS == OPT_OS_THREADX
   tx_kernel_enter();
-  #else
+#else
   board_test_loop(NULL);
-  #endif
+#endif
 
   return 0;
-#endif
 }
 
-#ifdef ESP_PLATFORM
-void app_main(void) {
-  main();
-}
-#endif
-
-#ifndef CI_BUILD
 //--------------------------------------------------------------------+
 // FreeRTOS
 //--------------------------------------------------------------------+
@@ -197,5 +181,10 @@ void tx_application_define(void *first_unused_memory) {
                    1, 1, TX_NO_TIME_SLICE, TX_AUTO_START);
 }
 #endif
-
 #endif // CI_BUILD
+
+#ifdef ESP_PLATFORM
+void app_main(void) {
+  main();
+}
+#endif

--- a/examples/device/board_test/src/main.c
+++ b/examples/device/board_test/src/main.c
@@ -64,7 +64,7 @@ int main(void) {
     vTaskDelay(portMAX_DELAY);
     #endif
   }
-  return 0;
+  // no return: the loop never exits (an unreachable return trips IAR's Pe111)
 }
 
 #else

--- a/examples/device/board_test/src/main.c
+++ b/examples/device/board_test/src/main.c
@@ -116,16 +116,16 @@ static void board_test_loop(RTOS_PARAM param) {
 
 int main(void) {
 #ifdef CI_BUILD
-  // Park the board in a quiet, low-power idle loop. board_init() is intentionally
-  // skipped: no clocks, peripherals, USB, LED, or UART are brought up, so the MCU
-  // just idles after CI flashes this over a board's previous test firmware.
+  // Park the board in a quiet idle loop. board_init() is intentionally skipped:
+  // no clocks, peripherals, USB, LED, or UART are brought up, so the MCU just
+  // idles after CI flashes this over a board's previous test firmware.
+  // Deliberately a busy spin, NOT wfe/wfi: on some MCUs (i.MX RT1064, MAX32666)
+  // sleeping gates the debug clocks, and since this image is the boot image the
+  // board comes back unflashable — SWD attach and connect-under-reset both fail,
+  // surviving power cycles until the chip is manually recovered.
   while (1) {
     #if defined(ESP_PLATFORM)
     vTaskDelay(portMAX_DELAY); // ESP runs FreeRTOS: yield this task indefinitely
-    #elif defined(__ARM_ARCH) || defined(__arm__)
-    __asm volatile("wfe");     // Cortex-M: sleep until an event
-    #else
-    // other architectures (e.g. RISC-V): spin
     #endif
   }
   // no return: the loop never exits (an unreachable return trips IAR's Pe111)

--- a/test/hil/hfp.json
+++ b/test/hil/hfp.json
@@ -15,6 +15,10 @@
         {
             "name": "stm32f746disco",
             "uid": "210041000C51343237303334",
+            "variant": [
+                { "name": "stm32f746disco", "flags": "" },
+                { "name": "stm32f746disco-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1" }
+            ],
             "tests": {
                 "device": true, "host": false, "dual": false
             },

--- a/test/hil/hil_ci.sh
+++ b/test/hil/hil_ci.sh
@@ -67,8 +67,13 @@ copy_board_binaries() {
 
 if [ -n "$BOARD" ]; then
   # Copy the board's build dir plus any variant dirs (cmake-build-<BOARD>-<variant>).
+  # Collect only dirs that actually exist (the bare cmake-build-<BOARD> is a literal,
+  # not a glob, so it would otherwise stay in the list even when missing).
   shopt -s nullglob
-  BUILD_DIRS=("$ROOT_DIR"/examples/cmake-build-"$BOARD" "$ROOT_DIR"/examples/cmake-build-"$BOARD"-*)
+  BUILD_DIRS=()
+  for d in "$ROOT_DIR"/examples/cmake-build-"$BOARD" "$ROOT_DIR"/examples/cmake-build-"$BOARD"-*; do
+    [ -d "$d" ] && BUILD_DIRS+=("$d")
+  done
   shopt -u nullglob
   if [ ${#BUILD_DIRS[@]} -eq 0 ]; then
     echo "Error: no build directory found for $BOARD under $ROOT_DIR/examples/"
@@ -77,7 +82,7 @@ if [ -n "$BOARD" ]; then
   fi
   echo "==> Copying binaries for $BOARD (${#BUILD_DIRS[@]} build dir(s))"
   for d in "${BUILD_DIRS[@]}"; do
-    [ -d "$d" ] && copy_board_binaries "$d"
+    copy_board_binaries "$d"
   done
 else
   echo "==> Copying all built binaries"

--- a/test/hil/hil_ci.sh
+++ b/test/hil/hil_ci.sh
@@ -66,15 +66,32 @@ copy_board_binaries() {
 }
 
 if [ -n "$BOARD" ]; then
-  # Copy the board's build dir plus any variant dirs (cmake-build-<BOARD>-<variant>).
-  # Collect only dirs that actually exist (the bare cmake-build-<BOARD> is a literal,
-  # not a glob, so it would otherwise stay in the list even when missing).
-  shopt -s nullglob
+  # Copy the board's build dir plus its variant dirs. Variant names come from
+  # $CONFIG (they are not required to be prefixed with the board name); the
+  # cmake-build-<BOARD>-* glob is kept as a fallback for ad-hoc local builds.
+  # Collect only dirs that actually exist, deduplicated.
+  declare -A SEEN_DIRS=()
   BUILD_DIRS=()
+  add_build_dir() {
+    [[ -d "$1" && -z "${SEEN_DIRS[$1]:-}" ]] || return 0
+    SEEN_DIRS[$1]=1
+    BUILD_DIRS+=("$1")
+  }
+  shopt -s nullglob
   for d in "$ROOT_DIR"/examples/cmake-build-"$BOARD" "$ROOT_DIR"/examples/cmake-build-"$BOARD"-*; do
-    [ -d "$d" ] && BUILD_DIRS+=("$d")
+    add_build_dir "$d"
   done
   shopt -u nullglob
+  while IFS= read -r v; do
+    add_build_dir "$ROOT_DIR/examples/cmake-build-$v"
+  done < <(python3 -c '
+import json, sys
+cfg = json.load(open(sys.argv[1]))
+for b in cfg.get("boards", []):
+    if b["name"] == sys.argv[2]:
+        for v in b.get("variant") or []:
+            print(v["name"])
+' "$CONFIG" "$BOARD")
   if [ ${#BUILD_DIRS[@]} -eq 0 ]; then
     echo "Error: no build directory found for $BOARD under $ROOT_DIR/examples/"
     echo "Build first with: cd examples && cmake --preset $BOARD && cmake --build --preset $BOARD"

--- a/test/hil/hil_ci.sh
+++ b/test/hil/hil_ci.sh
@@ -66,14 +66,19 @@ copy_board_binaries() {
 }
 
 if [ -n "$BOARD" ]; then
-  BUILD_DIR="$ROOT_DIR/examples/cmake-build-$BOARD"
-  if [ ! -d "$BUILD_DIR" ]; then
-    echo "Error: build directory not found: $BUILD_DIR"
-    echo "Build first with: cd examples && cmake -DBOARD=$BOARD -G Ninja -B cmake-build-$BOARD . && cmake --build cmake-build-$BOARD"
+  # Copy the board's build dir plus any variant dirs (cmake-build-<BOARD>-<variant>).
+  shopt -s nullglob
+  BUILD_DIRS=("$ROOT_DIR"/examples/cmake-build-"$BOARD" "$ROOT_DIR"/examples/cmake-build-"$BOARD"-*)
+  shopt -u nullglob
+  if [ ${#BUILD_DIRS[@]} -eq 0 ]; then
+    echo "Error: no build directory found for $BOARD under $ROOT_DIR/examples/"
+    echo "Build first with: cd examples && cmake --preset $BOARD && cmake --build --preset $BOARD"
     exit 1
   fi
-  echo "==> Copying binaries for $BOARD"
-  copy_board_binaries "$BUILD_DIR"
+  echo "==> Copying binaries for $BOARD (${#BUILD_DIRS[@]} build dir(s))"
+  for d in "${BUILD_DIRS[@]}"; do
+    [ -d "$d" ] && copy_board_binaries "$d"
+  done
 else
   echo "==> Copying all built binaries"
   # Use `%/` parameter expansion to strip the trailing slash from the glob —

--- a/test/hil/hil_ci_set_matrix.py
+++ b/test/hil/hil_ci_set_matrix.py
@@ -44,19 +44,19 @@ def main():
                 toolchain = 'arm-gcc'
 
             build_board = f'-b {name}'
-            if 'build' in board:
-                if 'args' in board['build']:
-                    build_board += ' ' + ' '.join(f'-D{a}' for a in board['build']['args'])
-                if 'flags_on' in board['build']:
-                    for f in board['build']['flags_on']:
-                        if f == '':
-                            append_build_arg(toolchain, build_board)
-                        else:
-                            append_build_arg(toolchain, f'{build_board} -f1 {f.replace(" ", " -f1 ")}')
-                else:
-                    append_build_arg(toolchain, build_board)
-            else:
-                append_build_arg(toolchain, build_board)
+            if 'build' in board and 'args' in board['build']:
+                build_board += ' ' + ' '.join(f'-D{a}' for a in board['build']['args'])
+
+            # Each variant builds into cmake-build-<variant.name> with its raw CFLAGS.
+            # No 'variant' -> a single build named after the board.
+            variants = board.get('variant') or [{'name': name, 'flags': ''}]
+            for v in variants:
+                arg = build_board
+                if v['name'] != name:
+                    arg += f' --build-name {v["name"]}'
+                for tok in v.get('flags', '').split():
+                    arg += f' --cflag={tok}'
+                append_build_arg(toolchain, arg)
 
     print(json.dumps(matrix))
 

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -228,7 +228,9 @@ def open_serial_dev(port: str):
     while timeout > 0:
         if os.path.exists(port):
             try:
-                ser = serial.Serial(port, baudrate=115200, timeout=5)
+                # write_timeout: a wedged device otherwise blocks ser.write() forever,
+                # hanging the worker until the pool/job timeout kills the whole run
+                ser = serial.Serial(port, baudrate=115200, timeout=5, write_timeout=5)
                 break
             except serial.SerialException:
                 print(f'serial {port} not reaady {timeout} sec')

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -122,8 +122,12 @@ class TestsCfg(TypedDict, total=False):
 
 
 class BuildCfg(TypedDict, total=False):
-    flags_on: list[str]
     args: list[str]
+
+
+class VariantCfg(TypedDict, total=False):
+    name: str   # build dir (cmake-build-<name>) and HIL report row
+    flags: str  # raw CFLAGS, e.g. "-DCFG_TUD_DWC2_DMA_ENABLE=1"
 
 
 class Board(TypedDict):
@@ -132,6 +136,7 @@ class Board(TypedDict):
     tests: TestsCfg
     flasher: FlasherCfg
     build: NotRequired[BuildCfg]
+    variant: NotRequired[list[VariantCfg]]
 
 
 class HilConfig(TypedDict):
@@ -1502,17 +1507,12 @@ host_test = [
 ]
 
 
-def f1_suffix(f1: str) -> str:
-    """Build dir / row-label suffix for a flags-on variant ('' for the default)."""
-    return '-f1_' + f1.replace(' ', '_') if f1 else ''
-
-
-def find_firmware(name: str, f1: str, example: str):
+def find_firmware(variant: str, example: str):
     """Locate a built example's firmware base path (no extension) under
-    cmake-build-<board>[-f1_...]/<example>/. Accepts the single-config layout
-    (firmware directly in the example dir) or Ninja Multi-Config (a per-config
-    subdir like RelWithDebInfo/). Returns the base Path, or None if not built."""
-    fw_dir = TINYUSB_ROOT / build_dir / f'cmake-build-{name}{f1_suffix(f1)}' / example
+    cmake-build-<variant>/<example>/. Accepts the single-config layout (firmware
+    directly in the example dir) or Ninja Multi-Config (a per-config subdir like
+    RelWithDebInfo/). Returns the base Path, or None if not built."""
+    fw_dir = TINYUSB_ROOT / build_dir / f'cmake-build-{variant}' / example
     base = Path(example).name
     if fw_dir.is_dir():
         for cand in [fw_dir / base, fw_dir / 'RelWithDebInfo' / base,
@@ -1522,25 +1522,24 @@ def find_firmware(name: str, f1: str, example: str):
     return None
 
 
-def test_example(board: Board, f1: str, example: str) -> tuple[int, str]:
+def test_example(board: Board, variant: str, example: str) -> tuple[int, str]:
     """
     Test example firmware
     :param board: board dict
-    :param f1: flags on
+    :param variant: build variant name = build dir (cmake-build-<variant>) and report row
     :param example: example name
     :return: (err_count, status, metric) where err_count is 0 on success/skip or
              1 on failure, status is one of 'pass'/'fail'/'skip' (a missing binary
              counts as 'skip'), and metric is an optional string a test returns to
              show in its report cell instead of the pass symbol (e.g. speed)
     """
-    name = board['name']
     err_count = 0
     result_status = 'fail'
     metric = None
 
-    test_name = f'{name + f1_suffix(f1):40} {example:30} ...'
+    test_name = f'{variant:40} {example:30} ...'
 
-    fw_name = find_firmware(name, f1, example)
+    fw_name = find_firmware(variant, example)
     if fw_name is None:
         log_line(f'{test_name} Skip (no binary)')
         return 0, 'skip', None
@@ -1619,21 +1618,22 @@ def test_example(board: Board, f1: str, example: str) -> tuple[int, str]:
 
 def build_board(board: Board) -> tuple[str, int]:
     """Build firmware for this board via tools/build.py.
-    Honors board config's build.flags_on variants and build.args defines.
-    Output goes to cmake-build/cmake-build-BOARD[-f1_...]/ (tools/build.py layout)."""
+    Honors board config's variant list and build.args defines.
+    Output goes to cmake-build/cmake-build-<variant>/ (tools/build.py layout)."""
     name = board['name']
     bcfg = cast(BuildCfg, board.get('build', {}))
-    flags_on_list = bcfg.get('flags_on', [''])
     extra_defs = bcfg.get('args', [])
+    variants = board.get('variant') or [{'name': name, 'flags': ''}]
 
     failed = 0
-    for f1 in flags_on_list:
+    for v in variants:
         cmd = [sys.executable, str(TINYUSB_ROOT / 'tools' / 'build.py'), '-b', name]
         for d in extra_defs:
             cmd += ['-D', d]
-        if f1:
-            for flag in f1.split():
-                cmd += ['-f1', flag]
+        if v['name'] != name:
+            cmd += ['--build-name', v['name']]
+        for tok in v.get('flags', '').split():
+            cmd += [f'--cflag={tok}']
         if verbose:
             cmd.append('-v')
             print(f'  + {" ".join(cmd)}')
@@ -1684,25 +1684,24 @@ def test_board(board: Board) -> tuple[str, int, list[str], list]:
 
     err_count = 0
     failed_tests = []
-    rows = []  # list of (row_label, {example: status}) — one row per board[-f1] variant
-    flags_on_list = [""]
-    if 'build' in board and 'flags_on' in board['build']:
-        flags_on_list = board['build']['flags_on']
+    rows = []  # list of (row_label, {example: status}) — one row per build variant
+    variants = board.get('variant') or [{'name': name, 'flags': ''}]
 
-    for f1 in flags_on_list:
+    for v in variants:
+        vname = v['name']
         cells = {}
         for test in test_list:
-            ec, status, metric = test_example(board, f1, test)
+            ec, status, metric = test_example(board, vname, test)
             err_count += ec
             cells[test] = metric if metric else status
             if ec > 0:
                 failed_tests.append(test)
-        rows.append((name + f1_suffix(f1), cells))
+        rows.append((vname, cells))
 
     # flash board_test last to disable board's usb (skipped when --skip-flash is set);
     # this is teardown/park, not a test — not recorded in the report
     if not skip_flash:
-        test_example(board, flags_on_list[0], 'device/board_test')
+        test_example(board, variants[0]['name'], 'device/board_test')
 
     return name, err_count, sorted(set(failed_tests)), rows
 

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -983,9 +983,9 @@ def test_device_cdc_msc_throughput(board):
         pass
 
     print(f'  CDC read {cdc_r} write {cdc_w}, MSC read {msc_r} write {msc_w}  ', end='')
-    # compact read/write speed for the report cell, e.g. "C 652k/422k M 1.1M/783k"
+    # compact read/write speed for the report cell, e.g. "✅ CDC 652k/422k MSC 1.1M/783k"
     short = lambda s: (s.split()[0].rstrip('0').rstrip('.') + s.split()[-1][0]) if ' ' in s else s
-    return f'C {short(cdc_r)}/{short(cdc_w)} M {short(msc_r)}/{short(msc_w)}'
+    return f'{REPORT_CELL["pass"]} CDC {short(cdc_r)}/{short(cdc_w)} MSC {short(msc_r)}/{short(msc_w)}'
 
 
 def test_device_dfu(board):

--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -370,7 +370,7 @@
             "uid": "460029001951373031313335",
             "variant": [
                 { "name": "stm32f723disco", "flags": "" },
-                { "name": "stm32f723disco-DMA", "flags": "-DCFG_TUH_DWC2_DMA_ENABLE=1" }
+                { "name": "stm32f723disco-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1" }
             ],
             "tests": {
                 "device": true,
@@ -404,7 +404,7 @@
             "uid": "110018000951383432343236",
             "variant": [
                 { "name": "stm32h743nucleo", "flags": "" },
-                { "name": "stm32h743nucleo-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1" }
+                { "name": "stm32h743nucleo-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1" }
             ],
             "tests": {
                 "device": true,
@@ -466,7 +466,7 @@
             "uid": "21002F000F51363531383437",
             "variant": [
                 { "name": "stm32f769disco", "flags": "" },
-                { "name": "stm32f769disco-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1" }
+                { "name": "stm32f769disco-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1" }
             ],
             "tests": {
                 "device": true,

--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -370,7 +370,7 @@
             "uid": "460029001951373031313335",
             "variant": [
                 { "name": "stm32f723disco", "flags": "" },
-                { "name": "stm32f723disco-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1" }
+                { "name": "stm32f723disco-DMA", "flags": "-DCFG_TUH_DWC2_DMA_ENABLE=1" }
             ],
             "tests": {
                 "device": true,

--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -17,12 +17,10 @@
         {
             "name": "espressif_p4_function_ev",
             "uid": "6055F9F98715",
-            "build": {
-                "flags_on": [
-                    "",
-                    "CFG_TUD_DWC2_DMA_ENABLE CFG_TUH_DWC2_DMA_ENABLE"
-                ]
-            },
+            "variant": [
+                { "name": "espressif_p4_function_ev", "flags": "" },
+                { "name": "espressif_p4_function_ev-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1" }
+            ],
             "tests": {
                 "only": [
                     "device/cdc_msc_freertos",
@@ -58,12 +56,10 @@
         {
             "name": "espressif_s3_devkitm",
             "uid": "84F703C084E4",
-            "build": {
-                "flags_on": [
-                    "",
-                    "CFG_TUD_DWC2_DMA_ENABLE CFG_TUH_DWC2_DMA_ENABLE"
-                ]
-            },
+            "variant": [
+                { "name": "espressif_s3_devkitm", "flags": "" },
+                { "name": "espressif_s3_devkitm-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1 -DCFG_TUH_DWC2_DMA_ENABLE=1" }
+            ],
             "tests": {
                 "only": [
                     "device/cdc_msc_freertos",
@@ -226,11 +222,9 @@
         {
             "name": "raspberry_pi_pico",
             "uid": "E6614C311B764A37",
-            "build": {
-                "flags_on": [
-                    "CFG_TUH_RPI_PIO_USB"
-                ]
-            },
+            "variant": [
+                { "name": "raspberry_pi_pico", "flags": "-DCFG_TUH_RPI_PIO_USB=1" }
+            ],
             "tests": {
                 "device": true,
                 "host": true,
@@ -374,12 +368,10 @@
         {
             "name": "stm32f723disco",
             "uid": "460029001951373031313335",
-            "build": {
-                "flags_on": [
-                    "",
-                    "CFG_TUH_DWC2_DMA_ENABLE"
-                ]
-            },
+            "variant": [
+                { "name": "stm32f723disco", "flags": "" },
+                { "name": "stm32f723disco-DMA", "flags": "-DCFG_TUH_DWC2_DMA_ENABLE=1" }
+            ],
             "tests": {
                 "device": true,
                 "host": true,
@@ -410,12 +402,10 @@
         {
             "name": "stm32h743nucleo",
             "uid": "110018000951383432343236",
-            "build": {
-                "flags_on": [
-                    "",
-                    "CFG_TUD_DWC2_DMA_ENABLE"
-                ]
-            },
+            "variant": [
+                { "name": "stm32h743nucleo", "flags": "" },
+                { "name": "stm32h743nucleo-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1" }
+            ],
             "tests": {
                 "device": true,
                 "host": false,
@@ -474,12 +464,10 @@
         {
             "name": "stm32f769disco",
             "uid": "21002F000F51363531383437",
-            "build": {
-                "flags_on": [
-                    "",
-                    "CFG_TUD_DWC2_DMA_ENABLE"
-                ]
-            },
+            "variant": [
+                { "name": "stm32f769disco", "flags": "" },
+                { "name": "stm32f769disco-DMA", "flags": "-DCFG_TUD_DWC2_DMA_ENABLE=1" }
+            ],
             "tests": {
                 "device": true,
                 "host": false,

--- a/tools/build.py
+++ b/tools/build.py
@@ -105,16 +105,14 @@ def print_build_result(board, build_target, status, duration):
 # -----------------------------
 # CMake
 # -----------------------------
-def cmake_board(board, build_args, build_flags_on, build_targets):
+def cmake_board(board, build_args, build_name, build_cflags, build_targets):
     ret = [0, 0, 0]
     start_time = time.monotonic()
 
-    build_dir = f'cmake-build/cmake-build-{board}'
+    build_dir = f'cmake-build/cmake-build-{build_name or board}'
     build_flags = []
-    if len(build_flags_on) > 0:
-        cli_flags = ' '.join(f'-D{flag}=1' for flag in build_flags_on)
-        build_flags.append(f'-DCFLAGS_CLI={cli_flags}')
-        build_dir += '-f1_' + '_'.join(build_flags_on)
+    if build_cflags:
+        build_flags.append('-DCFLAGS_CLI=' + ' '.join(build_cflags))
 
     family = find_family(board)
     if family == 'espressif':
@@ -194,13 +192,13 @@ def make_board(board, build_args, build_targets):
 # -----------------------------
 # Build Family
 # -----------------------------
-def build_boards_list(boards, build_defines, build_system, build_flags_on, build_targets):
+def build_boards_list(boards, build_defines, build_system, build_name, build_cflags, build_targets):
     ret = [0, 0, 0]
     for b in boards:
         r = [0, 0, 0]
         if build_system == 'cmake':
             build_args = [f'-D{d}' for d in build_defines]
-            r = cmake_board(b, build_args, build_flags_on, build_targets)
+            r = cmake_board(b, build_args, build_name, build_cflags, build_targets)
         elif build_system == 'make':
             build_args = ' '.join(f'{d}' for d in build_defines)
             r = make_board(b, build_args, build_targets)
@@ -261,7 +259,10 @@ def main():
     parser.add_argument('-t', '--toolchain', default='gcc', help='Toolchain to use, default is gcc')
     parser.add_argument('-s', '--build-system', default='cmake', help='Build system to use, default is cmake')
     parser.add_argument('-D', '--define-symbol', action='append', default=[], help='Define to pass to build system')
-    parser.add_argument('-f1', '--build-flags-on', action='append', default=[], help='Build flag to pass to build system')
+    parser.add_argument('--build-name', default=None,
+                        help='Override build dir name (cmake-build-<name>); default is the board name. Used for HIL variants.')
+    parser.add_argument('--cflag', action='append', default=[],
+                        help='Raw compiler flag appended to CFLAGS_CLI, e.g. --cflag=-DCFG_TUD_DWC2_DMA_ENABLE=1 (repeatable)')
     parser.add_argument('--one-random', action='store_true', default=False,
                         help='Build only one random board of each specified family')
     parser.add_argument('--one-first', action='store_true', default=False,
@@ -277,7 +278,8 @@ def main():
     toolchain = args.toolchain
     build_system = args.build_system
     build_defines = args.define_symbol
-    build_flags_on = args.build_flags_on
+    build_name = args.build_name
+    build_cflags = args.cflag
     one_random = args.one_random
     one_first = args.one_first
     build_targets = args.target if args.target else ['all']
@@ -310,7 +312,7 @@ def main():
         all_boards.extend(get_family_boards(f, one_random, one_first))
 
     # build all boards
-    result = build_boards_list(all_boards, build_defines, build_system, build_flags_on, build_targets)
+    result = build_boards_list(all_boards, build_defines, build_system, build_name, build_cflags, build_targets)
 
     total_time = time.monotonic() - total_time
     print(build_separator)

--- a/tools/build.py
+++ b/tools/build.py
@@ -292,6 +292,12 @@ def main():
         print("Please specify families or board to build")
         return 1
 
+    # --build-name renames the single shared build dir, so building more than one
+    # board with it would clobber/mix artifacts
+    if build_name and (len(families) > 0 or len(boards) != 1):
+        print("--build-name requires exactly one board (-b) and no families")
+        return 1
+
     print(build_separator)
     print(build_format.format('Board', 'Target', '\033[39mResult\033[0m', 'Time'))
     total_time = time.monotonic()

--- a/tools/get_deps.py
+++ b/tools/get_deps.py
@@ -366,6 +366,8 @@ def main():
     parser.add_argument('-b', '--board', action='append', default=[], help='Boards to fetch')
     parser.add_argument('-D', '--define', action='append', default=[], help='Have no effect')
     parser.add_argument('-f1', '--build-flags-on', action='append', default=[], help='Have no effect')
+    parser.add_argument('--build-name', default=None, help='Have no effect')
+    parser.add_argument('--cflag', action='append', default=[], help='Have no effect')
     args = parser.parse_args()
 
     families = args.families


### PR DESCRIPTION
## Summary
Replaces the HIL config's `build.flags_on` with an explicit, named **`variant`** schema. Each variant declares its own `name` (used as the build dir `cmake-build-<name>` and the HIL report row) and raw `flags` (CFLAGS, e.g. `-DCFG_TUD_DWC2_DMA_ENABLE=1`). A board with no `variant` builds a single target named after the board.

```json
"variant": [
  { "name": "stm32f723disco",     "flags": "" },
  { "name": "stm32f723disco-DMA", "flags": "-DCFG_TUH_DWC2_DMA_ENABLE=1" }
]
```

This makes variant build dirs and report rows explicit instead of the derived `-f1_<flags>` suffix.

## Changes
- **build.py** — `--build-name <name>` (build dir) + `--cflag=<token>` (raw CFLAGS into `CFLAGS_CLI`, repeatable; the `=`-form keeps `-D…=1` tokens space-free so they survive the CI matrix's shell word-splitting). Dropped `-f1`.
- **hil_ci_set_matrix.py** — emit one build arg per variant.
- **hil_test.py** — iterate variants; report row + firmware dir = variant name.
- **hil_ci.sh** — `-b` runs copy the board's dir plus any `cmake-build-<board>-*` variant dirs (and still fail fast when none exist).
- **get_deps.py** — accept/ignore `--build-name`/`--cflag` (matrix args are passed through it).
- **tinyusb.json** — migrate all 6 `flags_on` boards to `variant`.

## Test evidence
- Matrix emits correct per-variant args; tokens survive shell-splitting.
- `build.py` builds both `stm32f723disco` variants; DMA gets `CFLAGS_CLI=-DCFG_TUH_DWC2_DMA_ENABLE=1`, base none.
- **Hardware (ci.lan rig):** both `stm32f723disco` variants flashed and tested; report shows separate `stm32f723disco` / `stm32f723disco-DMA` rows, 0 failed.

> Stacked on #3686 (the variant report-row change depends on that PR's HIL report feature). Base will retarget to `master` once #3686 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)