### PR TITLE
test/hil: replace PCI reset with root-port VBUS cycle for D-state recovery

### DIFF
--- a/.claude/skills/usb-kernel-debug/SKILL.md
+++ b/.claude/skills/usb-kernel-debug/SKILL.md
@@ -12,11 +12,11 @@ sits in the link — the rig PC when it is the host, or a Linux gadget peer
 (dwc2/UDC + gadget modules) when TinyUSB is the host. It cannot see inside
 the TinyUSB MCU — that is the `target-debug` skill.
 
-Run this skill's `scripts/usb_dyndbg.sh` with `sudo` (abbreviated to
-`usb_dyndbg.sh` in the examples below). It flips the dynamic-debug print flag
-for an allowlisted set of USB modules only:
+Run this skill's `scripts/usb_dyndbg.sh` with `sudo`. It flips the dynamic-debug
+print flag for an allowlisted set of USB modules only:
 
 ```bash
+# all examples below abbreviate:  sudo .claude/skills/usb-kernel-debug/scripts/usb_dyndbg.sh
 sudo usb_dyndbg.sh on  usbcore xhci_hcd   # enable +p; pick modules from `lsusb -t` Driver=
 sudo usb_dyndbg.sh status [module]        # list enabled print sites
 sudo usb_dyndbg.sh off usbcore xhci_hcd   # ALWAYS turn off when done — very noisy

--- a/.claude/skills/usb-kernel-recover/SKILL.md
+++ b/.claude/skills/usb-kernel-recover/SKILL.md
@@ -15,8 +15,9 @@ sudo usb_recover.sh authorized <busport>       # deauthorize+reauthorize: re-enu
 sudo usb_recover.sh rebind     <busport>       # usb driver unbind+bind: re-probe
 sudo usb_recover.sh hub-cycle  <busport>       # uhubctl VBUS cycle of the feeding port, walking parent hub
                                                # -> root port until the device re-enumerates
-sudo usb_recover.sh root-cycle <busport>       # uhubctl VBUS cut straight at the ROOT port (real ppps), no
-                                               # leaf walk, no device-lock touch: the D-state cure
+sudo usb_recover.sh root-cycle <busport> [serial]  # uhubctl VBUS cut straight at the ROOT port (real ppps), no
+                                               # leaf walk, no device-lock touch: the D-state cure.
+                                               # [serial] is checked and a mismatch refused.
 sudo usb_recover.sh pci-rebind <pciaddr>       # whole HCD controller unbind+bind, e.g. 0000:02:00.0
 sudo usb_recover.sh pci-bind   <pciaddr> [drv] # re-bind a DRIVERLESS controller (auto-tries xHCI drivers)
 ```
@@ -43,10 +44,14 @@ sudo usb_recover.sh root-cycle <busport>     # e.g. 11-3.7 -> cycles bus 11 root
 
 This drops power to the wedged device, so its in-flight URB fails and the ioctl
 returns. It targets the *root hub* — a different USB device from the wedged one —
-and only ever *reads* an attribute of the wedged device (`devnum`, which takes no
-lock), so it does not join the convoy the way `authorized`/`rebind`/`pci-rebind`
-do. It exits non-zero if the device does not come back; a **zero exit only means
-it re-enumerated**, so still confirm the D-state process actually let go.
+and only ever *reads* the wedged device's sysfs (its directory inode, which takes
+no lock), so it does not join the convoy the way `authorized`/`rebind`/`pci-rebind`
+do. Recovery is proven by that inode changing — a real disconnect destroys the
+kobject and reconnecting creates a new one, whereas a disconnect blocked on the
+device lock leaves it untouched. It exits non-zero if the device does not come
+back; a **zero exit only means it re-enumerated**, so still confirm the D-state
+process actually let go. Pass the expected serial as a third argument and it
+refuses a busport that now names a different device.
 
 It bounces **every fixture under that root port** — on ci that is up to 25
 devices. Hold the affected boards' locks first if you can, but note

--- a/.claude/skills/usb-kernel-recover/SKILL.md
+++ b/.claude/skills/usb-kernel-recover/SKILL.md
@@ -43,12 +43,24 @@ sudo usb_recover.sh root-cycle <busport>     # e.g. 11-3.7 -> cycles bus 11 root
 
 This drops power to the wedged device, so its in-flight URB fails and the ioctl
 returns. It targets the *root hub* — a different USB device from the wedged one —
-and never touches the wedged device's sysfs, so it does not join the convoy the
-way `authorized`/`rebind`/`pci-rebind` do. It bounces every fixture under that
-root port, so hold their board locks first. It exits non-zero if the device does
-not come back; a **zero exit only means it re-enumerated**, so still confirm the
-D-state process actually let go. (Reasoned from the lock structure and the rigs'
-verified root-port ppps; not yet confirmed against a live D-state wedge. If
+and only ever *reads* an attribute of the wedged device (`devnum`, which takes no
+lock), so it does not join the convoy the way `authorized`/`rebind`/`pci-rebind`
+do. It exits non-zero if the device does not come back; a **zero exit only means
+it re-enumerated**, so still confirm the D-state process actually let go.
+
+It bounces **every fixture under that root port** — on ci that is up to 25
+devices. Hold the affected boards' locks first if you can, but note
+`board_lock.py` uses `LOCK_EX | LOCK_NB` and so fails immediately when CI already
+holds them; there is no wait-for-lock. When CI is mid-run you are choosing
+between bouncing its fixtures and leaving the bus wedged for everything. The
+automated path in `usbtest.py` takes no locks at all and accepts that collateral
+deliberately: by the time a D-state wedge exists the convoy will take the bus
+down anyway.
+
+(The VBUS mechanism is verified on the ci rig — the leaf hubs report
+`bmAttributes=e0`, "self-powered", but are physically bus-powered with no adapter,
+so a root-port cut really does kill downstream power. Do not re-derive this from
+the descriptor; it lies. Not yet confirmed against a live D-state wedge. If
 `uhubctl` itself hangs, the convoy has already spread — escalate.)
 
 If `root-cycle` does not free the D-state process, there is no software cure

--- a/.claude/skills/usb-kernel-recover/SKILL.md
+++ b/.claude/skills/usb-kernel-recover/SKILL.md
@@ -15,8 +15,9 @@ sudo usb_recover.sh authorized <busport>       # deauthorize+reauthorize: re-enu
 sudo usb_recover.sh rebind     <busport>       # usb driver unbind+bind: re-probe
 sudo usb_recover.sh hub-cycle  <busport>       # uhubctl VBUS cycle of the feeding port, walking parent hub
                                                # -> root port until the device re-enumerates
+sudo usb_recover.sh root-cycle <busport>       # uhubctl VBUS cut straight at the ROOT port (real ppps), no
+                                               # leaf walk, no device-lock touch: the D-state cure
 sudo usb_recover.sh pci-rebind <pciaddr>       # whole HCD controller unbind+bind, e.g. 0000:02:00.0
-sudo usb_recover.sh pci-reset  <pciaddr>       # PCI function-level reset: kills URBs at HW level, no device lock
 sudo usb_recover.sh pci-bind   <pciaddr> [drv] # re-bind a DRIVERLESS controller (auto-tries xHCI drivers)
 ```
 
@@ -34,21 +35,27 @@ ps -eo pid,stat,wchan:30,cmd | awk '$2 ~ /D/'
 ```
 
 **If yes** (uninterruptible sleep, typically a usbfs ioctl — e.g. testusb inside
-`usb_sg_wait`): run `pci-reset` and NOTHING ELSE first:
+`usb_sg_wait`): cut VBUS at the root port, and nothing else.
 
 ```bash
-sudo usb_recover.sh pci-reset <pciaddr>
+sudo usb_recover.sh root-cycle <busport>     # e.g. 11-3.7 -> cycles bus 11 root port 3
 ```
 
-FLR kills the URBs at the hardware level without taking the per-device lock;
-the ioctl then returns and the convoy unwinds on its own.
+This drops power to the wedged device, so its in-flight URB fails and the ioctl
+returns. It targets the *root hub* — a different USB device from the wedged one —
+and never touches the wedged device's sysfs, so it does not join the convoy the
+way `authorized`/`rebind`/`pci-rebind` do. It bounces every fixture under that
+root port, so hold their board locks first. It exits non-zero if the device does
+not come back; a **zero exit only means it re-enumerated**, so still confirm the
+D-state process actually let go. (Reasoned from the lock structure and the rigs'
+verified root-port ppps; not yet confirmed against a live D-state wedge. If
+`uhubctl` itself hangs, the convoy has already spread — escalate.)
 
-**Not every controller supports FLR.** The Renesas uPD720201 (`0000:01:00.0`)
-has no reset method — `pci-reset` fails with `Inappropriate ioctl for device`
-(ENOTTY). On those, there is no clean software D-state cure — a VM reboot is NOT
+If `root-cycle` does not free the D-state process, there is no software cure
+left: ask the operator for a full PVE **host** power cycle. A VM reboot is NOT
 reliable (downstream hubs can latch up across the PCIe reset and need a physical
-replug); ask the operator for a full PVE host power cycle instead. Do NOT
-fall through to `pci-rebind` (see next).
+replug), and a graceful reboot stalls on the D-state process anyway. Do NOT fall
+through to `pci-rebind` (see next).
 
 **`pci-rebind` can strand the controller driverless.** Its unbind succeeds but,
 with a D-state process still holding a URB, the *re-bind* hangs — leaving the
@@ -62,10 +69,9 @@ power cycle (operator action) recovers. The Renesas binds via `xhci-pci-renesas`
 **Ordering is critical.** `authorized`/`rebind`/`pci-rebind` all take the
 per-device lock the stuck ioctl holds — they block and join the convoy, and
 soon every libusb tool (uhubctl, JLinkExe) hangs too. Worse, a blocked
-`pci-rebind` grabs the PCI device lock on its way in, which `pci-reset` also
-needs: once a rebind has been attempted and is stuck, even FLR deadlocks and
-**only a full PVE host power cycle recovers**. pci-reset first (if supported), and never
-`pci-rebind` a D-state wedge.
+`pci-rebind` grabs the PCI device lock on its way in and can wedge the whole
+function, after which **only a full PVE host power cycle recovers**. `root-cycle`
+first, and never `pci-rebind` a D-state wedge.
 
 **If no** (device merely dead or silent), escalate gently:
 
@@ -93,15 +99,19 @@ hubs themselves claim "ganged" switching but do not actually cut power.
 ## Common mistakes
 
 - `resolve` takes a **/dev node**, not a busport or serial ("no such device node").
-- `authorized`/`rebind` take a **busport** (`3-4.7`); `pci-rebind`/`pci-reset`
-  take a **PCI addr**.
+- `authorized`/`rebind`/`hub-cycle`/`root-cycle` take a **busport** (`3-4.7`);
+  `pci-rebind`/`pci-bind` take a **PCI addr**.
 - Command produces no output and doesn't return → it is blocked on the device
   lock: a D-state holder exists; see above.
 - Trying `pci-rebind` on a D-state hang — its re-bind hangs and strands the
   controller **driverless**; recover with `pci-bind <addr>`, or a PVE host power
-  cycle if the D-state URB is unkillable. Use `pci-reset` (if supported) for D-state, never
+  cycle if the D-state URB is unkillable. Use `root-cycle` for D-state, never
   `pci-rebind`.
-- Running `pci-reset` on a controller without FLR support (Renesas) → ENOTTY;
-  no software recovery — needs a PVE host power cycle.
+- Writing `/sys/bus/pci/devices/<addr>/reset` because the attribute is there. No
+  rig controller has FLR, so it becomes a PCIe bus reset that resets the xHCI
+  behind its live driver — the write succeeds, the card is halted for good, and
+  only a PVE host power cycle brings it back. Use `root-cycle`.
+- `root-cycle` bounces **every** fixture under that root port, not just the target
+  — hold the sibling boards' locks first.
 - A J-Link reset (`r; go`) does not disconnect a wedged DUT from the host: the
   DWC2 soft-connect pullup stays up through a core halt, so stuck URBs stay stuck.

--- a/.claude/skills/usb-kernel-recover/SKILL.md
+++ b/.claude/skills/usb-kernel-recover/SKILL.md
@@ -44,9 +44,11 @@ sudo usb_recover.sh root-cycle <busport>     # e.g. 11-3.7 -> cycles bus 11 root
 
 This drops power to the wedged device, so its in-flight URB fails and the ioctl
 returns. It targets the *root hub* — a different USB device from the wedged one —
-and only ever *reads* the wedged device's sysfs (its directory inode, which takes
-no lock), so it does not join the convoy the way `authorized`/`rebind`/`pci-rebind`
-do. Recovery is proven by that inode changing — a real disconnect destroys the
+and never *writes* the wedged device's sysfs. It reads a few attributes from it —
+`idVendor`/`idProduct`/`serial`/`product` to report and check the target, and the
+directory inode plus `devnum` afterwards — none of which take the device lock, so
+it does not join the convoy the way `authorized`/`rebind`/`pci-rebind` do.
+Recovery is proven by that inode changing — a real disconnect destroys the
 kobject and reconnecting creates a new one, whereas a disconnect blocked on the
 device lock leaves it untouched. It exits non-zero if the device does not come
 back; a **zero exit only means it re-enumerated**, so still confirm the D-state

--- a/.claude/skills/usb-kernel-recover/SKILL.md
+++ b/.claude/skills/usb-kernel-recover/SKILL.md
@@ -5,11 +5,11 @@ description: Use when a USB device or fixture attached to the ci HIL rig's Linux
 
 # USB Recovery on the HIL Rig (Linux kernel side)
 
-Run this skill's `scripts/usb_recover.sh` with `sudo` (abbreviated to
-`usb_recover.sh` in the examples below). It wraps the sysfs reset actions, a
-uhubctl power-cycle escalator, and a resolver:
+Run this skill's `scripts/usb_recover.sh` with `sudo`. It wraps the sysfs reset
+actions, a uhubctl power-cycle escalator, and a resolver:
 
 ```bash
+# all examples below abbreviate:  sudo .claude/skills/usb-kernel-recover/scripts/usb_recover.sh
 sudo usb_recover.sh resolve    /dev/ttyACM3    # /dev node -> busport (e.g. 3-4.7); also ttyUSB*, sg*
 sudo usb_recover.sh authorized <busport>       # deauthorize+reauthorize: re-enumerate, no VBUS cut
 sudo usb_recover.sh rebind     <busport>       # usb driver unbind+bind: re-probe

--- a/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
+++ b/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
@@ -178,7 +178,7 @@ case "$action" in
     expect=${3:-}
     [ -z "$expect" ] || [ "$expect" = "$serial" ] || \
       die "root-cycle: $target has serial '$serial', expected '$expect' — stale busport, refusing"
-    echo "root-cycle: target $target is $(cat "$idf/idVendor" 2>/dev/null):$(cat "$idf/idProduct" 2>/dev/null)" \
+    echo "root-cycle: target $target is $(cat "$idf/idVendor" 2>/dev/null || echo -):$(cat "$idf/idProduct" 2>/dev/null || echo -)" \
          "serial=$serial product=$(cat "$idf/product" 2>/dev/null || echo -)"
     bus=${target%%-*}; rest=${target#*-}; rootport=${rest%%.*}
     gen=$(sysfs_gen "$target")

--- a/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
+++ b/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
@@ -40,7 +40,15 @@ die() { echo "usb_recover: $*" >&2; exit 1; }
 # never witness the gap. The inode survives the gap, so no observation window is needed.
 #
 # Crucially, if the disconnect is blocked on the wedged device's lock the kobject is never
-# recreated -- same inode -- which is exactly the case that must be reported as a failure.
+# recreated -- same inode -- which is exactly the case that must be reported as a failure. Verified
+# against kernfs: __kernfs_new_node() allocates via idr_alloc_cyclic() but kernfs_id_ino() exposes
+# the full 64-bit (id_highbits<<32 | lowbits) as st_ino on 64-bit ino_t, so a repeat needs ~2^64
+# node creations. authorized-toggle, set_configuration and suspend/resume all leave the parent
+# device kobject alone, so none of them can move the marker and fake a success.
+#
+# The trailing slash is load-bearing: /sys/bus/usb/devices/<busport> is a SYMLINK with its own
+# separate inode, so without it stat reports the link rather than the device it points at, and the
+# value would never change. Do not "tidy" it away.
 sysfs_gen() { stat -c %i "/sys/bus/usb/devices/$1/" 2>/dev/null || echo none; }
 usage() { grep -E '^#   sudo usb_recover' "$0" >&2; exit 2; }
 
@@ -155,7 +163,7 @@ case "$action" in
     # from the leaf (the 1a40:0201 hubs claim ganged switching but never cut power) and never
     # writes the wedged device's sysfs or takes its lock, so it cannot join a D-state convoy.
     # uhubctl exits 0 even when it does nothing ("No compatible devices detected" still returns
-    # 0), so its status proves nothing -- the devnum check below is the only real verdict.
+    # 0), so its status proves nothing -- the sysfs_gen check below is the only real verdict.
     [[ "$target" =~ $USBPATH_RE ]] || die "bad usb path: $target"
     UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
     [ -x "$UHUBCTL" ] || die "uhubctl not installed"

--- a/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
+++ b/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
@@ -14,7 +14,8 @@
 #                                              # re-enumerates. Ganged/fake-switching hubs may bounce ALL
 #                                              # siblings; self-powered hubs only reset their uplink, which
 #                                              # is why the walk ends at the root port (real xHCI ppps).
-#   sudo usb_recover.sh root-cycle <busport>   # e.g. 13-1.6 -> uhubctl VBUS cut at the ROOT port feeding it,
+#   sudo usb_recover.sh root-cycle <busport> [serial]  # e.g. 13-1.6 -> uhubctl VBUS cut at the ROOT port feeding
+#                                              # it; [serial] is verified against the device and refused on mismatch,
 #                                              # skipping the leaf hubs (which fake ganged switching and do not
 #                                              # actually cut power). Bounces every sibling under that root port.
 #                                              # The D-state escape: no device lock, so it cannot convoy.
@@ -26,6 +27,21 @@ PCI_RE='^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9]$'
 DRIVER_RE='^[A-Za-z0-9_-]+$'
 
 die() { echo "usb_recover: $*" >&2; exit 1; }
+
+# Generation marker for "did this device actually re-enumerate". A real disconnect destroys the
+# usb_device and its sysfs kobject; reconnecting creates a new one, and kernfs hands out inode
+# numbers monotonically, so the directory inode changes. Verified on the rig: ports re-enumerated
+# minutes ago carry inodes in the millions while ports untouched since boot are still in the tens
+# of thousands, ranking identically to their mtimes.
+#
+# This beats comparing devnum, which Linux reuses once the per-bus map wraps (observed live: a
+# single cycle moved one device 123 -> 113). It also beats watching for the node to vanish, since
+# `uhubctl -a cycle` holds the whole power-off window inside itself and a poll afterwards can
+# never witness the gap. The inode survives the gap, so no observation window is needed.
+#
+# Crucially, if the disconnect is blocked on the wedged device's lock the kobject is never
+# recreated -- same inode -- which is exactly the case that must be reported as a failure.
+sysfs_gen() { stat -c %i "/sys/bus/usb/devices/$1/" 2>/dev/null || echo none; }
 usage() { grep -E '^#   sudo usb_recover' "$0" >&2; exit 2; }
 
 # Refuse to touch a PCI function that is not a USB controller (class 0x0c03xx), so a stray or
@@ -108,12 +124,11 @@ case "$action" in
     [[ "$target" =~ $USBPATH_RE ]] || die "bad usb path: $target"
     UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
     [ -x "$UHUBCTL" ] || die "uhubctl not installed"
-    # devnum plus an observed disappearance, not node existence: a disconnect blocked on the
-    # device lock leaves the old node (and its idVendor) in place, so an existence check reports
-    # success without anything having happened -- and the walk to the root port, which is the
-    # part that actually cuts power on these fake-ganged leaf hubs, would never run.
-    before=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
-    saw_gone=0
+    # sysfs generation, not node existence: a disconnect blocked on the device lock leaves the
+    # old node (and its idVendor) in place, so an existence check reports success without anything
+    # having happened -- and the walk to the root port, which is the part that actually cuts power
+    # on these fake-ganged leaf hubs, would never run.
+    gen=$(sysfs_gen "$target")
     dev="$target"
     while :; do
       if [[ "$dev" =~ ^([0-9]+)-([0-9]+)$ ]]; then    # parent is the root hub
@@ -125,10 +140,9 @@ case "$action" in
       "$UHUBCTL" -l "$loc" -p "$port" -a cycle -d 5 -f || echo "  (uhubctl failed at $loc; walking up)"
       for _ in $(seq 1 10); do
         sleep 1
-        now=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
-        if [ "$now" = none ]; then saw_gone=1; continue; fi
-        if [ "$saw_gone" = 1 ] || [ "$now" != "$before" ]; then
-          echo "recovered: $target re-enumerated (devnum $before -> $now)"; exit 0
+        now=$(sysfs_gen "$target")
+        if [ "$now" != none ] && [ "$now" != "$gen" ]; then
+          echo "recovered: $target re-enumerated (gen $gen -> $now)"; exit 0
         fi
       done
       [ -n "$up" ] || break
@@ -145,16 +159,21 @@ case "$action" in
     [[ "$target" =~ $USBPATH_RE ]] || die "bad usb path: $target"
     UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
     [ -x "$UHUBCTL" ] || die "uhubctl not installed"
-    # Same existence guard as authorized/rebind. NB this only proves *something* occupies that
-    # path -- bus numbers renumber every boot, so a stale busport can name a different device
-    # entirely and we would cut power to its whole subtree. Print the identity we are about to
-    # bounce so a wrong target is visible; pass a freshly resolved busport (see `resolve`).
+    # Existence alone only proves *something* occupies that path -- bus numbers renumber every
+    # boot, so a stale busport can name a different device entirely and we would cut power to its
+    # whole subtree (up to 25 fixtures on this rig). Callers that know what they expect pass the
+    # serial as a third argument and we refuse on mismatch; otherwise print the identity so a
+    # wrong target is at least visible.
     [ -e "/sys/bus/usb/devices/$target" ] || die "no such usb device: $target"
     idf="/sys/bus/usb/devices/$target"
+    serial=$(cat "$idf/serial" 2>/dev/null || echo -)
+    expect=${3:-}
+    [ -z "$expect" ] || [ "$expect" = "$serial" ] || \
+      die "root-cycle: $target has serial '$serial', expected '$expect' — stale busport, refusing"
     echo "root-cycle: target $target is $(cat "$idf/idVendor" 2>/dev/null):$(cat "$idf/idProduct" 2>/dev/null)" \
-         "serial=$(cat "$idf/serial" 2>/dev/null || echo -) product=$(cat "$idf/product" 2>/dev/null || echo -)"
+         "serial=$serial product=$(cat "$idf/product" 2>/dev/null || echo -)"
     bus=${target%%-*}; rest=${target#*-}; rootport=${rest%%.*}
-    before=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
+    gen=$(sysfs_gen "$target")
     echo "root-cycle: cutting VBUS on bus $bus root port $rootport (feeds $target, bounces its siblings)"
     # -S is load-bearing. By default uhubctl writes /sys/.../usb<bus>-port<n>/disable (verified:
     # two O_WRONLY opens per cycle), and the kernel's disable_store() takes the ROOT HUB's lock and
@@ -162,23 +181,17 @@ case "$action" in
     # blocks on the lock we are trying to free, so power would never drop and uhubctl would D-state
     # holding the root hub's lock, poisoning the whole bus. -S forces the libusb path, which sends
     # the power-off control transfer straight to the root hub with no child-disconnect in front.
-    "$UHUBCTL" -S -l "$bus" -p "$rootport" -a cycle -d 5
-    # Require evidence of a NEW enumeration, not merely that the sysfs node exists: if the
-    # disconnect is itself blocked on the device lock the old node stays put, so an existence
-    # check would report success in exactly the case we need to catch. Either an observed
-    # disappearance or a changed devnum proves it. devnum alone is not enough -- Linux reuses
-    # addresses once the per-bus map wraps, and this rig churns ~20 devnums a minute, so a
-    # same-address reassignment is not hypothetical.
-    saw_gone=0
+    "$UHUBCTL" -S -l "$bus" -p "$rootport" -a cycle -d 5 \
+      || die "uhubctl failed to cycle bus $bus port $rootport"
     for _ in $(seq 1 10); do
       sleep 1
-      now=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
-      if [ "$now" = none ]; then saw_gone=1; continue; fi
-      if [ "$saw_gone" = 1 ] || [ "$now" != "$before" ]; then
-        echo "root-cycled $bus port $rootport: $target re-enumerated (devnum $before -> $now)"; exit 0
+      now=$(sysfs_gen "$target")
+      if [ "$now" != none ] && [ "$now" != "$gen" ]; then
+        echo "root-cycled $bus port $rootport: $target re-enumerated"\
+             "(devnum $(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo ?), gen $gen -> $now)"; exit 0
       fi
     done
-    die "root-cycle: $target did not re-enumerate after cycling bus $bus port $rootport (devnum still $before)"
+    die "root-cycle: $target did not re-enumerate after cycling bus $bus port $rootport (sysfs generation still $gen: no disconnect happened)"
     ;;
   *)
     usage

--- a/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
+++ b/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
@@ -108,6 +108,11 @@ case "$action" in
     [[ "$target" =~ $USBPATH_RE ]] || die "bad usb path: $target"
     UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
     [ -x "$UHUBCTL" ] || die "uhubctl not installed"
+    # devnum, not node existence: a disconnect blocked on the device lock leaves the old node
+    # (and its idVendor) in place, so an existence check reports success without anything having
+    # happened -- and the walk to the root port, which is the part that actually cuts power on
+    # these fake-ganged leaf hubs, would never run.
+    before=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
     dev="$target"
     while :; do
       if [[ "$dev" =~ ^([0-9]+)-([0-9]+)$ ]]; then    # parent is the root hub
@@ -119,8 +124,9 @@ case "$action" in
       "$UHUBCTL" -l "$loc" -p "$port" -a cycle -d 5 -f || echo "  (uhubctl failed at $loc; walking up)"
       for _ in $(seq 1 10); do
         sleep 1
-        if [ -e "/sys/bus/usb/devices/$target/idVendor" ]; then
-          echo "recovered: $target re-enumerated"; exit 0
+        now=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
+        if [ "$now" != none ] && [ "$now" != "$before" ]; then
+          echo "recovered: $target re-enumerated (devnum $before -> $now)"; exit 0
         fi
       done
       [ -n "$up" ] || break
@@ -129,13 +135,17 @@ case "$action" in
     die "hub-cycle: $target still not enumerated after cycling up to the root port"
     ;;
   root-cycle)
-    # VBUS cut at the ROOT port, where xHCI ppps is real. Unlike hub-cycle this does not walk
-    # up from the leaf (the 1a40:0201 hubs claim ganged switching but never cut power) and does
-    # not touch the wedged device's sysfs, so it does not join a D-state convoy. No -f: uhubctl
-    # should fail loudly on a controller whose root ports have no per-port power.
+    # VBUS cut at the ROOT port, where xHCI ppps is real. Unlike hub-cycle this does not walk up
+    # from the leaf (the 1a40:0201 hubs claim ganged switching but never cut power) and never
+    # writes the wedged device's sysfs or takes its lock, so it cannot join a D-state convoy.
+    # uhubctl exits 0 even when it does nothing ("No compatible devices detected" still returns
+    # 0), so its status proves nothing -- the devnum check below is the only real verdict.
     [[ "$target" =~ $USBPATH_RE ]] || die "bad usb path: $target"
     UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
     [ -x "$UHUBCTL" ] || die "uhubctl not installed"
+    # Same existence guard as authorized/rebind: bus numbers renumber every boot, and a stale
+    # busport would otherwise cut power to whatever now occupies that root port.
+    [ -e "/sys/bus/usb/devices/$target" ] || die "no such usb device: $target"
     bus=${target%%-*}; rest=${target#*-}; rootport=${rest%%.*}
     before=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
     echo "root-cycle: cutting VBUS on bus $bus root port $rootport (feeds $target, bounces its siblings)"

--- a/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
+++ b/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
@@ -139,9 +139,13 @@ case "$action" in
     bus=${target%%-*}; rest=${target#*-}; rootport=${rest%%.*}
     before=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
     echo "root-cycle: cutting VBUS on bus $bus root port $rootport (feeds $target, bounces its siblings)"
-    # No -e: without it uhubctl also cycles the paired USB3 root port, which is the same physical
-    # connector, so the whole port really loses VBUS. -e would cut only the USB2 half.
-    "$UHUBCTL" -l "$bus" -p "$rootport" -a cycle -d 5
+    # -S is load-bearing. By default uhubctl writes /sys/.../usb<bus>-port<n>/disable (verified:
+    # two O_WRONLY opens per cycle), and the kernel's disable_store() takes the ROOT HUB's lock and
+    # synchronously usb_disconnect()s the child BEFORE cutting power -- against a wedged device that
+    # blocks on the lock we are trying to free, so power would never drop and uhubctl would D-state
+    # holding the root hub's lock, poisoning the whole bus. -S forces the libusb path, which sends
+    # the power-off control transfer straight to the root hub with no child-disconnect in front.
+    "$UHUBCTL" -S -l "$bus" -p "$rootport" -a cycle -d 5
     # Require a NEW enumeration (devnum changes), not merely that the sysfs node exists. If the
     # disconnect is itself blocked on the device lock, the old node and its idVendor stay put, so
     # an existence check would report success in exactly the case we need to catch.

--- a/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
+++ b/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
@@ -108,11 +108,12 @@ case "$action" in
     [[ "$target" =~ $USBPATH_RE ]] || die "bad usb path: $target"
     UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
     [ -x "$UHUBCTL" ] || die "uhubctl not installed"
-    # devnum, not node existence: a disconnect blocked on the device lock leaves the old node
-    # (and its idVendor) in place, so an existence check reports success without anything having
-    # happened -- and the walk to the root port, which is the part that actually cuts power on
-    # these fake-ganged leaf hubs, would never run.
+    # devnum plus an observed disappearance, not node existence: a disconnect blocked on the
+    # device lock leaves the old node (and its idVendor) in place, so an existence check reports
+    # success without anything having happened -- and the walk to the root port, which is the
+    # part that actually cuts power on these fake-ganged leaf hubs, would never run.
     before=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
+    saw_gone=0
     dev="$target"
     while :; do
       if [[ "$dev" =~ ^([0-9]+)-([0-9]+)$ ]]; then    # parent is the root hub
@@ -125,7 +126,8 @@ case "$action" in
       for _ in $(seq 1 10); do
         sleep 1
         now=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
-        if [ "$now" != none ] && [ "$now" != "$before" ]; then
+        if [ "$now" = none ]; then saw_gone=1; continue; fi
+        if [ "$saw_gone" = 1 ] || [ "$now" != "$before" ]; then
           echo "recovered: $target re-enumerated (devnum $before -> $now)"; exit 0
         fi
       done
@@ -143,9 +145,14 @@ case "$action" in
     [[ "$target" =~ $USBPATH_RE ]] || die "bad usb path: $target"
     UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
     [ -x "$UHUBCTL" ] || die "uhubctl not installed"
-    # Same existence guard as authorized/rebind: bus numbers renumber every boot, and a stale
-    # busport would otherwise cut power to whatever now occupies that root port.
+    # Same existence guard as authorized/rebind. NB this only proves *something* occupies that
+    # path -- bus numbers renumber every boot, so a stale busport can name a different device
+    # entirely and we would cut power to its whole subtree. Print the identity we are about to
+    # bounce so a wrong target is visible; pass a freshly resolved busport (see `resolve`).
     [ -e "/sys/bus/usb/devices/$target" ] || die "no such usb device: $target"
+    idf="/sys/bus/usb/devices/$target"
+    echo "root-cycle: target $target is $(cat "$idf/idVendor" 2>/dev/null):$(cat "$idf/idProduct" 2>/dev/null)" \
+         "serial=$(cat "$idf/serial" 2>/dev/null || echo -) product=$(cat "$idf/product" 2>/dev/null || echo -)"
     bus=${target%%-*}; rest=${target#*-}; rootport=${rest%%.*}
     before=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
     echo "root-cycle: cutting VBUS on bus $bus root port $rootport (feeds $target, bounces its siblings)"
@@ -156,13 +163,18 @@ case "$action" in
     # holding the root hub's lock, poisoning the whole bus. -S forces the libusb path, which sends
     # the power-off control transfer straight to the root hub with no child-disconnect in front.
     "$UHUBCTL" -S -l "$bus" -p "$rootport" -a cycle -d 5
-    # Require a NEW enumeration (devnum changes), not merely that the sysfs node exists. If the
-    # disconnect is itself blocked on the device lock, the old node and its idVendor stay put, so
-    # an existence check would report success in exactly the case we need to catch.
+    # Require evidence of a NEW enumeration, not merely that the sysfs node exists: if the
+    # disconnect is itself blocked on the device lock the old node stays put, so an existence
+    # check would report success in exactly the case we need to catch. Either an observed
+    # disappearance or a changed devnum proves it. devnum alone is not enough -- Linux reuses
+    # addresses once the per-bus map wraps, and this rig churns ~20 devnums a minute, so a
+    # same-address reassignment is not hypothetical.
+    saw_gone=0
     for _ in $(seq 1 10); do
       sleep 1
       now=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
-      if [ "$now" != none ] && [ "$now" != "$before" ]; then
+      if [ "$now" = none ]; then saw_gone=1; continue; fi
+      if [ "$saw_gone" = 1 ] || [ "$now" != "$before" ]; then
         echo "root-cycled $bus port $rootport: $target re-enumerated (devnum $before -> $now)"; exit 0
       fi
     done

--- a/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
+++ b/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
@@ -6,9 +6,6 @@
 #   sudo usb_recover.sh authorized <busport>   # e.g. 3-2  -> deauthorize+reauthorize (re-enumerate, NO VBUS cut)
 #   sudo usb_recover.sh rebind     <busport>   # e.g. 3-2  -> usb driver unbind+bind (re-probe)
 #   sudo usb_recover.sh pci-rebind <pciaddr>   # e.g. 0000:01:00.0 -> HCD unbind+bind (WHOLE controller)
-#   sudo usb_recover.sh pci-reset  <pciaddr>   # e.g. 0000:01:00.0 -> PCI function-level reset: kills URBs at
-#                                              # HW level WITHOUT the device lock; the only cure when a process
-#                                              # is stuck in D state (usbfs ioctl) and unbind paths would convoy
 #   sudo usb_recover.sh pci-bind   <pciaddr> [driver]  # bind a DRIVERLESS controller (e.g. after a pci-rebind
 #                                              # whose re-bind hung and left it unbound). Auto-tries the xHCI
 #                                              # drivers (xhci-pci-renesas, xhci_hcd) unless one is named.
@@ -17,6 +14,10 @@
 #                                              # re-enumerates. Ganged/fake-switching hubs may bounce ALL
 #                                              # siblings; self-powered hubs only reset their uplink, which
 #                                              # is why the walk ends at the root port (real xHCI ppps).
+#   sudo usb_recover.sh root-cycle <busport>   # e.g. 13-1.6 -> uhubctl VBUS cut at the ROOT port feeding it,
+#                                              # skipping the leaf hubs (which fake ganged switching and do not
+#                                              # actually cut power). Bounces every sibling under that root port.
+#                                              # The D-state escape: no device lock, so it cannot convoy.
 #   sudo usb_recover.sh resolve    <devnode>   # e.g. /dev/ttyACM3 -> print its <busport> (no privilege needed)
 set -euo pipefail
 
@@ -127,12 +128,26 @@ case "$action" in
     done
     die "hub-cycle: $target still not enumerated after cycling up to the root port"
     ;;
-  pci-reset)
-    [[ "$target" =~ $PCI_RE ]] || die "bad pci addr: $target"
-    require_usb_controller "$target"
-    [ -e "/sys/bus/pci/devices/$target/reset" ] || die "no reset support on $target"
-    echo 1 > "/sys/bus/pci/devices/$target/reset"
-    echo "flr-reset pci $target"
+  root-cycle)
+    # VBUS cut at the ROOT port, where xHCI ppps is real. Unlike hub-cycle this does not walk
+    # up from the leaf (the 1a40:0201 hubs claim ganged switching but never cut power) and does
+    # not touch the wedged device's sysfs, so it does not join a D-state convoy. No -f: uhubctl
+    # should fail loudly on a controller whose root ports have no per-port power.
+    [[ "$target" =~ $USBPATH_RE ]] || die "bad usb path: $target"
+    UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
+    [ -x "$UHUBCTL" ] || die "uhubctl not installed"
+    bus=${target%%-*}; rest=${target#*-}; rootport=${rest%%.*}
+    echo "root-cycle: cutting VBUS on bus $bus root port $rootport (feeds $target, bounces its siblings)"
+    "$UHUBCTL" -l "$bus" -p "$rootport" -a cycle -d 5
+    # Verify like hub-cycle does, so the exit status means something to an automated caller.
+    # NB: this proves the device came back, NOT that a D-state holder let go — check that too.
+    for _ in $(seq 1 10); do
+      sleep 1
+      if [ -e "/sys/bus/usb/devices/$target/idVendor" ]; then
+        echo "root-cycled $bus port $rootport: $target re-enumerated"; exit 0
+      fi
+    done
+    die "root-cycle: $target did not re-enumerate after cycling bus $bus port $rootport"
     ;;
   *)
     usage

--- a/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
+++ b/.claude/skills/usb-kernel-recover/scripts/usb_recover.sh
@@ -137,17 +137,22 @@ case "$action" in
     UHUBCTL=$(command -v uhubctl || echo /sbin/uhubctl)
     [ -x "$UHUBCTL" ] || die "uhubctl not installed"
     bus=${target%%-*}; rest=${target#*-}; rootport=${rest%%.*}
+    before=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
     echo "root-cycle: cutting VBUS on bus $bus root port $rootport (feeds $target, bounces its siblings)"
+    # No -e: without it uhubctl also cycles the paired USB3 root port, which is the same physical
+    # connector, so the whole port really loses VBUS. -e would cut only the USB2 half.
     "$UHUBCTL" -l "$bus" -p "$rootport" -a cycle -d 5
-    # Verify like hub-cycle does, so the exit status means something to an automated caller.
-    # NB: this proves the device came back, NOT that a D-state holder let go — check that too.
+    # Require a NEW enumeration (devnum changes), not merely that the sysfs node exists. If the
+    # disconnect is itself blocked on the device lock, the old node and its idVendor stay put, so
+    # an existence check would report success in exactly the case we need to catch.
     for _ in $(seq 1 10); do
       sleep 1
-      if [ -e "/sys/bus/usb/devices/$target/idVendor" ]; then
-        echo "root-cycled $bus port $rootport: $target re-enumerated"; exit 0
+      now=$(cat "/sys/bus/usb/devices/$target/devnum" 2>/dev/null || echo none)
+      if [ "$now" != none ] && [ "$now" != "$before" ]; then
+        echo "root-cycled $bus port $rootport: $target re-enumerated (devnum $before -> $now)"; exit 0
       fi
     done
-    die "root-cycle: $target did not re-enumerate after cycling bus $bus port $rootport"
+    die "root-cycle: $target did not re-enumerate after cycling bus $bus port $rootport (devnum still $before)"
     ;;
   *)
     usage

--- a/test/hil/usbtest.py
+++ b/test/hil/usbtest.py
@@ -427,18 +427,30 @@ def main():
                 # block into the finally cleanup with the flag still False -- running the exact
                 # remove_id/unbind the comments there forbid while a device lock is held.
                 unrecovered_hang = True
+                # Pass the serial so the helper refuses a stale busport rather than cutting power
+                # to whatever else now occupies that path. Popen rather than sudo()/subprocess.run:
+                # run() would kill() then wait() unbounded on timeout, which never returns if
+                # uhubctl is itself in D state -- the case the timeout exists for. Merge stderr
+                # into stdout so the helper's target-identity and action lines are not lost.
+                cmd = [str(USB_RECOVER), 'root-cycle', dev['sysname'], dev['serial']]
+                if os.geteuid() != 0:
+                    cmd = ['sudo', '-n'] + cmd
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                rc = None
                 try:
-                    # Normal run is ~8s (5s VBUS off + re-enumeration poll); 60s is 3x headroom.
-                    # Only helps if uhubctl is still killable -- a genuinely D-state uhubctl cannot
-                    # be reaped, but -S keeps it off the sysfs disable_store path that would cause
-                    # that. See the skill.
-                    rc = sudo([str(USB_RECOVER), 'root-cycle', dev['sysname']], timeout=60)
+                    out, _ = p.communicate(timeout=60)   # normal run is ~8s
+                    rc = p.returncode
                 except subprocess.TimeoutExpired:
-                    print('root-cycle did not return within 60s: uhubctl is itself wedged, the '
-                          'convoy has spread', file=sys.stderr)
-                else:
-                    if rc.returncode != 0:
-                        print(rc.stderr or '(no output from usb_recover.sh)', file=sys.stderr)
+                    p.kill()
+                    try:
+                        out, _ = p.communicate(timeout=5)
+                        rc = p.returncode
+                    except subprocess.TimeoutExpired:
+                        out = ('root-cycle abandoned after 60s: uhubctl did not die to SIGKILL, so '
+                               'it is wedged too and the convoy has spread beyond this device')
+                if out:
+                    print(out.strip(), file=sys.stderr)
+                if rc is not None:
                     time.sleep(5)  # let the bus settle and the freed ioctl unwind
                     # Authoritative either way. A non-zero exit only means the device did not come
                     # back within the poll (a slow bootloader will do that) -- if nothing still

--- a/test/hil/usbtest.py
+++ b/test/hil/usbtest.py
@@ -446,7 +446,15 @@ def main():
                     cmd.append(dev['serial'])
                 if os.geteuid() != 0:
                     cmd = ['sudo', '-n'] + cmd
-                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                try:
+                    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                         text=True)
+                except OSError as e:
+                    # helper missing or not executable, or sudo unavailable. unrecovered_hang is
+                    # already True so the finally block still skips the unsafe cleanup -- this only
+                    # replaces a traceback with a message that says what to fix.
+                    print(f'cannot run {USB_RECOVER}: {e}', file=sys.stderr)
+                    break
                 rc = None
                 try:
                     out, _ = p.communicate(timeout=60)   # normal run is ~8s

--- a/test/hil/usbtest.py
+++ b/test/hil/usbtest.py
@@ -254,11 +254,14 @@ def dmesg_tail():
     return '\n'.join(lines[-8:])
 
 
-def pci_addr_of_bus(busnum):
-    """Return the PCI B:D.F backing a USB bus, or None for a non-PCI (SoC/platform) controller."""
-    m = re.search(r'([0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9])/usb\d+$',
-                  os.path.realpath(f'/sys/bus/usb/devices/usb{int(busnum)}'))
-    return m.group(1) if m else None
+def still_wedged(pid):
+    """True if pid is still in uninterruptible sleep, i.e. its usbfs ioctl never returned.
+    A killed-but-freed child shows up as Z (or is gone) once the URB completes."""
+    try:
+        stat = Path(f'/proc/{pid}/stat').read_text()
+        return stat[stat.rindex(')') + 2] == 'D'   # comm may contain ')', so scan from the right
+    except (OSError, ValueError, IndexError):
+        return False
 
 
 def run_case(num, dev, testusb, quick, timeout):
@@ -283,7 +286,7 @@ def run_case(num, dev, testusb, quick, timeout):
             # in-kernel usbfs ioctl (device stopped responding mid-transfer).
             # Abandon it — waiting or re-signalling can never succeed.
             result.update(status='HUNG', detail=f'testusb stuck in D state after {timeout}s',
-                          dmesg=dmesg_tail())
+                          pid=p.pid, dmesg=dmesg_tail())
             return result
         result.update(status='FAIL', detail=f'timeout after {timeout}s', dmesg=dmesg_tail())
         return result
@@ -387,20 +390,25 @@ def main():
                 extra += f" {r['mbps']} MB/s" if 'mbps' in r else ''
                 print(f"test {num:2d} {r['name']:22s} {r['status']:6s}{extra}")
             if r['status'] == 'HUNG':
-                pci = pci_addr_of_bus(dev['node'].split('/')[-2])
-                if pci:
-                    print(f'aborting battery: kernel-side hang, device wedged mid-transfer.\n'
-                          f'auto-recovering: sudo {USB_RECOVER} pci-reset {pci} '
-                          f'(see .claude/skills/usb-kernel-recover)', file=sys.stderr)
-                    # FLR frees the D-state ioctl without the device lock; must run BEFORE
-                    # any unbind/remove_id, which would deadlock the bus otherwise
-                    if sudo([str(USB_RECOVER), 'pci-reset', pci]).returncode != 0:
-                        unrecovered_hang = True
-                    time.sleep(5)  # let the bus re-enumerate before cleanup touches sysfs
-                else:
+                print(f'aborting battery: kernel-side hang, device wedged mid-transfer.\n'
+                      f'auto-recovering: {USB_RECOVER.name} root-cycle {dev["sysname"]} '
+                      f'(see .claude/skills/usb-kernel-recover)', file=sys.stderr)
+                # Cutting VBUS at the root port should fail the in-flight URB so the usbfs ioctl
+                # returns (reasoned, not yet confirmed against a live wedge — see the skill).
+                # Must run BEFORE any unbind/remove_id, which would take the device lock the
+                # stuck ioctl holds and deadlock the bus.
+                # Exit 0 means the device re-enumerated, not that the D-state holder let go.
+                rc = sudo([str(USB_RECOVER), 'root-cycle', dev['sysname']])
+                time.sleep(5)  # let the bus settle and the freed ioctl unwind
+                if rc.returncode != 0:
                     unrecovered_hang = True
-                    print('aborting battery: kernel-side hang, and the controller has no PCI address '
-                          'for FLR recovery — manual intervention (reboot) required', file=sys.stderr)
+                    print(rc.stderr or '(no output from usb_recover.sh)', file=sys.stderr)
+                elif still_wedged(r['pid']):
+                    # Device came back but the ioctl never returned, so the device lock is still
+                    # held: the remove_id/unbind cleanup below would join the convoy and deadlock.
+                    unrecovered_hang = True
+                    print(f'root-cycle re-enumerated {dev["sysname"]} but pid {r["pid"]} is still '
+                          'in D state — the device lock was never released', file=sys.stderr)
                 break
             # re-resolve: after a mid-battery re-enumeration the devnum (and thus the node
             # path) changes; keep testing the live node instead of the stale one. Match on the
@@ -419,7 +427,8 @@ def main():
             if unrecovered_hang:
                 # testusb is still stuck in a usbfs ioctl holding the device lock; remove_id/unbind
                 # would join the convoy and deadlock the bus (see usb-kernel-recover skill) — leave it be
-                print('skipping cleanup after unrecovered hang: reboot required to release the bus',
+                print('skipping cleanup after unrecovered hang: ask the operator for a full PVE host '
+                      'power cycle (a VM reboot is not reliable — hubs latch up across the PCIe reset)',
                       file=sys.stderr)
             elif not args.keep_binding:
                 sysfs_write(DRIVER / 'remove_id', f'{VID} {PID}', check=False)

--- a/test/hil/usbtest.py
+++ b/test/hil/usbtest.py
@@ -422,10 +422,10 @@ def main():
                 # Must run BEFORE any unbind/remove_id, which would take the device lock the stuck
                 # ioctl holds and deadlock the bus.
                 #
-                # Assume unrecovered until proven otherwise: sudo() calls sys.exit() when `sudo -n`
-                # needs a password, and that SystemExit would otherwise unwind straight past this
-                # block into the finally cleanup with the flag still False -- running the exact
-                # remove_id/unbind the comments there forbid while a device lock is held.
+                # Assume unrecovered until proven otherwise, so that any early exit from this block
+                # -- an OSError spawning the helper, a KeyboardInterrupt, a sudo prompt killing the
+                # run -- still reaches the finally cleanup with the flag set, instead of running
+                # the remove_id/unbind the comments there forbid while a device lock is held.
                 unrecovered_hang = True
                 # Pass the serial so the helper refuses a stale busport rather than cutting power
                 # to whatever else now occupies that path. Popen rather than sudo()/subprocess.run:

--- a/test/hil/usbtest.py
+++ b/test/hil/usbtest.py
@@ -404,25 +404,38 @@ def main():
                 print(f'aborting battery: kernel-side hang, device wedged mid-transfer.\n'
                       f'auto-recovering: {USB_RECOVER.name} root-cycle {dev["sysname"]} '
                       f'(see .claude/skills/usb-kernel-recover)', file=sys.stderr)
-                # Cutting VBUS at the root port should fail the in-flight URB so the usbfs ioctl
-                # returns (reasoned, not yet confirmed against a live wedge — see the skill).
-                # Must run BEFORE any unbind/remove_id, which would take the device lock the
-                # stuck ioctl holds and deadlock the bus.
-                # Exit 0 means the device re-enumerated, not that the D-state holder let go.
-                rc = sudo([str(USB_RECOVER), 'root-cycle', dev['sysname']])
-                time.sleep(5)  # let the bus settle and the freed ioctl unwind
-                if rc.returncode != 0:
-                    unrecovered_hang = True
-                    print(rc.stderr or '(no output from usb_recover.sh)', file=sys.stderr)
+                # Cutting VBUS at the root port fails the in-flight URB so the usbfs ioctl returns.
+                # Must run BEFORE any unbind/remove_id, which would take the device lock the stuck
+                # ioctl holds and deadlock the bus.
+                #
+                # Assume unrecovered until proven otherwise: sudo() calls sys.exit() when `sudo -n`
+                # needs a password, and that SystemExit would otherwise unwind straight past this
+                # block into the finally cleanup with the flag still False -- running the exact
+                # remove_id/unbind the comments there forbid while a device lock is held.
+                unrecovered_hang = True
+                try:
+                    # Normal run is ~8s (5s VBUS off + re-enumeration poll); 60s is 3x headroom.
+                    # Only helps if uhubctl is still killable -- a genuinely D-state uhubctl cannot
+                    # be reaped, but -S keeps it off the sysfs disable_store path that would cause
+                    # that. See the skill.
+                    rc = sudo([str(USB_RECOVER), 'root-cycle', dev['sysname']], timeout=60)
+                except subprocess.TimeoutExpired:
+                    print('root-cycle did not return within 60s: uhubctl is itself wedged, the '
+                          'convoy has spread', file=sys.stderr)
                 else:
+                    if rc.returncode != 0:
+                        print(rc.stderr or '(no output from usb_recover.sh)', file=sys.stderr)
+                    time.sleep(5)  # let the bus settle and the freed ioctl unwind
+                    # Authoritative either way. A non-zero exit only means the device did not come
+                    # back within the poll (a slow bootloader will do that) -- if nothing still
+                    # holds the lock, the bus is usable and cleanup is safe. Conversely a zero exit
+                    # only proves re-enumeration, not that the D-state holder let go.
                     stuck = wedged_pids(dev['node'])
                     if stuck:
-                        # Device came back but the ioctl never returned, so the device lock is still
-                        # held: the remove_id/unbind cleanup below would join the convoy and deadlock.
-                        unrecovered_hang = True
-                        print(f'root-cycle re-enumerated {dev["sysname"]} but pid(s) {stuck} are '
-                              f'still in D state on {dev["node"]} — the device lock was never '
-                              'released', file=sys.stderr)
+                        print(f'{dev["sysname"]}: pid(s) {stuck} still in D state on '
+                              f'{dev["node"]} — the device lock was never released', file=sys.stderr)
+                    else:
+                        unrecovered_hang = False
                 break
             # re-resolve: after a mid-battery re-enumeration the devnum (and thus the node
             # path) changes; keep testing the live node instead of the stale one. Match on the

--- a/test/hil/usbtest.py
+++ b/test/hil/usbtest.py
@@ -255,24 +255,38 @@ def dmesg_tail():
 
 
 def wedged_pids(devnode):
-    """PIDs in uninterruptible sleep whose cmdline names devnode, i.e. still holding its usbfs
-    device lock. Matched by device node rather than by our child's pid because run_case() may wrap
-    testusb in sudo, in which case the Popen pid is the wrapper and the blocked process is its
-    child -- killing the wrapper would then make a pid-based check look clean while the real
-    holder is still stuck."""
-    stuck = []
+    """Return (pids, complete): PIDs in uninterruptible sleep whose cmdline names devnode, i.e.
+    still holding its usbfs device lock, and whether every /proc entry could actually be read.
+
+    Matched by device node rather than by our child's pid because run_case() may wrap testusb in
+    sudo, in which case the Popen pid is the wrapper and the blocked process is its child --
+    killing the wrapper would make a pid-based check look clean while the real holder is stuck.
+
+    complete is False when a PermissionError hid an entry (a hidepid/ProtectProc mount, or the
+    root-owned child of that same sudo). An entry we could not read might be the holder, so the
+    caller must treat that as unrecovered rather than as an all-clear."""
+    stuck, complete = [], True
     for entry in Path('/proc').iterdir():
         if not entry.name.isdigit():
             continue
         try:
-            if devnode.encode() not in (entry / 'cmdline').read_bytes():
-                continue
+            cmdline = (entry / 'cmdline').read_bytes()
+        except PermissionError:
+            complete = False        # cannot rule this pid out
+            continue
+        except OSError:
+            continue                # raced with process exit: genuinely gone, not hidden
+        if devnode.encode() not in cmdline:
+            continue
+        try:
             stat = (entry / 'stat').read_text()
             if stat[stat.rindex(')') + 2] == 'D':   # comm may contain ')', so scan from the right
                 stuck.append(int(entry.name))
+        except PermissionError:
+            complete = False
         except (OSError, ValueError, IndexError):
             continue
-    return stuck
+    return stuck, complete
 
 
 def run_case(num, dev, testusb, quick, timeout):
@@ -430,10 +444,13 @@ def main():
                     # back within the poll (a slow bootloader will do that) -- if nothing still
                     # holds the lock, the bus is usable and cleanup is safe. Conversely a zero exit
                     # only proves re-enumeration, not that the D-state holder let go.
-                    stuck = wedged_pids(dev['node'])
+                    stuck, complete = wedged_pids(dev['node'])
                     if stuck:
                         print(f'{dev["sysname"]}: pid(s) {stuck} still in D state on '
                               f'{dev["node"]} — the device lock was never released', file=sys.stderr)
+                    elif not complete:
+                        print('cannot confirm recovery: /proc is only partly readable, so a '
+                              'hidden D-state holder cannot be ruled out', file=sys.stderr)
                     else:
                         unrecovered_hang = False
                 break

--- a/test/hil/usbtest.py
+++ b/test/hil/usbtest.py
@@ -254,14 +254,25 @@ def dmesg_tail():
     return '\n'.join(lines[-8:])
 
 
-def still_wedged(pid):
-    """True if pid is still in uninterruptible sleep, i.e. its usbfs ioctl never returned.
-    A killed-but-freed child shows up as Z (or is gone) once the URB completes."""
-    try:
-        stat = Path(f'/proc/{pid}/stat').read_text()
-        return stat[stat.rindex(')') + 2] == 'D'   # comm may contain ')', so scan from the right
-    except (OSError, ValueError, IndexError):
-        return False
+def wedged_pids(devnode):
+    """PIDs in uninterruptible sleep whose cmdline names devnode, i.e. still holding its usbfs
+    device lock. Matched by device node rather than by our child's pid because run_case() may wrap
+    testusb in sudo, in which case the Popen pid is the wrapper and the blocked process is its
+    child -- killing the wrapper would then make a pid-based check look clean while the real
+    holder is still stuck."""
+    stuck = []
+    for entry in Path('/proc').iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            if devnode.encode() not in (entry / 'cmdline').read_bytes():
+                continue
+            stat = (entry / 'stat').read_text()
+            if stat[stat.rindex(')') + 2] == 'D':   # comm may contain ')', so scan from the right
+                stuck.append(int(entry.name))
+        except (OSError, ValueError, IndexError):
+            continue
+    return stuck
 
 
 def run_case(num, dev, testusb, quick, timeout):
@@ -286,7 +297,7 @@ def run_case(num, dev, testusb, quick, timeout):
             # in-kernel usbfs ioctl (device stopped responding mid-transfer).
             # Abandon it — waiting or re-signalling can never succeed.
             result.update(status='HUNG', detail=f'testusb stuck in D state after {timeout}s',
-                          pid=p.pid, dmesg=dmesg_tail())
+                          dmesg=dmesg_tail())
             return result
         result.update(status='FAIL', detail=f'timeout after {timeout}s', dmesg=dmesg_tail())
         return result
@@ -403,12 +414,15 @@ def main():
                 if rc.returncode != 0:
                     unrecovered_hang = True
                     print(rc.stderr or '(no output from usb_recover.sh)', file=sys.stderr)
-                elif still_wedged(r['pid']):
-                    # Device came back but the ioctl never returned, so the device lock is still
-                    # held: the remove_id/unbind cleanup below would join the convoy and deadlock.
-                    unrecovered_hang = True
-                    print(f'root-cycle re-enumerated {dev["sysname"]} but pid {r["pid"]} is still '
-                          'in D state — the device lock was never released', file=sys.stderr)
+                else:
+                    stuck = wedged_pids(dev['node'])
+                    if stuck:
+                        # Device came back but the ioctl never returned, so the device lock is still
+                        # held: the remove_id/unbind cleanup below would join the convoy and deadlock.
+                        unrecovered_hang = True
+                        print(f'root-cycle re-enumerated {dev["sysname"]} but pid(s) {stuck} are '
+                              f'still in D state on {dev["node"]} — the device lock was never '
+                              'released', file=sys.stderr)
                 break
             # re-resolve: after a mid-battery re-enumeration the devnum (and thus the node
             # path) changes; keep testing the live node instead of the stale one. Match on the

--- a/test/hil/usbtest.py
+++ b/test/hil/usbtest.py
@@ -266,6 +266,13 @@ def wedged_pids(devnode):
     root-owned child of that same sudo). An entry we could not read might be the holder, so the
     caller must treat that as unrecovered rather than as an all-clear."""
     stuck, complete = [], True
+    # hidepid=2 and systemd's ProtectProc=invisible omit other users' processes from iterdir()
+    # entirely -- no entry at all, so no PermissionError to catch -- and testusb runs under sudo
+    # whenever the device node is not writable. The scan would then look clean while hiding the
+    # very holder it exists to find. pid 1 is always root-owned, so being unable to read it means
+    # enumeration is restricted and no result from this scan can be trusted as complete.
+    if os.geteuid() != 0 and not os.access('/proc/1/cmdline', os.R_OK):
+        complete = False
     for entry in Path('/proc').iterdir():
         if not entry.name.isdigit():
             continue
@@ -432,7 +439,11 @@ def main():
                 # run() would kill() then wait() unbounded on timeout, which never returns if
                 # uhubctl is itself in D state -- the case the timeout exists for. Merge stderr
                 # into stdout so the helper's target-identity and action lines are not lost.
-                cmd = [str(USB_RECOVER), 'root-cycle', dev['sysname'], dev['serial']]
+                # Only pass the serial when we actually have one: an empty third argument reads as
+                # "no expectation" and would silently disable the helper's stale-busport guard.
+                cmd = [str(USB_RECOVER), 'root-cycle', dev['sysname']]
+                if dev['serial']:
+                    cmd.append(dev['serial'])
                 if os.geteuid() != 0:
                     cmd = ['sudo', '-n'] + cmd
                 p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)


### PR DESCRIPTION
## Problem

`usb_recover.sh pci-reset` wrote `/sys/bus/pci/devices/<addr>/reset`, and the skill documented this as an FLR that fails harmlessly with `ENOTTY` on the Renesas uPD720201. **Neither half is true**, and the combination destroyed the ci HIL rig's controller twice (2026-07-23, 2026-07-27) — both times reported as a plain test hang.

No USB controller on either rig supports FLR:

| controller | `reset_method` |
|---|---|
| Renesas uPD720201 (ci `01:00.0`, `03:00.0`; hifiphile `01:00.0`) | `bus` |
| AMD Matisse (ci `02:00.0`) | `pm bus` |
| Intel ICH9 UHCI/EHCI (all 8) | *(none)* |

The sysfs `reset` attribute exists whenever *any* reset method is available, so the old `[ -e .../reset ]` guard passed and the kernel issued a **PCIe secondary bus reset** on a live, driver-bound xHCI. The HC returns to power-on defaults (`USBCMD=0`, `HCHalted`, zeroed CRCR/DCBAA) while xhci keeps driving rings it no longer owns — card permanently halted, every fixture on it lost until the PVE host is power-cycled. The write **succeeds**, so `usbtest.py`'s `returncode != 0` check never fired.

## Change

Drop `pci-reset` entirely rather than gating it on FLR — no controller here has FLR, so gating would leave a permanently-unreachable branch.

Replace it with **`root-cycle <busport>`**, cutting VBUS at the xHCI root port where per-port power is real. It talks only to the root hub, so it never takes the per-device lock the stuck ioctl holds, and it skips the leaf hubs that advertise ganged switching but never actually cut power.

**`-S` is load-bearing.** By default uhubctl drives port power through `/sys/.../usb<bus>-port<n>/disable` (strace: two `O_WRONLY` opens per cycle). The kernel's `disable_store()` takes the *root hub's* lock and synchronously `usb_disconnect()`s the child **before** `usb_hub_set_port_power()`. Against the wedge this exists for, that disconnect blocks on the very lock being rescued: power never drops and uhubctl itself wedges holding the root hub's lock, taking down the whole bus rather than one port. `-S` selects the libusb path, sending the power-off control transfer straight to the root hub.

`usbtest.py` auto-recovery calls `root-cycle` with the busport it already has (so `pci_addr_of_bus()` is gone), prints the helper's stderr, bounds the call at 60 s, assumes unrecovered until proven otherwise (`sudo()` can `sys.exit()` mid-call and would otherwise unwind past the guard into the forbidden `remove_id`/`unbind` cleanup), and checks `wedged_pids()` on **both** outcomes — matched by device node rather than pid, since `run_case()` may wrap testusb in `sudo` and the Popen pid is then the wrapper.

Skill scripts are now repo-only. The hand-copied `/usr/local/sbin` snapshots were not symlinks, never tracked the repo, and had drifted (`usb_recover.sh` Jul 15 on ci / Jul 6 on hifiphile; `usb_dyndbg.sh` differing outright). Deleted from both rigs; the skills name the script path instead.

## Testing

Verified on the ci rig against an empty root port (bus 11 port 4, no downstream fixtures): port status `0507 power/connect` → `0000 off` → `0507 power/connect`, devnum increments every run, exit 0 in ~8 s, zero opens of the `disable` attribute with `-S`, rig left with no D-state processes. `hub-cycle` re-verified the same way after its liveness check changed.

- Guard logic exercised against real sysfs with the destructive write stubbed, so no controller was reset.
- Port derivation checked for `11-3.7`, `11-3`, `13-1.6.2`, `9-4.7` and path-traversal input; a stale busport is now refused before any power action.
- `/proc/<pid>/stat` parsing verified against a live process, a zombie, a missing pid, and a `comm` containing both `)` and a space.
- Six subagent tabletop scenarios against the skill (nonexistent BDF throughout): before, 3/3 fired `pci-reset` believing it harmless; after, 3/3 choose `root-cycle`, one refusing a hand-written `echo 1 > .../reset` under time pressure.
- `pre-commit run --all-files` passes.

**Not verified:** `root-cycle` has not faced a live D-state wedge. The happy path is measured; the behaviour of the libusb power-on pass against a held root-hub lock is not. The first real hang should be watched rather than trusted.

## Known gaps, not addressed here

- No board-lock coordination before an action that bounces every fixture under the root port. `board_lock.py` is `LOCK_EX | LOCK_NB` and cannot wait, so with `USBTEST_PARALLEL=4` there is no clean way to acquire them mid-run; SKILL.md documents this as a deliberate tradeoff.
- `find_device(..., first=True)` picks arbitrarily among same-serial dual-port parts, and that choice now selects which root port loses VBUS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SXzYLicAHtdx7ZTzKK75D

## Disposition of earlier bot findings (head was `fd98eb4f`, now `cb12b2210`)

- **Track testusb rather than its sudo wrapper** — accepted, fixed in `0fc74560`. Detection matches D-state holders by device node across `/proc` rather than by the Popen pid, so a wrapper or its child is caught equally. `run_case()`'s `p.kill()` still targets the wrapper; that is pre-existing and left out of scope.
- **Verify that the device actually re-enumerated** — accepted, fixed in `0fc74560`. `root-cycle` records `devnum` before cycling and requires it to change. `hub-cycle` had the identical flaw and got the same fix.
- **Match only the root hub location (`-e`)** — not applied. In uhubctl 2.6.0 `-e/--exact` is documented as "exact location (no USB3 duality handling)", i.e. it governs USB3 pairing rather than prefix matching, and `uhubctl -l 11` empirically selects only the root hub (the leaf hubs are `ganged` and not controllable without `-f`, which is not passed). The rationale first given for declining this was itself wrong — it claimed omitting `-e` cycles the paired USB3 port, but that pairing does not fire on Linux root hubs. The conclusion rests on the empirical result, not that reasoning.

The recovery path has changed materially since that review: uhubctl is now invoked with `-S`, because strace showed the default backend writes the sysfs `disable` attribute, whose `disable_store()` handler disconnects the child before cutting power and would block on exactly the lock being rescued. That is the part most worth fresh scrutiny.

## Disposition of second review round (head `cb12b2210`, fixed in `5e29ebdb2`)

- **devnum reuse can report a false failure** (Codex, and independently Copilot) — accepted. Linux reuses USB addresses once the per-bus map wraps, so a device that really did power-cycle can return on the same number and be reported as unrecovered, escalating to an unnecessary host power cycle. Not theoretical here: a single `root-cycle` on the idle rig moved devnum `59 → 123`, so the 127-entry map wraps within minutes of normal churn. `root-cycle` and `hub-cycle` now accept **either** an observed disappearance or a changed devnum — the disappearance being the direct evidence that the power cut landed, which devnum inequality was only ever a proxy for.
- **Existence check does not verify identity** — accepted. `[ -e ... ]` only proves *something* occupies that sysfs path; after a reboot renumbers the bus a stale busport can name a different device, whose entire subtree would then lose power. The comment claiming stale busports are refused overstated this. It now prints the target's VID:PID, serial and product before acting so a wrong target is visible.
- **`wedged_pids()` blind under restricted procfs** — accepted, though it cannot fire on these rigs (no `hidepid`; root-owned cmdlines are readable). It swallowed `PermissionError` and returned an empty list, which the caller read as an all-clear and followed with the `remove_id`/`unbind` that must never run while a device lock is held. It now returns `(pids, complete)` and treats incomplete visibility as unrecovered, distinguishing an entry that raced away (`ENOENT`, genuinely gone) from one that is hidden (`PermissionError`) — conflating those would make every scan permanently pessimistic.

## Third review round (head `5e29ebdb2`, fixed in `490dee9c8` + `7c2c98aee`)

Codex was right that the previous round's fix did not resolve its own finding. Watching for the sysfs node to disappear cannot work: `uhubctl -a cycle` holds the entire power-off window inside itself, so the poll only begins once power is already back. Measured on the rig, the disappearance was never observed on any run and success came from the devnum fallback — the very check under question. That left a guard that looked like one and contributed nothing.

**Recovery is now proven by the device's sysfs directory inode.** A real disconnect destroys the `usb_device` and its kobject; reconnecting creates a new one and kernfs allocates a fresh id, so the inode changes. It survives the gap, so no observation window is needed, and it is immune to address reuse. If the disconnect is blocked on the wedged device's lock the kobject is never recreated and the inode is unchanged — which is exactly the case that must fail.

Why it cannot produce a false success: `kernfs_id_ino()` exposes the full 64-bit `(id_highbits<<32 | lowbits)` as `st_ino` on 64-bit `ino_t`, so a repeat needs ~2^64 node creations; and `authorized`-toggle, `set_configuration` and suspend/resume all leave the parent device kobject intact, so none of them can move the marker. The trailing slash in `sysfs_gen()` is load-bearing — `/sys/bus/usb/devices/<busport>` is a symlink with its own inode — and is now called out in the code so it does not get tidied away.

The devnum wrap is not hypothetical: two separate cycles on an idle rig moved devices `123 → 113` and `121 → 61`.

Also in this round: `root-cycle` takes an optional expected serial and refuses on mismatch (the previous round only *printed* the identity, which this PR body previously overstated as a fix); `usbtest.py` drives the helper with `Popen` rather than `subprocess.run`, whose timeout path kills then waits unbounded and so never returns against a D-state child; the helper's stdout is no longer discarded; and `uhubctl` is wrapped in `|| die`.

Verified: end to end on an idle empty root port (`gen 7447801 → 7769803`, exit 0, ~8 s); with `uhubctl` stubbed so no power is cut, the generation is unchanged and it correctly fails; a mismatched serial is refused before any power action. `pre-commit run --all-files` passes.

## Fourth review round (head `7c2c98aee`, fixed in `5b1ff800a`)

- **Processes hidden from `/proc` enumeration** (Codex, P1) — accepted, and a real hole in the previous round's fix. That fix assumed an uninspectable process surfaces as an entry whose `cmdline` read raises `PermissionError`. Under `hidepid=2` or systemd's `ProtectProc=invisible` it does not appear in `iterdir()` at all — no entry, no exception — and `testusb` runs under `sudo` whenever the device node is not writable. The scan returned `([], True)` while hiding the very holder it exists to find, clearing `unrecovered_hang` and running the `remove_id`/`unbind` that must never execute while a device lock is held. `pid 1` is always root-owned, so failing to read it means enumeration is restricted; the scan is now marked incomplete in that case while still reporting whatever is visible.
- **Empty serial silently disables the stale-busport guard** (Copilot) — accepted. `find_device()` strips the sysfs value and it can be empty; an empty third argument reads as "no expectation", so the guard did nothing while the surrounding comment claimed it was active. Only passed when non-empty.
- **SKILL.md overclaimed what is read** (Copilot) — accepted. `root-cycle` reads `idVendor`/`idProduct`/`serial`/`product` to report and check the target, and `devnum` for the success message, not only the directory inode. Reworded to say it never *writes* the wedged device's sysfs and takes no device lock, which is the property that matters.
- **Verify target identity before cycling** (Codex, P2) — not applied; third re-raise of a resolved finding. The `expect=${3:-}` guard and its `die` are present and the comment describes the optional contract accurately. The two findings did interact, though: the empty-serial bug above was the path by which this concern could still bite, so fixing that closes the practical gap.

## Fifth review round (head `5b1ff800a`, fixed in `0f9db2a2e`)

Codex reported no issues on this head. Copilot raised two:

- **`subprocess.Popen()` unwrapped** — accepted. It raises `OSError` when the helper is missing or not executable, or sudo is unavailable (verified: `FileNotFoundError`). The safety property already held, since `unrecovered_hang` is set to `True` before the call and the `finally` block therefore still skipped the unsafe cleanup — but the run died with a traceback instead of a message naming what to fix, and the `--json` payload was lost. Now caught, reported, and the battery ends cleanly.
- **`set -e` aborting on a failed `cat`** — declined as stated. A failed command substitution in an *argument to `echo`* does not trigger errexit (verified: exit 0, script continues); only *assignments* do, and the assignments in that block (`serial=`, `gen=`) already carry `|| echo -` fallbacks, as does `sysfs_gen()` internally. `idVendor`/`idProduct` were given the same fallback anyway so an unreadable attribute prints `-` rather than an empty field, but that is cosmetic, not a crash fix.
