### PR TITLE
audio: flow control never starts if the host asks for the sample rate before selecting alt 1

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -1176,6 +1176,15 @@ static bool audiod_set_interface(uint8_t rhport, tusb_control_request_t const *p
             // If flow control is enabled, parse for the corresponding parameters - doing this here means only AS interfaces with EPs get scanned for parameters
   #if  CFG_TUD_AUDIO_EP_IN_FLOW_CONTROL
             audiod_parse_flow_control_params(audio, p_desc_parse_for_params);
+            // The host sends the clock source SAM_FREQ request before selecting
+            // this alternate setting, so ep_in_sz was still 0 when
+            // audiod_calc_tx_packet_sz() ran there and it bailed on its
+            // TU_ASSERT(packet_sz_tx_max <= audio->ep_in_sz), leaving
+            // packet_sz_tx[] zeroed and flow control disengaged. The endpoint size
+            // and the format parameters are both known now, so recompute.
+            if (audio->sample_rate_tx) {
+              audiod_calc_tx_packet_sz(audio);
+            }
   #endif
             // Schedule first transmit if alternate interface is not zero, as sample data is available a ZLP is loaded
   #if !CFG_TUD_EDPT_DEDICATED_HWFIFO


### PR DESCRIPTION
I jumped in with @FoamyGuy and @relic-se on the usb_audio module for
CircuitPython, adafruit/circuitpython#11102, and trying to get UAC2 microphone
support going on the ESP32-S2 and S3. That PR already works on RP2040, RP2350 and
nRF52840, so I went looking for what was different on ESP32 and found this along
the way. It is not ESP32 specific.

`packet_sz_tx[]` is never computed, so EP IN flow control silently never engages.

`audiod_calc_tx_packet_sz()` asserts `packet_sz_tx_max <= audio->ep_in_sz`, but it
runs from the clock source `SAM_FREQ CUR` handlers, `audio_device.c:1288` and
`:1697`. Hosts send that before `SET_INTERFACE alt=1`, which is where `ep_in_sz`
gets set. So it is still 0, the assert fails, and nothing recomputes once the
endpoint opens.

`audiod_tx_packet_size()` then checks `nominal_size[1]`, finds 0, skips flow
control entirely and returns `tu_min16(data_count, max_depth)`.

Read off the device at 48 kHz stereo 16 bit:

| | before | after |
|---|---|---|
| `sample_rate_tx` | 48000 | 48000 |
| `ep_in_sz` at calc time | 0 | 196 |
| `packet_sz_tx[0]` | 0 | 188 |
| `packet_sz_tx[1]` | 0 | 192 |

With the fix the endpoint sends the expected mix. A bus capture of a running
stream shows 3671 packets of 192 bytes and 335 of 188.

The fix recomputes once `ep_in_sz` is known. 

Tested on ESP32-S3 and ESP32-S2 against the TinyUSB commit CircuitPython currently pins, `5453ed09f`.
