### PR TITLE
Cast BMaxPower in TUD_CONFIG_DESCRIPTOR to uint8_t

### DIFF
--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -13,49 +13,43 @@
 #include "tusb_compiler.h"
 
 #ifdef __cplusplus
-extern "C" {
+ extern "C" {
 #endif
 
 //------------- Device DCache declaration -------------//
-#define TUD_EPBUF_DCACHE_SIZE(_size)                                                                             \
-  (CFG_TUD_MEM_DCACHE_ENABLE ? (TU_DIV_CEIL(_size, CFG_TUD_MEM_DCACHE_LINE_SIZE) * CFG_TUD_MEM_DCACHE_LINE_SIZE) \
-                             : (_size))
+#define TUD_EPBUF_DCACHE_SIZE(_size) (CFG_TUD_MEM_DCACHE_ENABLE ? \
+  (TU_DIV_CEIL(_size, CFG_TUD_MEM_DCACHE_LINE_SIZE) * CFG_TUD_MEM_DCACHE_LINE_SIZE) : (_size))
 
 // Declare an endpoint buffer with uint8_t[size]
-#define TUD_EPBUF_DEF(_name, _size)                                               \
-  union {                                                                         \
-    CFG_TUD_MEM_ALIGN uint8_t _name[_size];                                       \
-    TU_ATTR_ALIGNED(CFG_TUD_MEM_DCACHE_ENABLE ? CFG_TUD_MEM_DCACHE_LINE_SIZE : 1) \
-    uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(_size)];                 \
+#define TUD_EPBUF_DEF(_name, _size) \
+  union { \
+    CFG_TUD_MEM_ALIGN uint8_t _name[_size]; \
+    TU_ATTR_ALIGNED(CFG_TUD_MEM_DCACHE_ENABLE ? CFG_TUD_MEM_DCACHE_LINE_SIZE : 1) uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(_size)]; \
   }
 
 // Declare an endpoint buffer with a type
-#define TUD_EPBUF_TYPE_DEF(_type, _name)                                          \
-  union {                                                                         \
-    CFG_TUD_MEM_ALIGN _type _name;                                                \
-    TU_ATTR_ALIGNED(CFG_TUD_MEM_DCACHE_ENABLE ? CFG_TUD_MEM_DCACHE_LINE_SIZE : 1) \
-    uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(sizeof(_type))];         \
+#define TUD_EPBUF_TYPE_DEF(_type, _name) \
+  union { \
+    CFG_TUD_MEM_ALIGN _type _name; \
+    TU_ATTR_ALIGNED(CFG_TUD_MEM_DCACHE_ENABLE ? CFG_TUD_MEM_DCACHE_LINE_SIZE : 1) uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(sizeof(_type))]; \
   }
 
 //------------- Host DCache declaration -------------//
-#define TUH_EPBUF_DCACHE_SIZE(_size)                                                                             \
-  (CFG_TUH_MEM_DCACHE_ENABLE ? (TU_DIV_CEIL(_size, CFG_TUH_MEM_DCACHE_LINE_SIZE) * CFG_TUH_MEM_DCACHE_LINE_SIZE) \
-                             : (_size))
+#define TUH_EPBUF_DCACHE_SIZE(_size) (CFG_TUH_MEM_DCACHE_ENABLE ? \
+  (TU_DIV_CEIL(_size, CFG_TUH_MEM_DCACHE_LINE_SIZE) * CFG_TUH_MEM_DCACHE_LINE_SIZE) : (_size))
 
 // Declare an endpoint buffer with uint8_t[size]
-#define TUH_EPBUF_DEF(_name, _size)                                               \
-  union {                                                                         \
-    CFG_TUH_MEM_ALIGN uint8_t _name[_size];                                       \
-    TU_ATTR_ALIGNED(CFG_TUH_MEM_DCACHE_ENABLE ? CFG_TUH_MEM_DCACHE_LINE_SIZE : 1) \
-    uint8_t _name##_dcache_padding[TUH_EPBUF_DCACHE_SIZE(_size)];                 \
+#define TUH_EPBUF_DEF(_name, _size) \
+  union { \
+    CFG_TUH_MEM_ALIGN uint8_t _name[_size]; \
+    TU_ATTR_ALIGNED(CFG_TUH_MEM_DCACHE_ENABLE ? CFG_TUH_MEM_DCACHE_LINE_SIZE : 1) uint8_t _name##_dcache_padding[TUH_EPBUF_DCACHE_SIZE(_size)]; \
   }
 
 // Declare an endpoint buffer with a type
-#define TUH_EPBUF_TYPE_DEF(_type, _name)                                          \
-  union {                                                                         \
-    CFG_TUH_MEM_ALIGN _type _name;                                                \
-    TU_ATTR_ALIGNED(CFG_TUH_MEM_DCACHE_ENABLE ? CFG_TUH_MEM_DCACHE_LINE_SIZE : 1) \
-    uint8_t _name##_dcache_padding[TUH_EPBUF_DCACHE_SIZE(sizeof(_type))];         \
+#define TUH_EPBUF_TYPE_DEF(_type, _name) \
+  union { \
+    CFG_TUH_MEM_ALIGN _type _name; \
+    TU_ATTR_ALIGNED(CFG_TUH_MEM_DCACHE_ENABLE ? CFG_TUH_MEM_DCACHE_LINE_SIZE : 1) uint8_t _name##_dcache_padding[TUH_EPBUF_DCACHE_SIZE(sizeof(_type))]; \
   }
 
 
@@ -71,10 +65,10 @@ typedef enum {
 
 /// defined base on EHCI specs value for Endpoint Speed
 typedef enum {
-  TUSB_SPEED_FULL    = 0,
-  TUSB_SPEED_LOW     = 1,
-  TUSB_SPEED_HIGH    = 2,
-  TUSB_SPEED_AUTO    = 0xaa,
+  TUSB_SPEED_FULL = 0,
+  TUSB_SPEED_LOW  = 1,
+  TUSB_SPEED_HIGH = 2,
+  TUSB_SPEED_AUTO = 0xaa,
   TUSB_SPEED_INVALID = 0xff,
 } tusb_speed_t;
 
@@ -105,18 +99,18 @@ enum {
 };
 
 // Endpoint Bulk size depending on host/device max speed
-#define TUD_EPSIZE_BULK_MAX (TUD_OPT_HIGH_SPEED ? 512 : 64)
-#define TUH_EPSIZE_BULK_MAX (TUH_OPT_HIGH_SPEED ? 512 : 64)
+#define TUD_EPSIZE_BULK_MAX   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define TUH_EPSIZE_BULK_MAX   (TUH_OPT_HIGH_SPEED ? 512 : 64)
 
 /// Isochronous Endpoint Attributes
 typedef enum {
-  TUSB_ISO_EP_ATT_NO_SYNC      = 0x00,
-  TUSB_ISO_EP_ATT_ASYNCHRONOUS = 0x04,
-  TUSB_ISO_EP_ATT_ADAPTIVE     = 0x08,
-  TUSB_ISO_EP_ATT_SYNCHRONOUS  = 0x0C,
-  TUSB_ISO_EP_ATT_DATA         = 0x00, ///< Data End Point
-  TUSB_ISO_EP_ATT_EXPLICIT_FB  = 0x10, ///< Feedback End Point
-  TUSB_ISO_EP_ATT_IMPLICIT_FB  = 0x20, ///< Data endpoint that also serves as an implicit feedback
+  TUSB_ISO_EP_ATT_NO_SYNC         = 0x00,
+  TUSB_ISO_EP_ATT_ASYNCHRONOUS    = 0x04,
+  TUSB_ISO_EP_ATT_ADAPTIVE        = 0x08,
+  TUSB_ISO_EP_ATT_SYNCHRONOUS     = 0x0C,
+  TUSB_ISO_EP_ATT_DATA            = 0x00, ///< Data End Point
+  TUSB_ISO_EP_ATT_EXPLICIT_FB     = 0x10, ///< Feedback End Point
+  TUSB_ISO_EP_ATT_IMPLICIT_FB     = 0x20, ///< Data endpoint that also serves as an implicit feedback
 } tusb_iso_ep_attribute_t;
 
 /// USB Descriptor Types
@@ -133,35 +127,35 @@ typedef enum {
   TUSB_DESC_DEBUG                 = 0x0A,
   TUSB_DESC_INTERFACE_ASSOCIATION = 0x0B,
 
-  TUSB_DESC_BOS               = 0x0F,
-  TUSB_DESC_DEVICE_CAPABILITY = 0x10,
+  TUSB_DESC_BOS                   = 0x0F,
+  TUSB_DESC_DEVICE_CAPABILITY     = 0x10,
 
-  TUSB_DESC_FUNCTIONAL = 0x21,
+  TUSB_DESC_FUNCTIONAL            = 0x21,
 
   // Class Specific Descriptor
-  TUSB_DESC_CS_DEVICE        = 0x21,
-  TUSB_DESC_CS_CONFIGURATION = 0x22,
-  TUSB_DESC_CS_STRING        = 0x23,
-  TUSB_DESC_CS_INTERFACE     = 0x24,
-  TUSB_DESC_CS_ENDPOINT      = 0x25,
+  TUSB_DESC_CS_DEVICE             = 0x21,
+  TUSB_DESC_CS_CONFIGURATION      = 0x22,
+  TUSB_DESC_CS_STRING             = 0x23,
+  TUSB_DESC_CS_INTERFACE          = 0x24,
+  TUSB_DESC_CS_ENDPOINT           = 0x25,
 
   TUSB_DESC_SUPERSPEED_ENDPOINT_COMPANION     = 0x30,
   TUSB_DESC_SUPERSPEED_ISO_ENDPOINT_COMPANION = 0x31
 } tusb_desc_type_t;
 
 typedef enum {
-  TUSB_REQ_GET_STATUS        = 0,
-  TUSB_REQ_CLEAR_FEATURE     = 1,
-  TUSB_REQ_RESERVED          = 2,
-  TUSB_REQ_SET_FEATURE       = 3,
-  TUSB_REQ_RESERVED2         = 4,
-  TUSB_REQ_SET_ADDRESS       = 5,
-  TUSB_REQ_GET_DESCRIPTOR    = 6,
-  TUSB_REQ_SET_DESCRIPTOR    = 7,
-  TUSB_REQ_GET_CONFIGURATION = 8,
-  TUSB_REQ_SET_CONFIGURATION = 9,
-  TUSB_REQ_GET_INTERFACE     = 10,
-  TUSB_REQ_SET_INTERFACE     = 11,
+  TUSB_REQ_GET_STATUS        = 0  ,
+  TUSB_REQ_CLEAR_FEATURE     = 1  ,
+  TUSB_REQ_RESERVED          = 2  ,
+  TUSB_REQ_SET_FEATURE       = 3  ,
+  TUSB_REQ_RESERVED2         = 4  ,
+  TUSB_REQ_SET_ADDRESS       = 5  ,
+  TUSB_REQ_GET_DESCRIPTOR    = 6  ,
+  TUSB_REQ_SET_DESCRIPTOR    = 7  ,
+  TUSB_REQ_GET_CONFIGURATION = 8  ,
+  TUSB_REQ_SET_CONFIGURATION = 9  ,
+  TUSB_REQ_GET_INTERFACE     = 10 ,
+  TUSB_REQ_SET_INTERFACE     = 11 ,
   TUSB_REQ_SYNCH_FRAME       = 12
 } tusb_request_code_t;
 
@@ -179,7 +173,7 @@ typedef enum {
 } tusb_request_type_t;
 
 typedef enum {
-  TUSB_REQ_RCPT_DEVICE = 0,
+  TUSB_REQ_RCPT_DEVICE =0,
   TUSB_REQ_RCPT_INTERFACE,
   TUSB_REQ_RCPT_ENDPOINT,
   TUSB_REQ_RCPT_OTHER
@@ -187,41 +181,42 @@ typedef enum {
 
 // https://www.usb.org/defined-class-codes
 typedef enum {
-  TUSB_CLASS_UNSPECIFIED         = 0,
-  TUSB_CLASS_AUDIO               = 1,
-  TUSB_CLASS_CDC                 = 2,
-  TUSB_CLASS_HID                 = 3,
-  TUSB_CLASS_RESERVED_4          = 4,
-  TUSB_CLASS_PHYSICAL            = 5,
-  TUSB_CLASS_IMAGE               = 6,
-  TUSB_CLASS_PRINTER             = 7,
-  TUSB_CLASS_MSC                 = 8,
-  TUSB_CLASS_HUB                 = 9,
-  TUSB_CLASS_CDC_DATA            = 10,
-  TUSB_CLASS_SMART_CARD          = 11,
-  TUSB_CLASS_RESERVED_12         = 12,
-  TUSB_CLASS_CONTENT_SECURITY    = 13,
-  TUSB_CLASS_VIDEO               = 14,
-  TUSB_CLASS_PERSONAL_HEALTHCARE = 15,
-  TUSB_CLASS_AUDIO_VIDEO         = 16,
+  TUSB_CLASS_UNSPECIFIED          = 0    ,
+  TUSB_CLASS_AUDIO                = 1    ,
+  TUSB_CLASS_CDC                  = 2    ,
+  TUSB_CLASS_HID                  = 3    ,
+  TUSB_CLASS_RESERVED_4           = 4    ,
+  TUSB_CLASS_PHYSICAL             = 5    ,
+  TUSB_CLASS_IMAGE                = 6    ,
+  TUSB_CLASS_PRINTER              = 7    ,
+  TUSB_CLASS_MSC                  = 8    ,
+  TUSB_CLASS_HUB                  = 9    ,
+  TUSB_CLASS_CDC_DATA             = 10   ,
+  TUSB_CLASS_SMART_CARD           = 11   ,
+  TUSB_CLASS_RESERVED_12          = 12   ,
+  TUSB_CLASS_CONTENT_SECURITY     = 13   ,
+  TUSB_CLASS_VIDEO                = 14   ,
+  TUSB_CLASS_PERSONAL_HEALTHCARE  = 15   ,
+  TUSB_CLASS_AUDIO_VIDEO          = 16   ,
 
-  TUSB_CLASS_DIAGNOSTIC           = 0xDC,
-  TUSB_CLASS_WIRELESS_CONTROLLER  = 0xE0,
-  TUSB_CLASS_MISC                 = 0xEF,
-  TUSB_CLASS_APPLICATION_SPECIFIC = 0xFE,
+  TUSB_CLASS_DIAGNOSTIC           = 0xDC ,
+  TUSB_CLASS_WIRELESS_CONTROLLER  = 0xE0 ,
+  TUSB_CLASS_MISC                 = 0xEF ,
+  TUSB_CLASS_APPLICATION_SPECIFIC = 0xFE ,
   TUSB_CLASS_VENDOR_SPECIFIC      = 0xFF
 } tusb_class_code_t;
 
-typedef enum {
+typedef enum
+{
   MISC_SUBCLASS_COMMON = 2
-} misc_subclass_type_t;
+}misc_subclass_type_t;
 
 typedef enum {
   MISC_PROTOCOL_IAD = 1
 } misc_protocol_type_t;
 
 typedef enum {
-  APP_SUBCLASS_USBTMC      = 0x03,
+  APP_SUBCLASS_USBTMC = 0x03,
   APP_SUBCLASS_DFU_RUNTIME = 0x01
 } app_subclass_type_t;
 
@@ -249,14 +244,14 @@ enum {
   TUSB_DESC_CONFIG_ATT_SELF_POWERED  = 1 << 6,
 };
 
-#define TUSB_DESC_CONFIG_POWER_MA(x) (uint8_t)((x) / 2)
+#define TUSB_DESC_CONFIG_POWER_MA(x)  (uint8_t)((x)/2)
 
 // USB 2.0 Spec Table 9-7: Test Mode Selectors
 typedef enum {
-  TUSB_FEATURE_TEST_J            = 1,
-  TUSB_FEATURE_TEST_K            = 2,
-  TUSB_FEATURE_TEST_SE0_NAK      = 3,
-  TUSB_FEATURE_TEST_PACKET       = 4,
+  TUSB_FEATURE_TEST_J = 1,
+  TUSB_FEATURE_TEST_K = 2,
+  TUSB_FEATURE_TEST_SE0_NAK = 3,
+  TUSB_FEATURE_TEST_PACKET = 4,
   TUSB_FEATURE_TEST_FORCE_ENABLE = 5,
 } tusb_feature_test_mode_t;
 
@@ -276,8 +271,8 @@ typedef enum {
 
 // TODO remove
 enum {
-  DESC_OFFSET_LEN     = 0,
-  DESC_OFFSET_TYPE    = 1,
+  DESC_OFFSET_LEN  = 0,
+  DESC_OFFSET_TYPE = 1,
   DESC_OFFSET_SUBTYPE = 2
 };
 
@@ -309,8 +304,8 @@ enum {
 };
 
 enum {
-  TU_EP0_OUT = 0x00,
-  TU_EP0_IN  = 0x80
+ TU_EP0_OUT = 0x00,
+ TU_EP0_IN = 0x80
 };
 
 
@@ -318,7 +313,7 @@ enum {
 //
 //--------------------------------------------------------------------+
 typedef struct {
-  tusb_role_t  role;
+  tusb_role_t role;
   tusb_speed_t speed;
 } tusb_rhport_init_t;
 
@@ -337,101 +332,77 @@ TU_ATTR_BIT_FIELD_ORDER_BEGIN
 
 /// USB Device Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;         ///< Size of this descriptor in bytes.
-  uint8_t  bDescriptorType; ///< DEVICE Descriptor Type.
-  uint16_t bcdUSB;          ///< BUSB Specification Release Number in Binary-Coded Decimal (i.e., 2.10 is 210H).
-  uint8_t  bDeviceClass;    ///< Class code (assigned by the USB-IF).
-  uint8_t  bDeviceSubClass; ///< Subclass code (assigned by the USB-IF).
-  uint8_t  bDeviceProtocol; ///< Protocol code (assigned by the USB-IF).
-  uint8_t  bMaxPacketSize0; ///< Maximum packet size for endpoint zero (only 8, 16, 32, or 64 are valid). For HS devices
-                            ///< is fixed to 64.
-  uint16_t idVendor;        ///< Vendor ID (assigned by the USB-IF).
-  uint16_t idProduct;       ///< Product ID (assigned by the manufacturer).
-  uint16_t bcdDevice;       ///< Device release number in binary-coded decimal.
-  uint8_t  iManufacturer;   ///< Index of string descriptor describing manufacturer.
-  uint8_t  iProduct;        ///< Index of string descriptor describing product.
-  uint8_t  iSerialNumber;   ///< Index of string descriptor describing the device's serial number.
-  uint8_t  bNumConfigurations; ///< Number of possible configurations.
+  uint8_t  bLength            ; ///< Size of this descriptor in bytes.
+  uint8_t  bDescriptorType    ; ///< DEVICE Descriptor Type.
+  uint16_t bcdUSB             ; ///< BUSB Specification Release Number in Binary-Coded Decimal (i.e., 2.10 is 210H).
+  uint8_t  bDeviceClass       ; ///< Class code (assigned by the USB-IF).
+  uint8_t  bDeviceSubClass    ; ///< Subclass code (assigned by the USB-IF).
+  uint8_t  bDeviceProtocol    ; ///< Protocol code (assigned by the USB-IF).
+  uint8_t  bMaxPacketSize0    ; ///< Maximum packet size for endpoint zero (only 8, 16, 32, or 64 are valid). For HS devices is fixed to 64.
+  uint16_t idVendor           ; ///< Vendor ID (assigned by the USB-IF).
+  uint16_t idProduct          ; ///< Product ID (assigned by the manufacturer).
+  uint16_t bcdDevice          ; ///< Device release number in binary-coded decimal.
+  uint8_t  iManufacturer      ; ///< Index of string descriptor describing manufacturer.
+  uint8_t  iProduct           ; ///< Index of string descriptor describing product.
+  uint8_t  iSerialNumber      ; ///< Index of string descriptor describing the device's serial number.
+  uint8_t  bNumConfigurations ; ///< Number of possible configurations.
 } tusb_desc_device_t;
 
-TU_VERIFY_STATIC(sizeof(tusb_desc_device_t) == 18u, "size is not correct");
+TU_VERIFY_STATIC( sizeof(tusb_desc_device_t) == 18u, "size is not correct");
 
 // USB Binary Device Object Store (BOS) Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;         ///< Size of this descriptor in bytes
-  uint8_t  bDescriptorType; ///< CONFIGURATION Descriptor Type
-  uint16_t wTotalLength;    ///< Total length of data returned for this descriptor
-  uint8_t  bNumDeviceCaps;  ///< Number of device capability descriptors in the BOS
+  uint8_t  bLength         ; ///< Size of this descriptor in bytes
+  uint8_t  bDescriptorType ; ///< CONFIGURATION Descriptor Type
+  uint16_t wTotalLength    ; ///< Total length of data returned for this descriptor
+  uint8_t  bNumDeviceCaps  ; ///< Number of device capability descriptors in the BOS
 } tusb_desc_bos_t;
 
-TU_VERIFY_STATIC(sizeof(tusb_desc_bos_t) == 5u, "size is not correct");
+TU_VERIFY_STATIC( sizeof(tusb_desc_bos_t) == 5u, "size is not correct");
 
 /// USB Configuration Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;         ///< Size of this descriptor in bytes
-  uint8_t  bDescriptorType; ///< CONFIGURATION Descriptor Type
-  uint16_t wTotalLength;  ///< Total length of data returned for this configuration. Includes the combined length of all
-                          ///< descriptors (configuration, interface, endpoint, and class- or vendor-specific) returned
-                          ///< for this configuration.
+  uint8_t  bLength             ; ///< Size of this descriptor in bytes
+  uint8_t  bDescriptorType     ; ///< CONFIGURATION Descriptor Type
+  uint16_t wTotalLength        ; ///< Total length of data returned for this configuration. Includes the combined length of all descriptors (configuration, interface, endpoint, and class- or vendor-specific) returned for this configuration.
 
-  uint8_t bNumInterfaces; ///< Number of interfaces supported by this configuration
-  uint8_t bConfigurationValue; ///< Value to use as an argument to the SetConfiguration() request to select this
-                               ///< configuration.
-  uint8_t iConfiguration;      ///< Index of string descriptor describing this configuration
-  uint8_t bmAttributes; ///< Configuration characteristics \n D7: Reserved (set to one)\n D6: Self-powered \n D5: Remote
-                        ///< Wakeup \n D4...0: Reserved (reset to zero) \n D7 is reserved and must be set to one for
-                        ///< historical reasons. \n A device configuration that uses power from the bus and a local
-                        ///< source reports a non-zero value in bMaxPower to indicate the amount of bus power required
-                        ///< and sets D6. The actual power source at runtime may be determined using the
-                        ///< GetStatus(DEVICE) request (see USB 2.0 spec Section 9.4.5). \n If a device configuration
-                        ///< supports remote wakeup, D5 is set to one.
-  uint8_t bMaxPower; ///< Maximum power consumption of the USB device from the bus in this specific configuration when
-                     ///< the device is fully operational. Expressed in 2 mA units (i.e., 50 = 100 mA).
+  uint8_t  bNumInterfaces      ; ///< Number of interfaces supported by this configuration
+  uint8_t  bConfigurationValue ; ///< Value to use as an argument to the SetConfiguration() request to select this configuration.
+  uint8_t  iConfiguration      ; ///< Index of string descriptor describing this configuration
+  uint8_t  bmAttributes        ; ///< Configuration characteristics \n D7: Reserved (set to one)\n D6: Self-powered \n D5: Remote Wakeup \n D4...0: Reserved (reset to zero) \n D7 is reserved and must be set to one for historical reasons. \n A device configuration that uses power from the bus and a local source reports a non-zero value in bMaxPower to indicate the amount of bus power required and sets D6. The actual power source at runtime may be determined using the GetStatus(DEVICE) request (see USB 2.0 spec Section 9.4.5). \n If a device configuration supports remote wakeup, D5 is set to one.
+  uint8_t  bMaxPower           ; ///< Maximum power consumption of the USB device from the bus in this specific configuration when the device is fully operational. Expressed in 2 mA units (i.e., 50 = 100 mA).
 } tusb_desc_configuration_t;
 
-TU_VERIFY_STATIC(sizeof(tusb_desc_configuration_t) == 9u, "size is not correct");
+TU_VERIFY_STATIC( sizeof(tusb_desc_configuration_t) == 9u, "size is not correct");
 
 /// USB Interface Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t bLength;          ///< Size of this descriptor in bytes
-  uint8_t bDescriptorType;  ///< INTERFACE Descriptor Type
+  uint8_t  bLength            ; ///< Size of this descriptor in bytes
+  uint8_t  bDescriptorType    ; ///< INTERFACE Descriptor Type
 
-  uint8_t bInterfaceNumber; ///< Number of this interface. Zero-based value identifying the index in the array of
-                            ///< concurrent interfaces supported by this configuration.
-  uint8_t
-    bAlternateSetting; ///< Value used to select this alternate setting for the interface identified in the prior field
-  uint8_t bNumEndpoints;   ///< Number of endpoints used by this interface (excluding endpoint zero). If this value is
-                           ///< zero, this interface only uses the Default Control Pipe.
-  uint8_t bInterfaceClass; ///< Class code (assigned by the USB-IF). \li A value of zero is reserved for future
-                           ///< standardization. \li If this field is set to FFH, the interface class is
-                           ///< vendor-specific. \li All other values are reserved for assignment by the USB-IF.
-  uint8_t bInterfaceSubClass; ///< Subclass code (assigned by the USB-IF). \n These codes are qualified by the value of
-                              ///< the bInterfaceClass field. \li If the bInterfaceClass field is reset to zero, this
-                              ///< field must also be reset to zero. \li If the bInterfaceClass field is not set to FFH,
-                              ///< all values are reserved for assignment by the USB-IF.
-  uint8_t bInterfaceProtocol; ///< Protocol code (assigned by the USB). \n These codes are qualified by the value of the
-                              ///< bInterfaceClass and the bInterfaceSubClass fields. If an interface supports
-                              ///< class-specific requests, this code identifies the protocols that the device uses as
-                              ///< defined by the specification of the device class. \li If this field is reset to zero,
-                              ///< the device does not use a class-specific protocol on this interface. \li If this
-                              ///< field is set to FFH, the device uses a vendor-specific protocol for this interface.
-  uint8_t iInterface;         ///< Index of string descriptor describing this interface
+  uint8_t  bInterfaceNumber   ; ///< Number of this interface. Zero-based value identifying the index in the array of concurrent interfaces supported by this configuration.
+  uint8_t  bAlternateSetting  ; ///< Value used to select this alternate setting for the interface identified in the prior field
+  uint8_t  bNumEndpoints      ; ///< Number of endpoints used by this interface (excluding endpoint zero). If this value is zero, this interface only uses the Default Control Pipe.
+  uint8_t  bInterfaceClass    ; ///< Class code (assigned by the USB-IF). \li A value of zero is reserved for future standardization. \li If this field is set to FFH, the interface class is vendor-specific. \li All other values are reserved for assignment by the USB-IF.
+  uint8_t  bInterfaceSubClass ; ///< Subclass code (assigned by the USB-IF). \n These codes are qualified by the value of the bInterfaceClass field. \li If the bInterfaceClass field is reset to zero, this field must also be reset to zero. \li If the bInterfaceClass field is not set to FFH, all values are reserved for assignment by the USB-IF.
+  uint8_t  bInterfaceProtocol ; ///< Protocol code (assigned by the USB). \n These codes are qualified by the value of the bInterfaceClass and the bInterfaceSubClass fields. If an interface supports class-specific requests, this code identifies the protocols that the device uses as defined by the specification of the device class. \li If this field is reset to zero, the device does not use a class-specific protocol on this interface. \li If this field is set to FFH, the device uses a vendor-specific protocol for this interface.
+  uint8_t  iInterface         ; ///< Index of string descriptor describing this interface
 } tusb_desc_interface_t;
 
-TU_VERIFY_STATIC(sizeof(tusb_desc_interface_t) == 9u, "size is not correct");
+TU_VERIFY_STATIC( sizeof(tusb_desc_interface_t) == 9u, "size is not correct");
 
 /// USB Endpoint Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t bLength;          // Size of this descriptor in bytes
-  uint8_t bDescriptorType;  // ENDPOINT Descriptor Type
+  uint8_t  bLength          ; // Size of this descriptor in bytes
+  uint8_t  bDescriptorType  ; // ENDPOINT Descriptor Type
 
-  uint8_t bEndpointAddress; // The address of the endpoint
+  uint8_t  bEndpointAddress ; // The address of the endpoint
 
   struct TU_ATTR_PACKED {
 #if (TU_BITFIELD_ORDER == TU_BITFIELD_LE)
-    uint8_t xfer  : 2; // Control, ISO, Bulk, Interrupt
-    uint8_t sync  : 2; // None, Asynchronous, Adaptive, Synchronous
-    uint8_t usage : 2; // Data, Feedback, Implicit feedback
+    uint8_t xfer  : 2;        // Control, ISO, Bulk, Interrupt
+    uint8_t sync  : 2;        // None, Asynchronous, Adaptive, Synchronous
+    uint8_t usage : 2;        // Data, Feedback, Implicit feedback
     uint8_t       : 2;
 #elif (TU_BITFIELD_ORDER == TU_BITFIELD_BE)
     uint8_t       : 2;
@@ -443,70 +414,70 @@ typedef struct TU_ATTR_PACKED {
 #endif
   } bmAttributes;
 
-  uint16_t wMaxPacketSize; // Bit 10..0 : max packet size, bit 12..11 additional transaction per highspeed micro-frame
-  uint8_t  bInterval;      // Polling interval, in frames or microframes depending on the operating speed
+  uint16_t wMaxPacketSize   ; // Bit 10..0 : max packet size, bit 12..11 additional transaction per highspeed micro-frame
+  uint8_t  bInterval        ; // Polling interval, in frames or microframes depending on the operating speed
 } tusb_desc_endpoint_t;
 
-TU_VERIFY_STATIC(sizeof(tusb_desc_endpoint_t) == 7u, "size is not correct");
+TU_VERIFY_STATIC( sizeof(tusb_desc_endpoint_t) == 7u, "size is not correct");
 
 /// USB Other Speed Configuration Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;            ///< Size of descriptor
-  uint8_t  bDescriptorType;    ///< Other_speed_Configuration Type
-  uint16_t wTotalLength;       ///< Total length of data returned
+  uint8_t  bLength             ; ///< Size of descriptor
+  uint8_t  bDescriptorType     ; ///< Other_speed_Configuration Type
+  uint16_t wTotalLength        ; ///< Total length of data returned
 
-  uint8_t bNumInterfaces;      ///< Number of interfaces supported by this speed configuration
-  uint8_t bConfigurationValue; ///< Value to use to select configuration
-  uint8_t iConfiguration;      ///< Index of string descriptor
-  uint8_t bmAttributes;        ///< Same as Configuration descriptor
-  uint8_t bMaxPower;           ///< Same as Configuration descriptor
+  uint8_t  bNumInterfaces      ; ///< Number of interfaces supported by this speed configuration
+  uint8_t  bConfigurationValue ; ///< Value to use to select configuration
+  uint8_t  iConfiguration      ; ///< Index of string descriptor
+  uint8_t  bmAttributes        ; ///< Same as Configuration descriptor
+  uint8_t  bMaxPower           ; ///< Same as Configuration descriptor
 } tusb_desc_other_speed_t;
 
 /// USB Device Qualifier Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;           ///< Size of descriptor
-  uint8_t  bDescriptorType;   ///< Device Qualifier Type
-  uint16_t bcdUSB;            ///< USB specification version number (e.g., 0200H for V2.00)
+  uint8_t  bLength            ; ///< Size of descriptor
+  uint8_t  bDescriptorType    ; ///< Device Qualifier Type
+  uint16_t bcdUSB             ; ///< USB specification version number (e.g., 0200H for V2.00)
 
-  uint8_t bDeviceClass;       ///< Class Code
-  uint8_t bDeviceSubClass;    ///< SubClass Code
-  uint8_t bDeviceProtocol;    ///< Protocol Code
+  uint8_t  bDeviceClass       ; ///< Class Code
+  uint8_t  bDeviceSubClass    ; ///< SubClass Code
+  uint8_t  bDeviceProtocol    ; ///< Protocol Code
 
-  uint8_t bMaxPacketSize0;    ///< Maximum packet size for other speed
-  uint8_t bNumConfigurations; ///< Number of Other-speed Configurations
-  uint8_t bReserved;          ///< Reserved for future use, must be zero
+  uint8_t  bMaxPacketSize0    ; ///< Maximum packet size for other speed
+  uint8_t  bNumConfigurations ; ///< Number of Other-speed Configurations
+  uint8_t  bReserved          ; ///< Reserved for future use, must be zero
 } tusb_desc_device_qualifier_t;
 
-TU_VERIFY_STATIC(sizeof(tusb_desc_device_qualifier_t) == 10u, "size is not correct");
+TU_VERIFY_STATIC( sizeof(tusb_desc_device_qualifier_t) == 10u, "size is not correct");
 
 /// USB Interface Association Descriptor (IAD ECN)
 typedef struct TU_ATTR_PACKED {
-  uint8_t bLength;           ///< Size of descriptor
-  uint8_t bDescriptorType;   ///< Other_speed_Configuration Type
+  uint8_t bLength           ; ///< Size of descriptor
+  uint8_t bDescriptorType   ; ///< Other_speed_Configuration Type
 
-  uint8_t bFirstInterface;   ///< Index of the first associated interface.
-  uint8_t bInterfaceCount;   ///< Total number of associated interfaces.
+  uint8_t bFirstInterface   ; ///< Index of the first associated interface.
+  uint8_t bInterfaceCount   ; ///< Total number of associated interfaces.
 
-  uint8_t bFunctionClass;    ///< Interface class ID.
-  uint8_t bFunctionSubClass; ///< Interface subclass ID.
-  uint8_t bFunctionProtocol; ///< Interface protocol ID.
+  uint8_t bFunctionClass    ; ///< Interface class ID.
+  uint8_t bFunctionSubClass ; ///< Interface subclass ID.
+  uint8_t bFunctionProtocol ; ///< Interface protocol ID.
 
-  uint8_t iFunction;         ///< Index of the string descriptor describing the interface association.
+  uint8_t iFunction         ; ///< Index of the string descriptor describing the interface association.
 } tusb_desc_interface_assoc_t;
 
-TU_VERIFY_STATIC(sizeof(tusb_desc_interface_assoc_t) == 8u, "size is not correct");
+TU_VERIFY_STATIC( sizeof(tusb_desc_interface_assoc_t) == 8u, "size is not correct");
 
 // USB String Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;         ///< Size of this descriptor in bytes
-  uint8_t  bDescriptorType; ///< Descriptor Type
+  uint8_t  bLength         ; ///< Size of this descriptor in bytes
+  uint8_t  bDescriptorType ; ///< Descriptor Type
   uint16_t utf16le[];
 } tusb_desc_string_t;
 
 // USB Binary Device Object Store (BOS)
 typedef struct TU_ATTR_PACKED {
   uint8_t bLength;
-  uint8_t bDescriptorType;
+  uint8_t bDescriptorType ;
   uint8_t bDevCapabilityType;
   uint8_t bReserved;
   uint8_t PlatformCapabilityUUID[16];
@@ -523,8 +494,8 @@ typedef struct TU_ATTR_PACKED {
 
 // DFU Functional Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t bLength;
-  uint8_t bDescriptorType;
+  uint8_t  bLength;
+  uint8_t  bDescriptorType;
 
   union {
     struct TU_ATTR_PACKED {
@@ -551,13 +522,13 @@ typedef struct TU_ATTR_PACKED {
   union {
     struct TU_ATTR_PACKED {
 #if (TU_BITFIELD_ORDER == TU_BITFIELD_LE)
-      uint8_t recipient : 5; ///< Recipient type tusb_request_recipient_t.
-      uint8_t type      : 2; ///< Request type tusb_request_type_t.
-      uint8_t direction : 1; ///< Direction type. tusb_dir_t
+      uint8_t recipient :  5; ///< Recipient type tusb_request_recipient_t.
+      uint8_t type      :  2; ///< Request type tusb_request_type_t.
+      uint8_t direction :  1; ///< Direction type. tusb_dir_t
 #elif (TU_BITFIELD_ORDER == TU_BITFIELD_BE)
-      uint8_t direction : 1; ///< Direction type. tusb_dir_t
-      uint8_t type      : 2; ///< Request type tusb_request_type_t.
-      uint8_t recipient : 5; ///< Recipient type tusb_request_recipient_t.
+      uint8_t direction :  1; ///< Direction type. tusb_dir_t
+      uint8_t type      :  2; ///< Request type tusb_request_type_t.
+      uint8_t recipient :  5; ///< Recipient type tusb_request_recipient_t.
 #else
   #error "Please define TU_BITFIELD_ORDER as TU_BITFIELD_LE or TU_BITFIELD_BE"
 #endif
@@ -572,43 +543,42 @@ typedef struct TU_ATTR_PACKED {
   uint16_t wLength;
 } tusb_control_request_t;
 
-TU_VERIFY_STATIC(sizeof(tusb_control_request_t) == 8u, "size is not correct");
+TU_VERIFY_STATIC( sizeof(tusb_control_request_t) == 8u, "size is not correct");
 
-TU_ATTR_PACKED_END // End of all packed definitions
-  TU_ATTR_BIT_FIELD_ORDER_END
+TU_ATTR_PACKED_END  // End of all packed definitions
+TU_ATTR_BIT_FIELD_ORDER_END
 
-    //--------------------------------------------------------------------+
-    // Endpoint helper
-    //--------------------------------------------------------------------+
+//--------------------------------------------------------------------+
+// Endpoint helper
+//--------------------------------------------------------------------+
 
-    // Get direction from Endpoint address
-    TU_ATTR_ALWAYS_INLINE static inline tusb_dir_t
-    tu_edpt_dir(uint8_t addr) {
+// Get direction from Endpoint address
+TU_ATTR_ALWAYS_INLINE static inline tusb_dir_t tu_edpt_dir(uint8_t addr) {
   return (addr & TUSB_DIR_IN_MASK) ? TUSB_DIR_IN : TUSB_DIR_OUT;
 }
 
 // Get Endpoint number from address
 TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_edpt_number(uint8_t addr) {
-  return (uint8_t)(addr & TUSB_EPNUM_MASK);
+  return (uint8_t) (addr & TUSB_EPNUM_MASK);
 }
 
 TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_edpt_addr(uint8_t num, uint8_t dir) {
-  return (uint8_t)(num | (dir == (uint8_t)TUSB_DIR_IN ? (uint8_t)TUSB_DIR_IN_MASK : 0u));
+  return (uint8_t) (num | (dir == (uint8_t)TUSB_DIR_IN ? (uint8_t)TUSB_DIR_IN_MASK : 0u));
 }
 
-TU_ATTR_ALWAYS_INLINE static inline uint16_t tu_edpt_packet_size(const tusb_desc_endpoint_t *desc_ep) {
+TU_ATTR_ALWAYS_INLINE static inline uint16_t tu_edpt_packet_size(tusb_desc_endpoint_t const* desc_ep) {
   return tu_le16toh(desc_ep->wMaxPacketSize) & 0x7FF;
 }
 
 #if CFG_TUSB_DEBUG
 TU_ATTR_ALWAYS_INLINE static inline const char *tu_edpt_type_str(tusb_xfer_type_t t) {
-  const tu_static char *str[] = {"control", "isochronous", "bulk", "interrupt"};
+  tu_static const char *str[] = {"control", "isochronous", "bulk", "interrupt"};
   return str[t];
 }
 #endif
 
 #ifdef __cplusplus
-}
+ }
 #endif
 
 #endif // TUSB_TYPES_H_

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -244,7 +244,7 @@ enum {
   TUSB_DESC_CONFIG_ATT_SELF_POWERED  = 1 << 6,
 };
 
-#define TUSB_DESC_CONFIG_POWER_MA(x)  (uint8_t)((x)/2)
+#define TUSB_DESC_CONFIG_POWER_MA(x)  ((uint8_t)TU_MIN((x)/2, UINT8_MAX))
 
 // USB 2.0 Spec Table 9-7: Test Mode Selectors
 typedef enum {

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -13,43 +13,49 @@
 #include "tusb_compiler.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 //------------- Device DCache declaration -------------//
-#define TUD_EPBUF_DCACHE_SIZE(_size) (CFG_TUD_MEM_DCACHE_ENABLE ? \
-  (TU_DIV_CEIL(_size, CFG_TUD_MEM_DCACHE_LINE_SIZE) * CFG_TUD_MEM_DCACHE_LINE_SIZE) : (_size))
+#define TUD_EPBUF_DCACHE_SIZE(_size)                                                                             \
+  (CFG_TUD_MEM_DCACHE_ENABLE ? (TU_DIV_CEIL(_size, CFG_TUD_MEM_DCACHE_LINE_SIZE) * CFG_TUD_MEM_DCACHE_LINE_SIZE) \
+                             : (_size))
 
 // Declare an endpoint buffer with uint8_t[size]
-#define TUD_EPBUF_DEF(_name, _size) \
-  union { \
-    CFG_TUD_MEM_ALIGN uint8_t _name[_size]; \
-    TU_ATTR_ALIGNED(CFG_TUD_MEM_DCACHE_ENABLE ? CFG_TUD_MEM_DCACHE_LINE_SIZE : 1) uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(_size)]; \
+#define TUD_EPBUF_DEF(_name, _size)                                               \
+  union {                                                                         \
+    CFG_TUD_MEM_ALIGN uint8_t _name[_size];                                       \
+    TU_ATTR_ALIGNED(CFG_TUD_MEM_DCACHE_ENABLE ? CFG_TUD_MEM_DCACHE_LINE_SIZE : 1) \
+    uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(_size)];                 \
   }
 
 // Declare an endpoint buffer with a type
-#define TUD_EPBUF_TYPE_DEF(_type, _name) \
-  union { \
-    CFG_TUD_MEM_ALIGN _type _name; \
-    TU_ATTR_ALIGNED(CFG_TUD_MEM_DCACHE_ENABLE ? CFG_TUD_MEM_DCACHE_LINE_SIZE : 1) uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(sizeof(_type))]; \
+#define TUD_EPBUF_TYPE_DEF(_type, _name)                                          \
+  union {                                                                         \
+    CFG_TUD_MEM_ALIGN _type _name;                                                \
+    TU_ATTR_ALIGNED(CFG_TUD_MEM_DCACHE_ENABLE ? CFG_TUD_MEM_DCACHE_LINE_SIZE : 1) \
+    uint8_t _name##_dcache_padding[TUD_EPBUF_DCACHE_SIZE(sizeof(_type))];         \
   }
 
 //------------- Host DCache declaration -------------//
-#define TUH_EPBUF_DCACHE_SIZE(_size) (CFG_TUH_MEM_DCACHE_ENABLE ? \
-  (TU_DIV_CEIL(_size, CFG_TUH_MEM_DCACHE_LINE_SIZE) * CFG_TUH_MEM_DCACHE_LINE_SIZE) : (_size))
+#define TUH_EPBUF_DCACHE_SIZE(_size)                                                                             \
+  (CFG_TUH_MEM_DCACHE_ENABLE ? (TU_DIV_CEIL(_size, CFG_TUH_MEM_DCACHE_LINE_SIZE) * CFG_TUH_MEM_DCACHE_LINE_SIZE) \
+                             : (_size))
 
 // Declare an endpoint buffer with uint8_t[size]
-#define TUH_EPBUF_DEF(_name, _size) \
-  union { \
-    CFG_TUH_MEM_ALIGN uint8_t _name[_size]; \
-    TU_ATTR_ALIGNED(CFG_TUH_MEM_DCACHE_ENABLE ? CFG_TUH_MEM_DCACHE_LINE_SIZE : 1) uint8_t _name##_dcache_padding[TUH_EPBUF_DCACHE_SIZE(_size)]; \
+#define TUH_EPBUF_DEF(_name, _size)                                               \
+  union {                                                                         \
+    CFG_TUH_MEM_ALIGN uint8_t _name[_size];                                       \
+    TU_ATTR_ALIGNED(CFG_TUH_MEM_DCACHE_ENABLE ? CFG_TUH_MEM_DCACHE_LINE_SIZE : 1) \
+    uint8_t _name##_dcache_padding[TUH_EPBUF_DCACHE_SIZE(_size)];                 \
   }
 
 // Declare an endpoint buffer with a type
-#define TUH_EPBUF_TYPE_DEF(_type, _name) \
-  union { \
-    CFG_TUH_MEM_ALIGN _type _name; \
-    TU_ATTR_ALIGNED(CFG_TUH_MEM_DCACHE_ENABLE ? CFG_TUH_MEM_DCACHE_LINE_SIZE : 1) uint8_t _name##_dcache_padding[TUH_EPBUF_DCACHE_SIZE(sizeof(_type))]; \
+#define TUH_EPBUF_TYPE_DEF(_type, _name)                                          \
+  union {                                                                         \
+    CFG_TUH_MEM_ALIGN _type _name;                                                \
+    TU_ATTR_ALIGNED(CFG_TUH_MEM_DCACHE_ENABLE ? CFG_TUH_MEM_DCACHE_LINE_SIZE : 1) \
+    uint8_t _name##_dcache_padding[TUH_EPBUF_DCACHE_SIZE(sizeof(_type))];         \
   }
 
 
@@ -65,10 +71,10 @@ typedef enum {
 
 /// defined base on EHCI specs value for Endpoint Speed
 typedef enum {
-  TUSB_SPEED_FULL = 0,
-  TUSB_SPEED_LOW  = 1,
-  TUSB_SPEED_HIGH = 2,
-  TUSB_SPEED_AUTO = 0xaa,
+  TUSB_SPEED_FULL    = 0,
+  TUSB_SPEED_LOW     = 1,
+  TUSB_SPEED_HIGH    = 2,
+  TUSB_SPEED_AUTO    = 0xaa,
   TUSB_SPEED_INVALID = 0xff,
 } tusb_speed_t;
 
@@ -99,18 +105,18 @@ enum {
 };
 
 // Endpoint Bulk size depending on host/device max speed
-#define TUD_EPSIZE_BULK_MAX   (TUD_OPT_HIGH_SPEED ? 512 : 64)
-#define TUH_EPSIZE_BULK_MAX   (TUH_OPT_HIGH_SPEED ? 512 : 64)
+#define TUD_EPSIZE_BULK_MAX (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define TUH_EPSIZE_BULK_MAX (TUH_OPT_HIGH_SPEED ? 512 : 64)
 
 /// Isochronous Endpoint Attributes
 typedef enum {
-  TUSB_ISO_EP_ATT_NO_SYNC         = 0x00,
-  TUSB_ISO_EP_ATT_ASYNCHRONOUS    = 0x04,
-  TUSB_ISO_EP_ATT_ADAPTIVE        = 0x08,
-  TUSB_ISO_EP_ATT_SYNCHRONOUS     = 0x0C,
-  TUSB_ISO_EP_ATT_DATA            = 0x00, ///< Data End Point
-  TUSB_ISO_EP_ATT_EXPLICIT_FB     = 0x10, ///< Feedback End Point
-  TUSB_ISO_EP_ATT_IMPLICIT_FB     = 0x20, ///< Data endpoint that also serves as an implicit feedback
+  TUSB_ISO_EP_ATT_NO_SYNC      = 0x00,
+  TUSB_ISO_EP_ATT_ASYNCHRONOUS = 0x04,
+  TUSB_ISO_EP_ATT_ADAPTIVE     = 0x08,
+  TUSB_ISO_EP_ATT_SYNCHRONOUS  = 0x0C,
+  TUSB_ISO_EP_ATT_DATA         = 0x00, ///< Data End Point
+  TUSB_ISO_EP_ATT_EXPLICIT_FB  = 0x10, ///< Feedback End Point
+  TUSB_ISO_EP_ATT_IMPLICIT_FB  = 0x20, ///< Data endpoint that also serves as an implicit feedback
 } tusb_iso_ep_attribute_t;
 
 /// USB Descriptor Types
@@ -127,35 +133,35 @@ typedef enum {
   TUSB_DESC_DEBUG                 = 0x0A,
   TUSB_DESC_INTERFACE_ASSOCIATION = 0x0B,
 
-  TUSB_DESC_BOS                   = 0x0F,
-  TUSB_DESC_DEVICE_CAPABILITY     = 0x10,
+  TUSB_DESC_BOS               = 0x0F,
+  TUSB_DESC_DEVICE_CAPABILITY = 0x10,
 
-  TUSB_DESC_FUNCTIONAL            = 0x21,
+  TUSB_DESC_FUNCTIONAL = 0x21,
 
   // Class Specific Descriptor
-  TUSB_DESC_CS_DEVICE             = 0x21,
-  TUSB_DESC_CS_CONFIGURATION      = 0x22,
-  TUSB_DESC_CS_STRING             = 0x23,
-  TUSB_DESC_CS_INTERFACE          = 0x24,
-  TUSB_DESC_CS_ENDPOINT           = 0x25,
+  TUSB_DESC_CS_DEVICE        = 0x21,
+  TUSB_DESC_CS_CONFIGURATION = 0x22,
+  TUSB_DESC_CS_STRING        = 0x23,
+  TUSB_DESC_CS_INTERFACE     = 0x24,
+  TUSB_DESC_CS_ENDPOINT      = 0x25,
 
   TUSB_DESC_SUPERSPEED_ENDPOINT_COMPANION     = 0x30,
   TUSB_DESC_SUPERSPEED_ISO_ENDPOINT_COMPANION = 0x31
 } tusb_desc_type_t;
 
 typedef enum {
-  TUSB_REQ_GET_STATUS        = 0  ,
-  TUSB_REQ_CLEAR_FEATURE     = 1  ,
-  TUSB_REQ_RESERVED          = 2  ,
-  TUSB_REQ_SET_FEATURE       = 3  ,
-  TUSB_REQ_RESERVED2         = 4  ,
-  TUSB_REQ_SET_ADDRESS       = 5  ,
-  TUSB_REQ_GET_DESCRIPTOR    = 6  ,
-  TUSB_REQ_SET_DESCRIPTOR    = 7  ,
-  TUSB_REQ_GET_CONFIGURATION = 8  ,
-  TUSB_REQ_SET_CONFIGURATION = 9  ,
-  TUSB_REQ_GET_INTERFACE     = 10 ,
-  TUSB_REQ_SET_INTERFACE     = 11 ,
+  TUSB_REQ_GET_STATUS        = 0,
+  TUSB_REQ_CLEAR_FEATURE     = 1,
+  TUSB_REQ_RESERVED          = 2,
+  TUSB_REQ_SET_FEATURE       = 3,
+  TUSB_REQ_RESERVED2         = 4,
+  TUSB_REQ_SET_ADDRESS       = 5,
+  TUSB_REQ_GET_DESCRIPTOR    = 6,
+  TUSB_REQ_SET_DESCRIPTOR    = 7,
+  TUSB_REQ_GET_CONFIGURATION = 8,
+  TUSB_REQ_SET_CONFIGURATION = 9,
+  TUSB_REQ_GET_INTERFACE     = 10,
+  TUSB_REQ_SET_INTERFACE     = 11,
   TUSB_REQ_SYNCH_FRAME       = 12
 } tusb_request_code_t;
 
@@ -173,7 +179,7 @@ typedef enum {
 } tusb_request_type_t;
 
 typedef enum {
-  TUSB_REQ_RCPT_DEVICE =0,
+  TUSB_REQ_RCPT_DEVICE = 0,
   TUSB_REQ_RCPT_INTERFACE,
   TUSB_REQ_RCPT_ENDPOINT,
   TUSB_REQ_RCPT_OTHER
@@ -181,42 +187,41 @@ typedef enum {
 
 // https://www.usb.org/defined-class-codes
 typedef enum {
-  TUSB_CLASS_UNSPECIFIED          = 0    ,
-  TUSB_CLASS_AUDIO                = 1    ,
-  TUSB_CLASS_CDC                  = 2    ,
-  TUSB_CLASS_HID                  = 3    ,
-  TUSB_CLASS_RESERVED_4           = 4    ,
-  TUSB_CLASS_PHYSICAL             = 5    ,
-  TUSB_CLASS_IMAGE                = 6    ,
-  TUSB_CLASS_PRINTER              = 7    ,
-  TUSB_CLASS_MSC                  = 8    ,
-  TUSB_CLASS_HUB                  = 9    ,
-  TUSB_CLASS_CDC_DATA             = 10   ,
-  TUSB_CLASS_SMART_CARD           = 11   ,
-  TUSB_CLASS_RESERVED_12          = 12   ,
-  TUSB_CLASS_CONTENT_SECURITY     = 13   ,
-  TUSB_CLASS_VIDEO                = 14   ,
-  TUSB_CLASS_PERSONAL_HEALTHCARE  = 15   ,
-  TUSB_CLASS_AUDIO_VIDEO          = 16   ,
+  TUSB_CLASS_UNSPECIFIED         = 0,
+  TUSB_CLASS_AUDIO               = 1,
+  TUSB_CLASS_CDC                 = 2,
+  TUSB_CLASS_HID                 = 3,
+  TUSB_CLASS_RESERVED_4          = 4,
+  TUSB_CLASS_PHYSICAL            = 5,
+  TUSB_CLASS_IMAGE               = 6,
+  TUSB_CLASS_PRINTER             = 7,
+  TUSB_CLASS_MSC                 = 8,
+  TUSB_CLASS_HUB                 = 9,
+  TUSB_CLASS_CDC_DATA            = 10,
+  TUSB_CLASS_SMART_CARD          = 11,
+  TUSB_CLASS_RESERVED_12         = 12,
+  TUSB_CLASS_CONTENT_SECURITY    = 13,
+  TUSB_CLASS_VIDEO               = 14,
+  TUSB_CLASS_PERSONAL_HEALTHCARE = 15,
+  TUSB_CLASS_AUDIO_VIDEO         = 16,
 
-  TUSB_CLASS_DIAGNOSTIC           = 0xDC ,
-  TUSB_CLASS_WIRELESS_CONTROLLER  = 0xE0 ,
-  TUSB_CLASS_MISC                 = 0xEF ,
-  TUSB_CLASS_APPLICATION_SPECIFIC = 0xFE ,
+  TUSB_CLASS_DIAGNOSTIC           = 0xDC,
+  TUSB_CLASS_WIRELESS_CONTROLLER  = 0xE0,
+  TUSB_CLASS_MISC                 = 0xEF,
+  TUSB_CLASS_APPLICATION_SPECIFIC = 0xFE,
   TUSB_CLASS_VENDOR_SPECIFIC      = 0xFF
 } tusb_class_code_t;
 
-typedef enum
-{
+typedef enum {
   MISC_SUBCLASS_COMMON = 2
-}misc_subclass_type_t;
+} misc_subclass_type_t;
 
 typedef enum {
   MISC_PROTOCOL_IAD = 1
 } misc_protocol_type_t;
 
 typedef enum {
-  APP_SUBCLASS_USBTMC = 0x03,
+  APP_SUBCLASS_USBTMC      = 0x03,
   APP_SUBCLASS_DFU_RUNTIME = 0x01
 } app_subclass_type_t;
 
@@ -244,14 +249,14 @@ enum {
   TUSB_DESC_CONFIG_ATT_SELF_POWERED  = 1 << 6,
 };
 
-#define TUSB_DESC_CONFIG_POWER_MA(x)  ((x)/2)
+#define TUSB_DESC_CONFIG_POWER_MA(x) (uint8_t)((x) / 2)
 
 // USB 2.0 Spec Table 9-7: Test Mode Selectors
 typedef enum {
-  TUSB_FEATURE_TEST_J = 1,
-  TUSB_FEATURE_TEST_K = 2,
-  TUSB_FEATURE_TEST_SE0_NAK = 3,
-  TUSB_FEATURE_TEST_PACKET = 4,
+  TUSB_FEATURE_TEST_J            = 1,
+  TUSB_FEATURE_TEST_K            = 2,
+  TUSB_FEATURE_TEST_SE0_NAK      = 3,
+  TUSB_FEATURE_TEST_PACKET       = 4,
   TUSB_FEATURE_TEST_FORCE_ENABLE = 5,
 } tusb_feature_test_mode_t;
 
@@ -271,8 +276,8 @@ typedef enum {
 
 // TODO remove
 enum {
-  DESC_OFFSET_LEN  = 0,
-  DESC_OFFSET_TYPE = 1,
+  DESC_OFFSET_LEN     = 0,
+  DESC_OFFSET_TYPE    = 1,
   DESC_OFFSET_SUBTYPE = 2
 };
 
@@ -304,8 +309,8 @@ enum {
 };
 
 enum {
- TU_EP0_OUT = 0x00,
- TU_EP0_IN = 0x80
+  TU_EP0_OUT = 0x00,
+  TU_EP0_IN  = 0x80
 };
 
 
@@ -313,7 +318,7 @@ enum {
 //
 //--------------------------------------------------------------------+
 typedef struct {
-  tusb_role_t role;
+  tusb_role_t  role;
   tusb_speed_t speed;
 } tusb_rhport_init_t;
 
@@ -332,77 +337,101 @@ TU_ATTR_BIT_FIELD_ORDER_BEGIN
 
 /// USB Device Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength            ; ///< Size of this descriptor in bytes.
-  uint8_t  bDescriptorType    ; ///< DEVICE Descriptor Type.
-  uint16_t bcdUSB             ; ///< BUSB Specification Release Number in Binary-Coded Decimal (i.e., 2.10 is 210H).
-  uint8_t  bDeviceClass       ; ///< Class code (assigned by the USB-IF).
-  uint8_t  bDeviceSubClass    ; ///< Subclass code (assigned by the USB-IF).
-  uint8_t  bDeviceProtocol    ; ///< Protocol code (assigned by the USB-IF).
-  uint8_t  bMaxPacketSize0    ; ///< Maximum packet size for endpoint zero (only 8, 16, 32, or 64 are valid). For HS devices is fixed to 64.
-  uint16_t idVendor           ; ///< Vendor ID (assigned by the USB-IF).
-  uint16_t idProduct          ; ///< Product ID (assigned by the manufacturer).
-  uint16_t bcdDevice          ; ///< Device release number in binary-coded decimal.
-  uint8_t  iManufacturer      ; ///< Index of string descriptor describing manufacturer.
-  uint8_t  iProduct           ; ///< Index of string descriptor describing product.
-  uint8_t  iSerialNumber      ; ///< Index of string descriptor describing the device's serial number.
-  uint8_t  bNumConfigurations ; ///< Number of possible configurations.
+  uint8_t  bLength;         ///< Size of this descriptor in bytes.
+  uint8_t  bDescriptorType; ///< DEVICE Descriptor Type.
+  uint16_t bcdUSB;          ///< BUSB Specification Release Number in Binary-Coded Decimal (i.e., 2.10 is 210H).
+  uint8_t  bDeviceClass;    ///< Class code (assigned by the USB-IF).
+  uint8_t  bDeviceSubClass; ///< Subclass code (assigned by the USB-IF).
+  uint8_t  bDeviceProtocol; ///< Protocol code (assigned by the USB-IF).
+  uint8_t  bMaxPacketSize0; ///< Maximum packet size for endpoint zero (only 8, 16, 32, or 64 are valid). For HS devices
+                            ///< is fixed to 64.
+  uint16_t idVendor;        ///< Vendor ID (assigned by the USB-IF).
+  uint16_t idProduct;       ///< Product ID (assigned by the manufacturer).
+  uint16_t bcdDevice;       ///< Device release number in binary-coded decimal.
+  uint8_t  iManufacturer;   ///< Index of string descriptor describing manufacturer.
+  uint8_t  iProduct;        ///< Index of string descriptor describing product.
+  uint8_t  iSerialNumber;   ///< Index of string descriptor describing the device's serial number.
+  uint8_t  bNumConfigurations; ///< Number of possible configurations.
 } tusb_desc_device_t;
 
-TU_VERIFY_STATIC( sizeof(tusb_desc_device_t) == 18u, "size is not correct");
+TU_VERIFY_STATIC(sizeof(tusb_desc_device_t) == 18u, "size is not correct");
 
 // USB Binary Device Object Store (BOS) Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength         ; ///< Size of this descriptor in bytes
-  uint8_t  bDescriptorType ; ///< CONFIGURATION Descriptor Type
-  uint16_t wTotalLength    ; ///< Total length of data returned for this descriptor
-  uint8_t  bNumDeviceCaps  ; ///< Number of device capability descriptors in the BOS
+  uint8_t  bLength;         ///< Size of this descriptor in bytes
+  uint8_t  bDescriptorType; ///< CONFIGURATION Descriptor Type
+  uint16_t wTotalLength;    ///< Total length of data returned for this descriptor
+  uint8_t  bNumDeviceCaps;  ///< Number of device capability descriptors in the BOS
 } tusb_desc_bos_t;
 
-TU_VERIFY_STATIC( sizeof(tusb_desc_bos_t) == 5u, "size is not correct");
+TU_VERIFY_STATIC(sizeof(tusb_desc_bos_t) == 5u, "size is not correct");
 
 /// USB Configuration Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength             ; ///< Size of this descriptor in bytes
-  uint8_t  bDescriptorType     ; ///< CONFIGURATION Descriptor Type
-  uint16_t wTotalLength        ; ///< Total length of data returned for this configuration. Includes the combined length of all descriptors (configuration, interface, endpoint, and class- or vendor-specific) returned for this configuration.
+  uint8_t  bLength;         ///< Size of this descriptor in bytes
+  uint8_t  bDescriptorType; ///< CONFIGURATION Descriptor Type
+  uint16_t wTotalLength;  ///< Total length of data returned for this configuration. Includes the combined length of all
+                          ///< descriptors (configuration, interface, endpoint, and class- or vendor-specific) returned
+                          ///< for this configuration.
 
-  uint8_t  bNumInterfaces      ; ///< Number of interfaces supported by this configuration
-  uint8_t  bConfigurationValue ; ///< Value to use as an argument to the SetConfiguration() request to select this configuration.
-  uint8_t  iConfiguration      ; ///< Index of string descriptor describing this configuration
-  uint8_t  bmAttributes        ; ///< Configuration characteristics \n D7: Reserved (set to one)\n D6: Self-powered \n D5: Remote Wakeup \n D4...0: Reserved (reset to zero) \n D7 is reserved and must be set to one for historical reasons. \n A device configuration that uses power from the bus and a local source reports a non-zero value in bMaxPower to indicate the amount of bus power required and sets D6. The actual power source at runtime may be determined using the GetStatus(DEVICE) request (see USB 2.0 spec Section 9.4.5). \n If a device configuration supports remote wakeup, D5 is set to one.
-  uint8_t  bMaxPower           ; ///< Maximum power consumption of the USB device from the bus in this specific configuration when the device is fully operational. Expressed in 2 mA units (i.e., 50 = 100 mA).
+  uint8_t bNumInterfaces; ///< Number of interfaces supported by this configuration
+  uint8_t bConfigurationValue; ///< Value to use as an argument to the SetConfiguration() request to select this
+                               ///< configuration.
+  uint8_t iConfiguration;      ///< Index of string descriptor describing this configuration
+  uint8_t bmAttributes; ///< Configuration characteristics \n D7: Reserved (set to one)\n D6: Self-powered \n D5: Remote
+                        ///< Wakeup \n D4...0: Reserved (reset to zero) \n D7 is reserved and must be set to one for
+                        ///< historical reasons. \n A device configuration that uses power from the bus and a local
+                        ///< source reports a non-zero value in bMaxPower to indicate the amount of bus power required
+                        ///< and sets D6. The actual power source at runtime may be determined using the
+                        ///< GetStatus(DEVICE) request (see USB 2.0 spec Section 9.4.5). \n If a device configuration
+                        ///< supports remote wakeup, D5 is set to one.
+  uint8_t bMaxPower; ///< Maximum power consumption of the USB device from the bus in this specific configuration when
+                     ///< the device is fully operational. Expressed in 2 mA units (i.e., 50 = 100 mA).
 } tusb_desc_configuration_t;
 
-TU_VERIFY_STATIC( sizeof(tusb_desc_configuration_t) == 9u, "size is not correct");
+TU_VERIFY_STATIC(sizeof(tusb_desc_configuration_t) == 9u, "size is not correct");
 
 /// USB Interface Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength            ; ///< Size of this descriptor in bytes
-  uint8_t  bDescriptorType    ; ///< INTERFACE Descriptor Type
+  uint8_t bLength;          ///< Size of this descriptor in bytes
+  uint8_t bDescriptorType;  ///< INTERFACE Descriptor Type
 
-  uint8_t  bInterfaceNumber   ; ///< Number of this interface. Zero-based value identifying the index in the array of concurrent interfaces supported by this configuration.
-  uint8_t  bAlternateSetting  ; ///< Value used to select this alternate setting for the interface identified in the prior field
-  uint8_t  bNumEndpoints      ; ///< Number of endpoints used by this interface (excluding endpoint zero). If this value is zero, this interface only uses the Default Control Pipe.
-  uint8_t  bInterfaceClass    ; ///< Class code (assigned by the USB-IF). \li A value of zero is reserved for future standardization. \li If this field is set to FFH, the interface class is vendor-specific. \li All other values are reserved for assignment by the USB-IF.
-  uint8_t  bInterfaceSubClass ; ///< Subclass code (assigned by the USB-IF). \n These codes are qualified by the value of the bInterfaceClass field. \li If the bInterfaceClass field is reset to zero, this field must also be reset to zero. \li If the bInterfaceClass field is not set to FFH, all values are reserved for assignment by the USB-IF.
-  uint8_t  bInterfaceProtocol ; ///< Protocol code (assigned by the USB). \n These codes are qualified by the value of the bInterfaceClass and the bInterfaceSubClass fields. If an interface supports class-specific requests, this code identifies the protocols that the device uses as defined by the specification of the device class. \li If this field is reset to zero, the device does not use a class-specific protocol on this interface. \li If this field is set to FFH, the device uses a vendor-specific protocol for this interface.
-  uint8_t  iInterface         ; ///< Index of string descriptor describing this interface
+  uint8_t bInterfaceNumber; ///< Number of this interface. Zero-based value identifying the index in the array of
+                            ///< concurrent interfaces supported by this configuration.
+  uint8_t
+    bAlternateSetting; ///< Value used to select this alternate setting for the interface identified in the prior field
+  uint8_t bNumEndpoints;   ///< Number of endpoints used by this interface (excluding endpoint zero). If this value is
+                           ///< zero, this interface only uses the Default Control Pipe.
+  uint8_t bInterfaceClass; ///< Class code (assigned by the USB-IF). \li A value of zero is reserved for future
+                           ///< standardization. \li If this field is set to FFH, the interface class is
+                           ///< vendor-specific. \li All other values are reserved for assignment by the USB-IF.
+  uint8_t bInterfaceSubClass; ///< Subclass code (assigned by the USB-IF). \n These codes are qualified by the value of
+                              ///< the bInterfaceClass field. \li If the bInterfaceClass field is reset to zero, this
+                              ///< field must also be reset to zero. \li If the bInterfaceClass field is not set to FFH,
+                              ///< all values are reserved for assignment by the USB-IF.
+  uint8_t bInterfaceProtocol; ///< Protocol code (assigned by the USB). \n These codes are qualified by the value of the
+                              ///< bInterfaceClass and the bInterfaceSubClass fields. If an interface supports
+                              ///< class-specific requests, this code identifies the protocols that the device uses as
+                              ///< defined by the specification of the device class. \li If this field is reset to zero,
+                              ///< the device does not use a class-specific protocol on this interface. \li If this
+                              ///< field is set to FFH, the device uses a vendor-specific protocol for this interface.
+  uint8_t iInterface;         ///< Index of string descriptor describing this interface
 } tusb_desc_interface_t;
 
-TU_VERIFY_STATIC( sizeof(tusb_desc_interface_t) == 9u, "size is not correct");
+TU_VERIFY_STATIC(sizeof(tusb_desc_interface_t) == 9u, "size is not correct");
 
 /// USB Endpoint Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength          ; // Size of this descriptor in bytes
-  uint8_t  bDescriptorType  ; // ENDPOINT Descriptor Type
+  uint8_t bLength;          // Size of this descriptor in bytes
+  uint8_t bDescriptorType;  // ENDPOINT Descriptor Type
 
-  uint8_t  bEndpointAddress ; // The address of the endpoint
+  uint8_t bEndpointAddress; // The address of the endpoint
 
   struct TU_ATTR_PACKED {
 #if (TU_BITFIELD_ORDER == TU_BITFIELD_LE)
-    uint8_t xfer  : 2;        // Control, ISO, Bulk, Interrupt
-    uint8_t sync  : 2;        // None, Asynchronous, Adaptive, Synchronous
-    uint8_t usage : 2;        // Data, Feedback, Implicit feedback
+    uint8_t xfer  : 2; // Control, ISO, Bulk, Interrupt
+    uint8_t sync  : 2; // None, Asynchronous, Adaptive, Synchronous
+    uint8_t usage : 2; // Data, Feedback, Implicit feedback
     uint8_t       : 2;
 #elif (TU_BITFIELD_ORDER == TU_BITFIELD_BE)
     uint8_t       : 2;
@@ -414,70 +443,70 @@ typedef struct TU_ATTR_PACKED {
 #endif
   } bmAttributes;
 
-  uint16_t wMaxPacketSize   ; // Bit 10..0 : max packet size, bit 12..11 additional transaction per highspeed micro-frame
-  uint8_t  bInterval        ; // Polling interval, in frames or microframes depending on the operating speed
+  uint16_t wMaxPacketSize; // Bit 10..0 : max packet size, bit 12..11 additional transaction per highspeed micro-frame
+  uint8_t  bInterval;      // Polling interval, in frames or microframes depending on the operating speed
 } tusb_desc_endpoint_t;
 
-TU_VERIFY_STATIC( sizeof(tusb_desc_endpoint_t) == 7u, "size is not correct");
+TU_VERIFY_STATIC(sizeof(tusb_desc_endpoint_t) == 7u, "size is not correct");
 
 /// USB Other Speed Configuration Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength             ; ///< Size of descriptor
-  uint8_t  bDescriptorType     ; ///< Other_speed_Configuration Type
-  uint16_t wTotalLength        ; ///< Total length of data returned
+  uint8_t  bLength;            ///< Size of descriptor
+  uint8_t  bDescriptorType;    ///< Other_speed_Configuration Type
+  uint16_t wTotalLength;       ///< Total length of data returned
 
-  uint8_t  bNumInterfaces      ; ///< Number of interfaces supported by this speed configuration
-  uint8_t  bConfigurationValue ; ///< Value to use to select configuration
-  uint8_t  iConfiguration      ; ///< Index of string descriptor
-  uint8_t  bmAttributes        ; ///< Same as Configuration descriptor
-  uint8_t  bMaxPower           ; ///< Same as Configuration descriptor
+  uint8_t bNumInterfaces;      ///< Number of interfaces supported by this speed configuration
+  uint8_t bConfigurationValue; ///< Value to use to select configuration
+  uint8_t iConfiguration;      ///< Index of string descriptor
+  uint8_t bmAttributes;        ///< Same as Configuration descriptor
+  uint8_t bMaxPower;           ///< Same as Configuration descriptor
 } tusb_desc_other_speed_t;
 
 /// USB Device Qualifier Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength            ; ///< Size of descriptor
-  uint8_t  bDescriptorType    ; ///< Device Qualifier Type
-  uint16_t bcdUSB             ; ///< USB specification version number (e.g., 0200H for V2.00)
+  uint8_t  bLength;           ///< Size of descriptor
+  uint8_t  bDescriptorType;   ///< Device Qualifier Type
+  uint16_t bcdUSB;            ///< USB specification version number (e.g., 0200H for V2.00)
 
-  uint8_t  bDeviceClass       ; ///< Class Code
-  uint8_t  bDeviceSubClass    ; ///< SubClass Code
-  uint8_t  bDeviceProtocol    ; ///< Protocol Code
+  uint8_t bDeviceClass;       ///< Class Code
+  uint8_t bDeviceSubClass;    ///< SubClass Code
+  uint8_t bDeviceProtocol;    ///< Protocol Code
 
-  uint8_t  bMaxPacketSize0    ; ///< Maximum packet size for other speed
-  uint8_t  bNumConfigurations ; ///< Number of Other-speed Configurations
-  uint8_t  bReserved          ; ///< Reserved for future use, must be zero
+  uint8_t bMaxPacketSize0;    ///< Maximum packet size for other speed
+  uint8_t bNumConfigurations; ///< Number of Other-speed Configurations
+  uint8_t bReserved;          ///< Reserved for future use, must be zero
 } tusb_desc_device_qualifier_t;
 
-TU_VERIFY_STATIC( sizeof(tusb_desc_device_qualifier_t) == 10u, "size is not correct");
+TU_VERIFY_STATIC(sizeof(tusb_desc_device_qualifier_t) == 10u, "size is not correct");
 
 /// USB Interface Association Descriptor (IAD ECN)
 typedef struct TU_ATTR_PACKED {
-  uint8_t bLength           ; ///< Size of descriptor
-  uint8_t bDescriptorType   ; ///< Other_speed_Configuration Type
+  uint8_t bLength;           ///< Size of descriptor
+  uint8_t bDescriptorType;   ///< Other_speed_Configuration Type
 
-  uint8_t bFirstInterface   ; ///< Index of the first associated interface.
-  uint8_t bInterfaceCount   ; ///< Total number of associated interfaces.
+  uint8_t bFirstInterface;   ///< Index of the first associated interface.
+  uint8_t bInterfaceCount;   ///< Total number of associated interfaces.
 
-  uint8_t bFunctionClass    ; ///< Interface class ID.
-  uint8_t bFunctionSubClass ; ///< Interface subclass ID.
-  uint8_t bFunctionProtocol ; ///< Interface protocol ID.
+  uint8_t bFunctionClass;    ///< Interface class ID.
+  uint8_t bFunctionSubClass; ///< Interface subclass ID.
+  uint8_t bFunctionProtocol; ///< Interface protocol ID.
 
-  uint8_t iFunction         ; ///< Index of the string descriptor describing the interface association.
+  uint8_t iFunction;         ///< Index of the string descriptor describing the interface association.
 } tusb_desc_interface_assoc_t;
 
-TU_VERIFY_STATIC( sizeof(tusb_desc_interface_assoc_t) == 8u, "size is not correct");
+TU_VERIFY_STATIC(sizeof(tusb_desc_interface_assoc_t) == 8u, "size is not correct");
 
 // USB String Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength         ; ///< Size of this descriptor in bytes
-  uint8_t  bDescriptorType ; ///< Descriptor Type
+  uint8_t  bLength;         ///< Size of this descriptor in bytes
+  uint8_t  bDescriptorType; ///< Descriptor Type
   uint16_t utf16le[];
 } tusb_desc_string_t;
 
 // USB Binary Device Object Store (BOS)
 typedef struct TU_ATTR_PACKED {
   uint8_t bLength;
-  uint8_t bDescriptorType ;
+  uint8_t bDescriptorType;
   uint8_t bDevCapabilityType;
   uint8_t bReserved;
   uint8_t PlatformCapabilityUUID[16];
@@ -494,8 +523,8 @@ typedef struct TU_ATTR_PACKED {
 
 // DFU Functional Descriptor
 typedef struct TU_ATTR_PACKED {
-  uint8_t  bLength;
-  uint8_t  bDescriptorType;
+  uint8_t bLength;
+  uint8_t bDescriptorType;
 
   union {
     struct TU_ATTR_PACKED {
@@ -522,13 +551,13 @@ typedef struct TU_ATTR_PACKED {
   union {
     struct TU_ATTR_PACKED {
 #if (TU_BITFIELD_ORDER == TU_BITFIELD_LE)
-      uint8_t recipient :  5; ///< Recipient type tusb_request_recipient_t.
-      uint8_t type      :  2; ///< Request type tusb_request_type_t.
-      uint8_t direction :  1; ///< Direction type. tusb_dir_t
+      uint8_t recipient : 5; ///< Recipient type tusb_request_recipient_t.
+      uint8_t type      : 2; ///< Request type tusb_request_type_t.
+      uint8_t direction : 1; ///< Direction type. tusb_dir_t
 #elif (TU_BITFIELD_ORDER == TU_BITFIELD_BE)
-      uint8_t direction :  1; ///< Direction type. tusb_dir_t
-      uint8_t type      :  2; ///< Request type tusb_request_type_t.
-      uint8_t recipient :  5; ///< Recipient type tusb_request_recipient_t.
+      uint8_t direction : 1; ///< Direction type. tusb_dir_t
+      uint8_t type      : 2; ///< Request type tusb_request_type_t.
+      uint8_t recipient : 5; ///< Recipient type tusb_request_recipient_t.
 #else
   #error "Please define TU_BITFIELD_ORDER as TU_BITFIELD_LE or TU_BITFIELD_BE"
 #endif
@@ -543,42 +572,43 @@ typedef struct TU_ATTR_PACKED {
   uint16_t wLength;
 } tusb_control_request_t;
 
-TU_VERIFY_STATIC( sizeof(tusb_control_request_t) == 8u, "size is not correct");
+TU_VERIFY_STATIC(sizeof(tusb_control_request_t) == 8u, "size is not correct");
 
-TU_ATTR_PACKED_END  // End of all packed definitions
-TU_ATTR_BIT_FIELD_ORDER_END
+TU_ATTR_PACKED_END // End of all packed definitions
+  TU_ATTR_BIT_FIELD_ORDER_END
 
-//--------------------------------------------------------------------+
-// Endpoint helper
-//--------------------------------------------------------------------+
+    //--------------------------------------------------------------------+
+    // Endpoint helper
+    //--------------------------------------------------------------------+
 
-// Get direction from Endpoint address
-TU_ATTR_ALWAYS_INLINE static inline tusb_dir_t tu_edpt_dir(uint8_t addr) {
+    // Get direction from Endpoint address
+    TU_ATTR_ALWAYS_INLINE static inline tusb_dir_t
+    tu_edpt_dir(uint8_t addr) {
   return (addr & TUSB_DIR_IN_MASK) ? TUSB_DIR_IN : TUSB_DIR_OUT;
 }
 
 // Get Endpoint number from address
 TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_edpt_number(uint8_t addr) {
-  return (uint8_t) (addr & TUSB_EPNUM_MASK);
+  return (uint8_t)(addr & TUSB_EPNUM_MASK);
 }
 
 TU_ATTR_ALWAYS_INLINE static inline uint8_t tu_edpt_addr(uint8_t num, uint8_t dir) {
-  return (uint8_t) (num | (dir == (uint8_t)TUSB_DIR_IN ? (uint8_t)TUSB_DIR_IN_MASK : 0u));
+  return (uint8_t)(num | (dir == (uint8_t)TUSB_DIR_IN ? (uint8_t)TUSB_DIR_IN_MASK : 0u));
 }
 
-TU_ATTR_ALWAYS_INLINE static inline uint16_t tu_edpt_packet_size(tusb_desc_endpoint_t const* desc_ep) {
+TU_ATTR_ALWAYS_INLINE static inline uint16_t tu_edpt_packet_size(const tusb_desc_endpoint_t *desc_ep) {
   return tu_le16toh(desc_ep->wMaxPacketSize) & 0x7FF;
 }
 
 #if CFG_TUSB_DEBUG
 TU_ATTR_ALWAYS_INLINE static inline const char *tu_edpt_type_str(tusb_xfer_type_t t) {
-  tu_static const char *str[] = {"control", "isochronous", "bulk", "interrupt"};
+  const tu_static char *str[] = {"control", "isochronous", "bulk", "interrupt"};
   return str[t];
 }
 #endif
 
 #ifdef __cplusplus
- }
+}
 #endif
 
 #endif // TUSB_TYPES_H_

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -229,7 +229,7 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
 
 // Config number, interface count, string index, total length, attribute, power in mA
 #define TUD_CONFIG_DESCRIPTOR(config_num, _itfcount, _stridx, _total_len, _attribute, _power_ma) \
-  9, TUSB_DESC_CONFIGURATION, U16_TO_U8S_LE(_total_len), _itfcount, config_num, _stridx, TU_BIT(7) | _attribute, (uint8_t)((_power_ma)/2)
+  9, TUSB_DESC_CONFIGURATION, U16_TO_U8S_LE(_total_len), _itfcount, config_num, _stridx, TU_BIT(7) | _attribute, (uint8_t)TU_MIN((_power_ma)/2, UINT8_MAX)
 
 //--------------------------------------------------------------------+
 // CDC Descriptor Templates

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -229,7 +229,7 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
 
 // Config number, interface count, string index, total length, attribute, power in mA
 #define TUD_CONFIG_DESCRIPTOR(config_num, _itfcount, _stridx, _total_len, _attribute, _power_ma) \
-  9, TUSB_DESC_CONFIGURATION, U16_TO_U8S_LE(_total_len), _itfcount, config_num, _stridx, TU_BIT(7) | _attribute, (_power_ma)/2
+  9, TUSB_DESC_CONFIGURATION, U16_TO_U8S_LE(_total_len), _itfcount, config_num, _stridx, TU_BIT(7) | _attribute, (uint8_t)((_power_ma)/2)
 
 //--------------------------------------------------------------------+
 // CDC Descriptor Templates


### PR DESCRIPTION
## Issue
- Encountered this issue while using C++, `(_power_ma)/2` expands as an int due to integer promotion. When this macro is used to initialize a uint8_t descriptor array in C++, this is a narrowing conversion and fails under `-Wc++11-narrowing`, which is often enabled as an error (as it was for my project).
- Previously, any `_power_ma / 2` that was greater than 255 was truncated (mod 256) when used with a uint8_t array. Every example in tinyusb uses a uint8_t array with `TUD_CONFIG_DESCRIPTOR`.
- **bMaxPower is allocated a single byte in the Standard Configuration Descriptor (USB Spec Rev 2.0 Section Table 9-10), so any value larger should not be valid.**
## Fix
- This does not alter the old truncation behavior, only explicitly makes expression type a uint8_t (assuming uint8_t array)
- Even if not using uint8_t array, per the USB spec, `TUD_CONFIG_DESCRIPTOR` should not produce a `bMaxPower` field larger than uint8_t.
- Fixed `TUSB_DESC_CONFIG_POWER_MA` at same time to prevent similar issues