### PR TITLE
dcd(ci_hs): stage the device address before priming the status stage

### DIFF
--- a/src/portable/chipidea/ci_hs/ci_hs_type.h
+++ b/src/portable/chipidea/ci_hs/ci_hs_type.h
@@ -29,6 +29,14 @@ enum {
   USBCMD_INTR_THRESHOLD_MASK = 0x00FF0000u, // Interrupt Threshold bit 23:16
 };
 
+// DEVICEADDR
+#define DEVICEADDR_USBADR_POS 25
+
+enum {
+  DEVICEADDR_USBADRA     = TU_BIT(24),  ///< Device Address Advance: stage USBADR until the next EP0 IN is ACKed
+  DEVICEADDR_USBADR_MASK = 0xFE000000u, ///< Device Address bit 31:25
+};
+
 // PORTSC1
 #define PORTSC1_PORT_SPEED_POS    26
 

--- a/src/portable/chipidea/ci_hs/dcd_ci_hs.c
+++ b/src/portable/chipidea/ci_hs/dcd_ci_hs.c
@@ -361,12 +361,17 @@ void dcd_int_disable(uint8_t rhport) {
 }
 
 void dcd_set_address(uint8_t rhport, uint8_t dev_addr) {
-  // Response with status first before changing device address. A refused prime means a new
-  // setup superseded this transfer; staging an address whose ACK will never arrive would
-  // leave the device answering on it, so only arm the address when the status went out.
-  if (dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0, false)) {
-    ci_hs_regs_t *dcd_reg = CI_HS_REG(rhport);
-    dcd_reg->DEVICEADDR   = (dev_addr << 25) | TU_BIT(24);
+  ci_hs_regs_t  *dcd_reg = CI_HS_REG(rhport);
+  const uint32_t prev    = dcd_reg->DEVICEADDR & DEVICEADDR_USBADR_MASK;
+
+  // IMXRT1060RM 42.7.23 / UM10503 Table 478: stage the address before priming the status stage so
+  // hardware loads USBADR at the status ACK. Priming first races that ACK against this write.
+  dcd_reg->DEVICEADDR = ((uint32_t)dev_addr << DEVICEADDR_USBADR_POS) | DEVICEADDR_USBADRA;
+
+  if (!dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0, false)) {
+    // USB 2.0 9.4.6: the address changes only after the status stage completes successfully. The
+    // status never went out, so drop the stage - USBADRA=0 takes effect instantly.
+    dcd_reg->DEVICEADDR = prev;
   }
 }
 


### PR DESCRIPTION
## What

`dcd_set_address()` on ChipIdea HS wrote `DEVICEADDR` **after** priming the SET_ADDRESS status ZLP. Both manuals ask for the opposite order:

> If the DCD writes the USBADR with USBADRA=1 after the SET_ADDRESS data phase (**before the prime of the status phase**), the USBADR will be programmed instantly at the correct time and meet the 2 ms USB requirement.
> — IMXRT1060RM Rev 4, §42.7.23, p.2458. UM10503 Rev 2.4 Table 478 (p.662) is identical, and adds that `USBADRA` exists precisely "to preset the USBADR register bits before the status phase".

Priming first leaves a window between the `ENDPTPRIME` store and the `DEVICEADDR` store. An IN answered inside it ACKs with `USBADRA` still 0, so the holding register is never consulted: the device keeps answering on address 0 while the host has moved to the new one, and the staged address then waits for an ACK this transfer will never produce. Instruction timing alone cannot open that window, but `dcd_set_address()` runs in task context (`usbd.c` `process_std_device_request()`), so any interrupt landing between the two stores stretches it past a microframe.

Also casts `dev_addr` before the shift — it is `uint8_t`, promoted to `int`, so an address ≥ 64 reached the sign bit of a 32-bit `int`. Linux allocates 1–127.

## The refused-prime path

Hardware covers most of what `2fda873fa`'s prime-success gate did: RM condition 2 discards a staged address on a SETUP or OUT to EP0, condition 3 zeroes `USBADR` on a bus reset.

What it cannot cover is a SETUP latched *before* this write and still unconsumed after the full `CI_HS_BUSY_SPIN` spin in `qhd_start_xfer()`, which refuses the prime — condition 2 already fired for that earlier SETUP, so a stage written after it survives and would load `USBADR` on the next EP0 IN ACK of an unrelated transfer.

USB 2.0 §9.4.6 is explicit:

> "The USB device does not change its device address until after the Status stage of this request is completed successfully. Note that this is a difference between this request and all other requests."

So that is a spec violation, not just a race, and the refused-prime path now restores the previous `USBADR`.

**Restoring the previous value rather than writing zero** keeps §9.4.6's Address-state row correct — a device already at a non-zero address must stay there when the status fails, and `wValue = 0` from Address state is itself a defined transition to Default. On Linux the restore is always a no-op write of 0, since `hub_set_address()` only issues SET_ADDRESS from `USB_STATE_DEFAULT` (`drivers/usb/core/hub.c`).

For reference on recovery: the host always sends SET_ADDRESS to address 0 (`usb_sndaddr0pipe()`), retries `SET_ADDRESS_TRIES` (2 by default) 200 ms apart, inside `PORT_INIT_TRIES` (4) outer passes that each begin with a port reset — which clears `USBADRA`/`USBADR` in hardware.

## Documentation checked

- **Errata swept, nothing applies:** `IMXRT1060CE_A` Rev 1.3 lists only ERR050101 (ISO-IN endpoint conflict) and ERR010661 (VBUS leakage) for USB; `IMXRT1060CE_B` Rev 1.1 only ERR010661. Neither touches `DEVICEADDR`.
- Independent corroboration of the ordering: CherryUSB's ChipIdea port and `dcd_dwc2.c` both set the address before the status stage.

## Validation

| Gate | Result |
|---|---|
| Build sweep, **all 19 `ci_hs` boards** (imxrt ×11, lpc18 ×2, lpc43 ×2, MCXN9 ×2, hpmicro, rw61x) | 19/19 pass |
| Unit tests | 63/63 |
| `pre-commit run --all-files` | clean |
| PVS-Studio vs base | **−1 diagnostic** (the sign-bit shift), none added |
| HIL `mimxrt1064_evk` device + host suite | 18/19 — the gap failed at *flash* (probe contention) and passed on re-run |
| HIL `device/usbtest` battery | 8 × 30/30 |
| 100× forced re-enumeration, A/B vs base | 0/100 on this change, 0/100 on base |

The re-enumeration A/B was direct-flashed by JLink with the DUT selected by board serial and the rig lock verified.

**This is a regression gate, not a proof of fix.** The original defect needs an interrupt between the two stores and has never been reproduced in the field; base passes the same tests. The case for the change is the two manuals plus §9.4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)