### PR TITLE
hil: use stlink for stm32f746disco

### DIFF
--- a/test/hil/hfp.json
+++ b/test/hil/hfp.json
@@ -23,9 +23,8 @@
                 "device": true, "host": false, "dual": false
             },
             "flasher": {
-                "name": "jlink",
-                "uid": "770935966",
-                "args": "-device STM32F746NG"
+                "name": "stlink",
+                "uid": "0670FF515448787067122222"
             }
         },
         {


### PR DESCRIPTION
Reflashed it back to STLink, hope it's more stable.