### PR TITLE
audio: fix inverted FIFO-size guard in EP-IN flow control

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -1841,7 +1841,7 @@ static bool audiod_calc_tx_packet_sz(audiod_function_t *audio) {
 
 static uint16_t audiod_tx_packet_size(const uint16_t *nominal_size, uint16_t data_count, uint16_t fifo_depth, uint16_t fifo_threshold, uint16_t max_depth) {
   // Flow control need a FIFO size of at least 4*Navg
-  if (nominal_size[1] && nominal_size[1] <= fifo_depth * 4) {
+  if (nominal_size[1] && nominal_size[1] * 4 <= fifo_depth) {
     // Use blackout to prioritize normal size packet
     static int ctrl_blackout = 0;
     uint16_t packet_size;


### PR DESCRIPTION
`audiod_tx_packet_size()` is guarded by:

```c
// Flow control need a FIFO size of at least 4*Navg
if (nominal_size[1] && nominal_size[1] <= fifo_depth * 4) {
```

The comparison is inverted relative to the comment: as written it is true
for any FIFO larger than a quarter of one packet, so flow control engages
on FIFOs far below its own documented 4*Navg minimum. On such FIFOs the
depth/2 setpoint sits within one packet of empty, and the
`packet_size = 0` branch (a zero-length packet - an audible ~1 ms dropout
for audio hosts) becomes reachable from ordinary scheduling jitter rather
than only from gross clock deviation, which is what its comment ("your
I2S clock deviation is too big!") assumes.

This patch changes the guard to `nominal_size[1] * 4 <= fifo_depth`, so
undersized FIFOs fall back to the plain `min(count, max)` path as the
comment intends.

Observed in practice via espressif/usb_device_uac, which sizes its EP-IN
FIFO at 2-3 packets: flow control ran anyway and the capture stream
clicked under ordinary RTOS scheduling jitter. (A companion fix there
raises its FIFO depth; this guard would have made the undersized config
fail safe.)

