### PR TITLE
video: assert usbd_edpt_iso_activate() result in _open_vs_itf()

### DIFF
--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -865,7 +865,7 @@ static bool _open_vs_itf(uint8_t rhport, videod_streaming_interface_t *stm, uint
       /* FS must be less than or equal to max packet size */
       TU_VERIFY (tu_edpt_packet_size(ep) >= max_size);
 #ifdef TUP_DCD_EDPT_ISO_ALLOC
-      usbd_edpt_iso_activate(rhport, ep);
+      TU_ASSERT(usbd_edpt_iso_activate(rhport, ep));
 #else
       TU_ASSERT(usbd_edpt_open(rhport, ep));
 #endif


### PR DESCRIPTION
## Summary

In `_open_vs_itf()` (`src/class/video/video_device.c:868`), the isochronous streaming endpoint is activated with the `usbd_edpt_iso_activate()` return value **ignored**, while every neighbouring endpoint open in the same function wraps `usbd_edpt_open()` in `TU_ASSERT` (both the non-`TUP_DCD_EDPT_ISO_ALLOC` fallback and the bulk branch).

If a DCD refuses the iso endpoint — e.g. it has no isochronous support, or the requested packet size doesn't fit its endpoint buffers — the failure was silently swallowed and the alternate setting was reported as opened, leaving the host streaming to an endpoint the device never armed.

This wraps the call in `TU_ASSERT` so the open fails cleanly and the refusal propagates, matching the adjacent endpoint-open calls:

```diff
 #ifdef TUP_DCD_EDPT_ISO_ALLOC
-      usbd_edpt_iso_activate(rhport, ep);
+      TU_ASSERT(usbd_edpt_iso_activate(rhport, ep));
 #else
       TU_ASSERT(usbd_edpt_open(rhport, ep));
 #endif
```

## Context

Found while bringing up the CH58x USBFS device driver, which has no isochronous support and therefore refuses `dcd_edpt_iso_alloc()` / `dcd_edpt_iso_activate()`. The video class ignored that refusal. The fix is a general robustness improvement independent of CH58x.

## Test

- `video_capture` builds clean for `stm32f407disco` (arm-none-eabi-gcc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)