### PR TITLE
test/hil: fail audio test on missing alsa-utils instead of skipping

### DIFF
--- a/examples/device/audio_test_freertos/sdkconfig.defaults
+++ b/examples/device/audio_test_freertos/sdkconfig.defaults
@@ -1,3 +1,6 @@
 CONFIG_IDF_CMAKE=y
+# 1000 Hz tick: the UAC iso IN endpoint must be serviced every 1 ms frame;
+# ESP-IDF's default 100 Hz starves the audio task -> host capture fails (arecord EIO).
+CONFIG_FREERTOS_HZ=1000
 CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK=y
 CONFIG_FREERTOS_SUPPORT_STATIC_ALLOCATION=y

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Host setup:
+# Host setup (required: a missing tool fails its test rather than skipping it):
 #   - System packages: sudo apt install mtools libmtp9 alsa-utils iperf
 #       mtools     - read_disk_file (device/cdc_msc, device/msc_dual_lun)
 #       libmtp9    - pymtp ctypes load (device/mtp); Debian 13 uses libmtp9t64
@@ -51,7 +51,6 @@ import serial
 import subprocess
 import json
 import glob
-import shutil
 from multiprocessing import Pool, Lock
 from multiprocessing import TimeoutError as MpTimeoutError
 import hashlib
@@ -1380,10 +1379,6 @@ def test_device_audio_test_freertos(board):
     if os.name == 'nt':
         return 'skipped'
 
-    arecord = shutil.which('arecord')
-    if arecord is None:
-        return 'skipped'
-
     pcm = None
     timeout = ENUM_TIMEOUT
     while timeout > 0:
@@ -1397,7 +1392,7 @@ def test_device_audio_test_freertos(board):
 
     raw_path = f'/tmp/tinyusb_audio_{uid}.raw'
     cmd = [
-        arecord,
+        'arecord',
         '-D', pcm,
         '-q',
         '-f', 'S16_LE',

--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -132,6 +132,7 @@
                 "device": true,
                 "host": false,
                 "dual": true,
+                "skip": ["device/audio_test_freertos"],
                 "dev_attached": [
                     {
                         "vid_pid": "067b_2303",
@@ -139,7 +140,7 @@
                         "is_cdc": true
                     }
                 ],
-                "comment": "pl23x"
+                "comment": "pl23x; audio_test_freertos skipped: samd51 iso-IN capture fails (arecord EIO)"
             },
             "flasher": {
                 "name": "jlink",


### PR DESCRIPTION
## Problem

`device/audio_test_freertos` captures the firmware's UAC stream with `arecord` (alsa-utils), but the test silently returned `skipped` when `arecord` was missing — so on the ci.lan rig (which had no `alsa-utils`) audio had **never actually run on any board**. Once enabled, it also exposed real device-side failures on a few boards.

## Changes

1. **Stop skipping on a missing package** (`hil_test.py`) — remove the `shutil.which('arecord')` guard so a missing `alsa-utils` *fails* the test, consistent with the unguarded `mtools`/`libmtp9`/`iperf` tests; drop the now-unused `import shutil`; note in the host-setup header comment that these packages are required.
2. **Fix esp32 audio** (`examples/device/audio_test_freertos/sdkconfig.defaults`) — set `CONFIG_FREERTOS_HZ=1000`. ESP-IDF defaults to 100 Hz, so the audio task wakes only every 10 ms and can't service the 1 ms UAC iso frames → underrun → `arecord: pcm_read: read error: Input/output error`. The same dwc2 driver already passes on STM32 (FreeRTOSConfig = 1000 Hz). Verified the example's defaults are honored in the generated `sdkconfig` alongside the BSP's, so this takes effect.
3. **Skip metro_m4_express** (`tinyusb.json`) — SAMD51 also fails the iso IN read, but its FreeRTOSConfig is *already* 1000 Hz, so it's a separate iso issue, skipped for now.

## HIL results (`alsa-utils` now installed on ci.lan)

Audio passes on **18 boards** at `strict=1.000` (ek_tm4c123gxl, max32666fthr, feather_nrf52840, raspberry_pi_pico, adafruit_fruit_jam, mimxrt1015/1064, lpcxpresso11u37, stm32f072/f407/f723(+DMA)/g0b1/h743(+DMA)/l476/u083, …). The **hifiphile rig** (`hfp.json` + IAR) passes too, including `stm32f746disco`.

Before this PR, `espressif_p4_function_ev`, `espressif_s3_devkitm` and `metro_m4_express` failed with `arecord pcm_read EIO`. The FreeRTOS-tick fix addresses esp32 (audio re-enabled here); metro_m4 remains skipped pending a separate SAMD51 iso fix.

## Verification

- `python3 -m py_compile test/hil/hil_test.py` passes; `tinyusb.json` valid; replayed the `only`/`skip` selection — audio runs on esp32 + the rest, skipped only on metro_m4.
- Generated `sdkconfig` shows the example defaults applied (`FREERTOS_HZ` was 100 = ESP-IDF default; nothing else sets it), so `CONFIG_FREERTOS_HZ=1000` will land.
- The HIL run triggered by this push will confirm esp32 audio passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
