### PR TITLE
ci(claude-review): raise --max-turns 20 -> 50

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
           # TEMPORARY: expose the full Claude transcript in the Actions log for
           # debugging. Revert to remove once done.
           show_full_output: true
-          claude_args: '--max-turns 20'
+          claude_args: '--max-turns 50'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## What

Raise the Claude Code Review action's turn cap from `--max-turns 20` to `--max-turns 50` in `.github/workflows/claude-code-review.yml`.

## Why

The `claude-review` workflow runs `/code-review:code-review … --comment` with a hard `--max-turns` limit. On large PRs the agent spends all its turns reading the diff and source files and never reaches its final "post the review" step, so the SDK returns an error and the check fails red:

```
Reached maximum number of turns (20)
→ Process completed with exit code 1
```

This is what happened on **#3636** ("add stm32c5 support" — 29 files, +1689/−15): every build check was green, but `claude-review` died at 20 turns and posted nothing.

## Cost note

Cost scales with **tokens**, not the turn cap. A review that finishes in 25 turns costs the same whether the ceiling is 25 or 50 — the cap only bites when the agent would otherwise be force-stopped mid-run. Bumping it to 50 just lets port-sized PRs complete; the typical small PR is unaffected.

## Not in scope

The `show_full_output: true` line above it is still marked `TEMPORARY` for debugging — left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)