### PR TITLE
test/hil: run blocking device IO in a child, not on the worker

### DIFF
--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -44,7 +44,6 @@ import itertools
 import os
 import random
 import re
-import select
 import signal
 import shlex
 import sys
@@ -319,6 +318,67 @@ LP_READER = (
     '        break\n'
     '    buf += chunk\n'
     'sys.stdout.buffer.write(buf)\n'
+)
+# The write half, same shape and same reason: usblp_open() ignores O_NONBLOCK and stalls in
+# usb_autopm_get_interface() on a wedged device, holding the driver-global usblp_mutex. A
+# blocked THREAD cannot be abandoned without keeping the fd, and usblp allows a single opener
+# (v6.12.96 usblp.c), so the next open of this node returns -EBUSY for the life of the worker.
+# A killed process takes its fd with it. O_NONBLOCK is kept because usblp DOES honour it on
+# write, which is what the select()/partial-write loop below relies on.
+LP_WRITER = (
+    'import os, random, select, sys\n'
+    'lp, payload_path, ready = sys.argv[1], sys.argv[2], sys.argv[3]\n'
+    'data = open(payload_path, "rb").read()\n'
+    'fd = os.open(lp, os.O_WRONLY | os.O_NONBLOCK)\n'
+    # readiness marker, as in LP_READER: the parent must not read CDC before the node is open
+    'open(ready, "w").close()\n'
+    'off = 0\n'
+    'while off < len(data):\n'
+    '    n = min(random.randint(1, 64), len(data) - off)\n'
+    '    buf, w = data[off:off + n], 0\n'
+    '    while w < len(buf):\n'
+    '        _, wr, _ = select.select([], [fd], [], 5.0)\n'
+    '        if not wr:\n'
+    '            sys.exit("printer write timeout (firmware not draining OUT endpoint)")\n'
+    '        w += os.write(fd, buf[w:])\n'
+    '    off += n\n'
+)
+# hidapi's hidraw backend reads `manufacturer` and `product` for EVERY HID device it
+# lists (linux/hid.c), and both are usb_string_attr -- served under the device lock a
+# wedged usbfs ioctl holds (v6.12.96 sysfs.c:141-143). So hid.enumerate() can stall on a
+# device that is not even ours, in-process, with no timeout and no way to abandon it.
+# In a child it is bounded by run_alongside and a killed child takes its handle with it.
+# The enumeration retry lives here, not in the parent: re-spawning to poll would re-pay
+# interpreter start-up on every attempt.
+HID_ECHO = (
+    'import hid, random, sys, time\n'
+    'uid, deadline = sys.argv[1], time.monotonic() + float(sys.argv[2])\n'
+    'dev = None\n'
+    'while dev is None:\n'
+    '    for d in hid.enumerate(0xCafe):\n'
+    '        if d["serial_number"] == uid:\n'
+    '            dev = d\n'
+    '            break\n'
+    '    if dev is not None or time.monotonic() >= deadline:\n'
+    '        break\n'
+    '    time.sleep(1)\n'
+    'if dev is None:\n'
+    '    sys.exit(f"HID device not found for {uid}")\n'
+    'h = hid.device()\n'
+    'h.open(dev["vendor_id"], dev["product_id"], uid)\n'
+    'try:\n'
+    '    for size in (8, 32, 63):\n'
+    # Report ID (0) + payload, padded to 64 bytes
+    '        payload = bytes(random.randint(1, 255) for _ in range(size))\n'
+    '        h.write(bytes([0]) + payload + bytes(64 - size))\n'
+    '        echo = h.read(64, 2000)\n'
+    '        if not echo or len(echo) < size:\n'
+    '            sys.exit(f"HID echo timeout or short read ({size} bytes)")\n'
+    '        if bytes(echo[:size]) != payload:\n'
+    '            sys.exit(f"HID echo wrong data ({size} bytes): sent {payload.hex()} "\n'
+    '                     f"received {bytes(echo[:size]).hex()}")\n'
+    'finally:\n'
+    '    h.close()\n'
 )
 MTYPE_TIMEOUT = 30  # a README-sized read is <1 s; bounds a D-state hang on a wedged device
 
@@ -991,45 +1051,75 @@ def test_device_printer_to_cdc(board):
     ser.reset_input_buffer()
 
     # Test 1: Printer -> CDC with multiple sizes, write in random 1-64 byte chunks
-    LP_WRITE_TIMEOUT = 5.0  # seconds; firmware may stall draining the printer OUT endpoint
+    # The write runs in a PROCESS for the same reason the read below does: see LP_WRITER.
     for size in sizes:
         test_data = rand_ascii(size)
         ser.reset_input_buffer()
-        rd = b''
-        offset = 0
-        # bounded: O_NONBLOCK does NOT save us -- usblp_open() takes the device mutex
-        # first -- and this open runs on the worker itself, with no thread to abandon
-        lp_fd = hil_util.bounded_open(lp_dev, os.O_WRONLY | os.O_NONBLOCK, 5)
-        # Three-valued on purpose: an OSError here is a FACT about the node (EBUSY from
-        # usblp's single-opener rule, ENOENT from a re-enumeration race, EACCES from a
-        # udev gap) and must not be reported as a wedge -- that sends the operator to
-        # usb-kernel-recover for hardware that is fine.
-        assert lp_fd is not hil_util.SYSFS_UNKNOWN, (
-            f'printer: opening {lp_dev} for write blocked (device wedged)'
-            f'{hil_util.sysfs_blind_note()}')
-        assert lp_fd is not None, f'printer: {lp_dev} could not be opened for write'
+        rd = bytearray()
+
+        payload = Path(tempfile.gettempdir()) / f'hil-lp-tx-{os.getpid()}-{size}'
+        ready = Path(tempfile.gettempdir()) / f'hil-lp-ready-{os.getpid()}-{size}'
+        payload.write_bytes(test_data)
+        ready.unlink(missing_ok=True)
+        # +5 like write_cdc's sibling wait below: the bound is on the OPEN, and the child
+        # must first fork, exec and boot CPython, which on a loaded rig routinely exceeds
+        # LP_OPEN_TIMEOUT on its own. A tighter wait here reports a slow interpreter start
+        # as a wedged node.
+        open_deadline = time.monotonic() + LP_OPEN_TIMEOUT + 5
+        saw_ready = False
+
+        def read_cdc():
+            # WAIT for the writer to have the node open, as Test 2's write_cdc does: the
+            # child has to fork, exec and boot CPython, and reading before it starts just
+            # burns the serial timeout.
+            # ONE deadline, shared with the child's bound below. Two different ones let
+            # the writer open after the parent gave up: it writes the whole payload with
+            # nobody reading, exits 0, and the byte-compare reports FIRMWARE DATA
+            # CORRUPTION for a board whose only problem was a slow open.
+            nonlocal saw_ready
+            while not ready.exists():
+                if time.monotonic() > open_deadline:
+                    return       # never opened; the assert below reports THAT, not data
+                time.sleep(0.02)
+            saw_ready = True
+            # fullspeed devices may need extra time; ser.read is bounded by
+            # SERIAL_READ_TIMEOUT, so an empty return means the stream went quiet
+            while len(rd) < size:
+                chunk = ser.read(size - len(rd))
+                if not chunk:
+                    break
+                rd.extend(chunk)   # in place: `rd +=` would rebind it as a local
+
         try:
-            while offset < size:
-                chunk_size = min(random.randint(1, 64), size - offset)
-                buf = test_data[offset:offset + chunk_size]
-                written = 0
-                while written < len(buf):
-                    _, wr, _ = select.select([], [lp_fd], [], LP_WRITE_TIMEOUT)
-                    assert wr, f'Printer write timeout after {LP_WRITE_TIMEOUT}s (firmware not draining OUT endpoint)'
-                    n = os.write(lp_fd, buf[written:])
-                    written += n
-                rd += ser.read(chunk_size)
-                offset += chunk_size
+            r = hil_util.run_alongside(
+                [sys.executable, '-c', LP_WRITER, lp_dev, str(payload), str(ready)],
+                read_cdc, LP_OPEN_TIMEOUT + 12)
         finally:
-            os.close(lp_fd)
-        # read any remaining bytes (fullspeed devices may need extra time)
-        while len(rd) < size:
-            remaining = ser.read(size - len(rd))
-            if not remaining:
-                break
-            rd += remaining
-        assert rd == test_data, (f'Printer->CDC wrong data ({size} bytes):\n'
-                                 f'  expected: {test_data[:64]}\n  received: {rd[:64]}')
+            ready.unlink(missing_ok=True)
+            payload.unlink(missing_ok=True)
+        # rc 124 is run_alongside's kill, i.e. the open blocked -- and stderr is EMPTY
+        # there, so without the fallback the cell reads 'failed (32 bytes, rc 124):' and
+        # nothing, for the one failure this conversion exists to contain. An OSError is a
+        # FACT about the node (EBUSY from usblp's single-opener rule, ENOENT from a
+        # re-enumeration race) and must not send the operator to usb-kernel-recover.
+        # The bound covers the open AND the whole write, so rc 124 alone does not mean a
+        # wedged node. `ready` is written on the line after os.open() returns, so its
+        # ABSENCE is what says the open never completed -- the case that sends an operator
+        # to usb-kernel-recover. Anything else killed on the bound was a slow drain.
+        detail = hil_util.cmd_stdout_text(r.stderr).strip()[:200]
+        # saw_ready, not ready.exists(): a marker that appeared AFTER read_cdc gave up
+        # means the child wrote with nobody reading, and the byte-compare below would call
+        # that firmware data corruption. Report the slow open instead.
+        assert saw_ready, (f'printer: {lp_dev} was not opened for write within '
+                           f'{LP_OPEN_TIMEOUT + 5}s (device wedged, or the writer never '
+                           f'started); rc {r.returncode}')
+        assert r.returncode == 0, (
+            f'Printer->CDC writer failed ({size} bytes): {detail}' if detail else
+            f'Printer->CDC writer killed on its bound after opening {lp_dev} '
+            f'(rc {r.returncode}): the firmware stopped draining the OUT endpoint')
+        assert bytes(rd) == test_data, (f'Printer->CDC wrong data ({size} bytes):\n'
+                                        f'  expected: {test_data[:64]}\n'
+                                        f'  received: {bytes(rd)[:64]}')
 
     # Test 2: CDC -> Printer with multiple sizes, write in random 1-64 byte chunks.
     # The lp read runs in a PROCESS, not a thread: /dev/usb/lp* blocks on read, usblp
@@ -1069,8 +1159,6 @@ def test_device_printer_to_cdc(board):
             ready.unlink(missing_ok=True)
         # stderr, not stdout: run_alongside keeps the payload stream clean, so a traceback
         # from the reader now arrives on its own pipe
-        # rc 124 is run_alongside's kill -- a blocked usblp_open leaves stderr EMPTY, so
-        # without the fallback this renders as 'failed (32 bytes, rc 124):' and nothing
         rdetail = hil_util.cmd_stdout_text(r.stderr).strip()[:200]
         assert r.returncode == 0, (
             f'CDC->Printer reader failed ({size} bytes): {rdetail}' if rdetail else
@@ -1304,38 +1392,20 @@ def test_device_audio_test_freertos(board):
 
 
 def test_device_hid_generic_inout(board):
+    # The whole exchange runs in a child (see HID_ECHO): cython-hidapi is unbounded
+    # in-process. No parent-side work to interleave, so `work` is a no-op -- what is
+    # wanted from run_alongside is its own-session/killpg/bounded-reap contract and an
+    # argv list that needs no shell quoting.
     uid = board['uid']
-    import hid  # cython-hidapi (pip: hidapi, apt: python3-hid)
-
-    timeout = enum_timeout()
-    dev = None
-    while timeout > 0:
-        for d in hid.enumerate(0xCafe):
-            if d['serial_number'] == uid:
-                dev = d
-                break
-        if dev:
-            break
-        time.sleep(1)
-        timeout -= 1
-    assert dev is not None, f'HID device not found for {uid}'
-
-    h = hid.device()
-    h.open(dev['vendor_id'], dev['product_id'], uid)
-    try:
-        for size in [8, 32, 63]:
-            # Report ID (0) + payload, padded to 64 bytes
-            payload = bytes([random.randint(1, 255) for _ in range(size)])
-            report = bytes([0]) + payload + bytes(64 - size)
-            h.write(report)
-            echo = h.read(64, 2000)
-            assert echo and len(echo) >= size, (
-                f'HID echo timeout or short read ({size} bytes)')
-            assert bytes(echo[:size]) == payload, (
-                f'HID echo wrong data ({size} bytes):\n'
-                f'  expected: {payload.hex()}\n  received: {bytes(echo[:size]).hex()}')
-    finally:
-        h.close()
+    r = hil_util.run_alongside(
+        [sys.executable, '-c', HID_ECHO, uid, str(enum_timeout())],
+        lambda: None, enum_timeout() + 30)
+    # rc 124 is run_alongside's kill -- a wedged device, and stderr is empty there, so the
+    # fallback is what the report shows for the case this conversion exists to contain
+    detail = hil_util.cmd_stdout_text(r.stderr).strip()[:300]
+    assert r.returncode == 0, (f'hid_generic_inout: {detail}' if detail else
+                               f'hid_generic_inout: child exited {r.returncode} '
+                               f'with no message (124 = killed on the bound)')
 
 
 def test_device_usbtest(board):

--- a/test/hil/test/stubs/hid.py
+++ b/test/hil/test/stubs/hid.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+"""Scripted stand-in for cython-hidapi, for the HID_ECHO child tests.
+
+A real wedge cannot be manufactured on demand, so the failure modes are scripted here and
+selected with FAKE_HID_MODE. Mirrors test/stubs/pymtp.py, which does the same for libmtp.
+"""
+import os
+import time
+
+_MODE = os.environ.get('FAKE_HID_MODE', 'ok')
+_UID = os.environ.get('FAKE_HID_UID', 'CAFE01')
+
+
+def enumerate(vid=0xCafe):
+    """Real hid.enumerate(vid) filters by vendor and returns a 'path' key too."""
+    if _MODE == 'wedged_enumerate':
+        # hidapi's hidraw backend reads `manufacturer`/`product` for every device it
+        # lists, both served under the device lock -- this is that stall.
+        while True:
+            time.sleep(3600)
+    if _MODE == 'absent':
+        return []
+    if vid not in (0, 0xCafe):
+        return []
+    return [{'serial_number': _UID, 'vendor_id': 0xCafe, 'product_id': 0x4004,
+             'path': b'/dev/hidraw0'}]
+
+
+class device:
+    def __init__(self):
+        self._last = b''
+
+    def open(self, vid, pid, serial):
+        # HID_ECHO really does call this, and usb_autopm/hidraw can block in it, so the
+        # child must be bounded here too -- exercised by test_a_wedged_open_is_killed.
+        if _MODE == 'wedged_open':
+            while True:
+                time.sleep(3600)
+
+    def write(self, report):
+        self._last = bytes(report)
+
+    def read(self, size, timeout_ms):
+        if _MODE == 'wedged_read':
+            while True:
+                time.sleep(3600)
+        if _MODE == 'short_read':
+            return list(self._last[1:4])
+        if _MODE == 'wrong_data':
+            return list(bytes(b ^ 0xFF for b in self._last[1:]))
+        return list(self._last[1:])       # the device echoes the payload, minus report ID
+
+    def close(self):
+        pass

--- a/test/hil/test/test_ci_select.py
+++ b/test/hil/test/test_ci_select.py
@@ -955,7 +955,8 @@ class TestTheHarnessTestsAreNotTheHarness(unittest.TestCase):
 
     def test_the_harness_own_tests_select_nothing_on_either_axis(self):
         for p in ('test/hil/test/test_ci_select.py', 'test/hil/test/test_ci_metrics.py',
-                  'test/hil/test/test_hil_bounded.py', 'test/hil/test/stubs/pymtp.py'):
+                  'test/hil/test/test_hil_bounded.py', 'test/hil/test/stubs/pymtp.py',
+                  'test/hil/test/stubs/hid.py'):
             s = ci_select.classify([p], REPO, ROSTERS)
             self.assertFalse(s['full'], p)
             self.assertFalse(s['boards'], p)
@@ -979,6 +980,7 @@ class TestTheHarnessTestsAreNotTheHarness(unittest.TestCase):
         out = subprocess.run(['git', 'ls-files', 'test/hil/test'], cwd=REPO,
                              capture_output=True, text=True, check=True)
         self.assertEqual(sorted(out.stdout.split()), [
+            'test/hil/test/stubs/hid.py',
             'test/hil/test/stubs/pymtp.py',
             'test/hil/test/test_ci_metrics.py',
             'test/hil/test/test_ci_select.py',

--- a/test/hil/test/test_hil_bounded.py
+++ b/test/hil/test/test_hil_bounded.py
@@ -8,8 +8,10 @@
 # Scope: mtype, the gio unmount, the libmtp session, the arecord/iperf reaps, and the
 # printer read (a process now, via run_alongside, so a killed reader takes its fd with
 # it -- usblp allows ONE opener, and a blocked thread kept the node for the worker's life).
-# Known residue (unbounded, backstopped only by the pool guard): hid open/write and
-# midi's read(64).
+# The HID echo is a child too now (hid.enumerate reads manufacturer/product for every
+# device it lists, both under the device lock). midi's read(64) is NOT residue: rawmidi
+# honours O_NONBLOCK on open (v6.12.96 rawmidi.c:489, -EBUSY rather than queueing on
+# open_wait), unlike usblp, which ignores it.
 #
 # hil_test imports pyserial, which GitHub's bare pre-commit runner does not have — so
 # an inert serial module is stubbed into sys.modules BEFORE the import (nothing here
@@ -1928,6 +1930,199 @@ class WedgedBoardCannotReportAPass(unittest.TestCase):
                                 '"failed":0,"notrun":0,"wedged":false,"cases":[]}')
         self.assertEqual(kind, 'pass', f'a healthy board was failed: {cell}')
         self.assertIn('30/30', cell)
+
+
+class PrinterWriteRunsInAChild(unittest.TestCase):
+    """test_device_printer_to_cdc's WRITE half used to open /dev/usb/lp* on the worker
+    itself and abandon a thread when the open blocked. usblp allows one opener (v6.12.96
+    usblp.c returns -EBUSY while usblp->used), so that abandoned thread's fd poisoned the
+    node for every later test the worker ran -- the exact failure the READ half already
+    avoided by forking. Both halves are children now; these pin the writer's contract."""
+
+    def _stderr(self, r):
+        from helper import hil_util
+        return hil_util.cmd_stdout_text(r.stderr)
+
+    def _run(self, target, payload, ready, data=None):
+        from helper import hil_util
+        if data is not None:
+            payload.write_bytes(data)
+        return hil_util.run_alongside(
+            [sys.executable, '-c', hil_test.LP_WRITER,
+             str(target), str(payload), str(ready)], lambda: None, 20)
+
+    def test_the_payload_arrives_byte_exact_through_a_pipe(self):
+        """A FIFO, not a regular file: /dev/usb/lp* is a character device, and against a
+        regular file select() is always writable and os.write() never returns short -- so
+        the select-bound and the partial-write resume, the only non-trivial code in
+        LP_WRITER, would never execute."""
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            target, payload, ready = td / 'lp', td / 'tx', td / 'ready'
+            os.mkfifo(target)
+            # bigger than the 64 KiB pipe buffer and spanning every byte value, so the
+            # writer MUST block mid-payload and resume a short write
+            data = bytes(range(256)) * 512
+            got = bytearray()
+
+            def drain():
+                with open(target, 'rb') as f:
+                    while len(got) < len(data):
+                        chunk = f.read(4096)
+                        if not chunk:
+                            break
+                        got.extend(chunk)
+
+            payload.write_bytes(data)
+            t = threading.Thread(target=drain, daemon=True)
+            t.start()
+            r = self._run(target, payload, ready)
+            t.join(20)
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertEqual(bytes(got), data,
+                             'writer did not deliver the payload byte-exact')
+            self.assertGreater(len(data), 65536, 'payload must exceed the pipe buffer')
+
+    def test_a_reader_that_stops_draining_reports_instead_of_hanging(self):
+        """The firmware-not-draining case: LP_WRITER's select() bound must turn a stalled
+        OUT endpoint into a message. `grep 'printer write timeout'` used to find only the
+        string's own definition -- nothing exercised it."""
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            target, payload, ready = td / 'lp', td / 'tx', td / 'ready'
+            os.mkfifo(target)
+            payload.write_bytes(bytes(range(256)) * 512)
+            holder = []
+
+            def open_and_stall():          # opens, never reads: the pipe fills and stays full
+                holder.append(open(target, 'rb'))
+                time.sleep(30)
+
+            t = threading.Thread(target=open_and_stall, daemon=True)
+            t.start()
+            r = self._run(target, payload, ready)
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn('printer write timeout',
+                          self._stderr(r), 'the select() bound produced no message')
+
+    def test_readiness_is_signalled_so_the_parent_does_not_read_early(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            target, payload, ready = td / 'lp', td / 'tx', td / 'ready'
+            target.touch()
+            r = self._run(target, payload, ready, b'x' * 32)
+            self.assertEqual(r.returncode, 0, r.stderr)
+            self.assertTrue(ready.exists(),
+                            'no readiness marker: the parent would read CDC before the '
+                            'node is open and lose the leading bytes')
+
+    def test_a_blocked_open_leaves_no_readiness_marker(self):
+        """The signal test_device_printer_to_cdc keys on to tell a WEDGED NODE from a slow
+        drain. usblp_open ignores O_NONBLOCK and can stall in usb_autopm_get_interface, so
+        the child gets no further -- and the marker is written on the line AFTER os.open
+        returns. Without this distinction the parent reads "no data" as firmware data
+        corruption instead of a device that never opened.
+        """
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            target, payload, ready = td / 'lp', td / 'tx', td / 'ready'
+            os.mkfifo(target)          # O_WRONLY on a reader-less FIFO blocks in open()
+            payload.write_bytes(b'x' * 64)
+            r = self._run(target, payload, ready)
+            self.assertNotEqual(r.returncode, 0, 'a blocked open must not report success')
+            self.assertFalse(ready.exists(),
+                             'the marker appeared without the open completing, so the '
+                             'parent cannot tell a wedged node from a slow drain')
+
+    def test_an_unopenable_node_fails_the_case_instead_of_going_quiet(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            target, payload, ready = td / 'nope' / 'lp', td / 'tx', td / 'ready'
+            r = self._run(target, payload, ready, b'x' * 8)
+            self.assertNotEqual(r.returncode, 0,
+                                'a failed open must reach the caller as a non-zero rc')
+            self.assertFalse(ready.exists())
+
+
+class HidEchoRunsInAChild(unittest.TestCase):
+    """hid.enumerate() reads `manufacturer` and `product` for EVERY HID device it lists
+    (hidapi's hidraw backend), and both are usb_string_attr -- served under the device lock
+    a wedged usbfs ioctl holds. In-process that stalled the worker with no timeout and no
+    way to abandon it, on a device that need not even be ours. It is a child now; these
+    prove the bound and that failures still reach the caller as a message."""
+
+    def _run(self, mode, uid='CAFE01', budget='3', timeout=20):
+        from helper import hil_util
+        saved = {k: os.environ.get(k) for k in ('FAKE_HID_MODE', 'FAKE_HID_UID',
+                                                'PYTHONPATH', 'PYTHONSAFEPATH')}
+
+        def restore():
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+        self.addCleanup(restore)
+        os.environ['FAKE_HID_MODE'] = mode
+        os.environ['FAKE_HID_UID'] = uid
+        stubs = os.path.join(TEST_DIR, 'stubs')
+        pp = saved['PYTHONPATH']
+        os.environ['PYTHONPATH'] = stubs if not pp else f'{stubs}:{pp}'
+        # `python3 -c` puts the cwd at sys.path[0], AHEAD of PYTHONPATH, so any hid.py
+        # reachable from the suite's cwd would silently displace the stub and every
+        # mode-driven test below would pass or fail for the wrong reason. Safe-path mode
+        # (3.11+) drops that entry -- same practice as _MtpFakeRig.
+        os.environ['PYTHONSAFEPATH'] = '1'
+        return hil_util.run_alongside(
+            [sys.executable, '-c', hil_test.HID_ECHO, uid, budget], lambda: None, timeout)
+
+    def _stderr(self, r):
+        from helper import hil_util
+        return hil_util.cmd_stdout_text(r.stderr)
+
+    def test_a_healthy_device_passes(self):
+        r = self._run('ok')
+        self.assertEqual(r.returncode, 0, self._stderr(r))
+
+    def test_a_wedged_enumerate_is_killed_on_the_bound(self):
+        t0 = time.monotonic()
+        # a real child and a real bound -- deliberately not faked, this is the
+        # behaviour under test. 1s clears CPython start-up with room to spare.
+        r = self._run('wedged_enumerate', timeout=1)
+        self.assertEqual(r.returncode, 124,
+                         'a stalled hid.enumerate() must be killed, not waited on')
+        self.assertLess(time.monotonic() - t0, 20,
+                        'run_alongside did not bound the wedged child')
+
+    def test_a_wedged_read_is_killed_on_the_bound(self):
+        r = self._run('wedged_read', timeout=1)
+        self.assertEqual(r.returncode, 124)
+
+    def test_a_wedged_open_is_killed_on_the_bound(self):
+        """h.open() is a call HID_ECHO actually makes, and hidraw can block in it -- the
+        stub carried this mode with no test selecting it."""
+        r = self._run('wedged_open', timeout=1)
+        self.assertEqual(r.returncode, 124)
+
+    def test_an_absent_device_reports_why(self):
+        # budget 0: the retry loop checks the deadline after the first enumerate, so this
+        # exercises the give-up path without waiting out a real enumeration timeout
+        r = self._run('absent', budget='0')
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn('HID device not found', self._stderr(r))
+
+    def test_a_bad_echo_reports_both_payloads(self):
+        r = self._run('wrong_data')
+        self.assertNotEqual(r.returncode, 0)
+        msg = self._stderr(r)
+        self.assertIn('wrong data', msg)
+        self.assertIn('sent', msg)
+        self.assertIn('received', msg)
+
+    def test_a_short_echo_is_not_read_as_a_pass(self):
+        r = self._run('short_read')
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn('short read', self._stderr(r))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Two call sites in the HIL harness could hang a pool worker indefinitely. Both now run in a child process bounded by `run_alongside`, which already carries the own-session / killpg / bounded-reap contract.

### Why each one blocks

**`usblp_open()` never consults `O_NONBLOCK`.** It takes the driver-global `usblp_mutex`, then calls `usb_autopm_get_interface()` — a runtime-PM resume that does I/O (v6.12.96 `usblp.c`). One wedged printer blocks opens of *every* usblp node.

`test_device_printer_to_cdc` opened `/dev/usb/lp*` on the worker itself for its write half — while its read half, twenty lines below, already forked for exactly this reason:

> a blocked thread cannot be abandoned without keeping that fd, and usblp allows a SINGLE opener, so the next open returns `-EBUSY` for the life of the worker. A killed process takes its fd with it.

**`hid.enumerate()` reads `manufacturer` and `product` for every HID device it lists** (hidapi's hidraw backend), and both are `usb_string_attr` — served under the device lock a wedged usbfs ioctl holds (`sysfs.c:141-143`). So a wedged HID device that isn't even ours stalls the walk, unbounded, in-process. The enumeration retry moves into the child so a poll doesn't re-pay interpreter start-up.

### Not converted, deliberately

`test_device_midi_test` opens an ALSA rawmidi node and looks identical — but rawmidi **honours `O_NONBLOCK` on open** (v6.12.96 `rawmidi.c:489`, `-EBUSY` rather than queueing on `open_wait`), unlike usblp. Same-looking call, opposite behaviour.

### Tests

A scripted `hid` stub covers the wedged enumerate, the wedged open, the absent device and both bad-echo shapes. The printer writer runs against a **FIFO with a payload past the pipe buffer**, so its `select()` bound and partial-write resume actually execute — a regular-file target would run neither, since `select()` is always writable there and `os.write` never returns short. A stalled reader proves the timeout message, and a reader-less FIFO proves a blocked open leaves no readiness marker.

### One subtlety worth flagging

The parent and child share **one** readiness deadline. Two different ones let a slow open finish after the parent stopped reading — the writer then sent with nobody listening, and the byte-compare reported *firmware data corruption* for what was only a slow interpreter start. The wedged-node verdict keys on the readiness marker never appearing, not on the exit code, so a slow drain and a wedged node stay distinguishable.

All six suites green, `pre-commit run --all-files` clean.
