### PR TITLE
ci(metrics): collapse Average Code Size Metrics table when no base

### DIFF
--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -384,9 +384,9 @@ def render_combine_table(json_data, sort_order='name+'):
 def write_combine_markdown(json_data, path, sort_order='name+', title="TinyUSB Average Code Size Metrics"):
     """Write averaged size data to a markdown file."""
 
-    md_lines = [f"## {title}", ""]
+    md_lines = [f"## {title}", "", "<details><summary>Size table</summary>", ""]
     md_lines.extend(render_combine_table(json_data, sort_order))
-    md_lines.append("")
+    md_lines.extend(["", "</details>", ""])
 
     if json_data.get("file_list"):
         md_lines.extend(["<details>", "<summary>Input files</summary>", ""])


### PR DESCRIPTION
## Summary

When a PR has **no base metrics** to compare against, the metrics CI comment falls back to the combined *TinyUSB Average Code Size Metrics* report instead of the *Size Difference Report* (`.github/workflows/build.yml` copies `metrics.md` → `metrics_compare.md` when `base-metrics/metrics.json` is missing). That fallback posted the full per-example size table inline, which clutters the PR comment.

This wraps the size table in a collapsible `<details><summary>Size table</summary>` block in `write_combine_markdown()`. The `## TinyUSB Average Code Size Metrics` heading stays visible so the comment is still recognizable, but the detail is collapsed by default — consistent with the *Size Difference Report*'s collapsible sections.

## Change

- `tools/metrics.py` — `write_combine_markdown()` now emits the table inside `<details>`. The "Input files" section is unchanged.

## Rendered output

\`\`\`markdown
## TinyUSB Average Code Size Metrics

<details><summary>Size table</summary>

| File           | text | data | size |      % |
| :------------- | ---: | ---: | ---: | -----: |
| device/cdc_msc | 1234 |   56 | 1290 |  56.8% |
| ...            |  ... |  ... |  ... |    ... |

</details>

<details>
<summary>Input files</summary>
...
</details>
\`\`\`

The blank line after `<summary>` is required for GitHub to render the markdown table inside the fold.

## Test

- `python3 -m py_compile tools/metrics.py` ✓
- `pre-commit run --files tools/metrics.py` ✓ (codespell, whitespace, eof)
- Verified rendered markdown with a synthetic `json_data` (heading visible, table collapsed, input files collapsed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)