### PR TITLE
renesas/rusb2: add support for RA MCUs with USBFS device-only support

### DIFF
--- a/src/portable/renesas/rusb2/dcd_rusb2.c
+++ b/src/portable/renesas/rusb2/dcd_rusb2.c
@@ -51,10 +51,10 @@ static dcd_data_t _dcd;
 // - Pipes 3 to 5: Bulk
 // - Pipes 6 to 9: Interrupt
 //
-// Note: for small mcu such as
-// - RA2A1: only pipe 4-7 are available, and no support for ISO
+// Note: for small mcu which only support device mode
+// only pipe 4-7 are available, and no support for ISO
 static unsigned find_pipe(unsigned xfer_type) {
-  #if defined(BSP_MCU_GROUP_RA2A1)
+  #ifdef RUSB2_RA_USBFS_DEVICE_ONLY
   const uint8_t pipe_idx_arr[4][2] = {
       { 0, 0 }, // Control
       { 0, 0 }, // Isochronous not supported

--- a/src/portable/renesas/rusb2/hcd_rusb2.c
+++ b/src/portable/renesas/rusb2/hcd_rusb2.c
@@ -11,7 +11,7 @@
 
 #if CFG_TUH_ENABLED && defined(TUP_USBIP_RUSB2)
 
-#ifdef RUSB RUSB2_RA_USBFS_DEVICE_ONLY
+#ifdef RUSB2_RA_USBFS_DEVICE_ONLY
 #error "Host mode not supported for this device"
 #endif
 

--- a/src/portable/renesas/rusb2/hcd_rusb2.c
+++ b/src/portable/renesas/rusb2/hcd_rusb2.c
@@ -11,6 +11,10 @@
 
 #if CFG_TUH_ENABLED && defined(TUP_USBIP_RUSB2)
 
+#ifdef RUSB RUSB2_RA_USBFS_DEVICE_ONLY
+#error "Host mode not supported for this device"
+#endif
+
 #include "host/hcd.h"
 #include "host/usbh.h"
 #include "rusb2_common.h"

--- a/src/portable/renesas/rusb2/rusb2_common.h
+++ b/src/portable/renesas/rusb2/rusb2_common.h
@@ -14,8 +14,8 @@
 #elif TU_CHECK_MCU(OPT_MCU_RAXXX)
   #include "rusb2_ra.h"
 
-  // Hack for D0FIFO definitions on RA Cortex-M23
-  #if defined(RENESAS_CORTEX_M23)
+  // Hack for D0FIFO definitions on RA with usb device support only
+  #ifdef RUSB2_RA_USBFS_DEVICE_ONLY
     #define D0FIFO      CFIFO
     #define D0FIFOSEL   CFIFOSEL
     #define D0FIFOSEL_b CFIFOSEL_b

--- a/src/portable/renesas/rusb2/rusb2_ra.h
+++ b/src/portable/renesas/rusb2/rusb2_ra.h
@@ -38,6 +38,10 @@ extern "C" {
 //
 //--------------------------------------------------------------------+
 
+#if defined(BSP_MCU_GROUP_RA2A1) || defined(BSP_MCU_GROUP_RA2L2) || defined(BSP_MCU_GROUP_RA4E2) || defined(BSP_MCU_GROUP_RA6E2) || defined(BSP_MCU_GROUP_RA6T3)
+#define RUSB2_RA_USBFS_DEVICE_ONLY
+#endif
+
 typedef struct {
   uint32_t reg_base;
   int32_t irqnum;


### PR DESCRIPTION
Renesas RA MCUs with with usb device-only support have a different hardware stack as MCUs with host support, which has already been implemented for RA2A1 but also works for others like RA4E2 with the same hardware stack.

This introduces define RUSB2_RA_USBFS_DEVICE_ONLY for MCUs with this implementation and sets correct pipe allocation and FIFO register aliases for all supported MCUs instead of RA2A1 only.
RA2A1 specific checks have been replaced with a common check for RUSB2_RA_USBFS_DEVICE_ONLY.

Tested on RA4E2 with FreeRTOS and TinyUSB HID Gamepad Device.
Not tested for other usb device-only RA MCUs (RA2L2, RA6E2 and RA6T3), only verified by datasheet.