### PR TITLE
test/hil: enable cdc_msc_throughput on ch32v103r_r1_1v0

### DIFF
--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -486,8 +486,7 @@
             "tests": {
                 "device": true,
                 "host": false,
-                "dual": false,
-                "skip": ["device/cdc_msc_throughput"]
+                "dual": false
             },
             "flasher": {
                 "name": "openocd_wch",


### PR DESCRIPTION
## Summary
Enable the `device/cdc_msc_throughput` HIL test on `ch32v103r_r1_1v0`.

The board was added to the CI HIL pool with `device/cdc_msc_throughput` listed under `skip`, so the test had never actually run on it. This removes the skip to include it in the board's device test set.

## Test evidence
Ran on the `ci` rig (CH32V103 USBFS, full-speed):

| Board | cdc_msc_throughput |
| --- | :---: |
| ch32v103r_r1_1v0 | ✅ CDC 639k/544k · MSC 845k/575k |

- CDC read 639 / write 544 kBps
- MSC read 845 / write 575 kBps

🤖 Generated with [Claude Code](https://claude.com/claude-code)