### PR TITLE
ci(circleci): key the toolchain cache off a file that always exists

### DIFF
--- a/.circleci/config2.yml
+++ b/.circleci/config2.yml
@@ -8,18 +8,14 @@ commands:
 
     steps:
       - run:
-          name: Set toolchain url and key
+          name: Set toolchain url
           command: |
             toolchain_url=$(jq -r '."<< parameters.toolchain >>"' .github/actions/setup_toolchain/toolchain.json)
-            # only cache if not a github link
-            if [[ $toolchain_url != "https://github.com"* ]]; then
-              echo "<< parameters.toolchain >>-$toolchain_url" > toolchain_key
-            fi
             echo "export toolchain_url=$toolchain_url" >> $BASH_ENV
 
       - restore_cache:
           name: Restore Toolchain Cache
-          key: deps-{{ checksum "toolchain_key" }}
+          key: deps-<< parameters.toolchain >>-{{ checksum ".github/actions/setup_toolchain/toolchain.json" }}
           paths:
             - ~/cache/<< parameters.toolchain >>
 
@@ -59,7 +55,7 @@ commands:
 
       - save_cache:
           name: Save Toolchain Cache
-          key: deps-{{ checksum "toolchain_key" }}
+          key: deps-<< parameters.toolchain >>-{{ checksum ".github/actions/setup_toolchain/toolchain.json" }}
           paths:
             - ~/cache/<< parameters.toolchain >>
 


### PR DESCRIPTION
## The bug

`Restore Toolchain Cache` and `Save Toolchain Cache` fail on **every** CircleCI job whose toolchain is hosted on GitHub — `arm-gcc`, `arm-clang`, `riscv-gcc`, `rx-gcc`, `ft9xx-gcc`:

```
Restore Toolchain Cache
template: cacheKey:1:8: executing "cacheKey" at <checksum "toolchain_key">:
error calling checksum: open /home/circleci/project/tinyusb/toolchain_key: no such file or directory
```

`Set toolchain url and key` writes `toolchain_key` **only when the URL is not a github.com link**:

```bash
# only cache if not a github link
if [[ $toolchain_url != "https://github.com"* ]]; then
  echo "<< parameters.toolchain >>-$toolchain_url" > toolchain_key
fi
```

…but both cache steps reference `{{ checksum "toolchain_key" }}` unconditionally. For those toolchains the key can never be computed, so both steps error out.

The jobs still go green, because the build does not depend on the cache — which is why this has gone unnoticed. Two consequences:

- Two permanently red steps on most jobs, which makes real failures harder to spot.
- **No toolchain caching at all** for those toolchains: the tarball is re-downloaded on every run.

Verified on three jobs from a recent PR — the two cache steps are `FAIL` on all of them while the overall outcome is `success`:

| Job | Restore | Save | Build | Outcome |
|---|---|---|---|---|
| `build---one-random-make-apm32f0xx-large-arm-gcc` | FAIL | FAIL | success | success |
| `build---one-random-make-at32f402_405-large-arm-gcc` | FAIL | FAIL | success | success |
| `build---one-random-make-nrf-large-arm-gcc` | FAIL | FAIL | canceled | failed |

## The fix

Key the cache on the toolchain name plus a checksum of `toolchain.json`, which is committed in the repo and therefore always present:

```yaml
key: deps-<< parameters.toolchain >>-{{ checksum ".github/actions/setup_toolchain/toolchain.json" }}
```

The key still invalidates whenever a toolchain URL changes, and the per-toolchain prefix keeps entries separate. The runtime-generated `toolchain_key` file is no longer needed, so the conditional that created it goes away and the step is renamed to `Set toolchain url`.

## Behaviour change worth a look

GitHub-hosted toolchains are now **cached** rather than skipped. That skip was the intent of the removed condition, but it is also precisely what broke the steps: CircleCI resolves a cache key at config time and cannot skip a cache step based on a value only known at run time. Caching them also avoids re-downloading the toolchain on every job.

If you would rather keep GitHub-hosted toolchains out of the cache, the alternative is to thread a boolean parameter through `setup-toolchain` and split into cached/uncached variants — happy to do that instead.

## Notes

- `restore_cache` does not take a `paths:` key (only `save_cache` does); the existing `paths:` under `restore_cache` is inert. Left alone here to keep the diff to the bug.
- `circleci config validate` reports `[#/workflows/build] required key [jobs] not found` on this file both before and after the change — it is a continuation config whose jobs are injected by `set-matrix`, so that error is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)