### PR TITLE
Fix USBTMC status byte interrupt buffer

### DIFF
--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -826,7 +826,7 @@ bool usbtmcd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request
                   },
                   .StatusByte = tud_usbtmc_get_stb_cb(&(rsp.USBTMC_status))};
           // Must be queued before control request response sent (USB488v1.0 4.3.1.2)
-          usbd_edpt_xfer(rhport, usbtmc_state.ep_int_in, (void *) &intMsg, sizeof(intMsg), false);
+          (void) tud_usbtmc_transmit_notification_data(&intMsg, sizeof(intMsg));
         }
       } else {
         rsp.statusByte = tud_usbtmc_get_stb_cb(&(rsp.USBTMC_status));


### PR DESCRIPTION
## Summary
- copy the USB488 READ_STATUS_BYTE interrupt payload into the persistent USBTMC endpoint notification buffer
- avoid passing a stack-local buffer to usbd_edpt_xfer() for an interrupt IN transfer that completes asynchronously

Fixes #2928

## Testing
- git diff --check origin/master..HEAD
- Not run: local cmake/ninja/make/gcc/arm-none-eabi-gcc toolchains are not available in this environment.