### PR TITLE
class/midi: skip requeue in midih_xfer_cb on transfer failure

### DIFF
--- a/src/class/midi/midi_host.c
+++ b/src/class/midi/midi_host.c
@@ -141,7 +141,7 @@ void midih_close(uint8_t daddr) {
 }
 
 bool midih_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes) {
-  (void) result;
+  TU_VERIFY(result == XFER_RESULT_SUCCESS);
   const uint8_t idx = get_idx_by_ep_addr(dev_addr, ep_addr);
   TU_VERIFY(idx < CFG_TUH_MIDI);
   midih_interface_t *p_midi = &_midi_host[idx];

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -470,6 +470,15 @@ void hcd_device_close(uint8_t rhport, uint8_t dev_addr) {
 
   rp2usb_critical_enter();
 
+  // If this device currently owns the shared EPX (control/bulk) hardware pipe, stop the
+  // in-progress transfer and clear its buffer control register. Otherwise the AVAIL bit
+  // left set by the live transfer stays latched in hardware, and the next device to be
+  // armed on EPX (e.g. a replugged device's enumeration) panics with "already available".
+  if (epx->dev_addr == dev_addr && epx->state == EPSTATE_ACTIVE) {
+    sie_stop_xfer();
+    usbh_dpram->epx_buf_ctrl = 0;
+  }
+
   for (size_t i = 0; i < TU_ARRAY_SIZE(ep_pool); i++) {
     hw_endpoint_t *ep = &ep_pool[i];
     if (ep->dev_addr == dev_addr && ep->max_packet_size > 0) {


### PR DESCRIPTION
PR for #3805 - RP2xxx MIDI Host panics on device unplug

`midih_xfer_cb()` was just throwing away the transfer result and always re-queueing the next RX transfer regardless of what happened. So, when you unplug a MIDI device mid-transfer, the pending In transfer comes back as XFER_RESULT_FAILED, but the driver didn't noticed that and tried to re-arm the endpoint regardless. On RP2040, that collides with the host's controller abort/cleanup on the same buffer-control register and it panics with `buf_ctrl already available`

So, I fixed it by making t so that it bails out early if `result != XFER_RESULT_SUCCESS`. `cdc_host.c` already handles this in (in the same way) `cdch_xfer_cb` so this just brings the MIDI in line with other patterns in the host stack. 