### PR TITLE
dcd/raw_gadget: add Linux Raw Gadget backend

### DIFF
--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -716,6 +716,12 @@
   // Possible to share IN/OUT if only one direction is armed at any one time
   #define CFG_TUD_ENDPOINT_ONE_DIRECTION_ONLY 1
 
+//--------------------------------------------------------------------+
+// Linux
+//--------------------------------------------------------------------+
+#elif TU_CHECK_MCU(OPT_MCU_LINUX_RAW_GADGET)
+  #define TUP_DCD_ENDPOINT_MAX 16
+  #define TUP_RHPORT_HIGHSPEED 1
 #endif
 
 // External USB controller

--- a/src/portable/linux/raw_gadget/README.md
+++ b/src/portable/linux/raw_gadget/README.md
@@ -1,0 +1,104 @@
+# Linux Raw Gadget device controller driver
+
+This directory implements a TinyUSB device controller driver (DCD) for the
+Linux Raw Gadget userspace API. It allows TinyUSB device examples and tests to
+run as software USB devices through a Linux USB device controller, normally
+`dummy_hcd`/`dummy_udc`.
+
+## Architecture
+
+The port consists of two layers:
+
+- `dcd_raw_gadget.c` adapts the TinyUSB DCD API to the platform-neutral Raw
+  Gadget HAL.
+- `raw_gadget_*.c` implements the Linux Raw Gadget lifecycle, UDC discovery,
+  endpoint management, event handling and asynchronous transfers.
+
+Raw Gadget ioctls block while waiting for USB activity. The implementation
+therefore uses one event worker and at most one transfer worker per endpoint
+address. TinyUSB callbacks are serialized and are always delivered with
+`in_isr == false`.
+
+Endpoint zero requires special handling because TinyUSB and Raw Gadget expose
+different control-transfer semantics:
+
+- TinyUSB may submit an IN data stage in several endpoint-sized chunks, while
+  Raw Gadget expects the complete EP0 IN data stage in one ioctl. The HAL
+  aggregates these chunks before issuing `USB_RAW_IOCTL_EP0_WRITE`.
+- Raw Gadget completes the status stage as part of data-bearing control
+  requests. The subsequent logical zero-length status transfer submitted by
+  TinyUSB is therefore completed synthetically.
+- Requests without a data stage use Raw Gadget's delayed-status mechanism and
+  require a real EP0 ioctl.
+
+A transfer generation counter prevents completions from transfers cancelled by
+a bus reset from reaching the new TinyUSB device state.
+
+## Requirements
+
+- Linux with `CONFIG_USB_RAW_GADGET` enabled
+- `raw_gadget` kernel module
+- A userspace-accessible `/dev/raw-gadget`
+- A USB device controller visible in `/sys/class/udc`
+- `dummy_hcd` when no physical UDC is used
+- POSIX threads
+
+The current UDC discovery maps TinyUSB root-hub port `n` to a UDC named
+`dummy_udc.n`.
+
+## Supported functionality
+
+The port supports the transfer types provided reliably by the Linux Raw Gadget
+interface:
+
+- Control
+- Bulk
+- Interrupt
+
+The implementation has been exercised with TinyUSB CDC ACM, including
+enumeration, class control requests, interrupt endpoint configuration,
+bidirectional bulk transfers, zero-length packets and a 256 KiB echo transfer.
+
+## Limitations
+
+### Isochronous transfers
+
+Isochronous endpoints are intentionally not supported. Linux Raw Gadget does
+not provide complete isochronous transfer support, so
+`dcd_edpt_iso_alloc()` and `dcd_edpt_iso_activate()` return `false`. This is a
+platform limitation, not an unimplemented transfer path in the DCD.
+
+### Software disconnect and remote wakeup
+
+Raw Gadget does not expose a reversible software-disconnect ioctl or a remote
+wakeup operation. `dcd_disconnect()` and `dcd_remote_wakeup()` therefore have
+no effect. Closing the Raw Gadget file descriptor disconnects and destroys the
+instance during DCD deinitialization.
+
+### Start-of-frame events
+
+Raw Gadget does not expose SOF events. `dcd_sof_enable()` is a no-op.
+
+### Endpoint FIFO API
+
+The optional `dcd_edpt_xfer_fifo()` API is not implemented. TinyUSB uses the
+normal buffer transfer API for this port.
+
+## Threading and callback rules
+
+The HAL owns all worker threads. Application code must not call the HAL
+functions directly; TinyUSB accesses them through `dcd_raw_gadget.c`.
+
+Raw Gadget event callbacks:
+
+- may run on an implementation-owned worker thread;
+- are serialized by the HAL;
+- must not block indefinitely;
+- must not retain pointers to event objects after returning.
+
+## Security and permissions
+
+Access to `/dev/raw-gadget` normally requires elevated privileges. Prefer a
+narrow udev rule or dedicated group over running the complete test application
+as root. The exact policy is distribution-specific and is intentionally not
+installed by this port.

--- a/src/portable/linux/raw_gadget/dcd_raw_gadget.c
+++ b/src/portable/linux/raw_gadget/dcd_raw_gadget.c
@@ -1,0 +1,282 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2018, Ha Thach (tinyusb.org)
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "tusb_option.h"
+
+#if CFG_TUD_ENABLED && CFG_TUSB_MCU == OPT_MCU_LINUX_RAW_GADGET
+
+#include "device/dcd.h"
+#include "raw_gadget_hal.h"
+
+//--------------------------------------------------------------------+
+// Internal Helpers
+//--------------------------------------------------------------------+
+
+static raw_gadget_handle_t raw_gadget_handle_from_rhport(uint8_t rhport)
+{
+  return (raw_gadget_handle_t) rhport;
+}
+
+static raw_gadget_speed_t raw_gadget_speed_from_tusb(tusb_speed_t speed)
+{
+  switch (speed)
+  {
+    case TUSB_SPEED_LOW:
+      return RAW_GADGET_SPEED_LOW;
+
+    case TUSB_SPEED_FULL:
+      return RAW_GADGET_SPEED_FULL;
+
+    case TUSB_SPEED_HIGH:
+    case TUSB_SPEED_AUTO:
+      return RAW_GADGET_SPEED_HIGH;
+
+    case TUSB_SPEED_INVALID:
+    default:
+      return RAW_GADGET_SPEED_INVALID;
+  }
+}
+
+static tusb_speed_t raw_gadget_speed_to_tusb(raw_gadget_speed_t speed)
+{
+  switch (speed)
+  {
+    case RAW_GADGET_SPEED_LOW:
+      return TUSB_SPEED_LOW;
+
+    case RAW_GADGET_SPEED_FULL:
+      return TUSB_SPEED_FULL;
+
+    case RAW_GADGET_SPEED_HIGH:
+      return TUSB_SPEED_HIGH;
+
+    case RAW_GADGET_SPEED_INVALID:
+    default:
+      return TUSB_SPEED_INVALID;
+  }
+}
+
+static xfer_result_t raw_gadget_transfer_result_to_tusb(raw_gadget_transfer_result_t result)
+{
+  switch (result)
+  {
+    case RAW_GADGET_TRANSFER_RESULT_SUCCESS:
+      return XFER_RESULT_SUCCESS;
+
+    case RAW_GADGET_TRANSFER_RESULT_STALLED:
+      return XFER_RESULT_STALLED;
+
+    case RAW_GADGET_TRANSFER_RESULT_CANCELLED:
+    case RAW_GADGET_TRANSFER_RESULT_FAILED:
+    default:
+      return XFER_RESULT_FAILED;
+  }
+}
+
+static void raw_gadget_event_callback(raw_gadget_handle_t handle,
+                                      raw_gadget_event_t const *event)
+{
+  uint8_t const rhport = (uint8_t) handle;
+
+  if (event == NULL)
+  {
+    return;
+  }
+
+  switch (event->type)
+  {
+    case RAW_GADGET_EVENT_RESET:
+      dcd_event_bus_reset(rhport, raw_gadget_speed_to_tusb(event->data.reset.speed), false);
+      break;
+
+    case RAW_GADGET_EVENT_SUSPEND:
+      dcd_event_bus_signal(rhport, DCD_EVENT_SUSPEND, false);
+      break;
+
+    case RAW_GADGET_EVENT_RESUME:
+      dcd_event_bus_signal(rhport, DCD_EVENT_RESUME, false);
+      break;
+
+    case RAW_GADGET_EVENT_DISCONNECT:
+      dcd_event_bus_signal(rhport, DCD_EVENT_UNPLUGGED, false);
+      break;
+
+    case RAW_GADGET_EVENT_SETUP_RECEIVED:
+      dcd_event_setup_received(rhport, event->data.setup.data, false);
+      break;
+
+    case RAW_GADGET_EVENT_TRANSFER_COMPLETE:
+      dcd_event_xfer_complete(
+          rhport, event->data.transfer.endpoint_address,
+          (uint32_t) event->data.transfer.transferred_bytes,
+          (uint8_t) raw_gadget_transfer_result_to_tusb(event->data.transfer.result), false);
+      break;
+
+    case RAW_GADGET_EVENT_CONNECT:
+    default:
+      break;
+  }
+}
+
+//--------------------------------------------------------------------+
+// Device API
+//--------------------------------------------------------------------+
+
+bool dcd_init(uint8_t rhport, tusb_rhport_init_t const *rh_init)
+{
+  raw_gadget_speed_t speed;
+
+  if (rh_init == NULL)
+  {
+    return false;
+  }
+
+  speed = raw_gadget_speed_from_tusb(rh_init->speed);
+  if (speed == RAW_GADGET_SPEED_INVALID)
+  {
+    return false;
+  }
+
+  return raw_gadget_init(raw_gadget_handle_from_rhport(rhport), speed,
+                         raw_gadget_event_callback) == RAW_GADGET_RESULT_SUCCESS;
+}
+
+bool dcd_deinit(uint8_t rhport)
+{
+  return raw_gadget_deinit(raw_gadget_handle_from_rhport(rhport)) ==
+         RAW_GADGET_RESULT_SUCCESS;
+}
+
+/* Raw Gadget is serviced by worker threads rather than a hardware ISR. */
+void dcd_int_handler(uint8_t rhport)
+{
+  (void) rhport;
+}
+
+void dcd_int_enable(uint8_t rhport)
+{
+  (void) rhport;
+}
+
+void dcd_int_disable(uint8_t rhport)
+{
+  (void) rhport;
+}
+
+void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
+{
+  (void) dev_addr;
+
+  /* Raw Gadget handles the address internally after the status stage. */
+  (void) dcd_edpt_xfer(rhport, 0x80u, NULL, 0u, false);
+}
+
+void dcd_remote_wakeup(uint8_t rhport)
+{
+  /* The Raw Gadget userspace API does not expose remote wakeup. */
+  (void) rhport;
+}
+
+void dcd_connect(uint8_t rhport)
+{
+  (void) raw_gadget_connect(raw_gadget_handle_from_rhport(rhport));
+}
+
+void dcd_disconnect(uint8_t rhport)
+{
+  /* Raw Gadget has no reversible software-disconnect operation. */
+  (void) raw_gadget_disconnect(raw_gadget_handle_from_rhport(rhport));
+}
+
+void dcd_sof_enable(uint8_t rhport, bool enabled)
+{
+  /* Raw Gadget does not expose SOF events. */
+  (void) rhport;
+  (void) enabled;
+}
+
+//--------------------------------------------------------------------+
+// Endpoint API
+//--------------------------------------------------------------------+
+
+bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const *ep_desc)
+{
+  raw_gadget_handle_t const handle = raw_gadget_handle_from_rhport(rhport);
+  raw_gadget_result_t result;
+
+  if ((ep_desc == NULL) || (ep_desc->bLength < sizeof(*ep_desc)))
+  {
+    return false;
+  }
+
+  /* USB_RAW_IOCTL_CONFIGURE must precede the first endpoint enable. */
+  result = raw_gadget_configure(handle);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return false;
+  }
+
+  result = raw_gadget_endpoint_open(handle, (uint8_t const *) ep_desc, ep_desc->bLength);
+  return result == RAW_GADGET_RESULT_SUCCESS;
+}
+
+bool dcd_edpt_iso_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t largest_packet_size)
+{
+  (void) rhport;
+  (void) ep_addr;
+  (void) largest_packet_size;
+
+  /* Linux Raw Gadget does not provide complete isochronous support. */
+  return false;
+}
+
+bool dcd_edpt_iso_activate(uint8_t rhport, tusb_desc_endpoint_t const *ep_desc)
+{
+  (void) rhport;
+  (void) ep_desc;
+
+  return false;
+}
+
+void dcd_edpt_close_all(uint8_t rhport)
+{
+  (void) raw_gadget_endpoint_close_all(raw_gadget_handle_from_rhport(rhport));
+}
+
+bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer,
+                   uint16_t total_bytes, bool is_isr)
+{
+  (void) is_isr;
+
+  return raw_gadget_endpoint_transfer(raw_gadget_handle_from_rhport(rhport), ep_addr, buffer,
+                                      total_bytes) == RAW_GADGET_RESULT_SUCCESS;
+}
+
+bool dcd_edpt_xfer_fifo(uint8_t rhport, uint8_t ep_addr, tu_fifo_t *fifo,
+                        uint16_t total_bytes, bool is_isr)
+{
+  (void) rhport;
+  (void) ep_addr;
+  (void) fifo;
+  (void) total_bytes;
+  (void) is_isr;
+
+  return false;
+}
+
+void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr)
+{
+  (void) raw_gadget_endpoint_stall(raw_gadget_handle_from_rhport(rhport), ep_addr);
+}
+
+void dcd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr)
+{
+  (void) raw_gadget_endpoint_clear_stall(raw_gadget_handle_from_rhport(rhport), ep_addr);
+}
+
+#endif

--- a/src/portable/linux/raw_gadget/raw_gadget_context.c
+++ b/src/portable/linux/raw_gadget/raw_gadget_context.c
@@ -1,0 +1,255 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "raw_gadget_private.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+//--------------------------------------------------------------------+
+// Internal Data
+//--------------------------------------------------------------------+
+
+static raw_gadget_manager_t raw_gadget_manager = {
+  .contexts = NULL,
+  .context_count = 0,
+  .mutex = PTHREAD_MUTEX_INITIALIZER,
+  .discovered = false,
+};
+
+//--------------------------------------------------------------------+
+// Internal Helpers
+//--------------------------------------------------------------------+
+
+static void raw_gadget_endpoints_reset(raw_gadget_context_t *context)
+{
+  for (size_t index = 0; index < RAW_GADGET_ENDPOINT_COUNT; index++)
+  {
+    raw_gadget_endpoint_t *endpoint = &context->endpoints[index];
+
+    endpoint->enabled = false;
+    endpoint->address = 0;
+    endpoint->kernel_handle = RAW_GADGET_INVALID_ENDPOINT_HANDLE;
+    endpoint->transfer_active = false;
+    endpoint->transfer_thread_created = false;
+    endpoint->transfer_cancel_pending = false;
+    memset(&endpoint->transfer_thread, 0, sizeof(endpoint->transfer_thread));
+  }
+}
+
+//--------------------------------------------------------------------+
+// Manager and Context API
+//--------------------------------------------------------------------+
+
+raw_gadget_manager_t *raw_gadget_manager_get(void)
+{
+  return &raw_gadget_manager;
+}
+
+raw_gadget_result_t raw_gadget_context_table_create(size_t context_count)
+{
+  raw_gadget_context_t *contexts;
+  size_t initialized_count = 0;
+
+  if ((context_count == 0) || (context_count > (size_t) UINT8_MAX + 1u))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  if (pthread_mutex_lock(&raw_gadget_manager.mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  if (raw_gadget_manager.contexts != NULL)
+  {
+    (void) pthread_mutex_unlock(&raw_gadget_manager.mutex);
+    return RAW_GADGET_RESULT_ALREADY_INITIALIZED;
+  }
+
+  contexts = calloc(context_count, sizeof(*contexts));
+  if (contexts == NULL)
+  {
+    (void) pthread_mutex_unlock(&raw_gadget_manager.mutex);
+    return RAW_GADGET_RESULT_NO_MEMORY;
+  }
+
+  for (size_t index = 0; index < context_count; index++)
+  {
+    raw_gadget_context_t *context = &contexts[index];
+
+    if (pthread_mutex_init(&context->mutex, NULL) != 0)
+    {
+      initialized_count = index;
+      goto context_initialization_failed;
+    }
+
+    if (pthread_mutex_init(&context->callback_mutex, NULL) != 0)
+    {
+      (void) pthread_mutex_destroy(&context->mutex);
+      initialized_count = index;
+      goto context_initialization_failed;
+    }
+
+    if (pthread_cond_init(&context->ep0_condition, NULL) != 0)
+    {
+      (void) pthread_mutex_destroy(&context->callback_mutex);
+      (void) pthread_mutex_destroy(&context->mutex);
+      initialized_count = index;
+      goto context_initialization_failed;
+    }
+
+    context->available = false;
+    context->initialized = false;
+    context->shutting_down = false;
+    context->event_thread_created = false;
+    context->handle = (raw_gadget_handle_t) index;
+    context->speed = RAW_GADGET_SPEED_INVALID;
+    context->udc_name[0] = '\0';
+    context->file_descriptor = RAW_GADGET_INVALID_FILE_DESCRIPTOR;
+    memset(&context->event_thread, 0, sizeof(context->event_thread));
+    atomic_init(&context->event_thread_running, false);
+    context->ep0_request_active = false;
+    context->ep0_direction_in = false;
+    context->ep0_requested_length = 0;
+    context->ep0_max_packet_size = 0;
+    context->ep0_accumulated_length = 0;
+    context->ep0_buffer = NULL;
+    context->ep0_buffer_capacity = 0;
+    context->transfer_generation = 0;
+    context->event_callback = NULL;
+    raw_gadget_endpoints_reset(context);
+  }
+
+  raw_gadget_manager.contexts = contexts;
+  raw_gadget_manager.context_count = context_count;
+  raw_gadget_manager.discovered = false;
+
+  (void) pthread_mutex_unlock(&raw_gadget_manager.mutex);
+  return RAW_GADGET_RESULT_SUCCESS;
+
+context_initialization_failed:
+  for (size_t index = 0; index < initialized_count; index++)
+  {
+    (void) pthread_cond_destroy(&contexts[index].ep0_condition);
+    (void) pthread_mutex_destroy(&contexts[index].callback_mutex);
+    (void) pthread_mutex_destroy(&contexts[index].mutex);
+  }
+
+  free(contexts);
+  (void) pthread_mutex_unlock(&raw_gadget_manager.mutex);
+
+  return RAW_GADGET_RESULT_INTERNAL_ERROR;
+}
+
+void raw_gadget_context_table_destroy(void)
+{
+  if (pthread_mutex_lock(&raw_gadget_manager.mutex) != 0)
+  {
+    return;
+  }
+
+  if (raw_gadget_manager.contexts == NULL)
+  {
+    raw_gadget_manager.context_count = 0;
+    raw_gadget_manager.discovered = false;
+    (void) pthread_mutex_unlock(&raw_gadget_manager.mutex);
+    return;
+  }
+
+  for (size_t index = 0; index < raw_gadget_manager.context_count; index++)
+  {
+    free(raw_gadget_manager.contexts[index].ep0_buffer);
+    raw_gadget_manager.contexts[index].ep0_buffer = NULL;
+    (void) pthread_cond_destroy(&raw_gadget_manager.contexts[index].ep0_condition);
+    (void) pthread_mutex_destroy(&raw_gadget_manager.contexts[index].callback_mutex);
+    (void) pthread_mutex_destroy(&raw_gadget_manager.contexts[index].mutex);
+  }
+
+  free(raw_gadget_manager.contexts);
+
+  raw_gadget_manager.contexts = NULL;
+  raw_gadget_manager.context_count = 0;
+  raw_gadget_manager.discovered = false;
+
+  (void) pthread_mutex_unlock(&raw_gadget_manager.mutex);
+}
+
+raw_gadget_context_t *raw_gadget_context_get(raw_gadget_handle_t handle)
+{
+  raw_gadget_context_t *context = NULL;
+
+  if (pthread_mutex_lock(&raw_gadget_manager.mutex) != 0)
+  {
+    return NULL;
+  }
+
+  if ((raw_gadget_manager.contexts != NULL) &&
+      ((size_t) handle < raw_gadget_manager.context_count))
+  {
+    context = &raw_gadget_manager.contexts[handle];
+  }
+
+  (void) pthread_mutex_unlock(&raw_gadget_manager.mutex);
+
+  return context;
+}
+
+void raw_gadget_context_reset(raw_gadget_context_t *context)
+{
+  if (context == NULL)
+  {
+    return;
+  }
+
+  context->initialized = false;
+  context->configured = false;
+  context->shutting_down = false;
+  context->event_thread_created = false;
+  context->speed = RAW_GADGET_SPEED_INVALID;
+  context->file_descriptor = RAW_GADGET_INVALID_FILE_DESCRIPTOR;
+  memset(&context->event_thread, 0, sizeof(context->event_thread));
+  atomic_store(&context->event_thread_running, false);
+  context->ep0_request_active = false;
+  context->ep0_direction_in = false;
+  context->ep0_requested_length = 0;
+  context->ep0_max_packet_size = 0;
+  context->ep0_accumulated_length = 0;
+  free(context->ep0_buffer);
+  context->ep0_buffer = NULL;
+  context->ep0_buffer_capacity = 0;
+  context->transfer_generation = 0;
+  context->event_callback = NULL;
+  raw_gadget_endpoints_reset(context);
+}
+
+//--------------------------------------------------------------------+
+// Endpoint Helpers
+//--------------------------------------------------------------------+
+
+size_t raw_gadget_endpoint_index(uint8_t endpoint_address)
+{
+  size_t index = endpoint_address & 0x0fu;
+
+  if ((endpoint_address & 0x80u) != 0u)
+  {
+    index += 16u;
+  }
+
+  return index;
+}
+
+raw_gadget_endpoint_t *raw_gadget_endpoint_get(raw_gadget_context_t *context,
+                                               uint8_t endpoint_address)
+{
+  if (context == NULL)
+  {
+    return NULL;
+  }
+
+  return &context->endpoints[raw_gadget_endpoint_index(endpoint_address)];
+}

--- a/src/portable/linux/raw_gadget/raw_gadget_endpoint.c
+++ b/src/portable/linux/raw_gadget/raw_gadget_endpoint.c
@@ -1,0 +1,354 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "raw_gadget_private.h"
+
+#include <errno.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#include <linux/usb/ch9.h>
+
+//--------------------------------------------------------------------+
+// Internal Helpers
+//--------------------------------------------------------------------+
+
+static bool raw_gadget_endpoint_address_valid(uint8_t endpoint_address)
+{
+  return (endpoint_address & 0x70u) == 0u;
+}
+
+static raw_gadget_result_t raw_gadget_endpoint_context_validate(
+    raw_gadget_context_t const *context)
+{
+  if (context == NULL)
+  {
+    return RAW_GADGET_RESULT_INVALID_HANDLE;
+  }
+
+  if (!context->available)
+  {
+    return RAW_GADGET_RESULT_NOT_AVAILABLE;
+  }
+
+  if (!context->initialized ||
+      (context->file_descriptor == RAW_GADGET_INVALID_FILE_DESCRIPTOR))
+  {
+    return RAW_GADGET_RESULT_NOT_INITIALIZED;
+  }
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+static raw_gadget_result_t raw_gadget_endpoint_disable_locked(
+    raw_gadget_context_t *context,
+    raw_gadget_endpoint_t *endpoint)
+{
+  uint32_t kernel_handle;
+
+  if (!endpoint->enabled)
+  {
+    return RAW_GADGET_RESULT_SUCCESS;
+  }
+
+  kernel_handle = endpoint->kernel_handle;
+
+  if (ioctl(context->file_descriptor,
+            USB_RAW_IOCTL_EP_DISABLE,
+            &kernel_handle) < 0)
+  {
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  endpoint->enabled = false;
+  endpoint->address = 0;
+  endpoint->kernel_handle = RAW_GADGET_INVALID_ENDPOINT_HANDLE;
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+//--------------------------------------------------------------------+
+// Endpoint API
+//--------------------------------------------------------------------+
+
+raw_gadget_result_t raw_gadget_endpoint_open(raw_gadget_handle_t handle,
+                                             uint8_t const *descriptor,
+                                             size_t descriptor_length)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_endpoint_t *endpoint;
+  struct usb_endpoint_descriptor kernel_descriptor;
+  raw_gadget_result_t result;
+  uint8_t endpoint_address;
+  int kernel_handle;
+
+  if ((descriptor == NULL) || (descriptor_length < USB_DT_ENDPOINT_SIZE))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  memset(&kernel_descriptor, 0, sizeof(kernel_descriptor));
+  memcpy(&kernel_descriptor, descriptor, USB_DT_ENDPOINT_SIZE);
+
+  if ((kernel_descriptor.bLength < USB_DT_ENDPOINT_SIZE) ||
+      (kernel_descriptor.bDescriptorType != USB_DT_ENDPOINT))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  endpoint_address = kernel_descriptor.bEndpointAddress;
+
+  if (!raw_gadget_endpoint_address_valid(endpoint_address) ||
+      ((endpoint_address & USB_ENDPOINT_NUMBER_MASK) == 0u))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_endpoint_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  endpoint = raw_gadget_endpoint_get(context, endpoint_address);
+  if (endpoint->enabled)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_ALREADY_INITIALIZED;
+  }
+
+  kernel_handle = ioctl(context->file_descriptor,
+                        USB_RAW_IOCTL_EP_ENABLE,
+                        &kernel_descriptor);
+  if (kernel_handle < 0)
+  {
+    TU_LOG1("Raw Gadget HAL: EP_ENABLE failed: ep=%02x errno=%d (%s)\r\n",
+            endpoint_address,
+            errno,
+            strerror(errno));
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  endpoint->enabled = true;
+  endpoint->address = endpoint_address;
+  endpoint->kernel_handle = (uint32_t) kernel_handle;
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+raw_gadget_result_t raw_gadget_endpoint_close(raw_gadget_handle_t handle,
+                                              uint8_t endpoint_address)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_endpoint_t *endpoint;
+  raw_gadget_result_t result;
+
+  if (!raw_gadget_endpoint_address_valid(endpoint_address) ||
+      ((endpoint_address & USB_ENDPOINT_NUMBER_MASK) == 0u))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_endpoint_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  result = raw_gadget_endpoint_transfer_cancel(handle, endpoint_address);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  endpoint = raw_gadget_endpoint_get(context, endpoint_address);
+  result = raw_gadget_endpoint_disable_locked(context, endpoint);
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  return result;
+}
+
+raw_gadget_result_t raw_gadget_endpoint_close_all(raw_gadget_handle_t handle)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_result_t result;
+  raw_gadget_result_t first_error = RAW_GADGET_RESULT_SUCCESS;
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_endpoint_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  raw_gadget_transfer_cancel_all(context);
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  for (size_t index = 0; index < RAW_GADGET_ENDPOINT_COUNT; index++)
+  {
+    result =
+        raw_gadget_endpoint_disable_locked(context, &context->endpoints[index]);
+
+    if ((result != RAW_GADGET_RESULT_SUCCESS) &&
+        (first_error == RAW_GADGET_RESULT_SUCCESS))
+    {
+      first_error = result;
+    }
+  }
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  return first_error;
+}
+
+raw_gadget_result_t raw_gadget_endpoint_stall(raw_gadget_handle_t handle,
+                                              uint8_t endpoint_address)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_endpoint_t *endpoint;
+  raw_gadget_result_t result;
+  uint32_t kernel_handle;
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_endpoint_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  if ((endpoint_address & USB_ENDPOINT_NUMBER_MASK) == 0u)
+  {
+    if (!context->ep0_request_active)
+    {
+      (void) pthread_mutex_unlock(&context->mutex);
+      return RAW_GADGET_RESULT_SUCCESS;
+    }
+
+    if (ioctl(context->file_descriptor, USB_RAW_IOCTL_EP0_STALL, 0) < 0)
+    {
+      TU_LOG1("Raw Gadget: EP0_STALL failed: errno=%d (%s)\r\n",
+              errno,
+              strerror(errno));
+      result = RAW_GADGET_RESULT_IO_ERROR;
+    }
+    else
+    {
+      result = RAW_GADGET_RESULT_SUCCESS;
+    }
+
+    (void) pthread_mutex_unlock(&context->mutex);
+    raw_gadget_control_request_complete_internal(context);
+    return result;
+  }
+
+  if (!raw_gadget_endpoint_address_valid(endpoint_address))
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  endpoint = raw_gadget_endpoint_get(context, endpoint_address);
+  if (!endpoint->enabled)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_NOT_AVAILABLE;
+  }
+
+  kernel_handle = endpoint->kernel_handle;
+
+  if (ioctl(context->file_descriptor,
+            USB_RAW_IOCTL_EP_SET_HALT,
+            &kernel_handle) < 0)
+  {
+    result = RAW_GADGET_RESULT_IO_ERROR;
+  }
+  else
+  {
+    result = RAW_GADGET_RESULT_SUCCESS;
+  }
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  return result;
+}
+
+raw_gadget_result_t raw_gadget_endpoint_clear_stall(
+    raw_gadget_handle_t handle,
+    uint8_t endpoint_address)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_endpoint_t *endpoint;
+  raw_gadget_result_t result;
+  uint32_t kernel_handle;
+
+  if (!raw_gadget_endpoint_address_valid(endpoint_address) ||
+      ((endpoint_address & USB_ENDPOINT_NUMBER_MASK) == 0u))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_endpoint_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  endpoint = raw_gadget_endpoint_get(context, endpoint_address);
+  if (!endpoint->enabled)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_NOT_AVAILABLE;
+  }
+
+  kernel_handle = endpoint->kernel_handle;
+
+  if (ioctl(context->file_descriptor,
+            USB_RAW_IOCTL_EP_CLEAR_HALT,
+            &kernel_handle) < 0)
+  {
+    result = RAW_GADGET_RESULT_IO_ERROR;
+  }
+  else
+  {
+    result = RAW_GADGET_RESULT_SUCCESS;
+  }
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  return result;
+}

--- a/src/portable/linux/raw_gadget/raw_gadget_event.c
+++ b/src/portable/linux/raw_gadget/raw_gadget_event.c
@@ -1,0 +1,374 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "raw_gadget_private.h"
+
+#include <errno.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+//--------------------------------------------------------------------+
+// Internal Types
+//--------------------------------------------------------------------+
+
+typedef struct
+{
+  uint32_t type;
+  uint32_t length;
+  uint8_t data[sizeof(raw_gadget_control_request_t)];
+} raw_gadget_kernel_event_t;
+
+//--------------------------------------------------------------------+
+// Internal Helpers
+//--------------------------------------------------------------------+
+
+static void raw_gadget_event_thread_cleanup(void *argument)
+{
+  raw_gadget_context_t *context = argument;
+
+  if (context != NULL)
+  {
+    atomic_store(&context->event_thread_running, false);
+  }
+}
+
+static bool raw_gadget_event_convert(raw_gadget_context_t const *context,
+                                     raw_gadget_kernel_event_t const *kernel_event,
+                                     raw_gadget_event_t *event)
+{
+  if ((context == NULL) || (kernel_event == NULL) || (event == NULL))
+  {
+    return false;
+  }
+
+  memset(event, 0, sizeof(*event));
+
+  switch (kernel_event->type)
+  {
+    case USB_RAW_EVENT_CONNECT:
+      event->type = RAW_GADGET_EVENT_CONNECT;
+      event->data.connect.speed = context->speed;
+      return true;
+
+    case USB_RAW_EVENT_CONTROL:
+      if (kernel_event->length != sizeof(event->data.setup.data))
+      {
+        return false;
+      }
+
+      event->type = RAW_GADGET_EVENT_SETUP_RECEIVED;
+      memcpy(event->data.setup.data,
+             kernel_event->data,
+             sizeof(event->data.setup.data));
+      return true;
+
+    case USB_RAW_EVENT_SUSPEND:
+      event->type = RAW_GADGET_EVENT_SUSPEND;
+      return true;
+
+    case USB_RAW_EVENT_RESUME:
+      event->type = RAW_GADGET_EVENT_RESUME;
+      return true;
+
+    case USB_RAW_EVENT_RESET:
+      event->type = RAW_GADGET_EVENT_RESET;
+      event->data.reset.speed = context->speed;
+      return true;
+
+    case USB_RAW_EVENT_DISCONNECT:
+      event->type = RAW_GADGET_EVENT_DISCONNECT;
+      return true;
+
+    case USB_RAW_EVENT_INVALID:
+    default:
+      return false;
+  }
+}
+
+static void *raw_gadget_event_thread(void *argument)
+{
+  raw_gadget_context_t *context = argument;
+  int previous_cancel_state;
+  int previous_cancel_type;
+
+  if (context == NULL)
+  {
+    return NULL;
+  }
+
+  (void) pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &previous_cancel_state);
+  (void) pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, &previous_cancel_type);
+
+  pthread_cleanup_push(raw_gadget_event_thread_cleanup, context);
+
+  atomic_store(&context->event_thread_running, true);
+
+  while (atomic_load(&context->event_thread_running))
+  {
+    raw_gadget_kernel_event_t kernel_event = {
+      .type = USB_RAW_EVENT_INVALID,
+      .length = sizeof(kernel_event.data),
+      .data = {0},
+    };
+    raw_gadget_event_t event;
+    int ioctl_result;
+
+    ioctl_result = ioctl(context->file_descriptor,
+                         USB_RAW_IOCTL_EVENT_FETCH,
+                         &kernel_event);
+
+    if (ioctl_result < 0)
+    {
+      if (errno == EINTR)
+      {
+        continue;
+      }
+
+      TU_LOG1(
+              "Raw Gadget: EVENT_FETCH failed: errno=%d (%s)\r\n",
+              errno,
+              strerror(errno));
+      break;
+    }
+
+    if (raw_gadget_event_convert(context, &kernel_event, &event))
+    {
+      if (event.type == RAW_GADGET_EVENT_RESET)
+      {
+        raw_gadget_bus_reset_prepare(context);
+      }
+      else if (event.type == RAW_GADGET_EVENT_SETUP_RECEIVED)
+      {
+        if (pthread_mutex_lock(&context->mutex) != 0)
+        {
+          break;
+        }
+
+        while (context->ep0_request_active &&
+               atomic_load(&context->event_thread_running))
+        {
+          (void) pthread_cond_wait(&context->ep0_condition, &context->mutex);
+        }
+
+        context->ep0_request_active = true;
+        context->ep0_direction_in =
+            (event.data.setup.data[0] & 0x80u) != 0u;
+        context->ep0_requested_length =
+            (uint16_t) event.data.setup.data[6] |
+            ((uint16_t) event.data.setup.data[7] << 8u);
+        context->ep0_accumulated_length = 0;
+        (void) pthread_mutex_unlock(&context->mutex);
+      }
+
+      raw_gadget_event_dispatch(context, &event);
+    }
+
+    pthread_testcancel();
+  }
+
+  pthread_cleanup_pop(1);
+
+  (void) pthread_setcanceltype(previous_cancel_type, NULL);
+  (void) pthread_setcancelstate(previous_cancel_state, NULL);
+
+  return NULL;
+}
+
+//--------------------------------------------------------------------+
+// Event API
+//--------------------------------------------------------------------+
+
+raw_gadget_result_t raw_gadget_event_start(raw_gadget_context_t *context)
+{
+  int create_result;
+
+  if (context == NULL)
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  if (!context->initialized)
+  {
+    return RAW_GADGET_RESULT_NOT_INITIALIZED;
+  }
+
+  if (context->file_descriptor == RAW_GADGET_INVALID_FILE_DESCRIPTOR)
+  {
+    return RAW_GADGET_RESULT_NOT_INITIALIZED;
+  }
+
+  if (context->event_callback == NULL)
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  if (context->event_thread_created)
+  {
+    return RAW_GADGET_RESULT_ALREADY_INITIALIZED;
+  }
+
+  atomic_store(&context->event_thread_running, true);
+
+  create_result =
+      pthread_create(&context->event_thread, NULL, raw_gadget_event_thread, context);
+  if (create_result != 0)
+  {
+    atomic_store(&context->event_thread_running, false);
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  context->event_thread_created = true;
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+void raw_gadget_event_stop(raw_gadget_context_t *context)
+{
+  if ((context == NULL) || !context->event_thread_created)
+  {
+    return;
+  }
+
+  atomic_store(&context->event_thread_running, false);
+
+  if (pthread_mutex_lock(&context->mutex) == 0)
+  {
+    context->ep0_request_active = false;
+    (void) pthread_cond_broadcast(&context->ep0_condition);
+    (void) pthread_mutex_unlock(&context->mutex);
+  }
+
+  /*
+   * USB_RAW_IOCTL_EVENT_FETCH blocks until a kernel event is available.
+   * Cancellation is used to wake the worker without generating a synthetic
+   * USB event or closing a file descriptor still owned by the context.
+   */
+  (void) pthread_cancel(context->event_thread);
+  (void) pthread_join(context->event_thread, NULL);
+
+  memset(&context->event_thread, 0, sizeof(context->event_thread));
+  context->event_thread_created = false;
+}
+
+void raw_gadget_event_dispatch(raw_gadget_context_t *context,
+                               raw_gadget_event_t const *event)
+{
+  raw_gadget_event_callback_t callback;
+
+  if ((context == NULL) || (event == NULL))
+  {
+    return;
+  }
+
+  if (pthread_mutex_lock(&context->callback_mutex) != 0)
+  {
+    return;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    (void) pthread_mutex_unlock(&context->callback_mutex);
+    return;
+  }
+
+  callback = context->shutting_down ? NULL : context->event_callback;
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  if (callback != NULL)
+  {
+    callback(context->handle, event);
+  }
+
+  (void) pthread_mutex_unlock(&context->callback_mutex);
+}
+
+void raw_gadget_event_dispatch_transfer(raw_gadget_context_t *context,
+                                        raw_gadget_event_t const *event,
+                                        uint32_t generation)
+{
+  raw_gadget_event_callback_t callback;
+  uint32_t current_generation;
+
+  if ((context == NULL) || (event == NULL))
+  {
+    return;
+  }
+
+  if (pthread_mutex_lock(&context->callback_mutex) != 0)
+  {
+    return;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    (void) pthread_mutex_unlock(&context->callback_mutex);
+    return;
+  }
+
+  current_generation = context->transfer_generation;
+  callback = (!context->shutting_down &&
+              (generation == current_generation))
+                ? context->event_callback
+                : NULL;
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  if (callback != NULL)
+  {
+    callback(context->handle, event);
+  }
+  else
+  {
+  }
+
+  (void) pthread_mutex_unlock(&context->callback_mutex);
+}
+
+void raw_gadget_control_request_complete_internal(raw_gadget_context_t *context)
+{
+  if (context == NULL)
+  {
+    return;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return;
+  }
+
+  context->ep0_request_active = false;
+  context->ep0_accumulated_length = 0;
+  (void) pthread_cond_broadcast(&context->ep0_condition);
+
+  (void) pthread_mutex_unlock(&context->mutex);
+}
+
+void raw_gadget_bus_reset_prepare(raw_gadget_context_t *context)
+{
+  if (context == NULL)
+  {
+    return;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return;
+  }
+
+  context->configured = false;
+  context->transfer_generation++;
+  context->ep0_request_active = false;
+  context->ep0_direction_in = false;
+  context->ep0_requested_length = 0;
+  context->ep0_accumulated_length = 0;
+  (void) pthread_cond_broadcast(&context->ep0_condition);
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  raw_gadget_transfer_cancel_all(context);
+}

--- a/src/portable/linux/raw_gadget/raw_gadget_hal.c
+++ b/src/portable/linux/raw_gadget/raw_gadget_hal.c
@@ -1,0 +1,344 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "raw_gadget_private.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <linux/usb/ch9.h>
+
+//--------------------------------------------------------------------+
+// Internal Helpers
+//--------------------------------------------------------------------+
+
+static raw_gadget_result_t raw_gadget_speed_convert(raw_gadget_speed_t speed,
+                                                    uint8_t *kernel_speed)
+{
+  if (kernel_speed == NULL)
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  switch (speed)
+  {
+    case RAW_GADGET_SPEED_LOW:
+      *kernel_speed = USB_SPEED_LOW;
+      return RAW_GADGET_RESULT_SUCCESS;
+
+    case RAW_GADGET_SPEED_FULL:
+      *kernel_speed = USB_SPEED_FULL;
+      return RAW_GADGET_RESULT_SUCCESS;
+
+    case RAW_GADGET_SPEED_HIGH:
+      *kernel_speed = USB_SPEED_HIGH;
+      return RAW_GADGET_RESULT_SUCCESS;
+
+    case RAW_GADGET_SPEED_INVALID:
+    default:
+      return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+}
+
+static raw_gadget_result_t raw_gadget_context_validate(
+    raw_gadget_context_t const *context)
+{
+  if (context == NULL)
+  {
+    return RAW_GADGET_RESULT_INVALID_HANDLE;
+  }
+
+  if (!context->available)
+  {
+    return RAW_GADGET_RESULT_NOT_AVAILABLE;
+  }
+
+  if (!context->initialized ||
+      (context->file_descriptor == RAW_GADGET_INVALID_FILE_DESCRIPTOR))
+  {
+    return RAW_GADGET_RESULT_NOT_INITIALIZED;
+  }
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+//--------------------------------------------------------------------+
+// Controller API
+//--------------------------------------------------------------------+
+
+raw_gadget_result_t raw_gadget_init(raw_gadget_handle_t handle,
+                                    raw_gadget_speed_t speed,
+                                    raw_gadget_event_callback_t callback)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_result_t result;
+  struct usb_raw_init init = {0};
+  uint8_t kernel_speed;
+  int file_descriptor;
+
+  if (callback == NULL)
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  result = raw_gadget_speed_convert(speed, &kernel_speed);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  result = raw_gadget_udc_discover_once();
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  context = raw_gadget_context_get(handle);
+  if (context == NULL)
+  {
+    return RAW_GADGET_RESULT_INVALID_HANDLE;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  if (!context->available)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_NOT_AVAILABLE;
+  }
+
+  if (context->initialized)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_ALREADY_INITIALIZED;
+  }
+
+  file_descriptor = open(RAW_GADGET_DEVICE_PATH, O_RDWR | O_CLOEXEC);
+  if (file_descriptor < 0)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  if ((strlen(RAW_GADGET_UDC_DRIVER_NAME) >= sizeof(init.driver_name)) ||
+      (strlen(context->udc_name) >= sizeof(init.device_name)))
+  {
+    (void) close(file_descriptor);
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  (void) strcpy((char *) init.driver_name, RAW_GADGET_UDC_DRIVER_NAME);
+  (void) strcpy((char *) init.device_name, context->udc_name);
+  init.speed = kernel_speed;
+
+  if (ioctl(file_descriptor, USB_RAW_IOCTL_INIT, &init) < 0)
+  {
+    (void) close(file_descriptor);
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  context->speed = speed;
+  context->ep0_max_packet_size =
+      speed == RAW_GADGET_SPEED_LOW ? 8u : 64u;
+  context->file_descriptor = file_descriptor;
+  context->event_callback = callback;
+  context->initialized = true;
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+raw_gadget_result_t raw_gadget_deinit(raw_gadget_handle_t handle)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_result_t result;
+  raw_gadget_result_t close_result;
+  int file_descriptor;
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  context->shutting_down = true;
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  /*
+   * Endpoint close cancels all transfer workers before disabling the kernel
+   * endpoints. The event worker is stopped afterwards so no new HAL events can
+   * be dispatched while the context is reset.
+   */
+  close_result = raw_gadget_endpoint_close_all(handle);
+  raw_gadget_event_stop(context);
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  file_descriptor = context->file_descriptor;
+  raw_gadget_context_reset(context);
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  if ((file_descriptor != RAW_GADGET_INVALID_FILE_DESCRIPTOR) &&
+      (close(file_descriptor) != 0))
+  {
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  return close_result;
+}
+
+raw_gadget_result_t raw_gadget_connect(raw_gadget_handle_t handle)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_result_t result;
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  if (context->event_thread_created)
+  {
+    return RAW_GADGET_RESULT_SUCCESS;
+  }
+
+  if (ioctl(context->file_descriptor, USB_RAW_IOCTL_RUN, 0) < 0)
+  {
+    TU_LOG1(
+            "Raw Gadget: USB_RAW_IOCTL_RUN failed: errno=%d (%s)\r\n",
+            errno,
+            strerror(errno));
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  result = raw_gadget_event_start(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    TU_LOG1(
+            "Raw Gadget: event thread start failed: result=%d\r\n",
+            (int) result);
+    /*
+     * USB_RAW_IOCTL_RUN cannot be reversed. Destroy the Raw Gadget instance
+     * if the event worker cannot be started, otherwise the connected device
+     * would remain active without processing control requests.
+     */
+    (void) raw_gadget_deinit(handle);
+    return result;
+  }
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+raw_gadget_result_t raw_gadget_disconnect(raw_gadget_handle_t handle)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_result_t result;
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  /*
+   * Raw Gadget currently has no ioctl for a reversible software disconnect.
+   * Closing the file descriptor disconnects and destroys the instance, which
+   * is handled by raw_gadget_deinit().
+   */
+  return RAW_GADGET_RESULT_UNSUPPORTED;
+}
+
+raw_gadget_result_t raw_gadget_configure(raw_gadget_handle_t handle)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_result_t result;
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  if (context->configured)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_SUCCESS;
+  }
+
+  if (ioctl(context->file_descriptor, USB_RAW_IOCTL_CONFIGURE, 0) < 0)
+  {
+    TU_LOG1("Raw Gadget HAL: CONFIGURE failed: errno=%d (%s)\r\n",
+            errno,
+            strerror(errno));
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  context->configured = true;
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+raw_gadget_result_t raw_gadget_set_vbus_draw(raw_gadget_handle_t handle,
+                                             uint16_t current_ma)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_result_t result;
+  uint32_t current_units;
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  /*
+   * USB_RAW_IOCTL_VBUS_DRAW expects the current limit in units of 2 mA.
+   * Round odd milliampere values up so the requested limit is not reduced.
+   */
+  current_units = ((uint32_t) current_ma + 1u) / 2u;
+
+  if (ioctl(context->file_descriptor,
+            USB_RAW_IOCTL_VBUS_DRAW,
+            &current_units) < 0)
+  {
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}

--- a/src/portable/linux/raw_gadget/raw_gadget_hal.h
+++ b/src/portable/linux/raw_gadget/raw_gadget_hal.h
@@ -1,0 +1,306 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Types
+//--------------------------------------------------------------------+
+
+/**
+ * @brief Raw Gadget controller handle.
+ *
+ * The handle identifies one Linux Raw Gadget instance. Handle values are
+ * mapped to dummy UDC instances by the implementation.
+ */
+typedef uint8_t raw_gadget_handle_t;
+
+/**
+ * @brief Result codes returned by the Raw Gadget HAL.
+ */
+typedef enum
+{
+  RAW_GADGET_RESULT_SUCCESS = 0,
+  RAW_GADGET_RESULT_INVALID_ARGUMENT,
+  RAW_GADGET_RESULT_INVALID_HANDLE,
+  RAW_GADGET_RESULT_NOT_AVAILABLE,
+  RAW_GADGET_RESULT_ALREADY_INITIALIZED,
+  RAW_GADGET_RESULT_NOT_INITIALIZED,
+  RAW_GADGET_RESULT_BUSY,
+  RAW_GADGET_RESULT_UNSUPPORTED,
+  RAW_GADGET_RESULT_NO_MEMORY,
+  RAW_GADGET_RESULT_IO_ERROR,
+  RAW_GADGET_RESULT_INTERNAL_ERROR
+} raw_gadget_result_t;
+
+/**
+ * @brief USB device operating speed.
+ */
+typedef enum
+{
+  RAW_GADGET_SPEED_INVALID = 0,
+  RAW_GADGET_SPEED_LOW,
+  RAW_GADGET_SPEED_FULL,
+  RAW_GADGET_SPEED_HIGH
+} raw_gadget_speed_t;
+
+/**
+ * @brief Transfer completion status.
+ */
+typedef enum
+{
+  RAW_GADGET_TRANSFER_RESULT_SUCCESS = 0,
+  RAW_GADGET_TRANSFER_RESULT_FAILED,
+  RAW_GADGET_TRANSFER_RESULT_STALLED,
+  RAW_GADGET_TRANSFER_RESULT_CANCELLED
+} raw_gadget_transfer_result_t;
+
+/**
+ * @brief Raw Gadget event type.
+ */
+typedef enum
+{
+  RAW_GADGET_EVENT_CONNECT = 0,
+  RAW_GADGET_EVENT_RESET,
+  RAW_GADGET_EVENT_SUSPEND,
+  RAW_GADGET_EVENT_RESUME,
+  RAW_GADGET_EVENT_DISCONNECT,
+  RAW_GADGET_EVENT_SETUP_RECEIVED,
+  RAW_GADGET_EVENT_TRANSFER_COMPLETE
+} raw_gadget_event_type_t;
+
+/**
+ * @brief USB control request received on endpoint zero.
+ *
+ * The request contains the unmodified eight-byte USB setup packet in wire
+ * format. Interpretation and byte-order conversion are intentionally left to
+ * the caller.
+ */
+typedef struct
+{
+  uint8_t data[8];
+} raw_gadget_control_request_t;
+
+/**
+ * @brief Raw Gadget event.
+ *
+ * The callback receives a pointer to this object. The object is valid only for
+ * the duration of the callback and must be copied by the caller if it is needed
+ * afterwards.
+ */
+typedef struct
+{
+  raw_gadget_event_type_t type;
+
+  union
+  {
+    struct
+    {
+      raw_gadget_speed_t speed;
+    } connect;
+
+    struct
+    {
+      raw_gadget_speed_t speed;
+    } reset;
+
+    raw_gadget_control_request_t setup;
+
+    struct
+    {
+      uint8_t endpoint_address;
+      size_t transferred_bytes;
+      raw_gadget_transfer_result_t result;
+    } transfer;
+  } data;
+} raw_gadget_event_t;
+
+/**
+ * @brief Raw Gadget event callback.
+ *
+ * The callback may be invoked from an implementation-owned worker thread.
+ * Callback implementations must therefore be thread-safe and must not block
+ * indefinitely.
+ *
+ * @param handle Raw Gadget controller handle that generated the event.
+ * @param event Event information.
+ */
+typedef void (*raw_gadget_event_callback_t)(raw_gadget_handle_t handle,
+                                            raw_gadget_event_t const *event);
+
+//--------------------------------------------------------------------+
+// Controller API
+//--------------------------------------------------------------------+
+
+/**
+ * @brief Initialize a Raw Gadget controller.
+ *
+ * The implementation maps @p handle to a Linux dummy UDC instance, opens the
+ * Raw Gadget device, initializes the kernel interface and starts event
+ * processing.
+ *
+ * @param handle Raw Gadget controller handle.
+ * @param speed Maximum USB device speed requested for the controller.
+ * @param callback Callback used to report controller and transfer events.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_init(raw_gadget_handle_t handle,
+                                    raw_gadget_speed_t speed,
+                                    raw_gadget_event_callback_t callback);
+
+/**
+ * @brief Deinitialize a Raw Gadget controller.
+ *
+ * Pending transfers are cancelled, enabled endpoints are disabled, event
+ * processing is stopped and all resources owned by the controller are
+ * released.
+ *
+ * @param handle Raw Gadget controller handle.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_deinit(raw_gadget_handle_t handle);
+
+/**
+ * @brief Connect the emulated USB device to its host.
+ *
+ * @param handle Raw Gadget controller handle.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_connect(raw_gadget_handle_t handle);
+
+/**
+ * @brief Disconnect the emulated USB device from its host.
+ *
+ * @param handle Raw Gadget controller handle.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_disconnect(raw_gadget_handle_t handle);
+
+/**
+ * @brief Notify the Raw Gadget controller that the device is configured.
+ *
+ * @param handle Raw Gadget controller handle.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_configure(raw_gadget_handle_t handle);
+
+/**
+ * @brief Set the USB bus current draw reported to the Raw Gadget controller.
+ *
+ * @param handle Raw Gadget controller handle.
+ * @param current_ma Current draw in milliamperes.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_set_vbus_draw(raw_gadget_handle_t handle,
+                                             uint16_t current_ma);
+
+//--------------------------------------------------------------------+
+// Endpoint API
+//--------------------------------------------------------------------+
+
+/**
+ * @brief Enable a non-control endpoint.
+ *
+ * @param handle Raw Gadget controller handle.
+ * @param descriptor USB endpoint descriptor in wire format.
+ * @param descriptor_length Size of @p descriptor in bytes.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_endpoint_open(raw_gadget_handle_t handle,
+                                             uint8_t const *descriptor,
+                                             size_t descriptor_length);
+
+/**
+ * @brief Disable an endpoint.
+ *
+ * @param handle Raw Gadget controller handle.
+ * @param endpoint_address USB endpoint address.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_endpoint_close(raw_gadget_handle_t handle,
+                                              uint8_t endpoint_address);
+
+/**
+ * @brief Disable all non-control endpoints.
+ *
+ * @param handle Raw Gadget controller handle.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_endpoint_close_all(raw_gadget_handle_t handle);
+
+/**
+ * @brief Submit an endpoint transfer.
+ *
+ * Transfer completion is reported asynchronously through
+ * RAW_GADGET_EVENT_TRANSFER_COMPLETE.
+ *
+ * @param handle Raw Gadget controller handle.
+ * @param endpoint_address USB endpoint address.
+ * @param buffer Transfer buffer.
+ * @param length Number of bytes to transfer.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS if the transfer was accepted; otherwise an
+ * error code.
+ */
+raw_gadget_result_t raw_gadget_endpoint_transfer(raw_gadget_handle_t handle,
+                                                 uint8_t endpoint_address,
+                                                 uint8_t *buffer,
+                                                 size_t length);
+
+/**
+ * @brief Cancel a pending endpoint transfer.
+ *
+ * @param handle Raw Gadget controller handle.
+ * @param endpoint_address USB endpoint address.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_endpoint_transfer_cancel(raw_gadget_handle_t handle,
+                                                        uint8_t endpoint_address);
+
+/**
+ * @brief Stall an endpoint.
+ *
+ * @param handle Raw Gadget controller handle.
+ * @param endpoint_address USB endpoint address.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_endpoint_stall(raw_gadget_handle_t handle,
+                                              uint8_t endpoint_address);
+
+/**
+ * @brief Clear the stall condition of an endpoint.
+ *
+ * @param handle Raw Gadget controller handle.
+ * @param endpoint_address USB endpoint address.
+ *
+ * @return RAW_GADGET_RESULT_SUCCESS on success; otherwise an error code.
+ */
+raw_gadget_result_t raw_gadget_endpoint_clear_stall(raw_gadget_handle_t handle,
+                                                    uint8_t endpoint_address);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/portable/linux/raw_gadget/raw_gadget_private.h
+++ b/src/portable/linux/raw_gadget/raw_gadget_private.h
@@ -1,0 +1,172 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#pragma once
+
+#include "raw_gadget_hal.h"
+#include "common/tusb_debug.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+#include <linux/usb/raw_gadget.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Constants
+//--------------------------------------------------------------------+
+
+/** Linux Raw Gadget device node. */
+#define RAW_GADGET_DEVICE_PATH "/dev/raw-gadget"
+
+/** Linux dummy UDC driver name. */
+#define RAW_GADGET_UDC_DRIVER_NAME "dummy_udc"
+
+/** Linux sysfs directory containing the available UDC instances. */
+#define RAW_GADGET_UDC_SYSFS_PATH "/sys/class/udc"
+
+/** Invalid file descriptor value. */
+#define RAW_GADGET_INVALID_FILE_DESCRIPTOR (-1)
+
+/** Maximum number of USB endpoint addresses, including both directions. */
+#define RAW_GADGET_ENDPOINT_COUNT 32u
+
+/** Invalid Raw Gadget kernel endpoint handle. */
+#define RAW_GADGET_INVALID_ENDPOINT_HANDLE UINT32_MAX
+
+//--------------------------------------------------------------------+
+// Internal Types
+//--------------------------------------------------------------------+
+
+/**
+ * @brief Internal state of one USB endpoint address.
+ *
+ * Endpoint zero uses only the transfer-related members. Non-control endpoints
+ * additionally use @ref enabled and @ref kernel_handle.
+ */
+typedef struct
+{
+  bool enabled;
+  uint8_t address;
+  uint32_t kernel_handle;
+
+  bool transfer_active;
+  bool transfer_thread_created;
+  bool transfer_cancel_pending;
+  pthread_t transfer_thread;
+} raw_gadget_endpoint_t;
+
+/**
+ * @brief Internal state of one Raw Gadget controller.
+ */
+typedef struct
+{
+  bool available;
+  bool initialized;
+  bool shutting_down;
+  bool event_thread_created;
+
+  raw_gadget_handle_t handle;
+  raw_gadget_speed_t speed;
+
+  char udc_name[UDC_NAME_LENGTH_MAX];
+
+  int file_descriptor;
+
+  pthread_t event_thread;
+  pthread_mutex_t mutex;
+  pthread_mutex_t callback_mutex;
+  pthread_cond_t ep0_condition;
+  atomic_bool event_thread_running;
+
+  bool ep0_request_active;
+  bool ep0_direction_in;
+  uint16_t ep0_requested_length;
+  uint16_t ep0_max_packet_size;
+  size_t ep0_accumulated_length;
+  uint8_t *ep0_buffer;
+  size_t ep0_buffer_capacity;
+  bool configured;
+  uint32_t transfer_generation;
+
+  raw_gadget_event_callback_t event_callback;
+
+  raw_gadget_endpoint_t endpoints[RAW_GADGET_ENDPOINT_COUNT];
+} raw_gadget_context_t;
+
+/**
+ * @brief Global Raw Gadget context manager.
+ */
+typedef struct
+{
+  raw_gadget_context_t *contexts;
+  size_t context_count;
+
+  pthread_mutex_t mutex;
+  bool discovered;
+} raw_gadget_manager_t;
+
+//--------------------------------------------------------------------+
+// Manager and Context API
+//--------------------------------------------------------------------+
+
+raw_gadget_manager_t *raw_gadget_manager_get(void);
+raw_gadget_result_t raw_gadget_context_table_create(size_t context_count);
+void raw_gadget_context_table_destroy(void);
+raw_gadget_context_t *raw_gadget_context_get(raw_gadget_handle_t handle);
+void raw_gadget_context_reset(raw_gadget_context_t *context);
+
+//--------------------------------------------------------------------+
+// Endpoint Helpers
+//--------------------------------------------------------------------+
+
+size_t raw_gadget_endpoint_index(uint8_t endpoint_address);
+
+raw_gadget_endpoint_t *raw_gadget_endpoint_get(raw_gadget_context_t *context,
+                                               uint8_t endpoint_address);
+
+//--------------------------------------------------------------------+
+// Transfer Helpers
+//--------------------------------------------------------------------+
+
+/**
+ * @brief Cancel and reap all endpoint transfer threads of a context.
+ *
+ * The context must still be initialized and its file descriptor must remain
+ * valid while this function runs.
+ *
+ * @param context Raw Gadget context.
+ */
+void raw_gadget_transfer_cancel_all(raw_gadget_context_t *context);
+
+//--------------------------------------------------------------------+
+// UDC Discovery API
+//--------------------------------------------------------------------+
+
+raw_gadget_result_t raw_gadget_udc_discover(void);
+raw_gadget_result_t raw_gadget_udc_discover_once(void);
+
+//--------------------------------------------------------------------+
+// Event API
+//--------------------------------------------------------------------+
+
+raw_gadget_result_t raw_gadget_event_start(raw_gadget_context_t *context);
+void raw_gadget_event_stop(raw_gadget_context_t *context);
+void raw_gadget_event_dispatch(raw_gadget_context_t *context,
+                               raw_gadget_event_t const *event);
+void raw_gadget_event_dispatch_transfer(raw_gadget_context_t *context,
+                                        raw_gadget_event_t const *event,
+                                        uint32_t generation);
+void raw_gadget_control_request_complete_internal(raw_gadget_context_t *context);
+void raw_gadget_bus_reset_prepare(raw_gadget_context_t *context);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/portable/linux/raw_gadget/raw_gadget_transfer.c
+++ b/src/portable/linux/raw_gadget/raw_gadget_transfer.c
@@ -1,0 +1,520 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "raw_gadget_private.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#include <linux/usb/ch9.h>
+
+//--------------------------------------------------------------------+
+// Internal Types
+//--------------------------------------------------------------------+
+
+typedef struct
+{
+  raw_gadget_context_t *context;
+  raw_gadget_endpoint_t *endpoint;
+
+  uint8_t endpoint_address;
+  uint8_t *buffer;
+  size_t length;
+
+  struct usb_raw_ep_io *io;
+  raw_gadget_transfer_result_t result;
+  size_t transferred_bytes;
+  size_t completion_bytes;
+  bool use_completion_bytes;
+  bool perform_ioctl;
+  bool force_ep0_read;
+  bool complete_control_request;
+  uint32_t generation;
+} raw_gadget_transfer_job_t;
+
+//--------------------------------------------------------------------+
+// Internal Helpers
+//--------------------------------------------------------------------+
+
+static bool raw_gadget_transfer_endpoint_address_valid(uint8_t endpoint_address)
+{
+  return (endpoint_address & 0x70u) == 0u;
+}
+
+static raw_gadget_result_t raw_gadget_transfer_context_validate(
+    raw_gadget_context_t const *context)
+{
+  if (context == NULL)
+  {
+    return RAW_GADGET_RESULT_INVALID_HANDLE;
+  }
+
+  if (!context->available)
+  {
+    return RAW_GADGET_RESULT_NOT_AVAILABLE;
+  }
+
+  if (!context->initialized ||
+      (context->file_descriptor == RAW_GADGET_INVALID_FILE_DESCRIPTOR))
+  {
+    return RAW_GADGET_RESULT_NOT_INITIALIZED;
+  }
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+static raw_gadget_transfer_result_t raw_gadget_transfer_result_from_errno(
+    int error_number)
+{
+  switch (error_number)
+  {
+    case EPIPE:
+      return RAW_GADGET_TRANSFER_RESULT_STALLED;
+
+    case ECANCELED:
+      return RAW_GADGET_TRANSFER_RESULT_CANCELLED;
+
+    default:
+      return RAW_GADGET_TRANSFER_RESULT_FAILED;
+  }
+}
+
+static void raw_gadget_transfer_job_cleanup(void *argument)
+{
+  raw_gadget_transfer_job_t *job = argument;
+  raw_gadget_event_t event;
+  bool detach_thread = false;
+  bool dispatch_event = false;
+
+  if (job == NULL)
+  {
+    return;
+  }
+
+  if (job->result == RAW_GADGET_TRANSFER_RESULT_CANCELLED)
+  {
+    job->transferred_bytes = 0;
+  }
+
+  memset(&event, 0, sizeof(event));
+  event.type = RAW_GADGET_EVENT_TRANSFER_COMPLETE;
+  event.data.transfer.endpoint_address = job->endpoint_address;
+  event.data.transfer.transferred_bytes = job->transferred_bytes;
+  event.data.transfer.result = job->result;
+
+  if (pthread_mutex_lock(&job->context->mutex) == 0)
+  {
+    job->endpoint->transfer_active = false;
+
+    if (!job->endpoint->transfer_cancel_pending)
+    {
+      job->endpoint->transfer_thread_created = false;
+      memset(&job->endpoint->transfer_thread,
+             0,
+             sizeof(job->endpoint->transfer_thread));
+
+      detach_thread = true;
+      dispatch_event = job->context->initialized &&
+                       !job->context->shutting_down;
+    }
+
+    (void) pthread_mutex_unlock(&job->context->mutex);
+  }
+
+  if (detach_thread)
+  {
+    (void) pthread_detach(pthread_self());
+  }
+
+  if (dispatch_event)
+  {
+    raw_gadget_event_dispatch_transfer(job->context, &event, job->generation);
+  }
+
+  if (job->complete_control_request && dispatch_event &&
+      (job->result == RAW_GADGET_TRANSFER_RESULT_SUCCESS))
+  {
+    raw_gadget_control_request_complete_internal(job->context);
+  }
+
+  free(job->io);
+  free(job);
+}
+
+static int raw_gadget_transfer_ioctl(raw_gadget_transfer_job_t *job)
+{
+  bool endpoint_zero;
+  bool direction_in;
+  unsigned long request;
+  int result;
+  int saved_errno;
+
+  endpoint_zero = (job->endpoint_address & USB_ENDPOINT_NUMBER_MASK) == 0u;
+  direction_in = (job->endpoint_address & USB_DIR_IN) != 0u;
+
+  if (endpoint_zero)
+  {
+     request = job->force_ep0_read
+                  ? USB_RAW_IOCTL_EP0_READ
+                  : (direction_in ? USB_RAW_IOCTL_EP0_WRITE
+                                  : USB_RAW_IOCTL_EP0_READ);
+  }
+  else
+  {
+     request = direction_in ? USB_RAW_IOCTL_EP_WRITE : USB_RAW_IOCTL_EP_READ;
+  }
+
+  result = ioctl(job->context->file_descriptor, request, job->io);
+  saved_errno = errno;
+
+  errno = saved_errno;
+  return result;
+}
+static void *raw_gadget_transfer_thread(void *argument)
+{
+  raw_gadget_transfer_job_t *job = argument;
+  int ioctl_result;
+  int previous_cancel_state;
+  int previous_cancel_type;
+
+  if (job == NULL)
+  {
+    return NULL;
+  }
+
+  (void) pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &previous_cancel_state);
+  (void) pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, &previous_cancel_type);
+
+  pthread_cleanup_push(raw_gadget_transfer_job_cleanup, job);
+
+  if (!job->perform_ioctl)
+  {
+    job->result = RAW_GADGET_TRANSFER_RESULT_SUCCESS;
+    job->transferred_bytes = job->completion_bytes;
+  }
+  else
+  {
+    ioctl_result = raw_gadget_transfer_ioctl(job);
+    if (ioctl_result < 0)
+    {
+      job->result = raw_gadget_transfer_result_from_errno(errno);
+      job->transferred_bytes = 0;
+    }
+    else
+    {
+      job->result = RAW_GADGET_TRANSFER_RESULT_SUCCESS;
+      job->transferred_bytes = job->use_completion_bytes
+                                 ? job->completion_bytes
+                                 : (size_t) ioctl_result;
+
+      if (((job->endpoint_address & USB_DIR_IN) == 0u) &&
+          (job->transferred_bytes > 0))
+      {
+        memcpy(job->buffer, job->io->data, job->transferred_bytes);
+      }
+    }
+  }
+
+  pthread_cleanup_pop(1);
+
+  (void) pthread_setcanceltype(previous_cancel_type, NULL);
+  (void) pthread_setcancelstate(previous_cancel_state, NULL);
+
+  return NULL;
+}
+
+static raw_gadget_result_t raw_gadget_transfer_cancel_endpoint(
+    raw_gadget_context_t *context,
+    raw_gadget_endpoint_t *endpoint)
+{
+  pthread_t transfer_thread;
+  bool cancel_required = false;
+  bool join_required = false;
+  int cancel_result = 0;
+  int join_result = 0;
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  if (endpoint->transfer_thread_created)
+  {
+    transfer_thread = endpoint->transfer_thread;
+    endpoint->transfer_cancel_pending = true;
+    cancel_required = endpoint->transfer_active;
+    join_required = true;
+  }
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  if (cancel_required)
+  {
+    cancel_result = pthread_cancel(transfer_thread);
+  }
+
+  if (join_required)
+  {
+    join_result = pthread_join(transfer_thread, NULL);
+
+    if (pthread_mutex_lock(&context->mutex) != 0)
+    {
+      return RAW_GADGET_RESULT_INTERNAL_ERROR;
+    }
+
+    endpoint->transfer_active = false;
+    endpoint->transfer_thread_created = false;
+    endpoint->transfer_cancel_pending = false;
+    memset(&endpoint->transfer_thread, 0, sizeof(endpoint->transfer_thread));
+
+    (void) pthread_mutex_unlock(&context->mutex);
+  }
+
+  if ((cancel_result != 0) || (join_result != 0))
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+//--------------------------------------------------------------------+
+// Transfer API
+//--------------------------------------------------------------------+
+
+raw_gadget_result_t raw_gadget_endpoint_transfer(raw_gadget_handle_t handle,
+                                                 uint8_t endpoint_address,
+                                                 uint8_t *buffer,
+                                                 size_t length)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_endpoint_t *endpoint;
+  raw_gadget_transfer_job_t *job;
+  raw_gadget_result_t result;
+  size_t allocation_size;
+  size_t ioctl_length;
+  bool endpoint_zero;
+  bool direction_in;
+  bool ep0_status_stage = false;
+  bool ep0_real_status_stage = false;
+  bool ep0_in_data = false;
+  bool ep0_in_complete = false;
+  int create_result;
+
+  if (!raw_gadget_transfer_endpoint_address_valid(endpoint_address) ||
+      ((buffer == NULL) && (length != 0u)) || (length > UINT32_MAX))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_transfer_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  endpoint = raw_gadget_endpoint_get(context, endpoint_address);
+  endpoint_zero = (endpoint_address & USB_ENDPOINT_NUMBER_MASK) == 0u;
+  direction_in = (endpoint_address & USB_DIR_IN) != 0u;
+
+  if (pthread_mutex_lock(&context->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  if (endpoint_zero && context->ep0_request_active)
+  {
+    ep0_status_stage = (length == 0u) &&
+                       (direction_in != context->ep0_direction_in);
+    ep0_real_status_stage = ep0_status_stage &&
+                            (context->ep0_requested_length == 0u);
+    ep0_in_data = context->ep0_direction_in && direction_in &&
+                  !ep0_status_stage;
+  }
+
+  if (ep0_status_stage && !ep0_real_status_stage)
+  {
+    raw_gadget_event_t event = {0};
+
+    (void) pthread_mutex_unlock(&context->mutex);
+
+    event.type = RAW_GADGET_EVENT_TRANSFER_COMPLETE;
+    event.data.transfer.endpoint_address = endpoint_address;
+    event.data.transfer.transferred_bytes = 0;
+    event.data.transfer.result = RAW_GADGET_TRANSFER_RESULT_SUCCESS;
+
+    raw_gadget_event_dispatch(context, &event);
+    raw_gadget_control_request_complete_internal(context);
+    return RAW_GADGET_RESULT_SUCCESS;
+  }
+
+  if (endpoint->transfer_active || endpoint->transfer_thread_created ||
+      endpoint->transfer_cancel_pending)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_BUSY;
+  }
+
+  if (!endpoint_zero && !endpoint->enabled)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_NOT_AVAILABLE;
+  }
+
+  if (!endpoint_zero && (endpoint->kernel_handle > UINT16_MAX))
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  ioctl_length = length;
+
+  if (ep0_in_data)
+  {
+    size_t required_length;
+    uint8_t *new_buffer;
+
+    if (length > SIZE_MAX - context->ep0_accumulated_length)
+    {
+      (void) pthread_mutex_unlock(&context->mutex);
+      return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+    }
+
+    required_length = context->ep0_accumulated_length + length;
+    if (required_length > context->ep0_buffer_capacity)
+    {
+      new_buffer = realloc(context->ep0_buffer, required_length);
+      if (new_buffer == NULL)
+      {
+        (void) pthread_mutex_unlock(&context->mutex);
+        return RAW_GADGET_RESULT_NO_MEMORY;
+      }
+
+      context->ep0_buffer = new_buffer;
+      context->ep0_buffer_capacity = required_length;
+    }
+
+    if (length > 0u)
+    {
+      memcpy(&context->ep0_buffer[context->ep0_accumulated_length],
+             buffer,
+             length);
+    }
+
+    context->ep0_accumulated_length = required_length;
+    ep0_in_complete =
+        (required_length >= context->ep0_requested_length) ||
+        (length < context->ep0_max_packet_size);
+    ioctl_length = ep0_in_complete ? required_length : 0u;
+  }
+
+  allocation_size = sizeof(struct usb_raw_ep_io) + ioctl_length;
+  job = calloc(1, sizeof(*job));
+  if (job == NULL)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    return RAW_GADGET_RESULT_NO_MEMORY;
+  }
+
+  job->io = malloc(allocation_size);
+  if (job->io == NULL)
+  {
+    (void) pthread_mutex_unlock(&context->mutex);
+    free(job);
+    return RAW_GADGET_RESULT_NO_MEMORY;
+  }
+
+  job->context = context;
+  job->endpoint = endpoint;
+  job->endpoint_address = endpoint_address;
+  job->buffer = buffer;
+  job->length = ioctl_length;
+  job->result = RAW_GADGET_TRANSFER_RESULT_CANCELLED;
+  job->transferred_bytes = 0;
+  job->completion_bytes = length;
+  job->use_completion_bytes = ep0_in_data;
+  job->perform_ioctl = !ep0_in_data || ep0_in_complete;
+  job->force_ep0_read = ep0_real_status_stage && !context->ep0_direction_in;
+  job->complete_control_request = ep0_real_status_stage;
+  job->generation = context->transfer_generation;
+
+  job->io->ep = endpoint_zero ? 0u : (uint16_t) endpoint->kernel_handle;
+  job->io->flags = 0;
+  job->io->length = (uint32_t) ioctl_length;
+
+  if (ep0_in_data && ep0_in_complete && (ioctl_length > 0u))
+  {
+    memcpy(job->io->data, context->ep0_buffer, ioctl_length);
+  }
+  else if (!ep0_in_data && direction_in && (length > 0u))
+  {
+    memcpy(job->io->data, buffer, length);
+  }
+
+  endpoint->transfer_active = true;
+  endpoint->transfer_cancel_pending = false;
+
+  create_result =
+      pthread_create(&endpoint->transfer_thread, NULL, raw_gadget_transfer_thread, job);
+  if (create_result != 0)
+  {
+    endpoint->transfer_active = false;
+    memset(&endpoint->transfer_thread, 0, sizeof(endpoint->transfer_thread));
+    (void) pthread_mutex_unlock(&context->mutex);
+    free(job->io);
+    free(job);
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  endpoint->transfer_thread_created = true;
+
+  (void) pthread_mutex_unlock(&context->mutex);
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+raw_gadget_result_t raw_gadget_endpoint_transfer_cancel(
+    raw_gadget_handle_t handle,
+    uint8_t endpoint_address)
+{
+  raw_gadget_context_t *context;
+  raw_gadget_endpoint_t *endpoint;
+  raw_gadget_result_t result;
+
+  if (!raw_gadget_transfer_endpoint_address_valid(endpoint_address))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  context = raw_gadget_context_get(handle);
+  result = raw_gadget_transfer_context_validate(context);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    return result;
+  }
+
+  endpoint = raw_gadget_endpoint_get(context, endpoint_address);
+
+  return raw_gadget_transfer_cancel_endpoint(context, endpoint);
+}
+
+void raw_gadget_transfer_cancel_all(raw_gadget_context_t *context)
+{
+  if (context == NULL)
+  {
+    return;
+  }
+
+  for (size_t index = 0; index < RAW_GADGET_ENDPOINT_COUNT; index++)
+  {
+    (void) raw_gadget_transfer_cancel_endpoint(context,
+                                               &context->endpoints[index]);
+  }
+}

--- a/src/portable/linux/raw_gadget/raw_gadget_udc.c
+++ b/src/portable/linux/raw_gadget/raw_gadget_udc.c
@@ -1,0 +1,249 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Roman Buchert
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "raw_gadget_private.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+//--------------------------------------------------------------------+
+// Internal Types
+//--------------------------------------------------------------------+
+
+typedef struct
+{
+  raw_gadget_handle_t handle;
+  char name[UDC_NAME_LENGTH_MAX];
+} raw_gadget_udc_entry_t;
+
+//--------------------------------------------------------------------+
+// Internal Helpers
+//--------------------------------------------------------------------+
+
+static bool raw_gadget_udc_name_parse(char const *name,
+                                      raw_gadget_handle_t *handle)
+{
+  static char const prefix[] = RAW_GADGET_UDC_DRIVER_NAME ".";
+  char *end;
+  unsigned long index;
+
+  if ((name == NULL) || (handle == NULL))
+  {
+    return false;
+  }
+
+  if (strncmp(name, prefix, sizeof(prefix) - 1u) != 0)
+  {
+    return false;
+  }
+
+  if (name[sizeof(prefix) - 1u] == '\0')
+  {
+    return false;
+  }
+
+  errno = 0;
+  index = strtoul(&name[sizeof(prefix) - 1u], &end, 10);
+
+  if ((errno != 0) || (*end != '\0') || (index > UINT8_MAX))
+  {
+    return false;
+  }
+
+  *handle = (raw_gadget_handle_t) index;
+
+  return true;
+}
+
+static raw_gadget_result_t raw_gadget_udc_entries_append(
+    raw_gadget_udc_entry_t **entries,
+    size_t *entry_count,
+    size_t *entry_capacity,
+    char const *name,
+    raw_gadget_handle_t handle)
+{
+  raw_gadget_udc_entry_t *new_entries;
+  size_t new_capacity;
+  raw_gadget_udc_entry_t *entry;
+
+  if ((entries == NULL) || (entry_count == NULL) ||
+      (entry_capacity == NULL) || (name == NULL))
+  {
+    return RAW_GADGET_RESULT_INVALID_ARGUMENT;
+  }
+
+  if (*entry_count == *entry_capacity)
+  {
+    new_capacity = (*entry_capacity == 0u) ? 4u : (*entry_capacity * 2u);
+
+    if (new_capacity > (SIZE_MAX / sizeof(**entries)))
+    {
+      return RAW_GADGET_RESULT_NO_MEMORY;
+    }
+
+    new_entries = realloc(*entries, new_capacity * sizeof(**entries));
+    if (new_entries == NULL)
+    {
+      return RAW_GADGET_RESULT_NO_MEMORY;
+    }
+
+    *entries = new_entries;
+    *entry_capacity = new_capacity;
+  }
+
+  entry = &(*entries)[*entry_count];
+  entry->handle = handle;
+
+  if (strlen(name) >= sizeof(entry->name))
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  (void) strcpy(entry->name, name);
+  (*entry_count)++;
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+//--------------------------------------------------------------------+
+// UDC Discovery API
+//--------------------------------------------------------------------+
+
+raw_gadget_result_t raw_gadget_udc_discover(void)
+{
+  raw_gadget_manager_t *manager = raw_gadget_manager_get();
+  raw_gadget_udc_entry_t *entries = NULL;
+  size_t entry_count = 0;
+  size_t entry_capacity = 0;
+  raw_gadget_handle_t highest_handle = 0;
+  raw_gadget_result_t result = RAW_GADGET_RESULT_SUCCESS;
+  DIR *directory;
+  struct dirent *directory_entry;
+
+  if (manager == NULL)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  directory = opendir(RAW_GADGET_UDC_SYSFS_PATH);
+  if (directory == NULL)
+  {
+    return RAW_GADGET_RESULT_IO_ERROR;
+  }
+
+  while ((directory_entry = readdir(directory)) != NULL)
+  {
+    raw_gadget_handle_t handle;
+
+    if (!raw_gadget_udc_name_parse(directory_entry->d_name, &handle))
+    {
+      continue;
+    }
+
+    result = raw_gadget_udc_entries_append(&entries,
+                                           &entry_count,
+                                           &entry_capacity,
+                                           directory_entry->d_name,
+                                           handle);
+    if (result != RAW_GADGET_RESULT_SUCCESS)
+    {
+      break;
+    }
+
+    if ((entry_count == 1u) || (handle > highest_handle))
+    {
+      highest_handle = handle;
+    }
+  }
+
+  if (closedir(directory) != 0)
+  {
+    if (result == RAW_GADGET_RESULT_SUCCESS)
+    {
+      result = RAW_GADGET_RESULT_IO_ERROR;
+    }
+  }
+
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    free(entries);
+    return result;
+  }
+
+  if (entry_count == 0u)
+  {
+    free(entries);
+    return RAW_GADGET_RESULT_NOT_AVAILABLE;
+  }
+
+  result = raw_gadget_context_table_create((size_t) highest_handle + 1u);
+  if (result != RAW_GADGET_RESULT_SUCCESS)
+  {
+    free(entries);
+    return result;
+  }
+
+  for (size_t index = 0; index < entry_count; index++)
+  {
+    raw_gadget_context_t *context =
+        raw_gadget_context_get(entries[index].handle);
+
+    if (context == NULL)
+    {
+      raw_gadget_context_table_destroy();
+      free(entries);
+      return RAW_GADGET_RESULT_INTERNAL_ERROR;
+    }
+
+    context->available = true;
+    (void) strcpy(context->udc_name, entries[index].name);
+  }
+
+  free(entries);
+
+  if (pthread_mutex_lock(&manager->mutex) != 0)
+  {
+    raw_gadget_context_table_destroy();
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  manager->discovered = true;
+
+  (void) pthread_mutex_unlock(&manager->mutex);
+
+  return RAW_GADGET_RESULT_SUCCESS;
+}
+
+raw_gadget_result_t raw_gadget_udc_discover_once(void)
+{
+  raw_gadget_manager_t *manager = raw_gadget_manager_get();
+  bool discovered;
+
+  if (manager == NULL)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  if (pthread_mutex_lock(&manager->mutex) != 0)
+  {
+    return RAW_GADGET_RESULT_INTERNAL_ERROR;
+  }
+
+  discovered = manager->discovered;
+
+  (void) pthread_mutex_unlock(&manager->mutex);
+
+  if (discovered)
+  {
+    return RAW_GADGET_RESULT_SUCCESS;
+  }
+
+  return raw_gadget_udc_discover();
+}

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -207,6 +207,9 @@
 // Puya
 #define OPT_MCU_PY32F0           2700  ///< Puya PY32F0
 
+// Linux Raw Gadget
+#define OPT_MCU_LINUX_RAW_GADGET 3000 ///< Linux Raw Gadget
+
 // Check if configured MCU is one of listed
 // Apply TU_MCU_IS_EQUAL with || as separator to list of input
 #define TU_MCU_IS_EQUAL(_m)  (CFG_TUSB_MCU == (_m))


### PR DESCRIPTION
Add a TinyUSB device controller driver for the Linux Raw Gadget interface.

The driver implements the TinyUSB DCD API on top of the Linux Raw Gadget userspace interface and supports:

- Control transfers (EP0)
- Bulk endpoints
- Interrupt endpoints
- Dynamic endpoint configuration
- Remote wakeup handling
- Stall and clear-stall
- Asynchronous transfer processing

Isochronous transfers are not supported because the Linux Raw Gadget API does not expose the required functionality.

The implementation is intended for development, testing and virtual USB devices running entirely in userspace on Linux.