### PR TITLE
feat(midi2): opt-in app responder for UMP Stream

### DIFF
--- a/src/class/midi/midi2_device.c
+++ b/src/class/midi/midi2_device.c
@@ -270,6 +270,7 @@ static uint32_t _tx_ump_write(midi2d_interface_t* p_midi, const uint32_t* words,
 //--------------------------------------------------------------------+
 // Protocol Negotiation
 //--------------------------------------------------------------------+
+#if !CFG_TUD_MIDI2_USER_RESPONDER
 static void _nego_send_ump(midi2d_interface_t* p_midi, const uint32_t* words, uint8_t count) {
   if (!_tx_opened(p_midi)) return;
   if (tu_fifo_remaining(&p_midi->ep_stream.tx.ff) < (uint32_t) count * 4) return;
@@ -383,8 +384,16 @@ static void _nego_handle_stream_msg(midi2d_interface_t* p_midi, const uint32_t* 
       break;
   }
 }
+#endif // !CFG_TUD_MIDI2_USER_RESPONDER
 
 static void _nego_process_rx(midi2d_interface_t* p_midi) {
+#if CFG_TUD_MIDI2_USER_RESPONDER
+  // User responder owns UMP Stream discovery: MT 0xF messages stay in the
+  // RX FIFO and surface through tud_midi2_n_ump_read so the application can
+  // answer Endpoint / Function Block discovery itself. The app must drain
+  // them (e.g. in tud_midi2_rx_cb) to avoid RX FIFO backpressure.
+  (void)p_midi;
+#else
   tu_edpt_stream_t* ep_rx = &p_midi->ep_stream.rx;
   uint8_t word_bytes[4];
 
@@ -402,6 +411,7 @@ static void _nego_process_rx(midi2d_interface_t* p_midi) {
     tu_edpt_stream_read(ep_rx, buf, pkt_bytes);
     _nego_handle_stream_msg(p_midi, buf);
   }
+#endif
 }
 
 //--------------------------------------------------------------------+
@@ -508,6 +518,12 @@ bool tud_midi2_n_negotiated(uint8_t itf) {
 uint8_t tud_midi2_n_protocol(uint8_t itf) {
   TU_VERIFY(itf < CFG_TUD_MIDI2, 0);
   return _midi2d_itf[itf].protocol;
+}
+
+void tud_midi2_n_set_protocol(uint8_t itf, uint8_t protocol) {
+  TU_VERIFY(itf < CFG_TUD_MIDI2, );
+  _midi2d_itf[itf].protocol = protocol;
+  _midi2d_itf[itf].negotiated = true;
 }
 
 //--------------------------------------------------------------------+

--- a/src/class/midi/midi2_device.h
+++ b/src/class/midi/midi2_device.h
@@ -86,6 +86,16 @@ extern "C" {
   #define CFG_TUD_MIDI2_BLOCK_STRIDX 0
 #endif
 
+// When set to 1, the built-in UMP Stream responder is disabled and MT 0xF
+// (Stream) messages are left in the RX FIFO for the application to handle
+// (Endpoint / Function Block discovery, Stream Configuration). The app must
+// drain them (e.g. in tud_midi2_rx_cb) to avoid RX FIFO backpressure, and
+// call tud_midi2_n_set_protocol() after accepting a Stream Configuration
+// Request to keep tud_midi2_n_protocol / tud_midi2_n_negotiated accurate.
+#ifndef CFG_TUD_MIDI2_USER_RESPONDER
+  #define CFG_TUD_MIDI2_USER_RESPONDER 0
+#endif
+
 //--------------------------------------------------------------------+
 // MIDI Protocol Values (returned by tud_midi2_n_protocol)
 //--------------------------------------------------------------------+
@@ -118,6 +128,10 @@ uint32_t tud_midi2_n_available(uint8_t itf);
 uint8_t  tud_midi2_n_alt_setting(uint8_t itf);
 bool     tud_midi2_n_negotiated(uint8_t itf);
 uint8_t  tud_midi2_n_protocol(uint8_t itf);
+
+// Record the negotiated protocol when the application owns UMP Stream
+// negotiation (CFG_TUD_MIDI2_USER_RESPONDER). Marks the endpoint negotiated.
+void     tud_midi2_n_set_protocol(uint8_t itf, uint8_t protocol);
 
 // Read up to max_words UMP words from the RX FIFO. Returns the number of
 // words actually read (0 if FIFO is empty).
@@ -154,6 +168,10 @@ TU_ATTR_ALWAYS_INLINE static inline bool tud_midi2_negotiated(void) {
 
 TU_ATTR_ALWAYS_INLINE static inline uint8_t tud_midi2_protocol(void) {
   return tud_midi2_n_protocol(0);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline void tud_midi2_set_protocol(uint8_t protocol) {
+  tud_midi2_n_set_protocol(0, protocol);
 }
 
 TU_ATTR_ALWAYS_INLINE static inline uint32_t


### PR DESCRIPTION
## Summary
Small, opt-in change, quick to review. Touches only the MIDI 2.0 device class
(legacy MIDI 1.0 driver untouched) and is byte-identical to current behavior
when the flag is off.

Adds CFG_TUD_MIDI2_USER_RESPONDER (default off). When set, the driver leaves
UMP Stream messages in the RX FIFO so the application can answer Endpoint /
Function Block discovery and Stream Configuration itself, for endpoints whose
topology is dynamic (e.g. a bridge whose function blocks track the devices
plugged into it). Built-in responder is unchanged when off.

## Test plan
- [x] Builds with the flag off (default) and on (RP2350 midi2_device example).
- [x] Used on hardware by an ESP32-P4 USB MIDI bridge to expose dynamic FB names/groups.

Ref #3571