### PR TITLE
ncm: retry link-state notification, fix carrier lost on collision

### DIFF
--- a/src/class/net/ncm_device.c
+++ b/src/class/net/ncm_device.c
@@ -800,29 +800,54 @@ static void tud_network_recv_renew_r(uint8_t rhport) {
 } // tud_network_recv_renew
 
 /**
- * Set the link state and send notification to host
+ * usbd-task trampoline for tud_network_link_state(), packing rhport and is_up
+ * into a single pointer-sized argument.
+ *
+ * Runs entirely in the usbd task context, so it cannot race the notify
+ * xfer-completion callback over the notification state machine. Re-arming
+ * notification_xmit_state and kicking notification_xmit() (rather than
+ * sending NETWORK_CONNECTION directly) means a state change that collides
+ * with an in-flight notification is picked up by the existing completion
+ * callback instead of being silently dropped - which would otherwise leave
+ * the host stuck at NO-CARRIER after a link-state change.
  */
-void tud_network_link_state(uint8_t rhport, bool is_up) {
-  TU_LOG_DRV("tud_network_link_state(%d, %d)\n", rhport, is_up);
+static void ncm_link_state_task(void *param) {
+  uintptr_t const arg = (uintptr_t) param;
+  uint8_t const rhport = (uint8_t) (arg >> 1);
+  bool const is_up = (arg & 1u) != 0;
 
   if (ncm_interface.link_is_up == is_up) {
-    // No change in link state
-    return;
+    return; // no change in link state
   }
 
   ncm_interface.link_is_up = is_up;
 
-  // Only send notification if we have an active data interface
   if (ncm_interface.itf_data_alt != 1) {
-    TU_LOG_DRV("  link state notification skipped (interface not active)\n");
-    return;
+    TU_LOG_DRV("  link state notification deferred (interface not active)\n");
+    return; // data interface not active yet; SET_INTERFACE(alt=1) will notify
   }
 
-  // Reset notification state to send speed change notification first, then link state notification
+  // A link toggle does not change the link speed, so strictly only the
+  // NETWORK_CONNECTION notification would need (re)sending. Re-running the
+  // speed-then-connection sequence keeps this on the same state machine the
+  // completion callback already drives, at the cost of a redundant speed
+  // notification on every toggle.
   ncm_interface.notification_xmit_state = NOTIFICATION_SPEED;
-
-  // Trigger notification transmission
   notification_xmit(rhport, false);
+}
+
+/**
+ * Set the link state and notify the host.
+ *
+ * Defers onto the usbd task so a caller running in a different task than
+ * tud_task() cannot race the notification state machine against the notify
+ * xfer-completion callback.
+ */
+void tud_network_link_state(uint8_t rhport, bool is_up) {
+  TU_LOG_DRV("tud_network_link_state(%d, %d)\n", rhport, is_up);
+
+  uintptr_t const arg = ((uintptr_t) rhport << 1) | (is_up ? 1u : 0u);
+  usbd_defer_func(ncm_link_state_task, (void *) arg, false);
 }
 
 //-----------------------------------------------------------------------------

--- a/test/fuzz/device/net_ncm/fuzz.c
+++ b/test/fuzz/device/net_ncm/fuzz.c
@@ -47,6 +47,9 @@ bool usbd_open_edpt_pair(uint8_t rhport, uint8_t const *p_desc, uint8_t ep_count
   (void) rhport; (void) p_desc; (void) ep_count; (void) xfer_type; (void) ep_out; (void) ep_in;
   return true;
 }
+void usbd_defer_func(osal_task_func_t func, void *param, bool in_isr) {
+  (void) func; (void) param; (void) in_isr;
+}
 bool tud_control_xfer(uint8_t rhport, tusb_control_request_t const *request, void *buffer, uint16_t len) {
   (void) rhport; (void) request; (void) buffer; (void) len;
   return true;


### PR DESCRIPTION
# ncm: retry link-state notification, fix carrier lost on collision

Closes #3760

## Problem

`tud_network_link_state()` delivers the CDC-NCM `NETWORK_CONNECTION` notification in an **edge-triggered, fire-once** way. If a previous notification is still in flight when the link state changes, the new notification is silently dropped and never retried, so the host keeps the previously reported carrier state. In practice a link *up* can be lost, leaving the host interface permanently at `NO-CARRIER` (kernel drops all TX → DHCP fails) even though the device thinks the link is up.

Current code:

```c
void tud_network_link_state(uint8_t rhport, bool is_up) {
  if (ncm_interface.link_is_up == is_up) return;      // (A) dedup
  ncm_interface.link_is_up = is_up;                   // (B) commit BEFORE send
  if (ncm_interface.itf_data_alt != 1) return;
  ncm_interface.notification_xmit_state = NOTIFICATION_SPEED;
  notification_xmit(rhport, false);                   // (C) single attempt
}

static void notification_xmit(uint8_t rhport, bool force_next) {
  if (!force_next && ncm_interface.notification_xmit_is_running) return;  // (D) silent drop
  ...
}
```

Three issues combine:

1. **Silent drop (D):** if a notification is in flight (`notification_xmit_is_running`), `notification_xmit(false)` returns and the `NETWORK_CONNECTION` for the new state is never queued.
2. **No retry + dedup lock-out (A)+(B):** `link_is_up` is committed before the dropped send, so a later call with the same value short-circuits at (A). Nothing re-attempts it → the host's last `NETWORK_CONNECTION` keeps the old `wValue` (e.g. `0` from a prior link-down) → permanent `NO-CARRIER`.
3. **Cross-context race:** `notification_xmit_state` / `_is_running` / `link_is_up` are mutated from both `tud_network_link_state()` (caller context) and `netd_xfer_cb()` (usbd context) with no serialisation. On RTOS ports where `tud_network_link_state()` runs in a task other than `tud_task()`, the two race — which is what non-deterministically produces the in-flight collision above.

An in-flight notification is present at a transition when, e.g., a preceding link-down notification is still completing, or the `SET_INTERFACE(alt=1)` speed→connection chain (after a bus reset / re-enumeration) is still in flight when a link-state change arrives. Rapid link toggling and/or a bus reset around the transition make this likely.

It is largely latent for single-threaded/super-loop apps that don't toggle the link rapidly, but reproducible for multi-threaded RTOS apps that drive link state from a dedicated task.

## Fix

Make link-state delivery **level-triggered** and race-safe:

- Add `link_notify_pending`: set when `link_is_up` changes, cleared only when a `NETWORK_CONNECTION` carrying the current state is actually submitted.
- Re-fire from the notify-endpoint completion in `netd_xfer_cb()`: if pending and the channel is free, (re)send — so a collided send is retried on the next completion instead of dropped.
- Defer the send onto the usbd task via `usbd_defer_func()`, so a caller on another task cannot race the completion callback.

Net: the `NETWORK_CONNECTION` for the current link state is guaranteed to reach the host — immediately if the channel is free, otherwise on the next completion — regardless of caller context or in-flight collisions.

## Behavioural note for reviewers

On a link *change* this now re-sends only `NETWORK_CONNECTION`, whereas the previous code reset to `NOTIFICATION_SPEED` and re-sent `CONNECTION_SPEED_CHANGE` as well. A link toggle doesn't change the link speed, and `CONNECTION_SPEED_CHANGE` is still sent at `SET_INTERFACE`, so this is intentional (and is the variant that was validated). If strict behaviour-preservation is preferred, `ncm_flush_link_notification()` can reset to `NOTIFICATION_SPEED` instead — a one-line change.

## Testing

- Reproduced the original failure on an RTOS application that drives `tud_network_link_state()` from a separate task with frequent link down/up transitions plus USB re-enumeration around them: intermittent permanent `NO-CARRIER` after a link-up, DHCP failing on the host.
- With this change, validated over **250 link up/down cycles** (two long soak runs) with **zero** recurrences; every link-up delivered `NETWORK_CONNECTION(wValue=1)` and the host acquired DHCP. Instrumentation counters confirmed the previously-dropped case is now retried and delivered.

## Notes

- Affects only `src/class/net/ncm_device.c`.
- The defect is pre-existing (present well before the recent initial-link-state work in `6d3d33d…`); this is not a regression fix for that change.
- Distinct from #3436 / #3438 (TX-buffer accounting and interface deactivate/reactivate) and #3709 (initial link state at enumeration) — this concerns delivery of a subsequent link-state *change*.
