### PR TITLE
nrf5x: fix hfclk_running() for nrfx v2.0.0

### DIFF
--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -843,6 +843,10 @@ static bool hfclk_running(void) {
 
   #if CFG_TUD_NRF_NRFX_VERSION == 1
   return nrf_clock_hf_is_running(NRF_CLOCK_HFCLK_HIGH_ACCURACY);
+  #elif CFG_TUD_NRF_NRFX_VERSION == 2
+  // nrfx 2.0.0 (MDK 8.29.0) has no nrf_clock_is_running(); it arrived in 2.1.0.
+  // nrf_clock_hf_is_running() is present in all of 2.0.0-2.11.0 (deprecated from 2.1.0).
+  return nrf_clock_hf_is_running(NRF_CLOCK, NRF_CLOCK_HFCLK_HIGH_ACCURACY);
   #else
   return nrf_clock_is_running(NRF_CLOCK, NRF_CLOCK_DOMAIN_HFCLK, NULL);
   #endif


### PR DESCRIPTION
`hfclk_running()` doesn't compile against nrfx v2.0.0 (MDK 8.29.0):

```
dcd_nrf5x.c:847: implicit declaration of 'nrf_clock_is_running'
dcd_nrf5x.c:847: 'NRF_CLOCK_DOMAIN_HFCLK' undeclared
```

- `nrf_clock_is_running()` was added in nrfx **2.1.0** (MDK 8.30.2)
- autodetect (`:53`) puts MDK 8.29.0 in the **v2** bucket, which calls it
- `CFG_TUD_NRF_NRFX_VERSION=1` doesn't help: v1's `nrf_clock_hf_is_running()` takes 1 arg, v2.0.0's takes 2

Fix: route v2 through `nrf_clock_hf_is_running()`, present in all of 2.x.

The other two v1-gated sites (`nrf_clock_event_clear`, `nrf_clock_task_trigger`) already use v2.0.0-compatible signatures — this is the only broken call.

Verified on nRF52840 (CircuitPython pins nrfx v2.0.0). Blocks adafruit/circuitpython#11093.

Note: I checked 2.0.0 and 2.1.0, not every 2.x in between. If you'd rather be exact, gate on `MDK_VERSION < 83002` instead of the whole v2 tier.
