### PR TITLE
docs(AGENTS): prefer git worktrees for branch/multi-step work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Bias toward caution over speed. For trivial tasks, use judgment.
 - **Simplicity** — no features, abstractions, flexibility, or error handling beyond what was asked. If 200 lines could be 50, rewrite.
 - **Surgical changes** — touch only what the task requires; match existing style; don't refactor working code; mention unrelated dead code rather than deleting it. Remove only orphans *your* changes created.
 - **Goal-driven** — turn tasks into verifiable goals ("write failing test, make it pass"). For multi-step work, state a brief `step → verify` plan.
+- **Worktrees** — default to a git worktree (`git worktree add`) for any branch or multi-step work; never switch the shared primary checkout's branch. Sessions run concurrently: switching the primary checkout mid-flight disrupts other sessions and can silently point a review, build, or commit at the wrong diff. Only trivial one-shot fixes may skip this.
 
 ## Ground Rules
 


### PR DESCRIPTION
## What

Adds one **Behavioral Guidelines** bullet to `AGENTS.md` (mirrored to `CLAUDE.md` via its symlink) directing agents to work in a git worktree rather than switching the shared primary checkout's branch.

> **Worktrees** — default to a git worktree (`git worktree add`) for any branch or multi-step work; never switch the shared primary checkout's branch. Sessions run concurrently: switching the primary checkout mid-flight disrupts other sessions and can silently point a review, build, or commit at the wrong diff. Only trivial one-shot fixes may skip this.

## Why

Multiple agent sessions share the primary checkout. When one session switches that checkout's branch, other sessions silently operate on the wrong tree — e.g. a code review or build ends up pointed at an unrelated diff. Worktrees isolate each line of work and avoid this class of failure.

Docs-only; no code change. `pre-commit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeF2gZ1M7GWkz6Av4BpKPg