### PR TITLE
dcd/musb: harden & refactor the EP0 control state machine (review follow-up for #3643)

### DIFF
--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -152,7 +152,8 @@ static void pipe0_start_setup(uint8_t rhport, musb_ep_csr_t* ep_csr,
   dcd_event_setup_received(rhport, (const uint8_t *) req, is_isr);
 }
 
-static void pipe0_process_deferred_setup(uint8_t rhport, musb_ep_csr_t* ep_csr, bool is_isr) {
+// Replay a previously deferred SETUP, if any.
+static void pipe0_try_deferred_setup(uint8_t rhport, musb_ep_csr_t* ep_csr, bool is_isr) {
   pipe0_state_t* pipe0 = &_dcd.pipe0;
   if (!pipe0->deferred_setup_valid) {
     return;
@@ -466,13 +467,59 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
       // so a deferred SETUP can be replayed safely.
       pipe0->state = PIPE0_STATE_IDLE;
       dcd_event_xfer_complete(rhport, ep_addr, 0, XFER_RESULT_SUCCESS, is_isr);
-      pipe0_process_deferred_setup(rhport, ep_csr, is_isr);
+      pipe0_try_deferred_setup(rhport, ep_csr, is_isr);
       break;
 
     default: break;
   }
 
   return true;
+}
+
+// Advance EP0's status-stage state machine on a tail event: the csrl==0 confirmation IRQ, or such a
+// confirmation combined with a new SETUP (caller sets deferred_setup_valid first). ISR context only.
+static void pipe0_process_status_isr(uint8_t rhport, musb_regs_t* musb_regs, musb_ep_csr_t* ep_csr) {
+  pipe0_state_t* pipe0 = &_dcd.pipe0;
+  switch (pipe0->state) {
+    case PIPE0_STATE_DATA_IN:
+      if (pipe0->remain_wlength == 0 || pipe0->xact_len < CFG_TUD_ENDPOINT0_SIZE) { // last DATA IN packet
+        if (pipe0->deferred_setup_valid) {
+          pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ; // status confirm coalesced with deferred SETUP
+        } else {
+          pipe0->state = PIPE0_STATE_STATUS_OUT; // await host's STATUS-OUT ZLP IRQ
+        }
+      }
+      dcd_event_xfer_complete(rhport, TU_EP0_IN, pipe0->xact_len, XFER_RESULT_SUCCESS, true);
+      break;
+
+    case PIPE0_STATE_STATUS_OUT:
+      // Confirmation seen — await edpt0_xfer(STATUS OUT) to fire complete.
+      pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
+      break;
+
+    case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
+      // edpt0_xfer(STATUS OUT) already called — fire complete and replay now.
+      pipe0->state = PIPE0_STATE_IDLE;
+      dcd_event_xfer_complete(rhport, TU_EP0_OUT, 0, XFER_RESULT_SUCCESS, true);
+      pipe0_try_deferred_setup(rhport, ep_csr, true);
+      break;
+
+    case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
+      // Confirmation already accounted for — the pairing edpt0_xfer(STATUS OUT) fires complete.
+      break;
+
+    case PIPE0_STATE_STATUS_IN:
+      if (pipe0->pending_addr) {
+        musb_regs->faddr = pipe0->pending_addr;
+        pipe0->pending_addr = 0;
+      }
+      pipe0->state = PIPE0_STATE_IDLE;
+      dcd_event_xfer_complete(rhport, TU_EP0_IN, 0, XFER_RESULT_SUCCESS, true);
+      pipe0_try_deferred_setup(rhport, ep_csr, true);
+      break;
+
+    default: break;
+  }
 }
 
 // 21.1.5: endpoint 0 service routine as peripheral
@@ -535,64 +582,21 @@ static void process_ep0_isr(uint8_t rhport) {
         break;
       }
 
-      // New SETUP packet arrived while the old control transfer's tail events are still in flight
-      // (IRQs combined under high CPU load), e.g.:
-      // - Status IN/OUT finished, its IRQ and the new SETUP IRQ arrive at the same time.
-      // - Data IN finished and status OUT is received, both IRQs and the new SETUP IRQ arrive at the same time.
-      // Save the SETUP; it is replayed only once the old transfer is fully retired — i.e. when usbd has
-      // made (or already made) its final edpt0_xfer()/dcd_edpt_stall() call for it. Until the replayed
-      // packet is acked, its RXRDY stays parked so a stale latched EP0 IRQ cannot re-process it.
+      // New SETUP arrived while the old control transfer's tail events are still in flight (IRQs
+      // combined under high CPU load): the old transfer's status confirm and this SETUP land together.
       case PIPE0_STATE_DATA_IN:
       case PIPE0_STATE_STATUS_OUT:
       case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
       case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
-      case PIPE0_STATE_STATUS_IN: {
+      case PIPE0_STATE_STATUS_IN:
+        // Save it, then finish the old transfer's tail event; deferred_setup_valid makes
+        // pipe0_process_status_isr() synthesize the coalesced status confirm and replay the SETUP
+        // once the old transfer is retired. Its RXRDY stays parked so a stale IRQ can't re-process it.
         TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &pipe0->deferred_setup), );
         pipe0->deferred_setup_valid = true;
         pipe0->rxrdy_consumed = true;
-
-        switch (pipe0->state) {
-          case PIPE0_STATE_DATA_IN:
-            // Combined: last DATA IN sent + status OUT done + new SETUP in one csrl read. Fire the
-            // DATA IN completion and synthesize the missed status confirm; usbd's edpt0_xfer(STATUS OUT)
-            // fires the status completion and replays.
-            TU_ASSERT(pipe0->remain_wlength == 0, );
-            pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
-            dcd_event_xfer_complete(rhport, TU_EP0_IN, pipe0->xact_len, XFER_RESULT_SUCCESS, true);
-            break;
-
-          case PIPE0_STATE_STATUS_OUT:
-            // Status confirm IRQ combined with the SETUP — edpt0_xfer(STATUS OUT) fires complete.
-            pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
-            break;
-
-          case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
-            // edpt0_xfer(STATUS OUT) already called — old transfer retired, complete and replay now.
-            pipe0->state = PIPE0_STATE_IDLE;
-            dcd_event_xfer_complete(rhport, TU_EP0_OUT, 0, XFER_RESULT_SUCCESS, true);
-            pipe0_process_deferred_setup(rhport, ep_csr, true);
-            break;
-
-          case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
-            // usbd has not called edpt0_xfer(STATUS OUT) for the old transfer yet — only hold the
-            // SETUP. Replaying here would let that still-outstanding call land in the replayed
-            // transfer's state and corrupt it (e.g. NULL DATA OUT drain buffer).
-            break;
-
-          default:
-            // PIPE0_STATE_STATUS_IN: rxrdy_consumed gate + SetupEnd guarantee DATAEND was armed, i.e.
-            // usbd already made its status call; the ZLP-sent IRQ combined with the SETUP.
-            if (pipe0->pending_addr) {
-              musb_regs->faddr = pipe0->pending_addr;
-              pipe0->pending_addr = 0;
-            }
-            pipe0->state = PIPE0_STATE_IDLE;
-            dcd_event_xfer_complete(rhport, TU_EP0_IN, 0, XFER_RESULT_SUCCESS, true);
-            pipe0_process_deferred_setup(rhport, ep_csr, true);
-            break;
-        }
+        pipe0_process_status_isr(rhport, musb_regs, ep_csr);
         break;
-      }
 
       default: break;
     }
@@ -610,44 +614,7 @@ static void process_ep0_isr(uint8_t rhport) {
   /* When CSRL0 is zero, it means that either
  * - completion of sending any length packet TxPktRdy clear
  * - or status stage is complete (ZLP) after DataEnd is set */
-  switch (pipe0->state) {
-    case PIPE0_STATE_DATA_IN:
-      // DATA IN packet sent (TXRDY cleared). On the last packet (DATAEND condition above) move to
-      // STATUS_OUT to await the host's STATUS-OUT ZLP IRQ.
-      if (pipe0->remain_wlength == 0 || pipe0->xact_len < CFG_TUD_ENDPOINT0_SIZE) {
-        pipe0->state = PIPE0_STATE_STATUS_OUT;
-      }
-      dcd_event_xfer_complete(rhport, TU_EP0_IN, pipe0->xact_len, XFER_RESULT_SUCCESS, true);
-      break;
-
-    case PIPE0_STATE_STATUS_OUT:
-      // First event of the STATUS OUT pair — wait for edpt0_xfer(STATUS OUT) to fire complete.
-      pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
-      break;
-
-    case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
-      // Second event — edpt0_xfer(STATUS OUT) already called, fire complete now.
-      pipe0->state = PIPE0_STATE_IDLE;
-      dcd_event_xfer_complete(rhport, TU_EP0_OUT, 0, XFER_RESULT_SUCCESS, true);
-      pipe0_process_deferred_setup(rhport, ep_csr, true);
-      break;
-
-    case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
-      // Stale duplicate of the status confirm — already accounted for; edpt0_xfer fires complete.
-      break;
-
-    case PIPE0_STATE_STATUS_IN:
-      if (pipe0->pending_addr) {
-        musb_regs->faddr = pipe0->pending_addr;
-        pipe0->pending_addr = 0;
-      }
-      pipe0->state = PIPE0_STATE_IDLE;
-      dcd_event_xfer_complete(rhport, TU_EP0_IN, 0, XFER_RESULT_SUCCESS, true);
-      pipe0_process_deferred_setup(rhport, ep_csr, true);
-      break;
-
-    default: break;
-  }
+  pipe0_process_status_isr(rhport, musb_regs, ep_csr);
 }
 
 // Upon BUS RESET is detected, hardware havs already done:
@@ -950,7 +917,7 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
         // The transfer being stalled already completed on the wire (a deferred SETUP can only exist
         // once its status stage was seen) and the host's next request was already ACKed — SendStall
         // would land on that innocent request. Skip the stall and replay the deferred SETUP instead.
-        pipe0_process_deferred_setup(rhport, ep_csr, false);
+        pipe0_try_deferred_setup(rhport, ep_csr, false);
       } else {
         // Forcing EP0 to IDLE: any RXRDY parked by the aborted transfer's flow control is stale,
         // clear it so the next SETUP IRQ is not gated off.

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -104,6 +104,19 @@ typedef struct {
 
 static dcd_data_t _dcd;
 
+// Drain a SETUP packet (8 bytes) from the EP0 FIFO. Does not ack RxPktRdy.
+static bool pipe0_read_setup(musb_regs_t* musb_regs, musb_ep_csr_t* ep_csr, tusb_control_request_t* req) {
+  TU_ASSERT(sizeof(tusb_control_request_t) == ep_csr->count0);
+  union {
+    tusb_control_request_t req;
+    uint32_t               u32[2];
+  } setup_packet;
+  setup_packet.u32[0] = musb_regs->fifo[0];
+  setup_packet.u32[1] = musb_regs->fifo[0];
+  *req = setup_packet.req;
+  return true;
+}
+
 static void pipe0_start_setup(uint8_t rhport, musb_ep_csr_t* ep_csr,
                               tusb_control_request_t const* req, bool is_isr) {
   _dcd.pipe0.remain_wlength = req->wLength;
@@ -466,23 +479,18 @@ static void process_ep0(uint8_t rhport) {
 
   // Receive Data (Setup or OUT)
   if (csrl & MUSB_CSRL0_RXRDY) {
-    const uint16_t count0 = ep_csr->count0;
     switch (_dcd.pipe0.state) {
       case PIPE0_STATE_IDLE: {
-        TU_ASSERT(sizeof(tusb_control_request_t) == count0, );
-        union {
-          tusb_control_request_t req;
-          uint32_t               u32[2];
-        } setup_packet;
-        setup_packet.u32[0] = musb_regs->fifo[0];
-        setup_packet.u32[1] = musb_regs->fifo[0];
-        pipe0_start_setup(rhport, ep_csr, &setup_packet.req, true);
+        tusb_control_request_t req;
+        TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &req), );
+        pipe0_start_setup(rhport, ep_csr, &req, true);
         break;
       }
 
       case PIPE0_STATE_DATA_OUT: {
         // EP0 OUT is single-packet (TU_ASSERT total_bytes <= EP0_SIZE in edpt0_xfer)
         // so the whole packet drains in one shot.
+        const uint16_t count0 = ep_csr->count0;
         if (count0) {
           tu_hwfifo_read(&musb_regs->fifo[0], _dcd.pipe0.buf, count0, NULL);
           _dcd.pipe0.remain_wlength -= count0;
@@ -503,15 +511,7 @@ static void process_ep0(uint8_t rhport) {
       case PIPE0_STATE_STATUS_OUT_PENDING:
       case PIPE0_STATE_STATUS_IN:
       case PIPE0_STATE_DATA_IN: {
-        TU_ASSERT(sizeof(tusb_control_request_t) == count0, );
-        union {
-          tusb_control_request_t req;
-          uint32_t               u32[2];
-        } setup_packet;
-        setup_packet.u32[0] = musb_regs->fifo[0];
-        setup_packet.u32[1] = musb_regs->fifo[0];
-
-        _dcd.pipe0.deferred_setup = setup_packet.req;
+        TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &_dcd.pipe0.deferred_setup), );
         _dcd.pipe0.deferred_setup_valid = true;
         goto process_status;
       }

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -474,7 +474,7 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
 
 // Advance EP0's status-stage state machine on a tail event: the csrl==0 confirmation IRQ, or such a
 // confirmation combined with a new SETUP (caller sets deferred_setup_valid first). ISR context only.
-static void pipe0_process_status_isr(uint8_t rhport, musb_regs_t* musb_regs, musb_ep_csr_t* ep_csr) {
+static void pipe0_process_xfer_state_isr(uint8_t rhport, musb_regs_t* musb_regs, musb_ep_csr_t* ep_csr) {
   pipe0_state_t* pipe0 = &_dcd.pipe0;
   switch (pipe0->state) {
     case PIPE0_STATE_DATA_IN:
@@ -587,12 +587,12 @@ static void process_ep0_isr(uint8_t rhport) {
       case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
       case PIPE0_STATE_STATUS_IN:
         // Save it, then finish the old transfer's tail event; deferred_setup_valid makes
-        // pipe0_process_status_isr() synthesize the coalesced status confirm and replay the SETUP
+        // pipe0_process_xfer_state_isr() synthesize the coalesced status confirm and replay the SETUP
         // once the old transfer is retired. Its RXRDY stays parked so a stale IRQ can't re-process it.
         TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, pipe0->deferred_setup), );
         pipe0->deferred_setup_valid = true;
         pipe0->rxrdy_consumed = true;
-        pipe0_process_status_isr(rhport, musb_regs, ep_csr);
+        pipe0_process_xfer_state_isr(rhport, musb_regs, ep_csr);
         break;
 
       default: break;
@@ -611,7 +611,7 @@ static void process_ep0_isr(uint8_t rhport) {
   /* When CSRL0 is zero, it means that either
  * - completion of sending any length packet TxPktRdy clear
  * - or status stage is complete (ZLP) after DataEnd is set */
-  pipe0_process_status_isr(rhport, musb_regs, ep_csr);
+  pipe0_process_xfer_state_isr(rhport, musb_regs, ep_csr);
 }
 
 // Upon BUS RESET is detected, hardware havs already done:

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -93,7 +93,7 @@ enum {
 // EP0 control-transfer state (own scalars, not a pipe[] slot).
 typedef struct {
   uint8_t  *buf;            // DATA OUT drain target (only valid while EP0 is in DATA OUT stage)
-  uint16_t xact_len;        // chunk length most recently armed via edpt0_xfer; reported in xfer_complete
+  uint16_t xact_len;        // DATA IN chunk length armed via edpt0_xfer; reported in its xfer_complete (OUT reports count0)
   uint16_t remain_wlength;  // bytes remaining in the control transfer's DATA stage
   uint8_t  state;
   uint8_t  pending_addr;    // new USB address latched by dcd_set_address; applied when STATUS IN completes
@@ -157,6 +157,11 @@ static void pipe0_try_deferred_setup(uint8_t rhport, musb_ep_csr_t* ep_csr, bool
 
   pipe0->deferred_setup_valid = false;
   pipe0_start_setup(rhport, ep_csr, pipe0->deferred_setup, is_isr);
+}
+
+// Last DATA packet: wLength satisfied, or a short packet (incl. ZLP) ends the stage.
+TU_ATTR_ALWAYS_INLINE static inline bool pipe0_data_stage_done(uint16_t xfer_len) {
+  return _dcd.pipe0.remain_wlength == 0 || xfer_len < CFG_TUD_ENDPOINT0_SIZE;
 }
 
 // EP0 must not call this — it has its own scalars in dcd_data_t.
@@ -430,8 +435,8 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
       }
       tu_hwfifo_write(&musb_regs->fifo[0], buffer, total_bytes, NULL);
       pipe0->remain_wlength -= total_bytes;
-      // DATAEND on the last packet: wLength met, or a short packet (incl. ZLP) ends the data stage.
-      if (pipe0->remain_wlength == 0 || total_bytes < CFG_TUD_ENDPOINT0_SIZE) {
+      // Add DATAEND on the last packet to end the data stage.
+      if (pipe0_data_stage_done(total_bytes)) {
         ep_csr->csr0l = MUSB_CSRL0_TXRDY | MUSB_CSRL0_DATAEND;
       } else {
         ep_csr->csr0l = MUSB_CSRL0_TXRDY;
@@ -478,7 +483,7 @@ static void pipe0_process_xfer_state_isr(uint8_t rhport, musb_regs_t* musb_regs,
   pipe0_state_t* pipe0 = &_dcd.pipe0;
   switch (pipe0->state) {
     case PIPE0_STATE_DATA_IN:
-      if (pipe0->remain_wlength == 0 || pipe0->xact_len < CFG_TUD_ENDPOINT0_SIZE) { // last DATA IN packet
+      if (pipe0_data_stage_done(pipe0->xact_len)) {
         if (pipe0->deferred_setup_valid) {
           pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ; // status confirm coalesced with deferred SETUP
         } else {
@@ -571,8 +576,7 @@ static void process_ep0_isr(uint8_t rhport) {
         // RXRDY stays set until the next edpt0_xfer arm acks it (NAK flow control):
         // edpt0_xfer(DATA OUT) for a mid-stream packet, edpt0_xfer(STATUS IN) for the last.
         pipe0->rxrdy_consumed = true;
-        // Last packet: wLength received, or a short packet (host's end-of-data).
-        if (pipe0->remain_wlength == 0 || count0 < CFG_TUD_ENDPOINT0_SIZE) {
+        if (pipe0_data_stage_done(count0)) {
           pipe0->state = PIPE0_STATE_STATUS_IN;
         }
         dcd_event_xfer_complete(rhport, TU_EP0_OUT, count0, XFER_RESULT_SUCCESS, true);
@@ -911,9 +915,8 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
       pipe0->state = PIPE0_STATE_IDLE;
       pipe0->buf = NULL;
       if (pipe0->deferred_setup_valid) {
-        // The transfer being stalled already completed on the wire (a deferred SETUP can only exist
-        // once its status stage was seen) and the host's next request was already ACKed — SendStall
-        // would land on that innocent request. Skip the stall and replay the deferred SETUP instead.
+        // A deferred SETUP means the stalled transfer already ended on the wire and the host's next
+        // request was ACKed — SendStall would hit that innocent request. Replay it instead of stalling.
         pipe0_try_deferred_setup(rhport, ep_csr, false);
       } else {
         // Forcing EP0 to IDLE: any RXRDY parked by the aborted transfer's flow control is stale,

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -100,7 +100,7 @@ typedef struct {
   bool     rxrdy_consumed;  // RxPktRdy left set in hw for an already-consumed packet (NAK flow control);
                             // RXRDY events are stale while set. Cleared when RXRDYC is written.
   bool     deferred_setup_valid;
-  tusb_control_request_t deferred_setup;
+  uint32_t deferred_setup[2];  // raw SETUP words, replayed via pipe0_start_setup
 } pipe0_state_t;
 
 typedef struct {
@@ -110,21 +110,17 @@ typedef struct {
 
 static dcd_data_t _dcd;
 
-// Drain a SETUP packet (8 bytes) from the EP0 FIFO. Does not ack RxPktRdy.
-static bool pipe0_read_setup(musb_regs_t* musb_regs, musb_ep_csr_t* ep_csr, tusb_control_request_t* req) {
+// Read the 8-byte SETUP packet (2 words) from the EP0 FIFO into setup[]. Does not ack RxPktRdy.
+static bool pipe0_read_setup(musb_regs_t* musb_regs, musb_ep_csr_t* ep_csr, uint32_t setup[2]) {
   TU_ASSERT(sizeof(tusb_control_request_t) == ep_csr->count0);
-  union {
-    tusb_control_request_t req;
-    uint32_t               u32[2];
-  } setup_packet;
-  setup_packet.u32[0] = musb_regs->fifo[0];
-  setup_packet.u32[1] = musb_regs->fifo[0];
-  *req = setup_packet.req;
+  setup[0] = musb_regs->fifo[0];
+  setup[1] = musb_regs->fifo[0];
   return true;
 }
 
 static void pipe0_start_setup(uint8_t rhport, musb_ep_csr_t* ep_csr,
-                              tusb_control_request_t const* req, bool is_isr) {
+                              const uint32_t setup[2], bool is_isr) {
+  tusb_control_request_t const* req = (tusb_control_request_t const*) setup;
   pipe0_state_t* pipe0 = &_dcd.pipe0;
   pipe0->remain_wlength = req->wLength;
 
@@ -149,7 +145,7 @@ static void pipe0_start_setup(uint8_t rhport, musb_ep_csr_t* ep_csr,
     }
   }
 
-  dcd_event_setup_received(rhport, (const uint8_t *) req, is_isr);
+  dcd_event_setup_received(rhport, (const uint8_t *) setup, is_isr);
 }
 
 // Replay a previously deferred SETUP, if any.
@@ -160,7 +156,7 @@ static void pipe0_try_deferred_setup(uint8_t rhport, musb_ep_csr_t* ep_csr, bool
   }
 
   pipe0->deferred_setup_valid = false;
-  pipe0_start_setup(rhport, ep_csr, &pipe0->deferred_setup, is_isr);
+  pipe0_start_setup(rhport, ep_csr, pipe0->deferred_setup, is_isr);
 }
 
 // EP0 must not call this — it has its own scalars in dcd_data_t.
@@ -557,9 +553,9 @@ static void process_ep0_isr(uint8_t rhport) {
     }
     switch (pipe0->state) {
       case PIPE0_STATE_IDLE: {
-        tusb_control_request_t req;
-        TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &req), );
-        pipe0_start_setup(rhport, ep_csr, &req, true);
+        uint32_t setup[2];
+        TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, setup), );
+        pipe0_start_setup(rhport, ep_csr, setup, true);
         break;
       }
 
@@ -592,7 +588,7 @@ static void process_ep0_isr(uint8_t rhport) {
         // Save it, then finish the old transfer's tail event; deferred_setup_valid makes
         // pipe0_process_status_isr() synthesize the coalesced status confirm and replay the SETUP
         // once the old transfer is retired. Its RXRDY stays parked so a stale IRQ can't re-process it.
-        TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &pipe0->deferred_setup), );
+        TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, pipe0->deferred_setup), );
         pipe0->deferred_setup_valid = true;
         pipe0->rxrdy_consumed = true;
         pipe0_process_status_isr(rhport, musb_regs, ep_csr);

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -510,20 +510,55 @@ static void process_ep0(uint8_t rhport) {
       // - Status IN/OUT finished, IRQ and new setup packet IRQ arrive at the same time.
       // - Data IN finished and status OUT is received, both IRQs and new setup packet IRQ arrive at the same time.
       // could happen when CPU load is high, save the new setup packet for later processing after current status stage complete.
+      case PIPE0_STATE_DATA_IN:
       case PIPE0_STATE_STATUS_OUT:
       case PIPE0_STATE_STATUS_OUT_PENDING:
-      case PIPE0_STATE_STATUS_IN:
-      case PIPE0_STATE_DATA_IN: {
+      case PIPE0_STATE_STATUS_IN: {
         TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &_dcd.pipe0.deferred_setup), );
         _dcd.pipe0.deferred_setup_valid = true;
-        goto process_status;
+
+        switch (_dcd.pipe0.state) {
+          case PIPE0_STATE_DATA_IN:
+            // Last DATA IN packet sent (TXRDY-clear coalesced with the SETUP IRQ). The STATUS OUT
+            // confirm IRQ is missed too — promote so edpt0_xfer(STATUS OUT) fires complete immediately.
+            if (_dcd.pipe0.remain_wlength == 0) {
+              _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING;
+            }
+            dcd_event_xfer_complete(rhport, TU_EP0_IN, _dcd.pipe0.xact_len, XFER_RESULT_SUCCESS, true);
+            break;
+
+          case PIPE0_STATE_STATUS_OUT:
+            // Status confirm IRQ coalesced with the SETUP — edpt0_xfer(STATUS OUT) fires complete.
+            _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING;
+            break;
+
+          case PIPE0_STATE_STATUS_OUT_PENDING:
+            // edpt0_xfer(STATUS OUT) already called — fire complete and replay now.
+            _dcd.pipe0.state = PIPE0_STATE_IDLE;
+            dcd_event_xfer_complete(rhport, TU_EP0_OUT, 0, XFER_RESULT_SUCCESS, true);
+            pipe0_process_deferred_setup(rhport, ep_csr, true);
+            break;
+
+          default:
+            // PIPE0_STATE_STATUS_IN: ZLP-sent IRQ coalesced with the SETUP.
+            if (_dcd.pipe0.pending_addr) {
+              musb_regs->faddr = _dcd.pipe0.pending_addr;
+              _dcd.pipe0.pending_addr = 0;
+            }
+            _dcd.pipe0.state = PIPE0_STATE_IDLE;
+            dcd_event_xfer_complete(rhport, TU_EP0_IN, 0, XFER_RESULT_SUCCESS, true);
+            pipe0_process_deferred_setup(rhport, ep_csr, true);
+            break;
+        }
+        break;
       }
+
+      default: break;
     }
 
     return;
   }
 
-process_status:
   /* When CSRL0 is zero, it means that either
  * - completion of sending any length packet TxPktRdy clear
  * - or status stage is complete (ZLP) after DataEnd is set */

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -944,6 +944,9 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
         // would land on that innocent request. Skip the stall and replay the deferred SETUP instead.
         pipe0_process_deferred_setup(rhport, ep_csr, false);
       } else {
+        // Forcing EP0 to IDLE: any RXRDY parked by the aborted transfer's flow control is stale,
+        // clear it so the next SETUP IRQ is not gated off.
+        _dcd.pipe0.rxrdy_consumed = false;
         ep_csr->csr0l = MUSB_CSRL0_STALL;
       }
     }

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -86,7 +86,8 @@ enum {
   PIPE0_STATE_DATA_OUT,         // DATA OUT stage
   PIPE0_STATE_STATUS_IN,        // STATUS IN — device sends IN-ZLP; awaits send-ACK IRQ
   PIPE0_STATE_STATUS_OUT,       // post-DATAEND, neither edpt0_xfer(STATUS OUT) nor confirmation IRQ has happened yet
-  PIPE0_STATE_STATUS_OUT_PENDING, // one of {edpt0_xfer(STATUS OUT), confirmation IRQ} has happened; the other fires xfer_complete
+  PIPE0_STATE_STATUS_OUT_PENDING_XFER, // edpt0_xfer(STATUS OUT) called first; the confirmation IRQ fires xfer_complete
+  PIPE0_STATE_STATUS_OUT_PENDING_IRQ,  // confirmation IRQ seen (or synthesized) first; edpt0_xfer(STATUS OUT) fires xfer_complete
 };
 
 typedef struct {
@@ -436,11 +437,12 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
     case PIPE0_STATE_STATUS_OUT:
       TU_ASSERT(!dir_in && total_bytes == 0); // only STATUS OUT allowed
       // First event of the STATUS OUT pair — wait for the IRQ to fire complete.
-      _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING;
+      _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING_XFER;
       break;
 
-    case PIPE0_STATE_STATUS_OUT_PENDING:
-      // Second event — IRQ already arrived, fire complete now.
+    case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
+      // Second event — IRQ already arrived, fire complete now. The old transfer is retired here,
+      // so a deferred SETUP can be replayed safely.
       _dcd.pipe0.state = PIPE0_STATE_IDLE;
       dcd_event_xfer_complete(rhport, ep_addr, 0, XFER_RESULT_SUCCESS, is_isr);
       pipe0_process_deferred_setup(rhport, ep_csr, is_isr);
@@ -492,6 +494,7 @@ static void process_ep0(uint8_t rhport) {
         // so the whole packet drains in one shot.
         const uint16_t count0 = ep_csr->count0;
         if (count0) {
+          TU_ASSERT(_dcd.pipe0.buf, );
           tu_hwfifo_read(&musb_regs->fifo[0], _dcd.pipe0.buf, count0, NULL);
           _dcd.pipe0.remain_wlength -= count0;
         }
@@ -503,37 +506,46 @@ static void process_ep0(uint8_t rhport) {
         break;
       }
 
-      // New SETUP packet arrived  while old control transfer is not finished yet. This could happen in following scenarios:
-      // - Status IN/OUT finished, IRQ and new setup packet IRQ arrive at the same time.
-      // - Data IN finished and status OUT is received, both IRQs and new setup packet IRQ arrive at the same time.
-      // could happen when CPU load is high, save the new setup packet for later processing after current status stage complete.
+      // New SETUP packet arrived while the old control transfer's tail events are still in flight
+      // (IRQs coalesced under high CPU load), e.g.:
+      // - Status IN/OUT finished, its IRQ and the new SETUP IRQ arrive at the same time.
+      // - Data IN finished and status OUT is received, both IRQs and the new SETUP IRQ arrive at the same time.
+      // Save the SETUP; it is replayed only once the old transfer is fully retired — i.e. when usbd has
+      // made (or already made) its final edpt0_xfer() call for it.
       case PIPE0_STATE_DATA_IN:
       case PIPE0_STATE_STATUS_OUT:
-      case PIPE0_STATE_STATUS_OUT_PENDING:
+      case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
+      case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
       case PIPE0_STATE_STATUS_IN: {
         TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &_dcd.pipe0.deferred_setup), );
         _dcd.pipe0.deferred_setup_valid = true;
 
         switch (_dcd.pipe0.state) {
           case PIPE0_STATE_DATA_IN:
-            // Last DATA IN packet sent (TXRDY-clear coalesced with the SETUP IRQ). The STATUS OUT
-            // confirm IRQ is missed too — promote so edpt0_xfer(STATUS OUT) fires complete immediately.
-            if (_dcd.pipe0.remain_wlength == 0) {
-              _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING;
-            }
+            // Coalesced: last DATA IN sent + status OUT done + new SETUP in one csrl read. Fire the
+            // DATA IN completion and synthesize the missed status confirm; usbd's edpt0_xfer(STATUS OUT)
+            // fires the status completion and replays.
+            TU_ASSERT(_dcd.pipe0.remain_wlength == 0, );
+            _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
             dcd_event_xfer_complete(rhport, TU_EP0_IN, _dcd.pipe0.xact_len, XFER_RESULT_SUCCESS, true);
             break;
 
           case PIPE0_STATE_STATUS_OUT:
             // Status confirm IRQ coalesced with the SETUP — edpt0_xfer(STATUS OUT) fires complete.
-            _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING;
+            _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
             break;
 
-          case PIPE0_STATE_STATUS_OUT_PENDING:
-            // edpt0_xfer(STATUS OUT) already called — fire complete and replay now.
+          case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
+            // edpt0_xfer(STATUS OUT) already called — old transfer retired, complete and replay now.
             _dcd.pipe0.state = PIPE0_STATE_IDLE;
             dcd_event_xfer_complete(rhport, TU_EP0_OUT, 0, XFER_RESULT_SUCCESS, true);
             pipe0_process_deferred_setup(rhport, ep_csr, true);
+            break;
+
+          case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
+            // usbd has not called edpt0_xfer(STATUS OUT) for the old transfer yet — only hold the
+            // SETUP. Replaying here would let that still-outstanding call land in the replayed
+            // transfer's state and corrupt it (e.g. NULL DATA OUT drain buffer).
             break;
 
           default:
@@ -573,25 +585,24 @@ static void process_ep0(uint8_t rhport) {
       // to STATUS_OUT to await the host's STATUS-OUT ZLP confirmation IRQ.
       if (_dcd.pipe0.remain_wlength == 0) {
         _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT;
-        // If a new SETUP was deferred then STATUS OUT IRQ is missed, manually transition to STATUS_OUT_PENDING to allow ep0_xfer(STATUS OUT) to fire complete immediately.
-        if (_dcd.pipe0.deferred_setup_valid) {
-          _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING;
-        }
       }
       dcd_event_xfer_complete(rhport, TU_EP0_IN, _dcd.pipe0.xact_len, XFER_RESULT_SUCCESS, true);
-
       break;
 
     case PIPE0_STATE_STATUS_OUT:
       // First event of the STATUS OUT pair — wait for edpt0_xfer(STATUS OUT) to fire complete.
-      _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING;
+      _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
       break;
 
-    case PIPE0_STATE_STATUS_OUT_PENDING:
+    case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
       // Second event — edpt0_xfer(STATUS OUT) already called, fire complete now.
       _dcd.pipe0.state = PIPE0_STATE_IDLE;
       dcd_event_xfer_complete(rhport, TU_EP0_OUT, 0, XFER_RESULT_SUCCESS, true);
       pipe0_process_deferred_setup(rhport, ep_csr, true);
+      break;
+
+    case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
+      // Stale duplicate of the status confirm — already accounted for; edpt0_xfer fires complete.
       break;
 
     case PIPE0_STATE_STATUS_IN:

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -90,18 +90,21 @@ enum {
   PIPE0_STATE_STATUS_OUT_PENDING_IRQ,  // confirmation IRQ seen (or synthesized) first; edpt0_xfer(STATUS OUT) fires xfer_complete
 };
 
+// EP0 control-transfer state (own scalars, not a pipe[] slot).
 typedef struct {
-  struct {
-    uint8_t  *buf;            // DATA OUT drain target (only valid while EP0 is in DATA OUT stage)
-    uint16_t xact_len;        // chunk length most recently armed via edpt0_xfer; reported in xfer_complete
-    uint16_t remain_wlength;  // bytes remaining in the control transfer's DATA stage
-    uint8_t  state;
-    uint8_t  pending_addr;    // new USB address latched by dcd_set_address; applied when STATUS IN completes
-    tusb_control_request_t deferred_setup;
-    bool     deferred_setup_valid;
-    bool     rxrdy_consumed;    // RxPktRdy left set in hw for an already-consumed packet (NAK flow control);
-                              // RXRDY events are stale while set. Cleared when RXRDYC is written.
-  } pipe0;
+  uint8_t  *buf;            // DATA OUT drain target (only valid while EP0 is in DATA OUT stage)
+  uint16_t xact_len;        // chunk length most recently armed via edpt0_xfer; reported in xfer_complete
+  uint16_t remain_wlength;  // bytes remaining in the control transfer's DATA stage
+  uint8_t  state;
+  uint8_t  pending_addr;    // new USB address latched by dcd_set_address; applied when STATUS IN completes
+  bool     rxrdy_consumed;  // RxPktRdy left set in hw for an already-consumed packet (NAK flow control);
+                            // RXRDY events are stale while set. Cleared when RXRDYC is written.
+  bool     deferred_setup_valid;
+  tusb_control_request_t deferred_setup;
+} pipe0_state_t;
+
+typedef struct {
+  pipe0_state_t pipe0;
   pipe_state_t pipe[MUSB_PIPE_COUNT];
 } dcd_data_t;
 
@@ -122,26 +125,27 @@ static bool pipe0_read_setup(musb_regs_t* musb_regs, musb_ep_csr_t* ep_csr, tusb
 
 static void pipe0_start_setup(uint8_t rhport, musb_ep_csr_t* ep_csr,
                               tusb_control_request_t const* req, bool is_isr) {
-  _dcd.pipe0.remain_wlength = req->wLength;
+  pipe0_state_t* pipe0 = &_dcd.pipe0;
+  pipe0->remain_wlength = req->wLength;
 
   if (req->wLength == 0) {
     // Leave RXRDY set; edpt0_xfer(STATUS IN) acks it together with DATAEND.
-    _dcd.pipe0.state = PIPE0_STATE_STATUS_IN;
-    _dcd.pipe0.rxrdy_consumed = true;
+    pipe0->state = PIPE0_STATE_STATUS_IN;
+    pipe0->rxrdy_consumed = true;
   } else {
     if (req->bmRequestType & TUSB_DIR_IN_MASK) {
-      _dcd.pipe0.state = PIPE0_STATE_DATA_IN;
+      pipe0->state = PIPE0_STATE_DATA_IN;
       // On a deferred replay the packet's RXRDY stays parked until the edpt0_xfer(DATA IN) arm
       // acks it — a stale latched EP0 IRQ in between is gated by rxrdy_consumed.
-      if (!_dcd.pipe0.rxrdy_consumed) {
+      if (!pipe0->rxrdy_consumed) {
         ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
       }
     } else {
       // If OUT (rx) direction, let edpt0_xfer() clear RXRDY when it's ready to receive data.
       // Deliberate deviation from the databook's canonical flow (ack right after unload),
       // used as NAK flow control until usbd arms the drain buffer.
-      _dcd.pipe0.state = PIPE0_STATE_DATA_OUT;
-      _dcd.pipe0.rxrdy_consumed = true;
+      pipe0->state = PIPE0_STATE_DATA_OUT;
+      pipe0->rxrdy_consumed = true;
     }
   }
 
@@ -149,12 +153,13 @@ static void pipe0_start_setup(uint8_t rhport, musb_ep_csr_t* ep_csr,
 }
 
 static void pipe0_process_deferred_setup(uint8_t rhport, musb_ep_csr_t* ep_csr, bool is_isr) {
-  if (!_dcd.pipe0.deferred_setup_valid) {
+  pipe0_state_t* pipe0 = &_dcd.pipe0;
+  if (!pipe0->deferred_setup_valid) {
     return;
   }
 
-  _dcd.pipe0.deferred_setup_valid = false;
-  pipe0_start_setup(rhport, ep_csr, &_dcd.pipe0.deferred_setup, is_isr);
+  pipe0->deferred_setup_valid = false;
+  pipe0_start_setup(rhport, ep_csr, &pipe0->deferred_setup, is_isr);
 }
 
 // EP0 must not call this — it has its own scalars in dcd_data_t.
@@ -414,32 +419,36 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
   TU_ASSERT(total_bytes <= CFG_TUD_ENDPOINT0_SIZE); /* EP0 only supports 1 packet per dcd_edpt_xfer()*/
   musb_regs_t* musb_regs = MUSB_REGS(rhport);
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, 0);
+  pipe0_state_t* pipe0 = &_dcd.pipe0;
   const unsigned dir_in = tu_edpt_dir(ep_addr);
 
-  switch (_dcd.pipe0.state) {
+  switch (pipe0->state) {
+    // Combined: usbd can arm the opposite-direction status/ZLP while pipe0 is still in a DATA
+    // state, so dispatch on the call direction (dir_in), not the state. (Splitting into separate
+    // DATA_IN/DATA_OUT cases mis-routes those dir != state calls and breaks ADI MUSB.)
     case PIPE0_STATE_DATA_IN:
     case PIPE0_STATE_DATA_OUT: {
-      _dcd.pipe0.xact_len = total_bytes;
+      pipe0->xact_len = total_bytes;
       if (dir_in) {
         // Replayed SETUP keeps its RXRDY parked until here; ack it before loading the shared FIFO.
-        if (_dcd.pipe0.rxrdy_consumed) {
+        if (pipe0->rxrdy_consumed) {
           ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
-          _dcd.pipe0.rxrdy_consumed = false;
+          pipe0->rxrdy_consumed = false;
         }
         // DATA IN: load FIFO, set TXRDY. Add DATAEND on the last chunk
-        // (ep0_remain_datalen == 0 after this load) to end the data stage.
+        // (remain_wlength == 0 after this load) to end the data stage.
         tu_hwfifo_write(&musb_regs->fifo[0], buffer, total_bytes, NULL);
-        _dcd.pipe0.remain_wlength -= total_bytes;
-        if (_dcd.pipe0.remain_wlength == 0) {
+        pipe0->remain_wlength -= total_bytes;
+        if (pipe0->remain_wlength == 0) {
           ep_csr->csr0l = MUSB_CSRL0_TXRDY | MUSB_CSRL0_DATAEND;
         } else {
           ep_csr->csr0l = MUSB_CSRL0_TXRDY;
         }
       } else {
         // DATA OUT: arm drain target, ack RXRDY so host can send DATA OUT.
-        _dcd.pipe0.buf = buffer;
+        pipe0->buf = buffer;
         ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
-        _dcd.pipe0.rxrdy_consumed = false;
+        pipe0->rxrdy_consumed = false;
       }
       break;
     }
@@ -447,19 +456,19 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
     case PIPE0_STATE_STATUS_IN:
       TU_ASSERT(dir_in && total_bytes == 0); // only STATUS IN allowed
       ep_csr->csr0l = MUSB_CSRL0_RXRDYC | MUSB_CSRL0_DATAEND;
-      _dcd.pipe0.rxrdy_consumed = false;
+      pipe0->rxrdy_consumed = false;
       break;
 
     case PIPE0_STATE_STATUS_OUT:
       TU_ASSERT(!dir_in && total_bytes == 0); // only STATUS OUT allowed
       // First event of the STATUS OUT pair — wait for the IRQ to fire complete.
-      _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING_XFER;
+      pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_XFER;
       break;
 
     case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
       // Second event — IRQ already arrived, fire complete now. The old transfer is retired here,
       // so a deferred SETUP can be replayed safely.
-      _dcd.pipe0.state = PIPE0_STATE_IDLE;
+      pipe0->state = PIPE0_STATE_IDLE;
       dcd_event_xfer_complete(rhport, ep_addr, 0, XFER_RESULT_SUCCESS, is_isr);
       pipe0_process_deferred_setup(rhport, ep_csr, is_isr);
       break;
@@ -474,14 +483,15 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
 static void process_ep0(uint8_t rhport) {
   musb_regs_t* musb_regs = MUSB_REGS(rhport);
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, 0);
+  pipe0_state_t* pipe0 = &_dcd.pipe0;
   uint_fast8_t csrl = ep_csr->csr0l;
 
   // 21.1.5: SentStall and SetupEnd must be checked before anything else.
   if (csrl & MUSB_CSRL0_STALLED) {
     ep_csr->csr0l = 0;
-    _dcd.pipe0.state = PIPE0_STATE_IDLE;
-    _dcd.pipe0.deferred_setup_valid = false;
-    _dcd.pipe0.rxrdy_consumed = false;
+    pipe0->state = PIPE0_STATE_IDLE;
+    pipe0->deferred_setup_valid = false;
+    pipe0->rxrdy_consumed = false;
     return;
   }
 
@@ -489,9 +499,9 @@ static void process_ep0(uint8_t rhport) {
     // Host aborted the current control transfer (new SETUP or premature STATUS).
     // do nothing, it is probably another setup packet, usbd will reset its state.
     ep_csr->csr0l = MUSB_CSRL0_SETENDC;
-    _dcd.pipe0.state = PIPE0_STATE_IDLE;
-    _dcd.pipe0.deferred_setup_valid = false;
-    _dcd.pipe0.rxrdy_consumed = false;
+    pipe0->state = PIPE0_STATE_IDLE;
+    pipe0->deferred_setup_valid = false;
+    pipe0->rxrdy_consumed = false;
     if (!(csrl & MUSB_CSRL0_RXRDY)) {
       return; /* no SETUP waiting behind it */
     }
@@ -499,10 +509,10 @@ static void process_ep0(uint8_t rhport) {
 
   // Receive Data (Setup or OUT)
   if (csrl & MUSB_CSRL0_RXRDY) {
-    if (_dcd.pipe0.rxrdy_consumed) {
+    if (pipe0->rxrdy_consumed) {
       return; // stale latched IRQ: this RXRDY's packet was already drained
     }
-    switch (_dcd.pipe0.state) {
+    switch (pipe0->state) {
       case PIPE0_STATE_IDLE: {
         tusb_control_request_t req;
         TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &req), );
@@ -515,22 +525,22 @@ static void process_ep0(uint8_t rhport) {
         // so the whole packet drains in one shot.
         const uint16_t count0 = ep_csr->count0;
         if (count0) {
-          TU_ASSERT(_dcd.pipe0.buf, );
-          tu_hwfifo_read(&musb_regs->fifo[0], _dcd.pipe0.buf, count0, NULL);
-          _dcd.pipe0.remain_wlength -= count0;
+          TU_ASSERT(pipe0->buf, );
+          tu_hwfifo_read(&musb_regs->fifo[0], pipe0->buf, count0, NULL);
+          pipe0->remain_wlength -= count0;
         }
         // RXRDY stays set until the next edpt0_xfer arm acks it (NAK flow control):
         // edpt0_xfer(DATA OUT) for a mid-stream packet, edpt0_xfer(STATUS IN) for the last.
-        _dcd.pipe0.rxrdy_consumed = true;
-        if (_dcd.pipe0.remain_wlength == 0) {
-          _dcd.pipe0.state = PIPE0_STATE_STATUS_IN;
+        pipe0->rxrdy_consumed = true;
+        if (pipe0->remain_wlength == 0) {
+          pipe0->state = PIPE0_STATE_STATUS_IN;
         }
         dcd_event_xfer_complete(rhport, TU_EP0_OUT, count0, XFER_RESULT_SUCCESS, true);
         break;
       }
 
       // New SETUP packet arrived while the old control transfer's tail events are still in flight
-      // (IRQs coalesced under high CPU load), e.g.:
+      // (IRQs combined under high CPU load), e.g.:
       // - Status IN/OUT finished, its IRQ and the new SETUP IRQ arrive at the same time.
       // - Data IN finished and status OUT is received, both IRQs and the new SETUP IRQ arrive at the same time.
       // Save the SETUP; it is replayed only once the old transfer is fully retired — i.e. when usbd has
@@ -541,28 +551,28 @@ static void process_ep0(uint8_t rhport) {
       case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
       case PIPE0_STATE_STATUS_OUT_PENDING_IRQ:
       case PIPE0_STATE_STATUS_IN: {
-        TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &_dcd.pipe0.deferred_setup), );
-        _dcd.pipe0.deferred_setup_valid = true;
-        _dcd.pipe0.rxrdy_consumed = true;
+        TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &pipe0->deferred_setup), );
+        pipe0->deferred_setup_valid = true;
+        pipe0->rxrdy_consumed = true;
 
-        switch (_dcd.pipe0.state) {
+        switch (pipe0->state) {
           case PIPE0_STATE_DATA_IN:
-            // Coalesced: last DATA IN sent + status OUT done + new SETUP in one csrl read. Fire the
+            // Combined: last DATA IN sent + status OUT done + new SETUP in one csrl read. Fire the
             // DATA IN completion and synthesize the missed status confirm; usbd's edpt0_xfer(STATUS OUT)
             // fires the status completion and replays.
-            TU_ASSERT(_dcd.pipe0.remain_wlength == 0, );
-            _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
-            dcd_event_xfer_complete(rhport, TU_EP0_IN, _dcd.pipe0.xact_len, XFER_RESULT_SUCCESS, true);
+            TU_ASSERT(pipe0->remain_wlength == 0, );
+            pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
+            dcd_event_xfer_complete(rhport, TU_EP0_IN, pipe0->xact_len, XFER_RESULT_SUCCESS, true);
             break;
 
           case PIPE0_STATE_STATUS_OUT:
-            // Status confirm IRQ coalesced with the SETUP — edpt0_xfer(STATUS OUT) fires complete.
-            _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
+            // Status confirm IRQ combined with the SETUP — edpt0_xfer(STATUS OUT) fires complete.
+            pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
             break;
 
           case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
             // edpt0_xfer(STATUS OUT) already called — old transfer retired, complete and replay now.
-            _dcd.pipe0.state = PIPE0_STATE_IDLE;
+            pipe0->state = PIPE0_STATE_IDLE;
             dcd_event_xfer_complete(rhport, TU_EP0_OUT, 0, XFER_RESULT_SUCCESS, true);
             pipe0_process_deferred_setup(rhport, ep_csr, true);
             break;
@@ -575,12 +585,12 @@ static void process_ep0(uint8_t rhport) {
 
           default:
             // PIPE0_STATE_STATUS_IN: rxrdy_consumed gate + SetupEnd guarantee DATAEND was armed, i.e.
-            // usbd already made its status call; the ZLP-sent IRQ coalesced with the SETUP.
-            if (_dcd.pipe0.pending_addr) {
-              musb_regs->faddr = _dcd.pipe0.pending_addr;
-              _dcd.pipe0.pending_addr = 0;
+            // usbd already made its status call; the ZLP-sent IRQ combined with the SETUP.
+            if (pipe0->pending_addr) {
+              musb_regs->faddr = pipe0->pending_addr;
+              pipe0->pending_addr = 0;
             }
-            _dcd.pipe0.state = PIPE0_STATE_IDLE;
+            pipe0->state = PIPE0_STATE_IDLE;
             dcd_event_xfer_complete(rhport, TU_EP0_IN, 0, XFER_RESULT_SUCCESS, true);
             pipe0_process_deferred_setup(rhport, ep_csr, true);
             break;
@@ -604,25 +614,25 @@ static void process_ep0(uint8_t rhport) {
   /* When CSRL0 is zero, it means that either
  * - completion of sending any length packet TxPktRdy clear
  * - or status stage is complete (ZLP) after DataEnd is set */
-  switch (_dcd.pipe0.state) {
+  switch (pipe0->state) {
     case PIPE0_STATE_DATA_IN:
-      // csrl == 0 in DATA state = TXRDY just cleared, i.e. a DATA IN packet was successfully sent. If the just-sent
-      // packet was the last (DATAEND was set when ep0_remain_datalen hit zero), transition
-      // to STATUS_OUT to await the host's STATUS-OUT ZLP confirmation IRQ.
-      if (_dcd.pipe0.remain_wlength == 0) {
-        _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT;
+      // csrl == 0 in DATA IN = TXRDY just cleared, i.e. a DATA IN packet was successfully sent. If the
+      // just-sent packet was the last (DATAEND set when remain_wlength hit 0), transition to STATUS_OUT
+      // to await the host's STATUS-OUT ZLP confirmation IRQ.
+      if (pipe0->remain_wlength == 0) {
+        pipe0->state = PIPE0_STATE_STATUS_OUT;
       }
-      dcd_event_xfer_complete(rhport, TU_EP0_IN, _dcd.pipe0.xact_len, XFER_RESULT_SUCCESS, true);
+      dcd_event_xfer_complete(rhport, TU_EP0_IN, pipe0->xact_len, XFER_RESULT_SUCCESS, true);
       break;
 
     case PIPE0_STATE_STATUS_OUT:
       // First event of the STATUS OUT pair — wait for edpt0_xfer(STATUS OUT) to fire complete.
-      _dcd.pipe0.state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
+      pipe0->state = PIPE0_STATE_STATUS_OUT_PENDING_IRQ;
       break;
 
     case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
       // Second event — edpt0_xfer(STATUS OUT) already called, fire complete now.
-      _dcd.pipe0.state = PIPE0_STATE_IDLE;
+      pipe0->state = PIPE0_STATE_IDLE;
       dcd_event_xfer_complete(rhport, TU_EP0_OUT, 0, XFER_RESULT_SUCCESS, true);
       pipe0_process_deferred_setup(rhport, ep_csr, true);
       break;
@@ -632,11 +642,11 @@ static void process_ep0(uint8_t rhport) {
       break;
 
     case PIPE0_STATE_STATUS_IN:
-      if (_dcd.pipe0.pending_addr) {
-        musb_regs->faddr = _dcd.pipe0.pending_addr;
-        _dcd.pipe0.pending_addr = 0;
+      if (pipe0->pending_addr) {
+        musb_regs->faddr = pipe0->pending_addr;
+        pipe0->pending_addr = 0;
       }
-      _dcd.pipe0.state = PIPE0_STATE_IDLE;
+      pipe0->state = PIPE0_STATE_IDLE;
       dcd_event_xfer_complete(rhport, TU_EP0_IN, 0, XFER_RESULT_SUCCESS, true);
       pipe0_process_deferred_setup(rhport, ep_csr, true);
       break;
@@ -654,12 +664,13 @@ static void process_bus_reset(uint8_t rhport) {
   alloced_fifo_bytes = CFG_TUD_ENDPOINT0_SIZE;
 #endif
 
-  _dcd.pipe0.state = PIPE0_STATE_IDLE;
-  _dcd.pipe0.buf = NULL;
-  _dcd.pipe0.xact_len = 0;
-  _dcd.pipe0.remain_wlength = 0;
-  _dcd.pipe0.deferred_setup_valid = false;
-  _dcd.pipe0.rxrdy_consumed = false;
+  pipe0_state_t* pipe0 = &_dcd.pipe0;
+  pipe0->state = PIPE0_STATE_IDLE;
+  pipe0->buf = NULL;
+  pipe0->xact_len = 0;
+  pipe0->remain_wlength = 0;
+  pipe0->deferred_setup_valid = false;
+  pipe0->rxrdy_consumed = false;
 
   musb->intr_txen = 1; /* Enable only EP0 */
   musb->intr_rxen = 0;
@@ -729,13 +740,14 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   musb_regs_t* musb_regs = MUSB_REGS(rhport);
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, 0);
 
-  _dcd.pipe0.pending_addr = dev_addr;
-  _dcd.pipe0.buf      = NULL;
-  _dcd.pipe0.xact_len   = 0;
-  _dcd.pipe0.state    = PIPE0_STATE_STATUS_IN;
+  pipe0_state_t* pipe0 = &_dcd.pipe0;
+  pipe0->pending_addr = dev_addr;
+  pipe0->buf = NULL;
+  pipe0->xact_len = 0;
+  pipe0->state = PIPE0_STATE_STATUS_IN;
   /* Send STATUS IN ZLP with DATAEND; host ACK fires the confirmation IRQ. */
   ep_csr->csr0l = MUSB_CSRL0_RXRDYC | MUSB_CSRL0_DATAEND;
-  _dcd.pipe0.rxrdy_consumed = false;
+  pipe0->rxrdy_consumed = false;
 }
 
 // Wake up host
@@ -936,9 +948,10 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
 
   if (0 == epn) {
     if (ep_addr == TU_EP0_OUT) { /* Ignore EP0 IN */
-      _dcd.pipe0.state = PIPE0_STATE_IDLE;
-      _dcd.pipe0.buf = NULL;
-      if (_dcd.pipe0.deferred_setup_valid) {
+      pipe0_state_t* pipe0 = &_dcd.pipe0;
+      pipe0->state = PIPE0_STATE_IDLE;
+      pipe0->buf = NULL;
+      if (pipe0->deferred_setup_valid) {
         // The transfer being stalled already completed on the wire (a deferred SETUP can only exist
         // once its status stage was seen) and the host's next request was already ACKed — SendStall
         // would land on that innocent request. Skip the stall and replay the deferred SETUP instead.
@@ -946,7 +959,7 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
       } else {
         // Forcing EP0 to IDLE: any RXRDY parked by the aborted transfer's flow control is stale,
         // clear it so the next SETUP IRQ is not gated off.
-        _dcd.pipe0.rxrdy_consumed = false;
+        pipe0->rxrdy_consumed = false;
         ep_csr->csr0l = MUSB_CSRL0_STALL;
       }
     }

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -299,7 +299,7 @@ static void pipe_write(musb_regs_t* musb_regs, pipe_state_t* pipe, uint8_t epnum
 
 // Called from the TX interrupt. If the last queued packet finished the transfer,
 // signal completion; otherwise queue the next packet.
-static void process_epin(uint8_t rhport, musb_regs_t *musb_regs, uint8_t epnum) {
+static void process_epin_isr(uint8_t rhport, musb_regs_t *musb_regs, uint8_t epnum) {
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, epnum);
   const uint_fast8_t csrl = ep_csr->tx_csrl;
   if (csrl & MUSB_TXCSRL1_STALLED) {
@@ -329,7 +329,7 @@ static void process_epin(uint8_t rhport, musb_regs_t *musb_regs, uint8_t epnum) 
 // Drain one packet from the Rx FIFO into pipe->buf/fifo, update pipe state, and
 // release the FIFO slot by clearing RXRDY. return true if short packet
 static bool pipe_read(musb_regs_t* musb_regs, pipe_state_t* pipe, uint8_t epnum) {
-  musb_ep_csr_t* ep_csr = &musb_regs->indexed_csr; // index already set in process_epout()
+  musb_ep_csr_t* ep_csr = &musb_regs->indexed_csr; // index already set in process_epout_isr()
   const uint16_t mps = ep_csr->rx_maxp & MUSB_RXMAXP_PACKET_SIZE_M;
   const uint16_t rx_count = ep_csr->rx_count;
   const uint16_t xact_len = tu_min16(tu_min16(pipe->remaining, mps), rx_count);
@@ -348,7 +348,7 @@ static bool pipe_read(musb_regs_t* musb_regs, pipe_state_t* pipe, uint8_t epnum)
   return (xact_len < mps);
 }
 
-static void process_epout(uint8_t rhport, musb_regs_t *musb_regs, uint8_t epnum, bool is_isr) {
+static void process_epout_isr(uint8_t rhport, musb_regs_t *musb_regs, uint8_t epnum, bool is_isr) {
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, epnum);
   if (ep_csr->rx_csrl & MUSB_RXCSRL1_STALLED) {
     ep_csr->rx_csrl &= ~(MUSB_RXCSRL1_STALLED | MUSB_RXCSRL1_OVER);
@@ -403,13 +403,13 @@ static bool edpt_n_xfer(uint8_t rhport, uint8_t ep_addr, void *buffer, uint16_t 
   if (dir_in) {
     pipe_write(musb_regs, pipe, epnum);
   } else {
-    // Re-enable Rx interrupt (may have been masked by the no-buffer path in process_epout)
+    // Re-enable Rx interrupt (may have been masked by the no-buffer path in process_epout_isr)
     musb_regs->intr_rxen |= (uint16_t)TU_BIT(epnum);
 
     // Drain any packet staged in the Rx FIFO from a prior no-buffer interrupt.
-    // process_epout() fires dcd_event_xfer_complete() itself if the drain completes.
+    // process_epout_isr() fires dcd_event_xfer_complete() itself if the drain completes.
     if (ep_csr->rx_csrl & MUSB_RXCSRL1_RXRDY) {
-      process_epout(rhport, musb_regs, epnum, is_isr);
+      process_epout_isr(rhport, musb_regs, epnum, is_isr);
     }
   }
   return true;
@@ -476,7 +476,7 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
 }
 
 // 21.1.5: endpoint 0 service routine as peripheral
-static void process_ep0(uint8_t rhport) {
+static void process_ep0_isr(uint8_t rhport) {
   musb_regs_t* musb_regs = MUSB_REGS(rhport);
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, 0);
   pipe0_state_t* pipe0 = &_dcd.pipe0;
@@ -652,7 +652,7 @@ static void process_ep0(uint8_t rhport) {
 
 // Upon BUS RESET is detected, hardware havs already done:
 // faddr = 0, index = 0, flushes all ep fifos, clears all ep csr, enabled all ep interrupts
-static void process_bus_reset(uint8_t rhport) {
+static void process_bus_reset_isr(uint8_t rhport) {
   musb_regs_t* musb = MUSB_REGS(rhport);
 
 #if MUSB_CFG_DYNAMIC_FIFO
@@ -728,7 +728,7 @@ void dcd_int_disable(uint8_t rhport) {
 }
 
 // Receive Set Address request. Stash the new address here; hardware faddr is
-// latched from pending_addr in process_ep0 once the STATUS IN completes (per
+// latched from pending_addr in process_ep0_isr once the STATUS IN completes (per
 // USB spec, address must only take effect after the status stage).
 void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
 {
@@ -1008,7 +1008,7 @@ void dcd_int_handler(uint8_t rhport) {
     dcd_event_bus_signal(rhport, DCD_EVENT_SOF, true);
   }
   if (intr_usb & MUSB_IS_RESET) {
-    process_bus_reset(rhport);
+    process_bus_reset_isr(rhport);
   }
   if (intr_usb & MUSB_IS_RESUME) {
     dcd_event_bus_signal(rhport, DCD_EVENT_RESUME, true);
@@ -1022,9 +1022,9 @@ void dcd_int_handler(uint8_t rhport) {
   while (intr_tx) {
     const unsigned epnum = __builtin_ctz(intr_tx);
     if (epnum == 0) {
-      process_ep0(rhport);  // EP0 has its own state machine (control transfers)
+      process_ep0_isr(rhport);  // EP0 has its own state machine (control transfers)
     } else {
-      process_epin(rhport, musb_regs, epnum);
+      process_epin_isr(rhport, musb_regs, epnum);
     }
     intr_tx &= ~TU_BIT(epnum);
 
@@ -1039,7 +1039,7 @@ void dcd_int_handler(uint8_t rhport) {
   intr_rx &= musb_regs->intr_rxen; /* Clear disabled interrupts */
   while (intr_rx) {
     unsigned const epnum = __builtin_ctz(intr_rx);
-    process_epout(rhport, musb_regs, epnum, true);
+    process_epout_isr(rhport, musb_regs, epnum, true);
     intr_rx &= ~TU_BIT(epnum);
 
     // Double packet endpoint: RxPktRdy is set and interrupt is generated immediately if 2nd packet is received

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -99,6 +99,8 @@ typedef struct {
     uint8_t  pending_addr;    // new USB address latched by dcd_set_address; applied when STATUS IN completes
     tusb_control_request_t deferred_setup;
     bool     deferred_setup_valid;
+    bool     rxrdy_consumed;    // RxPktRdy left set in hw for an already-consumed packet (NAK flow control);
+                              // RXRDY events are stale while set. Cleared when RXRDYC is written.
   } pipe0;
   pipe_state_t pipe[MUSB_PIPE_COUNT];
 } dcd_data_t;
@@ -123,16 +125,23 @@ static void pipe0_start_setup(uint8_t rhport, musb_ep_csr_t* ep_csr,
   _dcd.pipe0.remain_wlength = req->wLength;
 
   if (req->wLength == 0) {
+    // Leave RXRDY set; edpt0_xfer(STATUS IN) acks it together with DATAEND.
     _dcd.pipe0.state = PIPE0_STATE_STATUS_IN;
+    _dcd.pipe0.rxrdy_consumed = true;
   } else {
     if (req->bmRequestType & TUSB_DIR_IN_MASK) {
       _dcd.pipe0.state = PIPE0_STATE_DATA_IN;
-      ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
+      // On a deferred replay the packet's RXRDY stays parked until the edpt0_xfer(DATA IN) arm
+      // acks it — a stale latched EP0 IRQ in between is gated by rxrdy_consumed.
+      if (!_dcd.pipe0.rxrdy_consumed) {
+        ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
+      }
     } else {
       // If OUT (rx) direction, let edpt0_xfer() clear RXRDY when it's ready to receive data.
       // Deliberate deviation from the databook's canonical flow (ack right after unload),
       // used as NAK flow control until usbd arms the drain buffer.
       _dcd.pipe0.state = PIPE0_STATE_DATA_OUT;
+      _dcd.pipe0.rxrdy_consumed = true;
     }
   }
 
@@ -412,6 +421,11 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
     case PIPE0_STATE_DATA_OUT: {
       _dcd.pipe0.xact_len = total_bytes;
       if (dir_in) {
+        // Replayed SETUP keeps its RXRDY parked until here; ack it before loading the shared FIFO.
+        if (_dcd.pipe0.rxrdy_consumed) {
+          ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
+          _dcd.pipe0.rxrdy_consumed = false;
+        }
         // DATA IN: load FIFO, set TXRDY. Add DATAEND on the last chunk
         // (ep0_remain_datalen == 0 after this load) to end the data stage.
         tu_hwfifo_write(&musb_regs->fifo[0], buffer, total_bytes, NULL);
@@ -425,6 +439,7 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
         // DATA OUT: arm drain target, ack RXRDY so host can send DATA OUT.
         _dcd.pipe0.buf = buffer;
         ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
+        _dcd.pipe0.rxrdy_consumed = false;
       }
       break;
     }
@@ -432,6 +447,7 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
     case PIPE0_STATE_STATUS_IN:
       TU_ASSERT(dir_in && total_bytes == 0); // only STATUS IN allowed
       ep_csr->csr0l = MUSB_CSRL0_RXRDYC | MUSB_CSRL0_DATAEND;
+      _dcd.pipe0.rxrdy_consumed = false;
       break;
 
     case PIPE0_STATE_STATUS_OUT:
@@ -465,6 +481,7 @@ static void process_ep0(uint8_t rhport) {
     ep_csr->csr0l = 0;
     _dcd.pipe0.state = PIPE0_STATE_IDLE;
     _dcd.pipe0.deferred_setup_valid = false;
+    _dcd.pipe0.rxrdy_consumed = false;
     return;
   }
 
@@ -474,6 +491,7 @@ static void process_ep0(uint8_t rhport) {
     ep_csr->csr0l = MUSB_CSRL0_SETENDC;
     _dcd.pipe0.state = PIPE0_STATE_IDLE;
     _dcd.pipe0.deferred_setup_valid = false;
+    _dcd.pipe0.rxrdy_consumed = false;
     if (!(csrl & MUSB_CSRL0_RXRDY)) {
       return; /* no SETUP waiting behind it */
     }
@@ -481,6 +499,9 @@ static void process_ep0(uint8_t rhport) {
 
   // Receive Data (Setup or OUT)
   if (csrl & MUSB_CSRL0_RXRDY) {
+    if (_dcd.pipe0.rxrdy_consumed) {
+      return; // stale latched IRQ: this RXRDY's packet was already drained
+    }
     switch (_dcd.pipe0.state) {
       case PIPE0_STATE_IDLE: {
         tusb_control_request_t req;
@@ -498,8 +519,10 @@ static void process_ep0(uint8_t rhport) {
           tu_hwfifo_read(&musb_regs->fifo[0], _dcd.pipe0.buf, count0, NULL);
           _dcd.pipe0.remain_wlength -= count0;
         }
+        // RXRDY stays set until the next edpt0_xfer arm acks it (NAK flow control):
+        // edpt0_xfer(DATA OUT) for a mid-stream packet, edpt0_xfer(STATUS IN) for the last.
+        _dcd.pipe0.rxrdy_consumed = true;
         if (_dcd.pipe0.remain_wlength == 0) {
-          // last packet: change state and leave RXRDY for edpt0_xfer(STATUS IN) to ack
           _dcd.pipe0.state = PIPE0_STATE_STATUS_IN;
         }
         dcd_event_xfer_complete(rhport, TU_EP0_OUT, count0, XFER_RESULT_SUCCESS, true);
@@ -511,7 +534,8 @@ static void process_ep0(uint8_t rhport) {
       // - Status IN/OUT finished, its IRQ and the new SETUP IRQ arrive at the same time.
       // - Data IN finished and status OUT is received, both IRQs and the new SETUP IRQ arrive at the same time.
       // Save the SETUP; it is replayed only once the old transfer is fully retired — i.e. when usbd has
-      // made (or already made) its final edpt0_xfer() call for it.
+      // made (or already made) its final edpt0_xfer() call for it. Until the replayed
+      // packet is acked, its RXRDY stays parked so a stale latched EP0 IRQ cannot re-process it.
       case PIPE0_STATE_DATA_IN:
       case PIPE0_STATE_STATUS_OUT:
       case PIPE0_STATE_STATUS_OUT_PENDING_XFER:
@@ -519,6 +543,7 @@ static void process_ep0(uint8_t rhport) {
       case PIPE0_STATE_STATUS_IN: {
         TU_VERIFY(pipe0_read_setup(musb_regs, ep_csr, &_dcd.pipe0.deferred_setup), );
         _dcd.pipe0.deferred_setup_valid = true;
+        _dcd.pipe0.rxrdy_consumed = true;
 
         switch (_dcd.pipe0.state) {
           case PIPE0_STATE_DATA_IN:
@@ -549,7 +574,8 @@ static void process_ep0(uint8_t rhport) {
             break;
 
           default:
-            // PIPE0_STATE_STATUS_IN: ZLP-sent IRQ coalesced with the SETUP.
+            // PIPE0_STATE_STATUS_IN: rxrdy_consumed gate + SetupEnd guarantee DATAEND was armed, i.e.
+            // usbd already made its status call; the ZLP-sent IRQ coalesced with the SETUP.
             if (_dcd.pipe0.pending_addr) {
               musb_regs->faddr = _dcd.pipe0.pending_addr;
               _dcd.pipe0.pending_addr = 0;
@@ -633,6 +659,7 @@ static void process_bus_reset(uint8_t rhport) {
   _dcd.pipe0.xact_len = 0;
   _dcd.pipe0.remain_wlength = 0;
   _dcd.pipe0.deferred_setup_valid = false;
+  _dcd.pipe0.rxrdy_consumed = false;
 
   musb->intr_txen = 1; /* Enable only EP0 */
   musb->intr_rxen = 0;
@@ -708,6 +735,7 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   _dcd.pipe0.state    = PIPE0_STATE_STATUS_IN;
   /* Send STATUS IN ZLP with DATAEND; host ACK fires the confirmation IRQ. */
   ep_csr->csr0l = MUSB_CSRL0_RXRDYC | MUSB_CSRL0_DATAEND;
+  _dcd.pipe0.rxrdy_consumed = false;
 }
 
 // Wake up host

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -128,6 +128,9 @@ static void pipe0_start_setup(uint8_t rhport, musb_ep_csr_t* ep_csr,
       _dcd.pipe0.state = PIPE0_STATE_DATA_IN;
       ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
     } else {
+      // If OUT (rx) direction, let edpt0_xfer() clear RXRDY when it's ready to receive data.
+      // Deliberate deviation from the databook's canonical flow (ack right after unload),
+      // used as NAK flow control until usbd arms the drain buffer.
       _dcd.pipe0.state = PIPE0_STATE_DATA_OUT;
     }
   }

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -458,10 +458,7 @@ static void process_ep0(uint8_t rhport) {
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, 0);
   uint_fast8_t csrl = ep_csr->csr0l;
 
-  if (csrl & MUSB_CSRL0_DATAEND) {
-    return;
-  }
-
+  // 21.1.5: SentStall and SetupEnd must be checked before anything else.
   if (csrl & MUSB_CSRL0_STALLED) {
     ep_csr->csr0l = 0;
     _dcd.pipe0.state = PIPE0_STATE_IDLE;
@@ -556,6 +553,13 @@ static void process_ep0(uint8_t rhport) {
       default: break;
     }
 
+    return;
+  }
+
+  if (csrl & MUSB_CSRL0_DATAEND) {
+    // Last DATA IN chunk / STATUS IN arm wrote TXRDY|DATAEND and the status stage has not completed
+    // yet — nothing to service. DataEnd is CPU-set-only per the CSR access table; whether it ever
+    // reads back 1 is vendor-dependent (on cores where it reads 0 this guard is dead code).
     return;
   }
 

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -423,35 +423,31 @@ static bool edpt0_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_
   const unsigned dir_in = tu_edpt_dir(ep_addr);
 
   switch (pipe0->state) {
-    // Combined: usbd can arm the opposite-direction status/ZLP while pipe0 is still in a DATA
-    // state, so dispatch on the call direction (dir_in), not the state. (Splitting into separate
-    // DATA_IN/DATA_OUT cases mis-routes those dir != state calls and breaks ADI MUSB.)
+    // DATA stage exits on its last packet, so state matches the call direction here.
     case PIPE0_STATE_DATA_IN:
-    case PIPE0_STATE_DATA_OUT: {
+      TU_ASSERT(dir_in);
       pipe0->xact_len = total_bytes;
-      if (dir_in) {
-        // Replayed SETUP keeps its RXRDY parked until here; ack it before loading the shared FIFO.
-        if (pipe0->rxrdy_consumed) {
-          ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
-          pipe0->rxrdy_consumed = false;
-        }
-        // DATA IN: load FIFO, set TXRDY. Add DATAEND on the last chunk
-        // (remain_wlength == 0 after this load) to end the data stage.
-        tu_hwfifo_write(&musb_regs->fifo[0], buffer, total_bytes, NULL);
-        pipe0->remain_wlength -= total_bytes;
-        if (pipe0->remain_wlength == 0) {
-          ep_csr->csr0l = MUSB_CSRL0_TXRDY | MUSB_CSRL0_DATAEND;
-        } else {
-          ep_csr->csr0l = MUSB_CSRL0_TXRDY;
-        }
-      } else {
-        // DATA OUT: arm drain target, ack RXRDY so host can send DATA OUT.
-        pipe0->buf = buffer;
+      if (pipe0->rxrdy_consumed) { // replayed SETUP: ack its parked RXRDY before loading the FIFO
         ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
         pipe0->rxrdy_consumed = false;
       }
+      tu_hwfifo_write(&musb_regs->fifo[0], buffer, total_bytes, NULL);
+      pipe0->remain_wlength -= total_bytes;
+      // DATAEND on the last packet: wLength met, or a short packet (incl. ZLP) ends the data stage.
+      if (pipe0->remain_wlength == 0 || total_bytes < CFG_TUD_ENDPOINT0_SIZE) {
+        ep_csr->csr0l = MUSB_CSRL0_TXRDY | MUSB_CSRL0_DATAEND;
+      } else {
+        ep_csr->csr0l = MUSB_CSRL0_TXRDY;
+      }
       break;
-    }
+
+    case PIPE0_STATE_DATA_OUT:
+      TU_ASSERT(!dir_in);
+      pipe0->xact_len = total_bytes;
+      pipe0->buf = buffer; // arm drain target, ack RXRDY so host can send DATA OUT
+      ep_csr->csr0l = MUSB_CSRL0_RXRDYC;
+      pipe0->rxrdy_consumed = false;
+      break;
 
     case PIPE0_STATE_STATUS_IN:
       TU_ASSERT(dir_in && total_bytes == 0); // only STATUS IN allowed
@@ -616,10 +612,9 @@ static void process_ep0(uint8_t rhport) {
  * - or status stage is complete (ZLP) after DataEnd is set */
   switch (pipe0->state) {
     case PIPE0_STATE_DATA_IN:
-      // csrl == 0 in DATA IN = TXRDY just cleared, i.e. a DATA IN packet was successfully sent. If the
-      // just-sent packet was the last (DATAEND set when remain_wlength hit 0), transition to STATUS_OUT
-      // to await the host's STATUS-OUT ZLP confirmation IRQ.
-      if (pipe0->remain_wlength == 0) {
+      // DATA IN packet sent (TXRDY cleared). On the last packet (DATAEND condition above) move to
+      // STATUS_OUT to await the host's STATUS-OUT ZLP IRQ.
+      if (pipe0->remain_wlength == 0 || pipe0->xact_len < CFG_TUD_ENDPOINT0_SIZE) {
         pipe0->state = PIPE0_STATE_STATUS_OUT;
       }
       dcd_event_xfer_complete(rhport, TU_EP0_IN, pipe0->xact_len, XFER_RESULT_SUCCESS, true);

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -566,12 +566,13 @@ static void process_ep0_isr(uint8_t rhport) {
         if (count0) {
           TU_ASSERT(pipe0->buf, );
           tu_hwfifo_read(&musb_regs->fifo[0], pipe0->buf, count0, NULL);
-          pipe0->remain_wlength -= count0;
+          pipe0->remain_wlength -= tu_min16(count0, pipe0->remain_wlength); // clamp: host may overrun
         }
         // RXRDY stays set until the next edpt0_xfer arm acks it (NAK flow control):
         // edpt0_xfer(DATA OUT) for a mid-stream packet, edpt0_xfer(STATUS IN) for the last.
         pipe0->rxrdy_consumed = true;
-        if (pipe0->remain_wlength == 0) {
+        // Last packet: wLength received, or a short packet (host's end-of-data).
+        if (pipe0->remain_wlength == 0 || count0 < CFG_TUD_ENDPOINT0_SIZE) {
           pipe0->state = PIPE0_STATE_STATUS_IN;
         }
         dcd_event_xfer_complete(rhport, TU_EP0_OUT, count0, XFER_RESULT_SUCCESS, true);

--- a/src/portable/mentor/musb/dcd_musb.c
+++ b/src/portable/mentor/musb/dcd_musb.c
@@ -534,7 +534,7 @@ static void process_ep0(uint8_t rhport) {
       // - Status IN/OUT finished, its IRQ and the new SETUP IRQ arrive at the same time.
       // - Data IN finished and status OUT is received, both IRQs and the new SETUP IRQ arrive at the same time.
       // Save the SETUP; it is replayed only once the old transfer is fully retired — i.e. when usbd has
-      // made (or already made) its final edpt0_xfer() call for it. Until the replayed
+      // made (or already made) its final edpt0_xfer()/dcd_edpt_stall() call for it. Until the replayed
       // packet is acked, its RXRDY stays parked so a stale latched EP0 IRQ cannot re-process it.
       case PIPE0_STATE_DATA_IN:
       case PIPE0_STATE_STATUS_OUT:
@@ -935,11 +935,17 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
   musb_ep_csr_t* ep_csr = get_ep_csr(musb_regs, epn);
 
   if (0 == epn) {
-    if (ep_addr == TU_EP0_OUT) { /* Ignore EP0 OUT */
+    if (ep_addr == TU_EP0_OUT) { /* Ignore EP0 IN */
       _dcd.pipe0.state = PIPE0_STATE_IDLE;
       _dcd.pipe0.buf = NULL;
-      _dcd.pipe0.deferred_setup_valid = false;
-      ep_csr->csr0l = MUSB_CSRL0_STALL;
+      if (_dcd.pipe0.deferred_setup_valid) {
+        // The transfer being stalled already completed on the wire (a deferred SETUP can only exist
+        // once its status stage was seen) and the host's next request was already ACKed — SendStall
+        // would land on that innocent request. Skip the stall and replay the deferred SETUP instead.
+        pipe0_process_deferred_setup(rhport, ep_csr, false);
+      } else {
+        ep_csr->csr0l = MUSB_CSRL0_STALL;
+      }
     }
   } else {
     const tusb_dir_t ep_dir = tu_edpt_dir(ep_addr);

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -145,8 +145,7 @@ class HilConfig(TypedDict):
 CMD_TIMEOUT = int(os.getenv('HIL_CMD_TIMEOUT', '180'))
 POOL_TIMEOUT = int(os.getenv('HIL_POOL_TIMEOUT', '3000'))
 SERIAL_READ_TIMEOUT = float(os.getenv('HIL_SERIAL_READ_TIMEOUT', '5'))
-SERIAL_WRITE_TIMEOUT = float(os.getenv('HIL_SERIAL_WRITE_TIMEOUT', '2'))
-SERIAL_WRITE_DEADLINE = float(os.getenv('HIL_SERIAL_WRITE_DEADLINE', '10'))
+SERIAL_WRITE_TIMEOUT = float(os.getenv('HIL_SERIAL_WRITE_TIMEOUT', '10'))
 
 
 def cmd_stdout_text(out: Any) -> str:
@@ -247,24 +246,14 @@ def open_serial_dev(port: str):
     return ser
 
 
-def serial_write_all(ser: serial.Serial, data: bytes, deadline: float = SERIAL_WRITE_DEADLINE):
-    total = 0
-    end = time.monotonic() + deadline
-
-    while total < len(data):
-        try:
-            written = ser.write(data[total:])
-        except serial.SerialTimeoutException:
-            written = 0
-
-        if written:
-            total += written
-            continue
-
-        if time.monotonic() >= end:
-            raise AssertionError(f'Serial write timeout after {deadline:.1f}s')
-
-        time.sleep(0.01)
+def serial_write_all(ser: serial.Serial, data: bytes):
+    # write_timeout is a total deadline for the whole call (pyserial keeps partial progress
+    # internally). A timeout means the device stopped draining — treat it as fatal: pyserial
+    # loses the partial-write count on raise, so retrying would duplicate bytes on the wire.
+    try:
+        ser.write(data)
+    except serial.SerialTimeoutException:
+        raise AssertionError(f'Serial write timeout after {SERIAL_WRITE_TIMEOUT:.1f}s')
 
 
 def read_disk_file(uid: str, lun: int, fname: str) -> bytes:


### PR DESCRIPTION
Follow-up to the review of #3643 (the MUSB EP0 deferred-SETUP feature). It started as fixes for the 10 review findings and grew into a correctness + clarity rework of the EP0 control state machine. Base: `musb_ep0_race`.

## Correctness — EP0 deferred-SETUP races (the #3643 review findings)

- **IRQ-first replay race:** split `STATUS_OUT_PENDING` into `_XFER` / `_IRQ` so the deferral never completes+replays while usbd's `edpt0_xfer(STATUS OUT)` is still outstanding (was a NULL `pipe0.buf` drain).
- **Stale RXRDY re-entry:** new `rxrdy_consumed` flag — RxPktRdy left set for an already-drained packet gates the guaranteed second `process_ep0` pass; replayed IN requests stay parked until the `edpt0_xfer(DATA IN)` arm acks them.
- **DATAEND guard ordering:** check SentStall/SetupEnd first (§21.1.5), and evaluate the DATAEND guard after the RXRDY block so a coalesced `DATAEND|RXRDY` can't swallow a SETUP on cores where the CPU-set-only DataEnd reads back 1.
- **Stall vs ACKed SETUP:** `dcd_edpt_stall(EP0 OUT)` replays the deferred SETUP instead of SendStall-ing the host's already-ACKed next request.

## Correctness — short control packets

- End the EP0 **IN** data stage on the last packet — wLength met **or** a short packet (incl. ZLP) — not only when `remain_wlength == 0`. A short IN response (e.g. an 18-byte device descriptor to a 64-byte `GET_DESCRIPTOR`) otherwise left `pipe0` stuck in `DATA_IN` through the status stage.
- Mirror it on the **OUT** drain, and clamp `remain_wlength -= tu_min16(count0, remain_wlength)` against a host overrun.

## Refactor / clarity (behavior-neutral)

- `pipe0_state_t` typedef + local `pipe0` pointer; group struct fields.
- `_isr` suffix on the ISR-context handlers (`process_ep0_isr`, `process_epin_isr`, `process_epout_isr`, `process_bus_reset_isr`).
- Helpers: `pipe0_read_setup()` (single-copy SETUP read into `uint32_t[2]`), `pipe0_data_stage_done()` (the one last-packet predicate), and `pipe0_process_xfer_state_isr()` unifying the two EP0 tail paths; `pipe0_try_deferred_setup()` rename.
- Drop the `goto`, restore/repair load-bearing comments.

## HIL

- `hil: make serial write timeout fatal` — pyserial loses the partial-write count on a `SerialTimeoutException`, so retrying duplicated bytes; write once and fail on timeout.

## Verification

- **HIL full device suite: ek_tm4c123gxl 13/13, max32666fthr 13/13**, including #3643's high-CPU-load IRQ-toggle coalescing stress (which exercises the deferred-SETUP/short-packet paths).
- `pre-commit run --all-files` clean (format, codespell, Ceedling unit tests); full example sets build for both MUSB families.
- Code size (max32666fthr `device/dfu`, MinSizeRel): `dcd_musb.c` .text +~180 B vs `musb_ep0_race`.

A separate buffer-overflow hardening found during this review (usbd copies an OUT data packet that overruns wLength into the caller buffer) is split out as **#3705** since it's in the shared control handler, not MUSB-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)