### PR TITLE
bound rndis data packet offset in handle_incoming_packet

### DIFF
--- a/src/class/net/ecm_rndis_device.c
+++ b/src/class/net/ecm_rndis_device.c
@@ -324,8 +324,11 @@ static void handle_incoming_packet(uint32_t len) {
     rndis_data_packet_t* r = (rndis_data_packet_t*)((void*)pnt);
     if (len >= sizeof(rndis_data_packet_t)) {
       if ((r->MessageType == REMOTE_NDIS_PACKET_MSG) && (r->MessageLength <= len)) {
-        if ((r->DataOffset + offsetof(rndis_data_packet_t, DataOffset) + r->DataLength) <= len) {
-          pnt = &_netd_epbuf.rx[r->DataOffset + offsetof(rndis_data_packet_t, DataOffset)];
+        // DataOffset and DataLength are host-controlled; validate the payload window fits
+        // within the received data without overflowing the uint32 addition (len >= header)
+        const uint32_t hdr = offsetof(rndis_data_packet_t, DataOffset);
+        if ((r->DataOffset <= len - hdr) && (r->DataLength <= len - hdr - r->DataOffset)) {
+          pnt = &_netd_epbuf.rx[hdr + r->DataOffset];
           size = r->DataLength;
         }
       }


### PR DESCRIPTION
**overflow in the rndis data packet window check**

the DataOffset and DataLength fields in handle_incoming_packet come straight from the host on the bulk-out endpoint, and the window check adds them to the header offset in uint32 before comparing against the received length. on a 32-bit target that sum wraps, so a REMOTE_NDIS_PACKET_MSG with a large DataOffset/DataLength slips past the check and leaves pnt pointing well past the small rx buffer while size is taken from DataLength, which tud_network_recv_cb then reads out of bounds. rewrote the check to subtract from the received length instead so it cannot overflow, which keeps well-formed packets unchanged.

verified with a host build under ASAN: a packet with DataOffset=0x1000, DataLength=0xFFFFF000 and len=44 reports a heap read 2502 bytes past the 1602-byte buffer before the change, and is rejected after it.