### PR TITLE
fix(rusb2): size ep/ctl_mps arrays for the full dev_addr range

### DIFF
--- a/src/portable/renesas/rusb2/hcd_rusb2.c
+++ b/src/portable/renesas/rusb2/hcd_rusb2.c
@@ -52,8 +52,8 @@ TU_ATTR_BIT_FIELD_ORDER_END
 
 typedef struct {
   pipe_state_t pipe[PIPE_COUNT];
-  uint8_t      ep[4][2][15]; /* a lookup table for a pipe index from an endpoint address */
-  uint8_t      ctl_mps[5];   /* EP0 max packet size for each device */
+  uint8_t      ep[5][2][15]; /* a lookup table for a pipe index from an endpoint address, indexed by dev_addr - 1 (dev_addr 1 to 5) */
+  uint8_t      ctl_mps[6];   /* EP0 max packet size for each device, indexed by dev_addr (0 to 5) */
 } hcd_data_t;
 
 //--------------------------------------------------------------------+
@@ -114,7 +114,7 @@ static volatile uint16_t* addr_to_pipectr(uint8_t rhport, uint8_t dev_addr, unsi
 
   if (epn) {
     const unsigned dir_in = tu_edpt_dir(ep_addr);
-    const unsigned num = _hcd.ep[dev_addr][dir_in][epn - 1];
+    const unsigned num = _hcd.ep[dev_addr - 1][dir_in][epn - 1];
     return get_pipectr(rusb, num);
   } else {
     return get_pipectr(rusb, 0);


### PR DESCRIPTION
## Summary

Fixes #2284. `hcd_edpt_open()`, `hcd_device_close()`, and `hcd_setup_send()` in `src/portable/renesas/rusb2/hcd_rusb2.c` all guard with `TU_ASSERT(dev_addr < 6)` (valid device addresses 0-5), but the backing per-device arrays in `hcd_data_t` were sized for fewer than 6 devices:

```c
uint8_t ep[4][2][15]; /* indexed by dev_addr - 1 -> only holds dev_addr 1-4, needs 5 slots for 1-5 */
uint8_t ctl_mps[5];   /* indexed by dev_addr directly -> only holds dev_addr 0-4, needs 6 slots for 0-5 */
```

`dev_addr == 5` — a real, reachable address once 5 devices are connected through a hub — passes the assert and then indexes one element past the end of both arrays in `hcd_edpt_open()` (`_hcd.ep[dev_addr - 1][dir_in][epn - 1] = num;` and `_hcd.ctl_mps[dev_addr] = mps;`), silently writing into whatever struct member follows. The reporter hit this "in the wild" (Portenta C33 / Arduino Renesas core) and worked around it by lowering `CFG_TUH_DEVICE_MAX`.

While tracing every access to both arrays to size them correctly, I also found `addr_to_pipectr()` indexes `_hcd.ep[dev_addr]` directly (no `-1`), inconsistent with the other three call sites (`hcd_edpt_open`, `hcd_device_close`, `process_pipe_xfer`), which all use `dev_addr - 1`. That's out of bounds starting at `dev_addr == 4` rather than 5, since `epn != 0` there implies a real (non-default) address just like the other call sites. Fixed it to match.

## Fix

- `ep[4][2][15]` -> `ep[5][2][15]` (5 slots for `dev_addr` 1-5, addressed via `dev_addr - 1`)
- `ctl_mps[5]` -> `ctl_mps[6]` (6 slots for `dev_addr` 0-5, addressed directly)
- `addr_to_pipectr()`: `_hcd.ep[dev_addr]` -> `_hcd.ep[dev_addr - 1]`, matching every other access site in the file

## Testing

I don't have the affected hardware (Renesas RUSB2, e.g. Portenta C33) or its toolchain set up, so I can't produce a board build/run log. What I did instead: read every reference to `_hcd.ep`/`_hcd.ctl_mps` in the file (`hcd_edpt_open`, `hcd_device_close`, `hcd_setup_send`, `process_pipe_xfer`, `addr_to_pipectr`) to confirm the full set of dev_addr ranges each array actually needs to hold, cross-checked against the `TU_ASSERT(dev_addr < 6)` guards already in the same functions, and confirmed no other code depends on the old array dimensions (no `sizeof(_hcd.ep)`/`sizeof(_hcd.ctl_mps)` elsewhere). Happy to adjust if a maintainer can point to a way to exercise the 5-device-via-hub path, or if `pre-commit`/CI surfaces anything I couldn't run locally.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.