### PR TITLE
clamp committed video payload size to streaming ep buffer

### DIFF
--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -1144,13 +1144,10 @@ static int handle_video_stm_cs_req(uint8_t rhport, uint8_t stage,
             video_probe_and_commit_control_t *param = &stm->probe_commit_payload;
             TU_VERIFY(_update_streaming_parameters(stm, param), VIDEO_ERROR_INVALID_VALUE_WITHIN_RANGE);
             /* Set the negotiated value */
-            stm->max_payload_transfer_size = param->dwMaxPayloadTransferSize;
-            /* A host may commit before the parameters are fully negotiated, in which case
-             * _update_streaming_parameters returns early without capping the payload size.
-             * Clamp here so a bulk stream cannot overrun the endpoint buffer. */
-            if (CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE < stm->max_payload_transfer_size) {
-              stm->max_payload_transfer_size = CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE;
+            if (CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE < param->dwMaxPayloadTransferSize) {
+              param->dwMaxPayloadTransferSize = CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE;
             }
+            stm->max_payload_transfer_size = param->dwMaxPayloadTransferSize;
             int ret = tud_video_commit_cb(stm->index_vc, stm->index_vs, param);
             if (VIDEO_ERROR_NONE == ret) {
               stm->state   = VS_STATE_COMMITTED;

--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -1145,6 +1145,12 @@ static int handle_video_stm_cs_req(uint8_t rhport, uint8_t stage,
             TU_VERIFY(_update_streaming_parameters(stm, param), VIDEO_ERROR_INVALID_VALUE_WITHIN_RANGE);
             /* Set the negotiated value */
             stm->max_payload_transfer_size = param->dwMaxPayloadTransferSize;
+            /* A host may commit before the parameters are fully negotiated, in which case
+             * _update_streaming_parameters returns early without capping the payload size.
+             * Clamp here so a bulk stream cannot overrun the endpoint buffer. */
+            if (CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE < stm->max_payload_transfer_size) {
+              stm->max_payload_transfer_size = CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE;
+            }
             int ret = tud_video_commit_cb(stm->index_vc, stm->index_vs, param);
             if (VIDEO_ERROR_NONE == ret) {
               stm->state   = VS_STATE_COMMITTED;


### PR DESCRIPTION
The UVC device driver takes dwMaxPayloadTransferSize straight from the probe/commit payload the host sends, and that value ends up sizing each bulk payload it builds. On the fully negotiated path _update_streaming_parameters caps it to the streaming endpoint buffer, but when the host commits before everything is settled (a zero bFormatIndex on a multi-format device, a zero bFrameIndex where the format has several frames, or a frame interval it never pins down) the function returns early and the raw host value is left untouched. handle_video_stm_cs_req then stores it into max_payload_transfer_size without a bound, and for a bulk stream nothing else limits it since only the isochronous open path checks the size against the endpoint packet size. When the application later hands a frame to _prepare_in_payload the memcpy uses that size and can write past the fixed CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE endpoint buffer. I came across it while comparing the committed path against the two get paths, which both already clamp to the same limit. The fix applies that clamp at commit so a partial or hostile commit cannot push the payload beyond the buffer.