### PR TITLE
ncm: add weak callback for initial link state

### DIFF
--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -152,6 +152,14 @@ TU_ATTR_WEAK void tud_network_set_packet_filter_cb(uint16_t packet_filter) {
   (void) packet_filter;
 }
 
+TU_ATTR_WEAK bool tud_network_default_link_state_cb(void) {
+  #ifdef CFG_TUD_NCM_DEFAULT_LINK_UP
+  return CFG_TUD_NCM_DEFAULT_LINK_UP;
+  #else
+  return true;
+  #endif
+}
+
 /**
  * This is the NTB parameter structure
  *
@@ -852,12 +860,7 @@ void netd_init(void) {
   for (int i = 0; i < RECV_NTB_N; ++i) {
     ncm_interface.recv_free_ntb[i] = &ncm_epbuf.recv[i].ntb;
   }
-  // Default link state - can be configured via CFG_TUD_NCM_DEFAULT_LINK_UP
-  #ifdef CFG_TUD_NCM_DEFAULT_LINK_UP
-  ncm_interface.link_is_up = CFG_TUD_NCM_DEFAULT_LINK_UP;
-  #else
-  ncm_interface.link_is_up = true; // Default to link up if not set.
-  #endif
+  ncm_interface.link_is_up = tud_network_default_link_state_cb();
 } // netd_init
 
 /**

--- a/src/class/net/net_device.h
+++ b/src/class/net/net_device.h
@@ -106,6 +106,10 @@ extern uint8_t tud_network_mac_address[6];
 // Optional callback: informs the application about host requested packet filter bits
 void tud_network_set_packet_filter_cb(uint16_t packet_filter);
 
+// Optional callback: called during netd_init() to get the initial link state.
+// Override to return the actual physical link state instead of the compile-time default.
+bool tud_network_default_link_state_cb(void);
+
 // Set the network link state (up/down) and notify the host
 void tud_network_link_state(uint8_t rhport, bool is_up);
 


### PR DESCRIPTION
Closes #3661

## Problem

When the host reboots without power-cycling the USB device, `netd_init` resets `ncm_interface.link_is_up` to the compile-time default (`CFG_TUD_NCM_DEFAULT_LINK_UP`, or `true`). If the application had previously set a different state, or if the physical link state differs from the default, the device reports an incorrect link state to the host after re-enumeration.

## Solution

Add a weak callback `tud_network_default_link_state_cb()` called by `netd_init` to determine the initial link state. The default implementation preserves existing behaviour (`CFG_TUD_NCM_DEFAULT_LINK_UP` if defined, else `true`). Applications that know the physical link state at init time can override it:

```c
bool tud_network_default_link_state_cb(void) {
  return phy_link_is_up();
}
```

## Testing

Built `net_lwip_webserver` and `cdc_msc` for `stm32f407disco` — both pass.