### PR TITLE
fix(rp2040): clear stale EPX buf_ctrl AVAIL bit before arming a transfer

### DIFF
--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -633,6 +633,19 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t dev_addr, uint8_t ep_addr, uint8_t *b
 
       epx = ep;
 
+      // EPX is shared across every non-interrupt endpoint of every connected device, and we
+      // just confirmed (above, under this same critical section, so authoritative) that
+      // nothing else currently believes it owns EPX. But the hardware doesn't reliably clear
+      // USB_BUF_CTRL_AVAIL in this register on its own once a transaction completes -- if the
+      // very next EPX user re-arms immediately (e.g. the MIDI host class driver's
+      // xfer-complete callback synchronously starting the next transfer on every zero-byte
+      // completion, with no scheduler tick in between), bufctrl_write32() can see a stale
+      // AVAILABLE bit left over from the just-finished transaction and panic ("buf_ctrl
+      // already available"), even though nothing is actually still in flight. Software's own
+      // epx->state is the real authority on whether EPX is free -- we already checked it --
+      // so it's safe to force-clear any such leftover bit here before arming the new transfer.
+      *buf_reg = 0;
+
       epx_ctrl_prepare(ep->transfer_type);
       rp2usb_xfer_start(ep, ep_reg, buf_reg, buffer, NULL, buflen); // prepare bufctrl
       usb_hw->dev_addr_ctrl = (uint32_t)(ep->dev_addr | (tu_edpt_number(ep->ep_addr) << USB_ADDR_ENDP_ENDPOINT_LSB));


### PR DESCRIPTION
### What

`hcd_edpt_xfer()` clears any stale `USB_BUF_CTRL_AVAIL` bit in `epx_buf_ctrl` before arming a new transfer on EPX.

### Why

EPX is shared by every non-interrupt endpoint of every connected device. The hardware does not reliably clear `USB_BUF_CTRL_AVAIL` in `epx_buf_ctrl` once a transaction completes. When the next EPX user re-arms immediately — with no intervening scheduler tick — `bufctrl_write32()` sees the leftover AVAILABLE bit from the *finished* transaction and panics:

```
buf_ctrl @ 0x... already available
```

despite nothing actually being in flight.

### Reproducing

Seen consistently with a USB-MIDI host on RP2040. The MIDI class driver's xfer-complete callback synchronously starts the next transfer on every zero-byte completion, which makes the re-arm immediate enough to hit this reliably. It presents as a hard panic partway through a MIDI session rather than at enumeration, which made it slow to attribute.

### Why this is safe here

At this point `hcd_edpt_xfer()` has already established, under the same critical section, that no endpoint currently owns EPX — the preceding check tests `epx->state`, and software's own state is the authority on EPX ownership rather than the hardware bit. So a set AVAILABLE bit at this point can only be a leftover, and clearing it cannot discard a live transaction.

### Notes

Draft: this is running in a downstream project against real hardware, but I have not exercised it beyond the RP2040 host path (MIDI class, full speed). Happy to adjust the placement or the comment if you would rather handle it inside `rp2usb_xfer_start()` / `bufctrl_write32()` instead — the fix is deliberately narrow and placed where the ownership check already is, but I do not have a strong view on where it belongs.
