### PR TITLE
hw/bsp/lpc55: implement board_get_unique_id from flash PFR UUID

### DIFF
--- a/hw/bsp/lpc55/family.c
+++ b/hw/bsp/lpc55/family.c
@@ -170,6 +170,14 @@ uint32_t board_button_read(void) {
   return BUTTON_STATE_ACTIVE == GPIO_PinRead(GPIO, BUTTON_PORT, BUTTON_PIN);
 }
 
+size_t board_get_unique_id(uint8_t id[], size_t max_len) {
+  // 128-bit UUID in the flash PFR region at 0x0009FC70 (UM11126 rev 2.1 section 48.8)
+  const uint8_t* uuid = (const uint8_t*) 0x0009FC70;
+  size_t const len = tu_min32(max_len, 16);
+  memcpy(id, uuid, len);
+  return len;
+}
+
 int board_uart_read(uint8_t* buf, int len) {
   (void) buf;
   (void) len;


### PR DESCRIPTION
The LPC55 BSP had no `board_get_unique_id`, so it fell back to the fixed
weak default in `hw/bsp/board.c`, giving every LPC55 board the same USB
serial (`0123456789ABCDEF`).

Read the real 128-bit device UUID from the flash PFR region instead.

## Reference

UM11126 (LPC55S6x/LPC55S2x/LPC552x User manual) Rev. 2.1, section 48.8, p.1023:

> LPC55S6x/LPC55S2x/LPC552x store 128-bit IETF RFC4122 compliant non-sequential
> Universally Unique Identifier (UUID). It can be read from flash PFR region at
> register location 0x0009_FC70 onwards.

Direct CPU read is what the manual specifies; the ROM `ffr_get_uuid()` API is an
alternative, not a requirement.

## Test evidence

Built `device/cdc_msc` for `lpcxpresso55s69` (MinSizeRel, clean) and flashed over
J-Link. The device enumerates with a real per-chip serial:

```
usb 3-1.4: New USB device found, idVendor=cafe, idProduct=4007
usb 3-1.4: SerialNumber: E059C3E208F9B955B3BA4C5CC7F3D13D
```

16 bytes rather than the 8-byte fallback, and it matches the `uid` already
recorded for that board in `test/hil/local.json`.

`pre-commit` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GppLdQsWxSNydLbcPTF5sD