### PR TITLE
usbtmc: re-arm (or stall) the bulk-OUT endpoint after a USB488 TRIGGER message

### DIFF
--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -497,9 +497,21 @@ bool usbtmcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint
 
 #if (CFG_TUD_USBTMC_ENABLE_488)
           case USBTMC_MSGID_USB488_TRIGGER:
-            // Spec says we halt the EP if we didn't declare we support it.
-            TU_VERIFY(usbtmc_state.capabilities->bmIntfcCapabilities488.supportsTrigger);
-            TU_VERIFY(tud_usbtmc_msg_trigger_cb(msg));
+            // Unlike the messages above, TRIGGER is complete on arrival and has no response, so nothing else
+            // will move us out of STATE_IDLE. Do it here, otherwise the tud_usbtmc_start_bus_read() below (and
+            // any call the application makes from its callback) is a no-op and the bulk-OUT endpoint is left
+            // un-armed, silently timing out every subsequent host transfer.
+            TU_VERIFY(atomicChangeState(STATE_IDLE, STATE_NAK));
+
+            // Spec says we halt the EP if we didn't declare we support it; do the same when the application
+            // rejects the trigger. The callback result must not be wrapped in TU_VERIFY() here: returning
+            // early would skip both the stall and the re-arm below.
+            if (!usbtmc_state.capabilities->bmIntfcCapabilities488.supportsTrigger ||
+                !tud_usbtmc_msg_trigger_cb(msg)) {
+              usbd_edpt_stall(rhport, usbtmc_state.ep_bulk_out);
+              return false;
+            }
+            tud_usbtmc_start_bus_read();
 
             break;
 #endif

--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -511,6 +511,9 @@ bool usbtmcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint
               usbd_edpt_stall(rhport, usbtmc_state.ep_bulk_out);
               return false;
             }
+            // Result deliberately ignored: false here means the endpoint is already armed - either the
+            // application re-armed it from its callback, or a transfer is still queued - not that arming
+            // failed. Stalling on it would halt a healthy endpoint.
             tud_usbtmc_start_bus_read();
 
             break;

--- a/src/class/usbtmc/usbtmc_device.h
+++ b/src/class/usbtmc/usbtmc_device.h
@@ -25,7 +25,6 @@
 // * tud_usbtmc_open_cb
 // * tud_usbtmc_msg_data_cb
 // * tud_usbtmc_msgBulkIn_complete_cb
-// * tud_usbtmc_msg_trigger_cb
 // * (successful) tud_usbtmc_check_abort_bulk_out_cb
 // * (successful) tud_usbtmc_check_abort_bulk_in_cb
 // * (successful) tud_usmtmc_bulkOut_clearFeature_cb


### PR DESCRIPTION
Fixes #3821.

### Problem

A single USB488 `TRIGGER` message leaves the bulk-OUT endpoint un-armed, so the host's *next* bulk-OUT transfer times out. The trigger itself succeeds silently, so the failure shows up on a later, unrelated command. A USBTMC device clear recovers it, but nothing short of that does.

The bundled `examples/device/usbtmc` reproduces this as shipped:

```python
inst.query("*IDN?")     # OK
inst.assert_trigger()   # returns without error
inst.query("*IDN?")     # VI_ERROR_TMO
```

### Cause

In `usbtmcd_xfer_cb()`, every branch of the `STATE_IDLE` message dispatch leaves the endpoint in a defined state — either it transitions out of `STATE_IDLE` (so a later `tud_usbtmc_start_bus_read()` can re-arm it), or it stalls and lets the `CLEAR_FEATURE(ENDPOINT_HALT)` path recover it. `USBTMC_MSGID_USB488_TRIGGER` does neither.

Because state is still `STATE_IDLE` when the branch returns, even an application that follows the contract documented in `usbtmc_device.h` ("app must call `tud_usbtmc_start_bus_read()` during or soon after `tud_usbtmc_msg_trigger_cb`") gets a no-op: `tud_usbtmc_start_bus_read()` only re-arms from `STATE_NAK` / `STATE_ABORTING_BULK_IN_ABORTED` / `STATE_RCV`, and falls through to `default: return false;` otherwise.

The `supportsTrigger == 0` path has the same problem: hosts send `TRIGGER` without consulting the device's declared capabilities (both the Windows in-box driver and Linux's `usbtmc488_ioctl_trigger()` do), and the current `TU_VERIFY` bails out leaving the endpoint un-armed instead of halted as the comment intends.

### Change

- `src/class/usbtmc/usbtmc_device.c`: transition `STATE_IDLE` → `STATE_NAK` on TRIGGER, stall the bulk-OUT endpoint when trigger is unsupported *or* the application callback rejects it, and re-arm otherwise.
- `src/class/usbtmc/usbtmc_device.h`: drop `tud_usbtmc_msg_trigger_cb` from the list of callbacks after which the application must call `tud_usbtmc_start_bus_read()`, since the driver now handles it.

Two details worth flagging for review:

1. **The callback result is deliberately not wrapped in `TU_VERIFY()`.** Doing so would return out of `usbtmcd_xfer_cb()` before the stall/re-arm below it, reintroducing exactly the bug being fixed for any application whose callback returns `false`.
2. **This makes the driver own the re-arm for TRIGGER**, unlike `DEV_DEP_MSG_OUT` where the application does it. I went this way because the reject path has no application callback at all, so the driver has to handle that case regardless — and because there's nothing an application could usefully defer here, since TRIGGER carries no data and has no response. If you'd rather keep the "application always re-arms" convention, the alternative is to keep only the `atomicChangeState()` line and add a `tud_usbtmc_start_bus_read()` call to the example's trigger callback; happy to switch. Note that calling `tud_usbtmc_start_bus_read()` from the application callback remains safe with this patch — the driver's subsequent call sees `STATE_IDLE` and returns early rather than double-submitting a transfer.

### Testing

Tested on real RP2040 hardware (Raspberry Pi Pico, Windows 11 host, PyVISA over the in-box USBTMC driver) by building **this branch's unmodified `examples/device/usbtmc`** twice — once at the parent commit, once with this patch — and running the same script against each.

Before (stock `master`, `53fef28`):

```
*IDN?            -> 'TinyUSB,ModelNumber,SerialNumber,FirmwareVer123456'
assert_trigger() -> returned without error
*IDN?            -> VI_ERROR_TMO          <-- hung
clear()          -> recovered
5x trigger+query -> cycle 0 failed
```

After (same example, this patch):

```
*IDN?            -> 'TinyUSB,ModelNumber,SerialNumber,FirmwareVer123456'
assert_trigger() -> returned without error
*IDN?            -> 'TinyUSB,ModelNumber,SerialNumber,FirmwareVer123456'
clear()          -> not needed
5x trigger+query -> all 5 cycles OK
```

Note the example needs no change for this to work — it does not call `tud_usbtmc_start_bus_read()` from its trigger callback, and with this patch it no longer has to.

The rejection path isn't reachable from the stock example (it declares `supportsTrigger = 1`), so I covered that separately with a custom USBTMC488/SCPI firmware on the same board, with this change applied to pico-sdk 2.3.0's vendored copy of the class driver:

- **`supportsTrigger = 0`**: the endpoint stalls instead of going quiet — the rejection surfaces to the host as `VI_ERROR_SYSTEM_ERROR` — and 10 back-to-back reject + `clear()` cycles all recover with no power cycle.
- **`supportsTrigger = 1`**: 10 back-to-back `assert_trigger()` + query cycles complete immediately; serial-poll status byte behaves as before (`SRQ` set by the trigger, cleared by `read_stb()`); normal SCPI traffic unaffected before and after.

Also compiles clean for cortex-m0plus with `-Wall -Wextra -Werror -Wconversion -Wsign-conversion -Wcast-align -Wcast-qual`, with no new warnings versus the parent commit.
