### PR TITLE
ci(metrics): collapse <1% size changes in Size Difference Report

### DIFF
--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -425,7 +425,7 @@ def write_compare_markdown(comparison, path, sort_order='size'):
             md_lines.append("")
 
     render("Changes >1% in size", significant)
-    render("Changes <1% in size", minor)
+    render("Changes <1% in size", minor, collapsed=True)
     render("No changes", unchanged, collapsed=True)
 
     with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Describe the PR

The Size Difference Report comment posted on PRs currently expands both the "Changes >1% in size" and "Changes <1% in size" tables, while only "No changes" is collapsed. Sub-1% deltas are mostly alignment/padding noise, so this wraps the "Changes <1% in size" section in a `<details>` block like "No changes" — leaving only meaningful (>1%) changes expanded.

Sample output with all three buckets:

```markdown
### Changes >1% in size
| file    |               size | % diff |
| :------ | -----------------: | -----: |
| dcd_a.c | 1000 ➙ 1100 (+100) | +10.0% |
| TOTAL   | 1000 ➙ 1100 (+100) | +10.0% |

<details><summary>Changes <1% in size</summary>
...table...
</details>

<details><summary>No changes</summary>
...table...
</details>
```

- `pre-commit run --files tools/metrics.py` passes.
- Verified by running `tools/metrics.py compare -m` on sample base/new metrics JSON covering all three buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)