### PR TITLE
ci probe: exercise scoped HIL selection with a WCH-only change (do not merge)

### DIFF
--- a/src/portable/wch/dcd_ch32_usbfs.c
+++ b/src/portable/wch/dcd_ch32_usbfs.c
@@ -28,7 +28,7 @@
   #endif
 
   // Struct-based EP register access (uniform layout). CH58X has a different register map and
-  // defines EP_DMA/EP_TX_LEN/EP_CTRL itself in ch32_usbfs_reg.h.
+  // defines EP_DMA/EP_TX_LEN/EP_CTRL itself in ch32_usbfs_reg.h (see ch32_usbfs_reg.h).
   #if CFG_TUSB_MCU == OPT_MCU_CH583
     // CH58X EP registers split into a low block (EP0-4) and a high block (EP5-7). Walk from each
     // block's first slot by the 4-byte slot stride (pointer arithmetic off slot 0, so the unused


### PR DESCRIPTION
## Purpose

CI probe for the PR-scoped HIL selection that landed in #3797 — **not intended to merge**.

A comment-only change to one WCH driver produces the one control path that #3797's own CI could never reach (its diff touched `test/hil/`, which is a fail-open trigger, so every job took the full matrix):

- `arm-gcc` bucket: **empty** -> `hil-build (arm-gcc)` leg skipped
- `riscv-gcc` bucket: 6 entries -> built normally
- `esp-idf` bucket: empty -> `hil-build-esp` skipped
- `hil-tinyusb (tinyusb.json)`: **must run**, scoped to the 4 WCH boards (`openocd_wch`)
- `hil-tinyusb (hfp.json)` and `hil-hfp-iar`: skipped, nothing affected on that rig

What this validates:

1. An empty toolchain bucket skips its matrix leg instead of failing it (`build_util.yml`'s `if: inputs.build-args != '[]'`).
2. A skipped leg still lets the dependent rig job run — the matrix-aggregation behavior the guard relies on.
3. Per-flasher gating: the esp leg skips while the tinyusb leg runs.
4. The rig actually runs only the selected boards.

Expected: green, with `hil-tinyusb (tinyusb.json)` testing 4 boards instead of 24.

Close once the run is observed.
