### PR TITLE
test/hil: bound the two hidapi calls that can stall a worker

### DIFF
--- a/test/hil/helper/hil_util.py
+++ b/test/hil/helper/hil_util.py
@@ -253,19 +253,38 @@ def read_sysfs(path: str, grace: float = SYSFS_READ_GRACE) -> str | None | _Sysf
         # of them recorded it -- spending the whole blindness budget on a single device,
         # which is what this memo exists to prevent. note_sysfs_strand takes the lock
         # itself, so call it after releasing.
-        with _sysfs_stuck_lock:
-            first = path not in _sysfs_stranded
-            if first:
-                try:
-                    # stat, never the thread's own open(): stat does not call ->show(), so
-                    # it cannot block on the device lock the reader is stuck behind
-                    _sysfs_stranded[path] = os.stat(path).st_ino
-                except OSError:
-                    _sysfs_stranded[path] = None   # unstattable, but still known-stranded
-        if first:
-            note_sysfs_strand()
+        _record_strand(path, stat_path=path)
         return SYSFS_UNKNOWN
     return out.get('v')
+
+
+def _record_strand(key: str, stat_path: str | None = None) -> None:
+    """Memoise `key` as stranded and spend ONE blindness credit for it.
+
+    The credit is per KEY, not per caller: hil_pool_check runs a ThreadPoolExecutor of
+    SYSFS_STUCK_MAX workers over one bus, so counting each reader let four threads on ONE
+    wedged device spend the whole budget between them -- latching blind on the single
+    wedge the tool was run to find.
+
+    `stat_path` memoises by kernfs INODE, which a re-enumeration changes: that is the
+    all-clear for a device that came back on the same busport, and without it a recovered
+    board would stay invisible for the life of the process. os.stat is safe on a wedged
+    device -- it does not call ->show(), so it cannot block on the lock the reader is
+    stuck behind. Omit it when there is no node to key on (see bounded_call); the entry is
+    then permanent, which is correct for something with no way to signal recovery.
+    """
+    with _sysfs_stuck_lock:
+        first = key not in _sysfs_stranded
+        if first:
+            ino = None
+            if stat_path is not None:
+                try:
+                    ino = os.stat(stat_path).st_ino
+                except OSError:
+                    pass          # unstattable, but still known-stranded
+            _sysfs_stranded[key] = ino
+    if first:
+        note_sysfs_strand()
 
 
 def note_sysfs_strand() -> None:
@@ -348,6 +367,49 @@ def usb_scan(vid_pid=None, serial=None, vid=None) -> tuple[list, bool]:
     return out, unknown
 
 
+def bounded_call(fn, timeout: float = SYSFS_READ_GRACE, key: str = ''):
+    """Call `fn()` with a WALL-CLOCK bound. Its return value, or SYSFS_UNKNOWN.
+
+    The generic form of bounded_open, for a library call that reads the same locked sysfs
+    attributes but hands back no fd we could close. hidapi's hidraw backend is the case
+    this exists for: hid.enumerate() reads `manufacturer` and `product` for EVERY HID
+    device on the bus (linux/hid.c), and both are usb_string_attr -- served under the
+    device lock a wedged usbfs ioctl holds (v6.12.96 sysfs.c:141-143). So one wedged HID
+    device, which need not even be the board under test, stalls the walk forever.
+
+    SYSFS_UNKNOWN, never None, on a give-up: the caller must not read "did not answer" as
+    "no such device" -- the absence/unknown conflation read_sysfs exists to prevent.
+
+    `key` names the thing being called for the strand memo, so a poll loop does not pay
+    the bound again once it is known stuck. The abandoned thread and whatever it holds are
+    gone for the life of the process; the blindness cap is what stops those accumulating.
+    """
+    if sysfs_blind():
+        return SYSFS_UNKNOWN
+    memo = f'call:{key or getattr(fn, "__name__", "?")}'
+    if memo in _sysfs_stranded:
+        return SYSFS_UNKNOWN
+    box: dict = {}
+    done = threading.Event()
+
+    def _run():
+        try:
+            box['v'] = fn()
+        except Exception:  # noqa: BLE001 - the caller's own asserts decide what a raise means
+            box['exc'] = sys.exc_info()[1]
+        done.set()
+
+    threading.Thread(target=_run, daemon=True).start()
+    if not done.wait(timeout):
+        # a value cannot be handed back safely here the way bounded_open closes a late fd:
+        # we do not know what fn() allocated, so the thread keeps whatever it has
+        _record_strand(memo)        # no node to key on: the entry is permanent
+        return SYSFS_UNKNOWN
+    if 'exc' in box:
+        raise box['exc']
+    return box['v']
+
+
 def bounded_open(path: str, flags: int, timeout: float = SYSFS_READ_GRACE):
     """os.open() with a wall-clock bound.
 
@@ -424,15 +486,7 @@ def bounded_open(path: str, flags: int, timeout: float = SYSFS_READ_GRACE):
         # thread/fd ceiling -- an exception there escapes the worker and loses every board.
         # Memoised by inode so a retry of the same node does not pay again.
         # same lock as read_sysfs, same reason
-        with _sysfs_stuck_lock:
-            first = path not in _sysfs_stranded
-            if first:
-                try:
-                    _sysfs_stranded[path] = os.stat(path).st_ino
-                except OSError:
-                    _sysfs_stranded[path] = None
-        if first:
-            note_sysfs_strand()
+        _record_strand(path, stat_path=path)
         return SYSFS_UNKNOWN
     return box.get('fd')
 

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -303,6 +303,9 @@ def serial_write_all(ser: serial.Serial, data: bytes):
 
 
 LP_OPEN_TIMEOUT = 5   # bound on opening the printer lp node; see test_device_printer_to_cdc
+# bound on one hidapi call; it walks every HID device on the bus, so it is sized for a busy
+# rig rather than for one device
+HID_ENUM_TIMEOUT = 10
 # Runs under hil_util.run_alongside as `python3 -c`. Inline rather than a file so hil_ci.sh's
 # staging list does not need another entry to keep the rig working.
 LP_READER = (
@@ -1307,21 +1310,42 @@ def test_device_hid_generic_inout(board):
     uid = board['uid']
     import hid  # cython-hidapi (pip: hidapi, apt: python3-hid)
 
+    # BOUNDED: hidapi's hidraw backend reads `manufacturer` and `product` for every HID
+    # device it lists, and both are usb_string_attr -- served under the device lock a
+    # wedged usbfs ioctl holds. One wedged HID device that need not even be ours would
+    # otherwise stall this walk forever, on the worker, with nothing to abandon it.
     timeout = enum_timeout()
     dev = None
+    unknown = False
     while timeout > 0:
-        for d in hid.enumerate(0xCafe):
-            if d['serial_number'] == uid:
-                dev = d
-                break
+        listed = hil_util.bounded_call(lambda: list(hid.enumerate(0xCafe)),
+                                       HID_ENUM_TIMEOUT, key='hid.enumerate')
+        if listed is hil_util.SYSFS_UNKNOWN:
+            unknown = True          # NOT proof the device is absent
+        else:
+            for d in listed:
+                if d['serial_number'] == uid:
+                    dev = d
+                    break
         if dev:
             break
         time.sleep(1)
         timeout -= 1
-    assert dev is not None, f'HID device not found for {uid}'
+    # "could not tell" is not "not there": reporting an unreadable bus as a missing board
+    # sends the operator after hardware that is fine
+    assert dev is not None, (
+        f'cannot tell whether HID device {uid} is present: the bounded enumerate did not '
+        f'answer{hil_util.sysfs_blind_note()}' if unknown else
+        f'HID device not found for {uid}')
 
     h = hid.device()
-    h.open(dev['vendor_id'], dev['product_id'], uid)
+    # same exposure: hid_open walks the same descriptors to match vid/pid/serial
+    opened = hil_util.bounded_call(
+        lambda: h.open(dev['vendor_id'], dev['product_id'], uid), HID_ENUM_TIMEOUT,
+        key='hid.open')
+    assert opened is not hil_util.SYSFS_UNKNOWN, (
+        f'HID open of {uid} blocked (device wedged)'
+        f'{hil_util.sysfs_blind_note()}')
     try:
         for size in [8, 32, 63]:
             # Report ID (0) + payload, padded to 64 bytes

--- a/test/hil/test/test_hil_util.py
+++ b/test/hil/test/test_hil_util.py
@@ -227,5 +227,59 @@ class RunAlongsideKeepsStderrOffThePayload(unittest.TestCase):
                          'child stderr leaked into the payload stream')
 
 
+class BoundedCallGivesUp(unittest.TestCase):
+    """The generic form of bounded_open, for a library call that hands back no fd we could
+    close. hid.enumerate() is the case: it reads `manufacturer` and `product` for every HID
+    device on the bus, both served under the device lock a wedged usbfs ioctl holds, so one
+    wedged device stalls the walk with nothing to abandon it."""
+
+    def setUp(self):
+        from helper import hil_util
+        self.hil_util = hil_util
+        saved = (dict(hil_util._sysfs_stranded), hil_util._sysfs_stuck)
+        self.addCleanup(self._restore, saved)
+        hil_util._sysfs_stranded.clear()
+        hil_util._sysfs_stuck = 0
+
+    def _restore(self, saved):
+        self.hil_util._sysfs_stranded.clear()
+        self.hil_util._sysfs_stranded.update(saved[0])
+        self.hil_util._sysfs_stuck = saved[1]
+
+    def test_a_value_comes_straight_back(self):
+        self.assertEqual(self.hil_util.bounded_call(lambda: [1, 2], 1, key='k1'), [1, 2])
+
+    def test_a_call_that_never_returns_gives_up(self):
+        t0 = time.monotonic()
+        got = self.hil_util.bounded_call(lambda: time.sleep(30), 0.3, key='k2')
+        self.assertIs(got, self.hil_util.SYSFS_UNKNOWN)
+        self.assertLess(time.monotonic() - t0, 5, 'bounded_call did not bound')
+
+    def test_a_give_up_is_not_an_empty_result(self):
+        """SYSFS_UNKNOWN, never None or []: the caller must not read 'did not answer' as
+        'no such device', which is what turns a wedged bus into a missing board."""
+        got = self.hil_util.bounded_call(lambda: time.sleep(30), 0.2, key='k3')
+        self.assertIsNot(got, None)
+        self.assertNotEqual(got, [])
+        self.assertFalse(got, 'the sentinel must stay falsy for `if not listed:` callers')
+
+    def test_a_known_stuck_call_is_not_paid_for_twice(self):
+        self.hil_util.bounded_call(lambda: time.sleep(30), 0.3, key='k4')
+        t0 = time.monotonic()
+        for _ in range(4):
+            self.assertIs(self.hil_util.bounded_call(lambda: time.sleep(30), 0.3, key='k4'),
+                          self.hil_util.SYSFS_UNKNOWN)
+        self.assertLess(time.monotonic() - t0, 0.3,
+                        'a poll loop re-paid the bound on a call already known stuck')
+
+    def test_the_callee_s_own_exception_still_reaches_the_caller(self):
+        """A raise is a FACT about the device, not a timeout -- swallowing it would report
+        a real hidapi error as an unreadable bus."""
+        def boom():
+            raise OSError('no such device')
+        with self.assertRaises(OSError):
+            self.hil_util.bounded_call(boom, 1, key='k5')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`test_device_hid_generic_inout` holds the last unbounded blocking IO in `hil_test.py`.

**Why it can stall.** hidapi's hidraw backend reads `manufacturer` and `product` for **every** HID device it lists (`linux/hid.c`), and both are `usb_string_attr` — served under the device lock a wedged usbfs ioctl holds (v6.12.96 `sysfs.c:141-143`). So one wedged HID device, which need not even be the board under test, stalls `hid.enumerate()` forever on the worker with nothing to abandon it. `hid_open` walks the same descriptors to match vid/pid/serial, so it carries the same exposure.

Every sibling in this file is already bounded — `run_cmd` for the subprocess paths, `bounded_open` for the printer's lp node, pyserial's own timeouts, the MTP session in its own process. These two were the gap.

**`bounded_call` is the generic form of `bounded_open`**, for a library call that hands back no fd we could close: same daemon thread, same wall-clock join, same `SYSFS_UNKNOWN` sentinel, and the same strand accounting — so a poll loop doesn't re-pay the bound on a call already known stuck, and the blindness cap still governs how many threads can accumulate.

`bounded_open` is **not** folded into it, deliberately: their resource semantics differ. `bounded_open` has a `handoff` lock that closes an fd arriving *after* the deadline — usblp is single-opener, so a leaked fd poisons the node — and `bounded_call` cannot know what `fn()` allocated. That is also why `bounded_open`'s memo clears on an inode change while `bounded_call`'s entry is permanent.

### The dedup that came out of it

What the two *did* share was the bookkeeping, and adding `bounded_call` made that three copies — `read_sysfs` and `bounded_open` carried an identical eight-line inode block. `_record_strand` now holds it once.

This is the piece where being subtly wrong is easy, and there is precedent: the credit must be spent per **key**, not per caller, or four `hil_pool_check` poll threads on *one* wedged device spend the whole blindness budget between them and latch on the single wedge the tool was run to find. And the memo must key on the kernfs **inode**, which a re-enumeration changes, or a board that recovered on the same busport stays invisible for the life of the process.

Two contract details that matter:

- **A give-up answers `SYSFS_UNKNOWN`, never `None` or `[]`.** Reading "did not answer" as "no such device" is the absence/unknown conflation `read_sysfs` exists to prevent; here it would report an unreadable bus as a missing board and send the operator after hardware that is fine.
- **The callee's own exception is re-raised**, not folded into the sentinel — a hidapi error is a fact about the device, a timeout is not.

### Tests

Cover the bound, the sentinel staying falsy for `if not listed:` callers, the memo not re-paying, and the raise passing through.

Mutation-checked: removing the bound **hangs** the suite; returning `None` instead of the sentinel fails two tests; swallowing the callee's raise fails one.

All six suites green, `pre-commit run --all-files` clean.
