### PR TITLE
ci(claude-review): run auto review on Opus (claude-opus-4-8)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
           # TEMPORARY: expose the full Claude transcript in the Actions log for
           # debugging. Revert to remove once done.
           show_full_output: true
-          claude_args: '--max-turns 50'
+          claude_args: '--max-turns 50 --model claude-opus-4-8'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## What

Pin the Claude Code Review action's main model to **`claude-opus-4-8`** via `claude_args` (was the action default, Sonnet 4.6). Subagents spawned by the review command keep their cheaper defaults (Haiku 4.5).

## Why

On #3643 (musb EP0 race fix) the Sonnet-driven auto review posted "No issues found", while an Opus pass over the same diff surfaced substantive review questions — ISR-boundary RXRDY/FIFO lifetime in the deferred-SETUP path, and the regression scope of the `PIPE0_STATE_DATA` split affecting every MUSB control transfer. For driver-level PRs that depth is worth the tier bump.

## Cost

Opus 4.8 is $5/$25 per MTok vs Sonnet 4.6 at $3/$15 — a typical review run goes from roughly $0.30–1 to $1–3. Follows up on #3692 (`--max-turns 50`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)