### PR TITLE
Fix USBTMC notification endpoint claim

### DIFF
--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -252,9 +252,12 @@ bool tud_usbtmc_transmit_notification_data(const void *data, size_t len) {
   TU_ASSERT(len > 0);
   TU_ASSERT(usbtmc_state.ep_int_in != 0);
 #endif
-  TU_VERIFY(usbd_edpt_busy(usbtmc_state.rhport, usbtmc_state.ep_int_in));
+  TU_VERIFY(usbd_edpt_claim(usbtmc_state.rhport, usbtmc_state.ep_int_in));
 
-  TU_VERIFY(tu_memcpy_s(usbtmc_epbuf.epnotif, CFG_TUD_USBTMC_INT_EP_SIZE, data, len) == 0);
+  if (tu_memcpy_s(usbtmc_epbuf.epnotif, CFG_TUD_USBTMC_INT_EP_SIZE, data, len) != 0) {
+    usbd_edpt_release(usbtmc_state.rhport, usbtmc_state.ep_int_in);
+    return false;
+  }
   TU_VERIFY(usbd_edpt_xfer(usbtmc_state.rhport, usbtmc_state.ep_int_in, usbtmc_epbuf.epnotif, (uint16_t) len, false));
   return true;
 }


### PR DESCRIPTION
## Summary
- Use `usbd_edpt_claim()` before queuing USBTMC interrupt notification data.
- Keep the notification payload in the persistent endpoint buffer and release the claim if the copy fails before the transfer is queued.

Fixes #2735.

## Testing
- `git diff --check HEAD~1..HEAD`
- `git ls-files --eol src/class/usbtmc/usbtmc_device.c`

Not run: local build, because this Windows environment does not have CMake, Make, GCC, or Clang available.