### PR TITLE
Fix RT-Thread MSC inquiry string bounds

### DIFF
--- a/lib/rt-thread/port/msc_device_port.c
+++ b/lib/rt-thread/port/msc_device_port.c
@@ -49,9 +49,9 @@ void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16
     const char pid[] = PKG_TINYUSB_DEVICE_MSC_PID;
     const char rev[] = PKG_TINYUSB_DEVICE_MSC_REV;
 
-    memcpy(vendor_id, vid, strlen(vid));
-    memcpy(product_id, pid, strlen(pid));
-    memcpy(product_rev, rev, strlen(rev));
+    strncpy((char*) vendor_id, vid, 8);
+    strncpy((char*) product_id, pid, 16);
+    strncpy((char*) product_rev, rev, 4);
 }
 
 bool tud_msc_test_unit_ready_cb(uint8_t lun)


### PR DESCRIPTION
## Summary
- Bound the RT-Thread MSC inquiry string copies to the fixed SCSI inquiry field sizes.
- Match the existing TinyUSB MSC examples that copy vendor/product/revision strings into 8/16/4 byte fields.

## Root cause
`tud_msc_inquiry_cb()` receives fixed-size output buffers: `vendor_id[8]`, `product_id[16]`, and `product_rev[4]`. The RT-Thread port copied `strlen()` bytes from configurable package strings into those buffers, so longer configuration values could write past the inquiry fields.

## Validation
- `git diff --check`
- Verified the old `memcpy(... strlen(...))` pattern is gone in `lib/rt-thread/port/msc_device_port.c`
- Verified the touched file still uses CRLF line endings

Local RT-Thread package build was not run because this checkout does not have the RT-Thread package build environment/toolchain configured.