### PR TITLE
cap tud_msc_scsi_cb bufsize to endpoint buffer size

### DIFF
--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -545,7 +545,8 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
 
           // Invoke user callback if not built-in
           if ((resplen < 0) && (p_msc->sense_key == 0)) {
-            resplen = tud_msc_scsi_cb(p_cbw->lun, p_cbw->command, _mscd_epbuf.buf, (uint16_t)p_msc->total_len);
+            resplen = tud_msc_scsi_cb(p_cbw->lun, p_cbw->command, _mscd_epbuf.buf,
+                                      (uint16_t) tu_min32(p_msc->total_len, CFG_TUD_MSC_EP_BUFSIZE));
           }
 
           if (resplen < 0) {


### PR DESCRIPTION
for a SCSI command that is neither built in nor READ10/WRITE10, mscd_xfer_cb hands tud_msc_scsi_cb a bufsize taken straight from the host-supplied CBW transfer length (total_len, truncated to 16 bits), while the buffer it points at is only CFG_TUD_MSC_EP_BUFSIZE bytes. a host requesting a large data-in transfer for a vendor command can thus tell the application callback it may fill far more than the buffer actually holds, and a callback that fills bufsize bytes as the documented contract allows will overrun _mscd_epbuf.buf. cap the reported size to CFG_TUD_MSC_EP_BUFSIZE, the same bound already used for the built-in command path just above.