### PR TITLE
Fix usbd empty builtin driver warning

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -361,13 +361,12 @@ static const usbd_class_driver_t _usbd_driver[] = {
     #endif
 };
 
-enum { BUILTIN_DRIVER_COUNT = TU_ARRAY_SIZE(_usbd_driver) };
-
 // Additional class drivers implemented by application
-static const usbd_class_driver_t *_app_driver       = NULL;
-static uint8_t                    _app_driver_count = 0;
+static const usbd_class_driver_t *_app_driver = NULL;
+static const uint8_t _builtin_driver_count    = TU_ARRAY_SIZE(_usbd_driver);
+static uint8_t              _app_driver_count = 0;
 
-#define TOTAL_DRIVER_COUNT    ((uint8_t) (_app_driver_count + BUILTIN_DRIVER_COUNT))
+#define TOTAL_DRIVER_COUNT    ((uint8_t) (_app_driver_count + _builtin_driver_count))
 
 // virtually joins built-in and application drivers together.
 // Application is positioned first to allow overwriting built-in ones.
@@ -378,7 +377,7 @@ TU_ATTR_ALWAYS_INLINE static inline usbd_class_driver_t const * get_driver(uint8
     driver = &_app_driver[drvid];
   } else{
     drvid -= _app_driver_count;
-    if (BUILTIN_DRIVER_COUNT > 0 && drvid < BUILTIN_DRIVER_COUNT) {
+    if (_builtin_driver_count > 0 && drvid < _builtin_driver_count) {
       driver = &_usbd_driver[drvid];
     }
   }
@@ -563,7 +562,7 @@ bool tud_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
 
   // Get application driver if available
   _app_driver = usbd_app_driver_get_cb(&_app_driver_count);
-  TU_ASSERT(_app_driver_count + BUILTIN_DRIVER_COUNT <= UINT8_MAX);
+  TU_ASSERT(_app_driver_count + _builtin_driver_count <= UINT8_MAX);
 
   // Init class drivers
   for (uint8_t i = 0; i < TOTAL_DRIVER_COUNT; i++) {

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -378,7 +378,7 @@ TU_ATTR_ALWAYS_INLINE static inline usbd_class_driver_t const * get_driver(uint8
     driver = &_app_driver[drvid];
   } else{
     drvid -= _app_driver_count;
-    if (drvid < BUILTIN_DRIVER_COUNT) {
+    if (BUILTIN_DRIVER_COUNT > 0 && drvid < BUILTIN_DRIVER_COUNT) {
       driver = &_usbd_driver[drvid];
     }
   }

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -319,13 +319,12 @@ static usbh_class_driver_t const usbh_class_drivers[] = {
   #endif
 };
 
-enum { BUILTIN_DRIVER_COUNT = TU_ARRAY_SIZE(usbh_class_drivers) };
-
 // Additional class drivers implemented by application
 static usbh_class_driver_t const * _app_driver = NULL;
-static uint8_t _app_driver_count = 0;
+static const uint8_t _builtin_driver_count     = TU_ARRAY_SIZE(usbh_class_drivers);
+static uint8_t _app_driver_count               = 0;
 
-#define TOTAL_DRIVER_COUNT    (_app_driver_count + BUILTIN_DRIVER_COUNT)
+#define TOTAL_DRIVER_COUNT    (_app_driver_count + _builtin_driver_count)
 
 // virtually joins built-in and application drivers together.
 // Application is positioned first to allow overwriting built-in ones.
@@ -335,7 +334,7 @@ TU_ATTR_ALWAYS_INLINE static inline usbh_class_driver_t const *get_driver(uint8_
     driver = &_app_driver[drv_id];
   } else {
     drv_id -= _app_driver_count;
-    if (drv_id < BUILTIN_DRIVER_COUNT) {
+    if (_builtin_driver_count > 0 && drv_id < _builtin_driver_count) {
       driver = &usbh_class_drivers[drv_id];
     }
   }
@@ -547,6 +546,7 @@ bool tuh_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
 
     // Get application driver if available
     _app_driver = usbh_app_driver_get_cb(&_app_driver_count);
+    TU_ASSERT(_app_driver_count + _builtin_driver_count <= UINT8_MAX);
 
     // Device
     tu_memclr(_usbh_devices, sizeof(_usbh_devices));


### PR DESCRIPTION
## Summary
- Guard the built-in driver lookup before comparing the uint8_t driver index against an empty built-in table.
- Keep `BUILTIN_DRIVER_COUNT` as the existing enum compile-time constant and leave app-driver ordering unchanged.

Fixes #3752

## Testing
- `git diff --check`
- `git ls-files --eol src/device/usbd.c`

Not run: C build/unit tests, because this Windows PATH has no `gcc`, `clang`, `arm-none-eabi-gcc`, `cmake`, `ninja`, `ruby`, or `ceedling` available.