### PR TITLE
bound cdc-data endpoints against descriptor length in acm_open

### DIFF
--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -1024,6 +1024,8 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   const uint8_t *p_desc   = (const uint8_t *)itf_desc;
   const uint8_t *desc_end = p_desc + max_len;
 
+  TU_ASSERT(TU_DESC_VALIDATE(tu_desc_len(p_desc) <= max_len), 0);
+
   cdch_interface_t *p_cdc = make_new_itf(daddr, itf_desc);
   TU_VERIFY(p_cdc, 0);
   p_cdc->serial_drid = SERIAL_DRIVER_ACM;
@@ -1033,11 +1035,12 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
 
   // Communication Functional Descriptors
   // need the 3-byte header (bLength/bDescriptorType/bDescriptorSubType) in bounds before reading it, and a
-  // bLength >= 3 both keeps those reads valid and stops a zero-length descriptor from spinning the walk
-  while ((p_desc < desc_end) && TU_DESC_VALIDATE(p_desc + 3 <= desc_end) &&
-         TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) && TU_DESC_VALIDATE(tu_desc_len(p_desc) >= 3)) {
+  // fully contained bLength >= 3 both keeps those reads valid and stops a zero-length descriptor from spinning
+  while ((p_desc < desc_end) && TU_DESC_VALIDATE((size_t)(desc_end - p_desc) >= 3) &&
+    TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) && TU_DESC_VALIDATE(tu_desc_len(p_desc) >= 3) &&
+         TU_DESC_VALIDATE(tu_desc_len(p_desc) <= (size_t)(desc_end - p_desc))) {
     if (CDC_FUNC_DESC_ABSTRACT_CONTROL_MANAGEMENT == cdc_functional_desc_typeof(p_desc) &&
-        TU_DESC_VALIDATE(p_desc + sizeof(cdc_desc_func_acm_t) <= desc_end)) {
+        TU_DESC_VALIDATE(tu_desc_len(p_desc) >= sizeof(cdc_desc_func_acm_t))) {
       // save ACM bmCapabilities
       p_cdc->acm.capability = ((cdc_desc_func_acm_t const *) p_desc)->bmCapabilities;
     }
@@ -1048,7 +1051,7 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   // Open notification endpoint of control interface if any
   if (itf_desc->bNumEndpoints == 1) {
     // whole endpoint descriptor must fit: tuh_edpt_open reads the full struct regardless of bLength
-    TU_ASSERT(TU_DESC_VALIDATE(p_desc + sizeof(tusb_desc_endpoint_t) <= desc_end), 0);
+    TU_ASSERT(TU_DESC_VALIDATE((size_t)(desc_end - p_desc) >= sizeof(tusb_desc_endpoint_t)), 0);
     TU_ASSERT(TUSB_DESC_ENDPOINT == tu_desc_type(p_desc), 0);
     const tusb_desc_endpoint_t *desc_ep = (const tusb_desc_endpoint_t *)p_desc;
     TU_ASSERT(tuh_edpt_open(daddr, desc_ep), 0);
@@ -1059,7 +1062,7 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   }
 
   //------------- Data Interface (if any) -------------//
-  if (TU_DESC_VALIDATE(p_desc + sizeof(tusb_desc_interface_t) <= desc_end) &&
+  if (TU_DESC_VALIDATE((size_t)(desc_end - p_desc) >= sizeof(tusb_desc_interface_t)) &&
       TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
     const tusb_desc_interface_t *data_itf = (const tusb_desc_interface_t *)p_desc;
     if (data_itf->bInterfaceClass == TUSB_CLASS_CDC_DATA) {
@@ -1067,7 +1070,7 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
 
       // open_ep_stream_pair consumes exactly two endpoints; require that count and that both fit before reading them
       TU_ASSERT(TU_DESC_VALIDATE(data_itf->bNumEndpoints == 2), 0);
-      TU_ASSERT(TU_DESC_VALIDATE(p_desc + 2 * sizeof(tusb_desc_endpoint_t) <= desc_end), 0);
+      TU_ASSERT(TU_DESC_VALIDATE((size_t)(desc_end - p_desc) >= 2 * sizeof(tusb_desc_endpoint_t)), 0);
       TU_ASSERT(open_ep_stream_pair(p_cdc, (const tusb_desc_endpoint_t *)p_desc), 0);
       p_desc += 2 * sizeof(tusb_desc_endpoint_t);
     }

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -716,7 +716,9 @@ bool cdch_xfer_cb(uint8_t daddr, uint8_t ep_addr, xfer_result_t event, uint32_t 
 //--------------------------------------------------------------------+
 static bool open_ep_stream_pair(cdch_interface_t *p_cdc, tusb_desc_endpoint_t const *desc_ep) {
   for (size_t i = 0; i < 2; i++) {
-    TU_ASSERT(TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType && TUSB_XFER_BULK == desc_ep->bmAttributes.xfer, 0);
+    // pin bLength so tu_desc_next() below cannot walk the second endpoint past a caller-checked bound
+    TU_ASSERT(sizeof(tusb_desc_endpoint_t) == desc_ep->bLength &&
+              TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType && TUSB_XFER_BULK == desc_ep->bmAttributes.xfer, 0);
     TU_ASSERT(tuh_edpt_open(p_cdc->daddr, desc_ep));
     const uint8_t     ep_dir = tu_edpt_dir(desc_ep->bEndpointAddress);
     tu_edpt_stream_t *stream = (ep_dir == TUSB_DIR_IN) ? &p_cdc->stream.rx : &p_cdc->stream.tx;
@@ -1031,7 +1033,8 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
 
   // Open notification endpoint of control interface if any
   if (itf_desc->bNumEndpoints == 1) {
-    TU_ASSERT(tu_desc_in_bounds(p_desc, desc_end), 0);
+    // whole endpoint descriptor must fit: tuh_edpt_open reads the full struct regardless of bLength
+    TU_ASSERT(p_desc + sizeof(tusb_desc_endpoint_t) <= desc_end, 0);
     TU_ASSERT(TUSB_DESC_ENDPOINT == tu_desc_type(p_desc), 0);
     const tusb_desc_endpoint_t *desc_ep = (const tusb_desc_endpoint_t *)p_desc;
     TU_ASSERT(tuh_edpt_open(daddr, desc_ep), 0);
@@ -1041,13 +1044,13 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   }
 
   //------------- Data Interface (if any) -------------//
-  if (tu_desc_in_bounds(p_desc, desc_end) && TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
+  if (p_desc + sizeof(tusb_desc_interface_t) <= desc_end && TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
     const tusb_desc_interface_t *data_itf = (const tusb_desc_interface_t *)p_desc;
     if (data_itf->bInterfaceClass == TUSB_CLASS_CDC_DATA) {
       p_desc = tu_desc_next(p_desc); // next to endpoint descriptor
 
       // data endpoints expected to be in pairs, make sure both fit before reading them
-      TU_ASSERT((uint16_t)(desc_end - p_desc) >= 2 * sizeof(tusb_desc_endpoint_t), 0);
+      TU_ASSERT(p_desc + 2 * sizeof(tusb_desc_endpoint_t) <= desc_end, 0);
       TU_ASSERT(open_ep_stream_pair(p_cdc, (const tusb_desc_endpoint_t *)p_desc), 0);
       p_desc += data_itf->bNumEndpoints * sizeof(tusb_desc_endpoint_t);
     }

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -714,11 +714,21 @@ bool cdch_xfer_cb(uint8_t daddr, uint8_t ep_addr, xfer_result_t event, uint32_t 
 //--------------------------------------------------------------------+
 // Enumeration
 //--------------------------------------------------------------------+
+
+  // Descriptor-walk hardening gated by CFG_TUH_VALIDATION_LEVEL: at NONE the guards collapse to a pass so
+  // trusted-device setups pay no code size; at BASIC (default) the walk stays inside the enumeration buffer.
+  #if CFG_TUH_VALIDATION_LEVEL >= TUSB_VALIDATION_BASIC
+    #define TU_DESC_VALIDATE(_cond) (_cond)
+  #else
+    #define TU_DESC_VALIDATE(_cond) (true)
+  #endif
+
 static bool open_ep_stream_pair(cdch_interface_t *p_cdc, tusb_desc_endpoint_t const *desc_ep) {
   for (size_t i = 0; i < 2; i++) {
     // pin bLength so tu_desc_next() below cannot walk the second endpoint past a caller-checked bound
-    TU_ASSERT(sizeof(tusb_desc_endpoint_t) == desc_ep->bLength &&
-              TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType && TUSB_XFER_BULK == desc_ep->bmAttributes.xfer, 0);
+    TU_ASSERT(TU_DESC_VALIDATE(sizeof(tusb_desc_endpoint_t) == desc_ep->bLength) &&
+                TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType && TUSB_XFER_BULK == desc_ep->bmAttributes.xfer,
+              0);
     TU_ASSERT(tuh_edpt_open(p_cdc->daddr, desc_ep));
     const uint8_t     ep_dir = tu_edpt_dir(desc_ep->bEndpointAddress);
     tu_edpt_stream_t *stream = (ep_dir == TUSB_DIR_IN) ? &p_cdc->stream.rx : &p_cdc->stream.tx;
@@ -1024,9 +1034,10 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   // Communication Functional Descriptors
   // need the 3-byte header (bLength/bDescriptorType/bDescriptorSubType) in bounds before reading it, and a
   // bLength >= 3 both keeps those reads valid and stops a zero-length descriptor from spinning the walk
-  while (p_desc + 3 <= desc_end && TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) && tu_desc_len(p_desc) >= 3) {
+  while ((p_desc < desc_end) && TU_DESC_VALIDATE(p_desc + 3 <= desc_end) &&
+         TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) && TU_DESC_VALIDATE(tu_desc_len(p_desc) >= 3)) {
     if (CDC_FUNC_DESC_ABSTRACT_CONTROL_MANAGEMENT == cdc_functional_desc_typeof(p_desc) &&
-        p_desc + sizeof(cdc_desc_func_acm_t) <= desc_end) {
+        TU_DESC_VALIDATE(p_desc + sizeof(cdc_desc_func_acm_t) <= desc_end)) {
       // save ACM bmCapabilities
       p_cdc->acm.capability = ((cdc_desc_func_acm_t const *) p_desc)->bmCapabilities;
     }
@@ -1037,7 +1048,7 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   // Open notification endpoint of control interface if any
   if (itf_desc->bNumEndpoints == 1) {
     // whole endpoint descriptor must fit: tuh_edpt_open reads the full struct regardless of bLength
-    TU_ASSERT(p_desc + sizeof(tusb_desc_endpoint_t) <= desc_end, 0);
+    TU_ASSERT(TU_DESC_VALIDATE(p_desc + sizeof(tusb_desc_endpoint_t) <= desc_end), 0);
     TU_ASSERT(TUSB_DESC_ENDPOINT == tu_desc_type(p_desc), 0);
     const tusb_desc_endpoint_t *desc_ep = (const tusb_desc_endpoint_t *)p_desc;
     TU_ASSERT(tuh_edpt_open(daddr, desc_ep), 0);
@@ -1048,14 +1059,15 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   }
 
   //------------- Data Interface (if any) -------------//
-  if (p_desc + sizeof(tusb_desc_interface_t) <= desc_end && TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
+  if (TU_DESC_VALIDATE(p_desc + sizeof(tusb_desc_interface_t) <= desc_end) &&
+      TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
     const tusb_desc_interface_t *data_itf = (const tusb_desc_interface_t *)p_desc;
     if (data_itf->bInterfaceClass == TUSB_CLASS_CDC_DATA) {
       p_desc += sizeof(tusb_desc_interface_t); // fixed struct size to endpoint descriptor, not device bLength
 
       // open_ep_stream_pair consumes exactly two endpoints; require that count and that both fit before reading them
-      TU_ASSERT(data_itf->bNumEndpoints == 2, 0);
-      TU_ASSERT(p_desc + 2 * sizeof(tusb_desc_endpoint_t) <= desc_end, 0);
+      TU_ASSERT(TU_DESC_VALIDATE(data_itf->bNumEndpoints == 2), 0);
+      TU_ASSERT(TU_DESC_VALIDATE(p_desc + 2 * sizeof(tusb_desc_endpoint_t) <= desc_end), 0);
       TU_ASSERT(open_ep_stream_pair(p_cdc, (const tusb_desc_endpoint_t *)p_desc), 0);
       p_desc += 2 * sizeof(tusb_desc_endpoint_t);
     }

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -1040,19 +1040,21 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
     TU_ASSERT(tuh_edpt_open(daddr, desc_ep), 0);
     p_cdc->ep_notif = desc_ep->bEndpointAddress;
 
-    p_desc = tu_desc_next(p_desc);
+    // advance by the fixed struct size, not device-supplied bLength, so p_desc stays inside the checked window
+    p_desc += sizeof(tusb_desc_endpoint_t);
   }
 
   //------------- Data Interface (if any) -------------//
   if (p_desc + sizeof(tusb_desc_interface_t) <= desc_end && TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
     const tusb_desc_interface_t *data_itf = (const tusb_desc_interface_t *)p_desc;
     if (data_itf->bInterfaceClass == TUSB_CLASS_CDC_DATA) {
-      p_desc = tu_desc_next(p_desc); // next to endpoint descriptor
+      p_desc += sizeof(tusb_desc_interface_t); // fixed struct size to endpoint descriptor, not device bLength
 
-      // data endpoints expected to be in pairs, make sure both fit before reading them
+      // open_ep_stream_pair consumes exactly two endpoints; require that count and that both fit before reading them
+      TU_ASSERT(data_itf->bNumEndpoints == 2, 0);
       TU_ASSERT(p_desc + 2 * sizeof(tusb_desc_endpoint_t) <= desc_end, 0);
       TU_ASSERT(open_ep_stream_pair(p_cdc, (const tusb_desc_endpoint_t *)p_desc), 0);
-      p_desc += data_itf->bNumEndpoints * sizeof(tusb_desc_endpoint_t);
+      p_desc += 2 * sizeof(tusb_desc_endpoint_t);
     }
   }
 

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -1208,6 +1208,7 @@ static uint16_t ftdi_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, 
   TU_VERIFY(itf_desc->bInterfaceSubClass == 0xff && itf_desc->bInterfaceProtocol == 0xff &&
               itf_desc->bNumEndpoints == 2,
             0);
+  TU_VERIFY(TUH_VALIDATE_BASIC(itf_desc->bLength == sizeof(tusb_desc_interface_t)), 0);
   const uint16_t drv_len =
     (uint16_t)(sizeof(tusb_desc_interface_t) + itf_desc->bNumEndpoints * sizeof(tusb_desc_endpoint_t));
   TU_VERIFY(drv_len <= max_len, 0);
@@ -1593,6 +1594,7 @@ enum {
 static uint16_t cp210x_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, uint16_t max_len) {
   // CP210x Interface includes 1 vendor interface + 2 bulk endpoints
   TU_VERIFY(itf_desc->bInterfaceSubClass == 0 && itf_desc->bInterfaceProtocol == 0 && itf_desc->bNumEndpoints == 2, 0);
+  TU_VERIFY(TUH_VALIDATE_BASIC(itf_desc->bLength == sizeof(tusb_desc_interface_t)), 0);
   const uint16_t drv_len =
     (uint16_t)(sizeof(tusb_desc_interface_t) + itf_desc->bNumEndpoints * sizeof(tusb_desc_endpoint_t));
   TU_VERIFY(drv_len <= max_len, 0);
@@ -1764,6 +1766,7 @@ enum {
 static uint16_t ch34x_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, uint16_t max_len) {
   // CH34x Interface includes 1 vendor interface + 2 bulk + 1 interrupt endpoints
   TU_VERIFY(itf_desc->bNumEndpoints == 3, 0);
+  TU_VERIFY(TUH_VALIDATE_BASIC(itf_desc->bLength == sizeof(tusb_desc_interface_t)), 0);
   const uint16_t drv_len =
     (uint16_t)(sizeof(tusb_desc_interface_t) + itf_desc->bNumEndpoints * sizeof(tusb_desc_endpoint_t));
   TU_VERIFY(drv_len <= max_len, 0);
@@ -2100,6 +2103,7 @@ enum {
 static uint16_t pl2303_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, uint16_t max_len) {
   // PL2303 Interface includes 1 vendor interface + 1 interrupt endpoints + 2 bulk
   TU_VERIFY(itf_desc->bNumEndpoints == 3, 0);
+  TU_VERIFY(TUH_VALIDATE_BASIC(itf_desc->bLength == sizeof(tusb_desc_interface_t)), 0);
   const uint16_t drv_len =
     (uint16_t)(sizeof(tusb_desc_interface_t) + itf_desc->bNumEndpoints * sizeof(tusb_desc_endpoint_t));
   TU_VERIFY(drv_len <= max_len, 0);

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -1022,8 +1022,11 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   p_desc = tu_desc_next(p_desc);
 
   // Communication Functional Descriptors
-  while ((p_desc < desc_end) && (TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc))) {
-    if (CDC_FUNC_DESC_ABSTRACT_CONTROL_MANAGEMENT == cdc_functional_desc_typeof(p_desc)) {
+  // need the 3-byte header (bLength/bDescriptorType/bDescriptorSubType) in bounds before reading it, and a
+  // bLength >= 3 both keeps those reads valid and stops a zero-length descriptor from spinning the walk
+  while (p_desc + 3 <= desc_end && TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) && tu_desc_len(p_desc) >= 3) {
+    if (CDC_FUNC_DESC_ABSTRACT_CONTROL_MANAGEMENT == cdc_functional_desc_typeof(p_desc) &&
+        p_desc + sizeof(cdc_desc_func_acm_t) <= desc_end) {
       // save ACM bmCapabilities
       p_cdc->acm.capability = ((cdc_desc_func_acm_t const *) p_desc)->bmCapabilities;
     }

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -715,18 +715,10 @@ bool cdch_xfer_cb(uint8_t daddr, uint8_t ep_addr, xfer_result_t event, uint32_t 
 // Enumeration
 //--------------------------------------------------------------------+
 
-  // Descriptor-walk hardening gated by CFG_TUH_VALIDATION_LEVEL: at NONE the guards collapse to a pass so
-  // trusted-device setups pay no code size; at BASIC (default) the walk stays inside the enumeration buffer.
-  #if CFG_TUH_VALIDATION_LEVEL >= TUSB_VALIDATION_BASIC
-    #define TU_DESC_VALIDATE(_cond) (_cond)
-  #else
-    #define TU_DESC_VALIDATE(_cond) (true)
-  #endif
-
 static bool open_ep_stream_pair(cdch_interface_t *p_cdc, tusb_desc_endpoint_t const *desc_ep) {
   for (size_t i = 0; i < 2; i++) {
     // pin bLength so tu_desc_next() below cannot walk the second endpoint past a caller-checked bound
-    TU_ASSERT(TU_DESC_VALIDATE(sizeof(tusb_desc_endpoint_t) == desc_ep->bLength) &&
+    TU_ASSERT(TUH_VALIDATE_BASIC(sizeof(tusb_desc_endpoint_t) == desc_ep->bLength) &&
                 TUSB_DESC_ENDPOINT == desc_ep->bDescriptorType && TUSB_XFER_BULK == desc_ep->bmAttributes.xfer,
               0);
     TU_ASSERT(tuh_edpt_open(p_cdc->daddr, desc_ep));
@@ -1024,7 +1016,7 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   const uint8_t *p_desc   = (const uint8_t *)itf_desc;
   const uint8_t *desc_end = p_desc + max_len;
 
-  TU_ASSERT(TU_DESC_VALIDATE(tu_desc_len(p_desc) <= max_len), 0);
+  TU_ASSERT(TUH_VALIDATE_BASIC(tu_desc_len(p_desc) <= max_len), 0);
 
   cdch_interface_t *p_cdc = make_new_itf(daddr, itf_desc);
   TU_VERIFY(p_cdc, 0);
@@ -1036,11 +1028,13 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   // Communication Functional Descriptors
   // need the 3-byte header (bLength/bDescriptorType/bDescriptorSubType) in bounds before reading it, and a
   // fully contained bLength >= 3 both keeps those reads valid and stops a zero-length descriptor from spinning
-  while ((p_desc < desc_end) && TU_DESC_VALIDATE((size_t)(desc_end - p_desc) >= 3) &&
-    TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) && TU_DESC_VALIDATE(tu_desc_len(p_desc) >= 3) &&
-         TU_DESC_VALIDATE(tu_desc_len(p_desc) <= (size_t)(desc_end - p_desc))) {
+  while ((p_desc < desc_end) &&
+         TUH_VALIDATE_BASIC((size_t)(desc_end - p_desc) >= 3) &&
+         TUSB_DESC_CS_INTERFACE == tu_desc_type(p_desc) &&
+         TUH_VALIDATE_BASIC(tu_desc_len(p_desc) >= 3) &&
+         TUH_VALIDATE_BASIC(tu_desc_len(p_desc) <= (size_t)(desc_end - p_desc))) {
     if (CDC_FUNC_DESC_ABSTRACT_CONTROL_MANAGEMENT == cdc_functional_desc_typeof(p_desc) &&
-        TU_DESC_VALIDATE(tu_desc_len(p_desc) >= sizeof(cdc_desc_func_acm_t))) {
+        TUH_VALIDATE_BASIC(tu_desc_len(p_desc) >= sizeof(cdc_desc_func_acm_t))) {
       // save ACM bmCapabilities
       p_cdc->acm.capability = ((cdc_desc_func_acm_t const *) p_desc)->bmCapabilities;
     }
@@ -1051,7 +1045,7 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   // Open notification endpoint of control interface if any
   if (itf_desc->bNumEndpoints == 1) {
     // whole endpoint descriptor must fit: tuh_edpt_open reads the full struct regardless of bLength
-    TU_ASSERT(TU_DESC_VALIDATE((size_t)(desc_end - p_desc) >= sizeof(tusb_desc_endpoint_t)), 0);
+    TU_ASSERT(TUH_VALIDATE_BASIC((size_t)(desc_end - p_desc) >= sizeof(tusb_desc_endpoint_t)), 0);
     TU_ASSERT(TUSB_DESC_ENDPOINT == tu_desc_type(p_desc), 0);
     const tusb_desc_endpoint_t *desc_ep = (const tusb_desc_endpoint_t *)p_desc;
     TU_ASSERT(tuh_edpt_open(daddr, desc_ep), 0);
@@ -1062,15 +1056,15 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   }
 
   //------------- Data Interface (if any) -------------//
-  if (TU_DESC_VALIDATE((size_t)(desc_end - p_desc) >= sizeof(tusb_desc_interface_t)) &&
+  if (TUH_VALIDATE_BASIC((size_t)(desc_end - p_desc) >= sizeof(tusb_desc_interface_t)) &&
       TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
     const tusb_desc_interface_t *data_itf = (const tusb_desc_interface_t *)p_desc;
     if (data_itf->bInterfaceClass == TUSB_CLASS_CDC_DATA) {
       p_desc += sizeof(tusb_desc_interface_t); // fixed struct size to endpoint descriptor, not device bLength
 
       // open_ep_stream_pair consumes exactly two endpoints; require that count and that both fit before reading them
-      TU_ASSERT(TU_DESC_VALIDATE(data_itf->bNumEndpoints == 2), 0);
-      TU_ASSERT(TU_DESC_VALIDATE((size_t)(desc_end - p_desc) >= 2 * sizeof(tusb_desc_endpoint_t)), 0);
+      TU_ASSERT(TUH_VALIDATE_BASIC(data_itf->bNumEndpoints == 2), 0);
+      TU_ASSERT(TUH_VALIDATE_BASIC((size_t)(desc_end - p_desc) >= 2 * sizeof(tusb_desc_endpoint_t)), 0);
       TU_ASSERT(open_ep_stream_pair(p_cdc, (const tusb_desc_endpoint_t *)p_desc), 0);
       p_desc += 2 * sizeof(tusb_desc_endpoint_t);
     }

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -1031,6 +1031,7 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
 
   // Open notification endpoint of control interface if any
   if (itf_desc->bNumEndpoints == 1) {
+    TU_ASSERT(tu_desc_in_bounds(p_desc, desc_end), 0);
     TU_ASSERT(TUSB_DESC_ENDPOINT == tu_desc_type(p_desc), 0);
     const tusb_desc_endpoint_t *desc_ep = (const tusb_desc_endpoint_t *)p_desc;
     TU_ASSERT(tuh_edpt_open(daddr, desc_ep), 0);
@@ -1040,12 +1041,13 @@ static uint16_t acm_open(uint8_t daddr, const tusb_desc_interface_t *itf_desc, u
   }
 
   //------------- Data Interface (if any) -------------//
-  if (TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
+  if (tu_desc_in_bounds(p_desc, desc_end) && TUSB_DESC_INTERFACE == tu_desc_type(p_desc)) {
     const tusb_desc_interface_t *data_itf = (const tusb_desc_interface_t *)p_desc;
     if (data_itf->bInterfaceClass == TUSB_CLASS_CDC_DATA) {
       p_desc = tu_desc_next(p_desc); // next to endpoint descriptor
 
-      // data endpoints expected to be in pairs
+      // data endpoints expected to be in pairs, make sure both fit before reading them
+      TU_ASSERT((uint16_t)(desc_end - p_desc) >= 2 * sizeof(tusb_desc_endpoint_t), 0);
       TU_ASSERT(open_ep_stream_pair(p_cdc, (const tusb_desc_endpoint_t *)p_desc), 0);
       p_desc += data_itf->bNumEndpoints * sizeof(tusb_desc_endpoint_t);
     }

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -240,13 +240,14 @@
 #define OPT_MODE_SPEED_MASK     0xff00u
 
 //--------------------------------------------------------------------+
-// Descriptor Validation Level
-// How much the stack hardens itself against mal-configured or hostile devices, traded against code size.
-// Higher levels add more checks; set CFG_TUD_VALIDATION_LEVEL / CFG_TUH_VALIDATION_LEVEL to pick one.
+// Validation Level
+// Optional validation of data received from the USB peer, traded against code size. Coverage is parser-specific
+// and expanded incrementally. CFG_TUSB_VALIDATION_LEVEL sets the default for both device and host; use the
+// CFG_TUD_VALIDATION_LEVEL / CFG_TUH_VALIDATION_LEVEL overrides when the roles need different policies.
 //--------------------------------------------------------------------+
-#define TUSB_VALIDATION_NONE   0 ///< trusted devices only, minimal code size
-#define TUSB_VALIDATION_BASIC  1 ///< default: mal-configured devices, no OOB reads / zero-length loops
-#define TUSB_VALIDATION_STRICT 2 ///< reject malformed/hostile descriptors, stricter class validation
+#define TUSB_VALIDATION_NONE   0 ///< trusted peers, minimal code size
+#define TUSB_VALIDATION_BASIC  1 ///< structural memory-safety checks where supported
+#define TUSB_VALIDATION_STRICT 2 ///< additional USB and class-specific conformance checks
 
 //--------------------------------------------------------------------+
 // Include tusb_config.h
@@ -260,6 +261,46 @@
 #endif
 
 #include "common/tusb_mcu.h"
+
+//--------------------------------------------------------------------+
+// Validation Options
+//--------------------------------------------------------------------+
+
+#ifndef CFG_TUSB_VALIDATION_LEVEL
+  #define CFG_TUSB_VALIDATION_LEVEL TUSB_VALIDATION_BASIC
+#endif
+
+#ifndef CFG_TUD_VALIDATION_LEVEL
+  #define CFG_TUD_VALIDATION_LEVEL CFG_TUSB_VALIDATION_LEVEL
+#endif
+
+#ifndef CFG_TUH_VALIDATION_LEVEL
+  #define CFG_TUH_VALIDATION_LEVEL CFG_TUSB_VALIDATION_LEVEL
+#endif
+
+#if (CFG_TUSB_VALIDATION_LEVEL < TUSB_VALIDATION_NONE) || \
+    (CFG_TUSB_VALIDATION_LEVEL > TUSB_VALIDATION_STRICT)
+  #error "CFG_TUSB_VALIDATION_LEVEL must be TUSB_VALIDATION_NONE, TUSB_VALIDATION_BASIC, or TUSB_VALIDATION_STRICT"
+#endif
+
+#if (CFG_TUD_VALIDATION_LEVEL < TUSB_VALIDATION_NONE) || \
+    (CFG_TUD_VALIDATION_LEVEL > TUSB_VALIDATION_STRICT)
+  #error "CFG_TUD_VALIDATION_LEVEL must be TUSB_VALIDATION_NONE, TUSB_VALIDATION_BASIC, or TUSB_VALIDATION_STRICT"
+#endif
+
+#if (CFG_TUH_VALIDATION_LEVEL < TUSB_VALIDATION_NONE) || \
+    (CFG_TUH_VALIDATION_LEVEL > TUSB_VALIDATION_STRICT)
+  #error "CFG_TUH_VALIDATION_LEVEL must be TUSB_VALIDATION_NONE, TUSB_VALIDATION_BASIC, or TUSB_VALIDATION_STRICT"
+#endif
+
+// Validation conditions are short-circuited at lower levels and compile out when the result is unused.
+#define TUD_VALIDATION_CHECK(_level, _cond) ((CFG_TUD_VALIDATION_LEVEL < (_level)) || (_cond))
+#define TUH_VALIDATION_CHECK(_level, _cond) ((CFG_TUH_VALIDATION_LEVEL < (_level)) || (_cond))
+
+#define TUD_VALIDATE_BASIC(_cond) TUD_VALIDATION_CHECK(TUSB_VALIDATION_BASIC, _cond)
+#define TUH_VALIDATE_BASIC(_cond) TUH_VALIDATION_CHECK(TUSB_VALIDATION_BASIC, _cond)
+#define TUD_VALIDATE_STRICT(_cond) TUD_VALIDATION_CHECK(TUSB_VALIDATION_STRICT, _cond)
+#define TUH_VALIDATE_STRICT(_cond) TUH_VALIDATION_CHECK(TUSB_VALIDATION_STRICT, _cond)
 
 //--------------------------------------------------------------------+
 // USBIP
@@ -704,9 +745,6 @@
     #define CFG_TUH_ENUMERATION_BUFSIZE 256
   #endif
 
-  #ifndef CFG_TUH_VALIDATION_LEVEL
-    #define CFG_TUH_VALIDATION_LEVEL TUSB_VALIDATION_BASIC
-  #endif
 #endif // CFG_TUH_ENABLED
 
 // Attribute to place data in accessible RAM for host controller (default: CFG_TUSB_MEM_SECTION)

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -240,6 +240,15 @@
 #define OPT_MODE_SPEED_MASK     0xff00u
 
 //--------------------------------------------------------------------+
+// Descriptor Validation Level
+// How much the stack hardens itself against mal-configured or hostile devices, traded against code size.
+// Higher levels add more checks; set CFG_TUD_VALIDATION_LEVEL / CFG_TUH_VALIDATION_LEVEL to pick one.
+//--------------------------------------------------------------------+
+#define TUSB_VALIDATION_NONE   0 ///< trusted devices only, minimal code size
+#define TUSB_VALIDATION_BASIC  1 ///< default: mal-configured devices, no OOB reads / zero-length loops
+#define TUSB_VALIDATION_STRICT 2 ///< reject malformed/hostile descriptors, stricter class validation
+
+//--------------------------------------------------------------------+
 // Include tusb_config.h
 //--------------------------------------------------------------------+
 
@@ -693,6 +702,10 @@
 
   #ifndef CFG_TUH_ENUMERATION_BUFSIZE
     #define CFG_TUH_ENUMERATION_BUFSIZE 256
+  #endif
+
+  #ifndef CFG_TUH_VALIDATION_LEVEL
+    #define CFG_TUH_VALIDATION_LEVEL TUSB_VALIDATION_BASIC
   #endif
 #endif // CFG_TUH_ENABLED
 


### PR DESCRIPTION
acm_open walks a device-supplied CDC-ACM configuration descriptor during host enumeration, but unlike the ftdi/cp210x/ch34x open paths it never checks that the notification endpoint, the data interface, or the two data endpoints actually lie within the descriptor before reading them. A malicious config whose wTotalLength equals CFG_TUH_ENUMERATION_BUFSIZE and which places the CDC-DATA interface right at the tail causes open_ep_stream_pair to read two 7-byte endpoint descriptors past the end of the enumeration buffer, so a rogue device can trigger an out-of-bounds read during enumeration. This bounds each read against desc_end with tu_desc_in_bounds and verifies the endpoint pair fits, which is the same guard the vendor serial drivers already apply.