### PR TITLE
dcd/stm32_fsdev: review fixes for the CH32 EP0 OUT workaround

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -833,6 +833,14 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
   ep_reg &= U_EPREG_MASK | EP_STAT_MASK(dir);
   ep_change_status(&ep_reg, dir, EP_STAT_STALL);
 
+#if defined(TUP_USBIP_FSDEV_CH32)
+  // Stall ends the transfer without edpt_xfer() (the only other CONTROL restore); else a rejected
+  // control-write leaves EP0 typed BULK and the host's recovery SETUP is ignored until bus reset.
+  if (ep_num == 0u) {
+    ep_reg = (ep_reg & ~U_EP_T_FIELD) | U_EP_CONTROL;
+  }
+#endif
+
   ep_write(ep_idx, ep_reg, true);
 }
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -159,12 +159,19 @@ TU_ATTR_ALWAYS_INLINE static inline xfer_ctl_t *xfer_ctl_ptr(uint8_t epnum, uint
 }
 
 #if defined(TUP_USBIP_FSDEV_CH32)
-// CH32 FSDEV workaround: gate EP0 handshakes by switching type between CONTROL and BULK.
+// CH32 EP0 workaround: gate handshakes by switching EP0 type CONTROL<->BULK.
+// need_exclusive brackets the read-modify-write so the USB ISR can't race it.
 TU_ATTR_ALWAYS_INLINE static inline void ep0_set_type(uint32_t ep_type, bool need_exclusive) {
+  if (need_exclusive) {
+    fsdev_int_disable(0);
+  }
   uint32_t ep_reg = ep_read(0) | U_EP_CTR_TX | U_EP_CTR_RX;
   ep_reg &= U_EPREG_MASK;
   ep_reg = (ep_reg & ~U_EP_T_FIELD) | ep_type;
-  ep_write(0, ep_reg, need_exclusive);
+  ep_write(0, ep_reg, false);
+  if (need_exclusive) {
+    fsdev_int_enable(0);
+  }
 }
 #endif
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -291,7 +291,7 @@ static void handle_ctr_tx(uint32_t ep_id) {
 #if defined(TUP_USBIP_FSDEV_CH32)
     // Control read: block unsolicited EP0 OUT ACK.
     if ((ep_num == 0u) && ep0_ctrl_dir_in && ep0_ctrl_has_data) {
-        ep0_set_type(U_EP_BULK, false);
+      ep0_set_type(U_EP_BULK, false);
     }
 #endif
     dcd_event_xfer_complete(0, ep_num | TUSB_DIR_IN_MASK, xfer->queued_len, XFER_RESULT_SUCCESS, true);
@@ -311,9 +311,9 @@ static void handle_ctr_setup(uint32_t ep_id) {
   // Setup packet should always be 8 bytes. If not, we probably missed the packet
   if (rx_count == 8) {
 #if defined(TUP_USBIP_FSDEV_CH32)
-    uint16_t const setup_w_length = (uint16_t) setup_packet[6] | ((uint16_t) setup_packet[7] << 8);
-    ep0_ctrl_dir_in = (setup_packet[0] & TUSB_DIR_IN_MASK) != 0u;
-    ep0_ctrl_has_data = (setup_w_length != 0u);
+    tusb_control_request_t const *request = (tusb_control_request_t const *) (void *) setup_packet;
+    ep0_ctrl_dir_in = (request->bmRequestType_bit.direction == TUSB_DIR_IN);
+    ep0_ctrl_has_data = (request->wLength != 0u);
 
     // For control write, block unsolicited EP0 OUT ACK until transfer is armed in edpt_xfer().
     if (!ep0_ctrl_dir_in && ep0_ctrl_has_data) {
@@ -365,7 +365,6 @@ static void handle_ctr_rx(uint32_t ep_id) {
     tu_hwfifo_read(pma_buf, xfer->buffer + xfer->queued_len, rx_count, NULL);
   }
   xfer->queued_len += rx_count;
-
 
   if ((rx_count < xfer->max_packet_size) || (xfer->queued_len >= xfer->total_len)) {
     // all bytes received or short packet

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -754,14 +754,13 @@ static bool edpt_xfer(uint8_t rhport, uint8_t ep_num, tusb_dir_t dir) {
 
   xfer_ctl_t   *xfer   = xfer_ctl_ptr(ep_num, dir);
   const uint8_t ep_idx = xfer->ep_idx;
-#if defined(TUP_USBIP_FSDEV_CH32)
-  // Re-enable normal control transfer semantics when EP0 transfer is explicitly armed.
-  if (ep_num == 0u) {
-    ep0_set_type(U_EP_CONTROL, true);
-  }
-#endif
-
   if (dir == TUSB_DIR_IN) {
+#if defined(TUP_USBIP_FSDEV_CH32)
+    // Safe to restore CONTROL before arming IN: no pending OUT for the errata to blind-ACK.
+    if (ep_num == 0u) {
+      ep0_set_type(U_EP_CONTROL, true);
+    }
+#endif
     dcd_transmit_packet(xfer, ep_idx);
   } else {
     uint32_t ep_reg = ep_read(ep_idx) | U_EP_CTR_TX | U_EP_CTR_RX; // reserve CTR
@@ -781,6 +780,13 @@ static bool edpt_xfer(uint8_t rhport, uint8_t ep_num, tusb_dir_t dir) {
       btable_set_rx_bufsize(ep_idx, BTABLE_BUF_RX, cnt);
     }
 
+#if defined(TUP_USBIP_FSDEV_CH32)
+    // Restore CONTROL in the same write as STAT_RX=VALID (after bufsize): a separate earlier
+    // write would re-enable the blind OUT ACK while still NAK'd with a stale buffer.
+    if (ep_num == 0u) {
+      ep_reg = (ep_reg & ~U_EP_T_FIELD) | U_EP_CONTROL;
+    }
+#endif
     ep_change_status(&ep_reg, dir, EP_STAT_VALID);
     ep_write(ep_idx, ep_reg, true);
   }


### PR DESCRIPTION
@HiFiPhile there are a few finding that detected by claude, I did manual review of everything it makes and do manual update. Please check it out to see if these make sense to you. 

Code review of the CH32 EP0 OUT premature-ACK workaround on this branch, plus on-hardware verification (nanoch32v203, fsdev). 4 commits, all CH32-gated. No behaviour change for STM32/AT32. Per-line rationale is in the inline review comments.

## Correctness

**1. `ep0_set_type` read-modify-write wasn't atomic**
`ep_write(.., need_exclusive)` masks the USB IRQ only around the *store*; the `ep_read` ran unmasked, so a SETUP arriving mid-RMW could have its BULK gate dropped:
```
task: r = ep_read(EP0)             // IRQ still enabled
ISR : SETUP -> ep0_set_type(BULK)  // installs the gate
task: ep_write(r, type=CONTROL)    // overwrites it -> the OUT it was meant to block gets ACKed
```
Bracket the whole RMW with `fsdev_int_disable/enable` when `need_exclusive`.

**2. Stall left EP0 typed BULK**
`dcd_edpt_stall` preserves the type field, and `edpt_xfer` is the only other place that restores CONTROL. A control-write rejected by the class (e.g. DFU `DNLOAD` in the wrong state) leaves EP0 stuck BULK+STALL; the host's recovery SETUP is ignored until a bus reset. Fix: restore CONTROL for EP0 in the stall write.

**3. CONTROL restored before the OUT was armed**
`edpt_xfer` flipped EP0 to CONTROL at the top of the function, before `btable_set_rx_bufsize`/`STAT_RX=VALID` — re-enabling the blind ACK with a stale, still-NAK'd buffer, so a host-retried DATA OUT / status ZLP could be ACKed into the wrong buffer. Fix: fold the CONTROL restore into the same exclusive write that sets `STAT_RX=VALID` on the OUT path; keep the early restore on the IN path (no pending OUT there).

## Cleanup
- Parse the setup packet via `tusb_control_request_t` (as `dcd_ch32_usbfs.c` does) instead of hand-rolled byte indexing; whitespace.

## Dropped during review
An earlier change gated `handle_ctr_tx` on `xfer->total_len > 0` (plus a dependent single-bool refactor). The Codex review + `test_usbd_control_in_zlp` showed it regresses the terminating data-stage ZLP of a control read: that ZLP completes `handle_ctr_tx` with `total_len == 0`, so the BULK gate would be skipped right before the status OUT, reopening the premature-ACK window. The original `ep0_ctrl_dir_in && ep0_ctrl_has_data` keys on transfer direction and handles the ZLP correctly, so it's kept.

The review also added a `#if !defined(TUP_USBIP_FSDEV_CH32)` guard to keep `edpt0_prepare_setup()` in `dcd_edpt0_status_complete` for STM32/AT32. Per @HiFiPhile that's unnecessary: the call only sizes the EP0 RX buffer (to 8), and the unconditional reset to MPS in `handle_ctr_rx` already re-arms it for all ports (a SETUP fits in any buffer ≥ 8). It was a ch32v203 setup-race fix originally (315dae6a8), so dropping it for all ports — as this PR does — is correct. Guard removed.

## Verified on hardware
nanoch32v203 (fsdev): instrumented DFU example with a deliberate delay before arming EP0 OUT to force the premature-ACK window. Baseline corrupts / fails the download; with these fixes a **16 KB multi-packet DFU download completes with 0 byte errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
