### PR TITLE
rp2xxx: added rp2usb_deinit() to fix 'No spinlocks are available'

### DIFF
--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -387,6 +387,9 @@ bool dcd_deinit(uint8_t rhport) {
   reset_block(RESETS_RESET_USBCTRL_BITS);
   unreset_block_wait(RESETS_RESET_USBCTRL_BITS);
 
+  // Release allocated resources
+  rp2usb_deinit();
+
   return true;
 }
 

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -427,6 +427,10 @@ bool hcd_deinit(uint8_t rhport) {
   irq_remove_handler(USBCTRL_IRQ, hcd_rp2040_irq);
   reset_block(RESETS_RESET_USBCTRL_BITS);
   unreset_block_wait(RESETS_RESET_USBCTRL_BITS);
+
+  // Release allocated resources
+  rp2usb_deinit();
+
   return true;
 }
 

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -85,6 +85,10 @@ void rp2usb_init(void) {
   critical_section_init(&rp2usb_lock);
 }
 
+void rp2usb_deinit(void) {
+  critical_section_deinit(&rp2usb_lock);
+}
+
 void __tusb_irq_path_func(rp2usb_reset_transfer)(hw_endpoint_t *ep) {
   ep->state         = EPSTATE_IDLE;
   ep->remaining_len = 0;

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.h
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.h
@@ -147,6 +147,7 @@ extern volatile uint32_t e15_last_sof;
 #endif
 
 void rp2usb_init(void);
+void rp2usb_deinit(void);
 
 // if usb hardware is in host mode
 TU_ATTR_ALWAYS_INLINE static inline bool rp2usb_is_host_mode(void) {


### PR DESCRIPTION
Fixes issue [#3793](https://github.com/hathach/tinyusb/issues/3793)