### PR TITLE
ci(review): run Claude PR review at max effort

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,8 @@ jobs:
           # TEMPORARY: expose the full Claude transcript in the Actions log for
           # debugging. Revert to remove once done.
           show_full_output: true
-          claude_args: '--max-turns 50 --model claude-opus-4-8'
+          claude_args: |
+            --max-turns 50
+            --model claude-opus-4-8
+            --effort max
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary
- Add `--effort max` to the `claude_args` passed to the auto-review workflow (`.github/workflows/claude-code-review.yml`) so PR reviews run at maximum reasoning effort.
- Switch `claude_args` from a single-line string to a multi-line YAML block scalar for readability; `--max-turns 50` and `--model claude-opus-4-8` are unchanged.

## Details
The block scalar is whitespace-tokenized by the action into `--max-turns 50 --model claude-opus-4-8 --effort max`. `--effort <level>` is a valid `claude` CLI flag (confirmed via `claude --help`).

## Test
- `pre-commit run --files .github/workflows/claude-code-review.yml` → check-yaml, trailing-whitespace, end-of-file-fixer, codespell all pass.
- YAML parses; `claude_args` resolves to `'--max-turns 50\n--model claude-opus-4-8\n--effort max\n'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)