### PR TITLE
bound endpoint number in tu_bind_driver_to_ep_itf

### DIFF
--- a/src/common/tusb_private.h
+++ b/src/common/tusb_private.h
@@ -63,7 +63,7 @@ TU_ATTR_ALWAYS_INLINE static inline bool tu_edpt_validate(const tusb_desc_endpoi
 
 // Bind drivers to all interfaces and endpoints in the provided configuration descriptor
 bool tu_bind_driver_to_ep_itf(uint8_t driver_id, uint8_t ep2drv[][2], uint8_t itf2drv[], uint8_t itf_max,
-                              const uint8_t *p_desc, uint16_t desc_len);
+                              uint8_t ep_max, const uint8_t *p_desc, uint16_t desc_len);
 
 // Claim an endpoint with provided mutex
 bool tu_edpt_claim(volatile uint8_t* ep_state, osal_mutex_t mutex);

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1281,8 +1281,8 @@ static bool process_set_config(uint8_t rhport, uint8_t cfg_num) {
         TU_LOG_USBD("  %s opened\r\n", driver->name);
 
         // bind found driver to all interfaces and endpoint within drv_len
-        TU_ASSERT(tu_bind_driver_to_ep_itf(drv_id, _usbd_dev.ep2drv, _usbd_dev.itf2drv, CFG_TUD_INTERFACE_MAX, p_desc,
-                                           drv_len));
+        TU_ASSERT(tu_bind_driver_to_ep_itf(drv_id, _usbd_dev.ep2drv, _usbd_dev.itf2drv, CFG_TUD_INTERFACE_MAX,
+                                           CFG_TUD_ENDPPOINT_MAX, p_desc, drv_len));
 
         p_desc += drv_len; // next Interface
         break; // exit driver find loop

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -2160,7 +2160,8 @@ static bool enum_parse_configuration_desc(uint8_t dev_addr, tusb_desc_configurat
           TU_LOG_USBH("  %s opened\r\n", driver->name);
 
           // bind found driver to all interfaces and endpoint within drv_len
-          tu_bind_driver_to_ep_itf(drv_id, dev->ep2drv, dev->itf2drv, CFG_TUH_INTERFACE_MAX, p_desc, drv_len);
+          tu_bind_driver_to_ep_itf(drv_id, dev->ep2drv, dev->itf2drv, CFG_TUH_INTERFACE_MAX, CFG_TUH_ENDPOINT_MAX,
+                                   p_desc, drv_len);
 
           p_desc += drv_len; // next Interface
           break;             // exit driver find loop

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -2160,8 +2160,8 @@ static bool enum_parse_configuration_desc(uint8_t dev_addr, tusb_desc_configurat
           TU_LOG_USBH("  %s opened\r\n", driver->name);
 
           // bind found driver to all interfaces and endpoint within drv_len
-          tu_bind_driver_to_ep_itf(drv_id, dev->ep2drv, dev->itf2drv, CFG_TUH_INTERFACE_MAX, CFG_TUH_ENDPOINT_MAX,
-                                   p_desc, drv_len);
+          TU_ASSERT(tu_bind_driver_to_ep_itf(drv_id, dev->ep2drv, dev->itf2drv, CFG_TUH_INTERFACE_MAX,
+                                             CFG_TUH_ENDPOINT_MAX, p_desc, drv_len));
 
           p_desc += drv_len; // next Interface
           break;             // exit driver find loop

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -274,7 +274,7 @@ bool tu_edpt_validate(const tusb_desc_endpoint_t *desc_ep, tusb_speed_t speed) {
 #endif
 
 bool tu_bind_driver_to_ep_itf(uint8_t driver_id, uint8_t ep2drv[][2], uint8_t itf2drv[], uint8_t itf_max,
-                              const uint8_t *p_desc, uint16_t desc_len) {
+                              uint8_t ep_max, const uint8_t *p_desc, uint16_t desc_len) {
   const uint8_t *desc_end = p_desc + desc_len;
   while (tu_desc_in_bounds(p_desc, desc_end)) {
     const uint8_t desc_type = tu_desc_type(p_desc);
@@ -283,6 +283,7 @@ bool tu_bind_driver_to_ep_itf(uint8_t driver_id, uint8_t ep2drv[][2], uint8_t it
       const uint8_t ep_addr  = ((const tusb_desc_endpoint_t *)p_desc)->bEndpointAddress;
       const uint8_t ep_num   = tu_edpt_number(ep_addr);
       const uint8_t ep_dir   = tu_edpt_dir(ep_addr);
+      TU_ASSERT(ep_num < ep_max);
       ep2drv[ep_num][ep_dir] = driver_id;
     } else if (desc_type == TUSB_DESC_INTERFACE) {
       const tusb_desc_interface_t *desc_itf = (const tusb_desc_interface_t *)p_desc;


### PR DESCRIPTION
During host enumeration the driver-binding walk writes the driver id into ep2drv indexed by the endpoint number taken from each endpoint descriptor, but that index is never bounded, even though the interface number on the sibling branch a few lines down is checked against itf_max. dev->ep2drv has CFG_TUH_ENDPOINT_MAX rows and that value is commonly reduced below 16 (the bare_api host example ships it at 8), so a rogue device whose bEndpointAddress low nibble is at or above the limit makes the write land past the array in adjacent device state during enumeration. This adds an ep_max argument and the matching bound so a malformed endpoint is rejected the same way an out-of-range interface already is, with the host and device callers passing their respective endpoint maximums.