### PR TITLE
fix(host): clamp illegal sub-8 fullspeed bulk max packet size

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1337,6 +1337,19 @@ bool tuh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const* desc_ep) {
     tusb_desc_endpoint_t *hacked_ep = (tusb_desc_endpoint_t *)(uintptr_t)desc_ep;
     hacked_ep->wMaxPacketSize       = tu_htole16(64);
   }
+  // HACK: some device reports an implausibly small bulk max packet size -- seen with a
+  // USB-MIDI device reporting 4, which is the size of a single USB-MIDI 1.0 event packet
+  // (cable number + code index + 3 data bytes), not a valid endpoint wMaxPacketSize (full
+  // speed bulk must be 8/16/32/64 per spec). Round up to the smallest legal size; actual
+  // transfers can still be shorter than this (a short packet is how bulk transfers normally
+  // terminate), so this doesn't change on-the-wire behavior, just what tu_edpt_validate()
+  // below is willing to accept
+  if (desc_ep->bmAttributes.xfer == TUSB_XFER_BULK && tu_edpt_packet_size(desc_ep) > 0 &&
+      tu_edpt_packet_size(desc_ep) < 8 && tuh_speed_get(dev_addr) == TUSB_SPEED_FULL) {
+    TU_LOG1("  WARN: EP max packet size is %u in fullspeed, force to 8\r\n", tu_edpt_packet_size(desc_ep));
+    tusb_desc_endpoint_t *hacked_ep = (tusb_desc_endpoint_t *)(uintptr_t)desc_ep;
+    hacked_ep->wMaxPacketSize       = tu_htole16(8);
+  }
   TU_ASSERT(tu_edpt_validate(desc_ep, tuh_speed_get(dev_addr)));
   return hcd_edpt_open(usbh_get_rhport(dev_addr), dev_addr, desc_ep);
 }

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1344,9 +1344,10 @@ bool tuh_edpt_open(uint8_t dev_addr, tusb_desc_endpoint_t const* desc_ep) {
   // transfers can still be shorter than this (a short packet is how bulk transfers normally
   // terminate), so this doesn't change on-the-wire behavior, just what tu_edpt_validate()
   // below is willing to accept
-  if (desc_ep->bmAttributes.xfer == TUSB_XFER_BULK && tu_edpt_packet_size(desc_ep) > 0 &&
-      tu_edpt_packet_size(desc_ep) < 8 && tuh_speed_get(dev_addr) == TUSB_SPEED_FULL) {
-    TU_LOG1("  WARN: EP max packet size is %u in fullspeed, force to 8\r\n", tu_edpt_packet_size(desc_ep));
+  const uint16_t ep_mps = tu_edpt_packet_size(desc_ep);
+  if (desc_ep->bmAttributes.xfer == TUSB_XFER_BULK && ep_mps > 0 && ep_mps < 8 &&
+      tuh_speed_get(dev_addr) == TUSB_SPEED_FULL) {
+    TU_LOG1("  WARN: EP max packet size is %u in fullspeed, force to 8\r\n", (unsigned) ep_mps);
     tusb_desc_endpoint_t *hacked_ep = (tusb_desc_endpoint_t *)(uintptr_t)desc_ep;
     hacked_ep->wMaxPacketSize       = tu_htole16(8);
   }


### PR DESCRIPTION
### What

`tuh_edpt_open()` rounds an illegally small full-speed bulk `wMaxPacketSize` up to 8, the smallest legal value.

### Why

A full-speed bulk endpoint must report a `wMaxPacketSize` of 8, 16, 32 or 64. A USB-MIDI device was seen reporting **4** — the size of a single USB-MIDI 1.0 event packet (cable number + code index + three data bytes), which is a plausible thing for device firmware to confuse it with.

`tu_edpt_validate()` correctly rejects it, so `tuh_edpt_open()` fails and the device never enumerates.

### Approach

This mirrors the existing hack immediately above it, which clamps an over-large 512 down to 64 for full speed for the same class of reason — so it extends an established pattern rather than introducing one, and is deliberately scoped the same way (full speed, bulk only).

Transfers may still be shorter than the advertised size — a short packet is how bulk transfers normally terminate — so this does not change on-the-wire behaviour, only what `tu_edpt_validate()` will accept.

### Notes

Draft: I am aware that working around non-compliant device descriptors is a judgement call rather than an obvious win, and that the answer may reasonably be "the device is broken, fix the device". Raising it because the adjacent 512→64 clamp suggests the project is already willing to accommodate this class of bug, but I will happily close it if you would rather not accumulate more of them.

Tested against the one offending device [a Moog Slim Phatty] on RP2040; I have no second implausible-MPS device to check against.
