### PR TITLE
hil: enable nanoch32v203 in CI with fsdev + usbfs variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,7 @@ jobs:
       matrix:
         toolchain:
           - 'arm-gcc'
+          - 'riscv-gcc'
           - 'esp-idf'
     with:
       build-system: 'cmake'

--- a/test/hil/hil_ci_set_matrix.py
+++ b/test/hil/hil_ci_set_matrix.py
@@ -19,8 +19,12 @@ def main():
     parser.add_argument('config_files', nargs='+', help='Configuration JSON file(s)')
     args = parser.parse_args()
 
+    # Toolchain buckets must match the toolchains instantiated by the hil-build
+    # job in .github/workflows/build.yml. Keep all keys present (even if empty)
+    # so `fromJSON(hil_json)[toolchain]` always resolves to a list.
     matrix = {
         'arm-gcc': [],
+        'riscv-gcc': [],
         'esp-idf': []
     }
 
@@ -38,10 +42,13 @@ def main():
         for board in config['boards']:
             name = board['name']
             flasher = board['flasher']
+            # esptool boards must build under esp-idf; others default to arm-gcc
+            # but may opt into another bucket via an explicit "toolchain" field
+            # (e.g. RISC-V boards like ch32v20x need "riscv-gcc").
             if flasher['name'] == 'esptool':
                 toolchain = 'esp-idf'
             else:
-                toolchain = 'arm-gcc'
+                toolchain = board.get('toolchain', 'arm-gcc')
 
             build_board = f'-b {name}'
             if 'build' in board and 'args' in board['build']:

--- a/test/hil/hil_ci_set_matrix.py
+++ b/test/hil/hil_ci_set_matrix.py
@@ -47,13 +47,16 @@ def main():
             if 'build' in board and 'args' in board['build']:
                 build_board += ' ' + ' '.join(f'-D{a}' for a in board['build']['args'])
 
-            # Each variant builds into cmake-build-<variant.name> with its raw CFLAGS.
-            # No 'variant' -> a single build named after the board.
+            # Each variant builds into cmake-build-<variant.name> with its own cmake
+            # -D defines and raw CFLAGS. No 'variant' -> a single build named after
+            # the board.
             variants = board.get('variant') or [{'name': name, 'flags': ''}]
             for v in variants:
                 arg = build_board
                 if v['name'] != name:
                     arg += f' --build-name {v["name"]}'
+                for d in v.get('defines', []):
+                    arg += f' -D{d}'
                 for tok in v.get('flags', '').split():
                     arg += f' --cflag={tok}'
                 append_build_arg(toolchain, arg)

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -138,6 +138,7 @@ class Board(TypedDict):
     flasher: FlasherCfg
     build: NotRequired[BuildCfg]
     variant: NotRequired[list[VariantCfg]]
+    toolchain: NotRequired[str]  # CI build bucket override, e.g. "riscv-gcc" (consumed by hil_ci_set_matrix.py)
 
 
 class HilConfig(TypedDict):

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -126,8 +126,9 @@ class BuildCfg(TypedDict, total=False):
 
 
 class VariantCfg(TypedDict, total=False):
-    name: str   # build dir (cmake-build-<name>) and HIL report row
-    flags: str  # raw CFLAGS, e.g. "-DCFG_TUD_DWC2_DMA_ENABLE=1"
+    name: str           # build dir (cmake-build-<name>) and HIL report row
+    flags: str          # raw CFLAGS, e.g. "-DCFG_TUD_DWC2_DMA_ENABLE=1"
+    defines: list[str]  # cmake -D defines, e.g. ["RHPORT_DEVICE=1"] (vs flags which are compiler-only)
 
 
 class Board(TypedDict):
@@ -1634,6 +1635,8 @@ def build_board(board: Board) -> tuple[str, int]:
             cmd += ['-D', d]
         if v['name'] != name:
             cmd += ['--build-name', v['name']]
+        for d in v.get('defines', []):
+            cmd += ['-D', d]
         for tok in v.get('flags', '').split():
             cmd += [f'--cflag={tok}']
         if verbose:

--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -458,6 +458,24 @@
                 "name": "stlink",
                 "uid": "0668FF575457657187061314"
             }
+        },
+        {
+            "name": "nanoch32v203",
+            "uid": "CDAB277B0FBC03E339E339E3",
+            "variant": [
+                {"name": "nanoch32v203-fsdev", "defines": ["RHPORT_DEVICE=0"]},
+                {"name": "nanoch32v203-usbfs", "defines": ["RHPORT_DEVICE=1"]}
+            ],
+            "tests": {
+                "device": true,
+                "host": false,
+                "dual": false
+            },
+            "flasher": {
+                "name": "openocd_wch",
+                "uid": "EBCA8F0670AF",
+                "args": ""
+            }
         }
     ],
     "boards-skip": [
@@ -477,20 +495,6 @@
                 "name": "jlink",
                 "uid": "000778170924",
                 "args": "-device stm32f769ni"
-            }
-        },
-        {
-            "name": "nanoch32v203",
-            "uid": "CDAB277B0FBC03E339E339E3",
-            "tests": {
-                "device": true,
-                "host": false,
-                "dual": false
-            },
-            "flasher": {
-                "name": "openocd_wch",
-                "uid": "EBCA8F0670AF",
-                "args": ""
             }
         }
     ]

--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -462,6 +462,7 @@
         {
             "name": "nanoch32v203",
             "uid": "CDAB277B0FBC03E339E339E3",
+            "toolchain": "riscv-gcc",
             "variant": [
                 {"name": "nanoch32v203-fsdev", "defines": ["RHPORT_DEVICE=0"]},
                 {"name": "nanoch32v203-usbfs", "defines": ["RHPORT_DEVICE=1"]}


### PR DESCRIPTION
## What

Activate **nanoch32v203** in the HIL CI pool (it was parked in `boards-skip`) and cover **both** of its USB device IPs as build variants:

| Variant | `RHPORT_DEVICE` | USB IP | DCD |
|---|---|---|---|
| `nanoch32v203-fsdev` | `0` | USBD / FSDev | `dcd_stm32_fsdev.c` |
| `nanoch32v203-usbfs` | `1` | WCH USBFS | `dcd_ch32_usbfs.c` |

## Why the new `defines` field

The fsdev/usbfs split is selected by the `RHPORT_DEVICE` **cmake** variable (see `hw/bsp/ch32v20x/family.cmake`). A variant's existing `flags` field is routed to compiler `--cflag`s (`CFLAGS_CLI`), which **cannot** set a cmake variable — so two variants with only `flags` would build identically.

This adds a per-variant `"defines": [...]` field that emits cmake `-D` options, wired through both build paths so local and CI builds match:
- `hil_test.py` `build_board()` — local `--build`
- `hil_ci_set_matrix.py` — CI build matrix

It mirrors the existing board-level `build.args` (which already emits `-D`), and is backward compatible: variants with only `flags`/`name` are unchanged.

## Verification

- `hil_ci_set_matrix.py test/hil/tinyusb.json` now emits:
  ```
  -b nanoch32v203 --build-name nanoch32v203-fsdev -DRHPORT_DEVICE=0
  -b nanoch32v203 --build-name nanoch32v203-usbfs -DRHPORT_DEVICE=1
  ```
- Fresh `tools/build.py … -DRHPORT_DEVICE=1` → `RHPORT_DEVICE=1` in cache, `CFG_TUD_WCH_USBIP_USBFS` baked into the firmware (and `=0` → `CFG_TUD_WCH_USBIP_FSDEV`).
- HIL on the ci.lan rig: **fsdev 11/11 pass**, **usbfs 11/11 pass**.

## Known flakiness

`usbfs` `cdc_msc_throughput` (device→host CDC bulk-IN read) is marginal: on the ci rig it passed only after retries (and hard-fails on a faster host). It's included here relying on the `-r` retry mechanism; the underlying `dcd_ch32_usbfs.c` bulk-IN throughput issue is pre-existing and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)