### PR TITLE
fix(usbd): restore sof_consumer state across SET_CONFIGURATION

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -974,9 +974,12 @@ static bool process_std_device_request(uint8_t rhport, tusb_control_request_t co
 
           // close all drivers and current configured state except bus speed
           const uint8_t speed = _usbd_dev.speed;
+          const uint8_t sof_consumer = _usbd_dev.sof_consumer;
           configuration_reset(rhport);
 
           _usbd_dev.speed = speed; // restore speed
+          _usbd_dev.sof_consumer = sof_consumer; // restore SOF consumer state
+          dcd_sof_enable(rhport, sof_consumer != 0); // restore SOF interrupt state
         }
 
         _usbd_dev.cfg_num = cfg_num;


### PR DESCRIPTION
## Summary

Fixes #2973. When a device that's already configured receives a new `SET_CONFIGURATION` (switching configs, not the initial one), `process_std_device_request()` unconditionally calls `dcd_sof_enable(rhport, false)` and then `configuration_reset()`, which does `tu_varclr(&_usbd_dev)` — wiping `_usbd_dev.sof_consumer` along with the rest of the struct.

`_usbd_dev.speed` is explicitly saved before the reset and restored right after (`const uint8_t speed = _usbd_dev.speed; ... _usbd_dev.speed = speed; // restore speed`), but `sof_consumer` gets no such treatment. So a user's earlier `tud_sof_cb_enable(true)` is silently lost, and the SOF interrupt stays permanently disabled after the reconfiguration — there's nothing left afterward to tell the driver it should come back on. Matches the issue's own description exactly, including the reporter's workaround of re-calling `tud_sof_cb_enable(false)`/`(true)` from `tud_mount_cb()`/`tud_umount_cb()`.

## Fix

Save/restore `sof_consumer` the same way `speed` already is, and re-apply the corresponding `dcd_sof_enable()` call afterward so the hardware interrupt state matches whatever was requested before the reconfiguration — rather than leaving it unconditionally off.

## Testing

I don't have the affected hardware or a Ruby/Ceedling environment set up locally to run `test/unit-test` (no Ruby on my host), so I can't provide a unit-test run for this one. What I did instead: read every reference to `sof_consumer` and `dcd_sof_enable()` in `src/device/usbd.c` to understand `usbd_sof_enable()`'s existing bitmask/enable-tracking pattern, and confirmed this change follows the exact same save/restore idiom already used for `speed` two lines above it in the same function — same type (`uint8_t`), same struct, same reset call in between. Happy to add a `test/unit-test/test/device/usbd` case for this (I see `mock_dcd.h` already mocks `dcd_sof_enable`) if that's wanted before merge.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.