### PR TITLE
device/cdc: avoid flushing tx buffer on connection

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -323,9 +323,7 @@ uint16_t cdcd_open(uint8_t rhport, const tusb_desc_interface_t* itf_desc, uint16
           tu_edpt_stream_t *stream_tx = &p_cdc->tx_stream;
           tu_edpt_stream_open(stream_tx, rhport, desc_ep, CFG_TUD_CDC_TX_EPSIZE);
 
-  #if CFG_TUD_CDC_TX_PERSISTENT
-          tu_edpt_stream_write_xfer(stream_tx); // flush pending data
-  #else
+  #if !CFG_TUD_CDC_TX_PERSISTENT
           tu_edpt_stream_clear(stream_tx);
   #endif
         } else {


### PR DESCRIPTION
With persistence enabled, buffered data is transmitted when the CDC endpoint opens during USB enumeration—before the host asserts DTR or opens the serial terminal. Consequently, the later application flush finds an empty FIFO, while the early data may be discarded or only partly observed by the host.

Restore behavior before f11adb02e, open the endpoint without flush the persistent FIFO.

Fix #3807