### PR TITLE
host: recover from hub and roothub failures, and fix low-speed devices behind a hub on ESP32-S2/S3

### DIFF
--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -35,6 +35,7 @@
 
 enum {
   USBH_CONTROL_RETRY_MAX = 3,
+  USBH_ENUM_ROOT_RETRY_MAX = 3, // re-reset and re-enumerate the root port after a failed attach
 };
 
 //--------------------------------------------------------------------+
@@ -205,6 +206,7 @@ TU_FIFO_DEF(_usbh_pending_ctrl_q, CFG_TUH_CONTROL_PENDING_QUEUE_SZ * sizeof(usbh
 typedef struct {
   uint8_t enumerating_daddr;  // device address of the device being enumerated
   uint8_t attach_debouncing_bm;  // bitmask for roothub port attach debouncing
+  uint8_t attach_teardown;    // an attach event is tearing down what was on its port
   tuh_bus_info_t dev0_bus;    // bus info for dev0 in enumeration
   usbh_ctrl_xfer_info_t ctrl_xfer_info; // control transfer
   usbh_call_after_t call_after;
@@ -756,7 +758,11 @@ void tuh_task_ext(uint32_t timeout_ms, bool in_isr) {
         // Should we miss the hub detach event due to high traffic, Or due to physical debouncing, some devices can
         // cause multiple attaches (actually reset) without a detached event.
         // Force remove currently mounted with the same bus info (rhport, hub addr, hub port) if exists
+        // Flagged because this teardown fails any in-flight enumeration, and its completion would
+        // otherwise ask for a roothub retry of the very attach being handled here.
+        _usbh_data.attach_teardown = 1;
         process_remove_event(&event);
+        _usbh_data.attach_teardown = 0;
 
         // due to the shared control buffer, we must fully complete enumerating one device first.
         if (_usbh_data.enumerating_daddr == TUSB_INDEX_INVALID_8) {
@@ -1627,8 +1633,11 @@ static void remove_device_tree(uint8_t rhport, uint8_t hub_addr, uint8_t hub_por
           removing_hubs[dev_id - CFG_TUH_DEVICE_MAX] = 1;
         } else
         #endif
-        {
-          // Invoke callback before closing driver (maybe call it later ?)
+        // Invoke callback before closing driver (maybe call it later ?). Only for a device that
+        // reached tuh_mounted(): enumeration marks a device connected as soon as it has an address,
+        // so failing after that point would otherwise report an unmount for a device the
+        // application was never told about.
+        if (dev->configured) {
           tuh_umount_cb(daddr);
         }
 
@@ -2222,6 +2231,8 @@ void usbh_driver_set_config_complete(uint8_t dev_addr, uint8_t itf_num) {
 }
 
 static void enum_full_complete(bool success) {
+  static uint8_t root_retry_count = 0;
+  static uint8_t root_retry_rhport = TUSB_INDEX_INVALID_8; // the port root_retry_count belongs to
   TU_LOG_USBH("Enumeration complete: success = %u\r\n", success);
 
   const uint8_t daddr = _usbh_data.enumerating_daddr;
@@ -2241,6 +2252,33 @@ static void enum_full_complete(bool success) {
     hub_edpt_status_xfer(_usbh_data.dev0_bus.hub_addr);
   }
   #endif
+
+  const uint8_t rhport = _usbh_data.dev0_bus.rhport;
+  if (rhport != root_retry_rhport) {
+    root_retry_rhport = rhport; // the budget is per port, and only one port enumerates at a time
+    root_retry_count = 0;
+  }
+
+  if (success || _usbh_data.attach_teardown || _usbh_data.dev0_bus.hub_addr != 0 ||
+      !hcd_port_connect_status(rhport)) {
+    // The budget covers one attachment, so it has to be given back when that attachment ends,
+    // whether it succeeded or the device was unplugged part-way through. Carrying a spent count
+    // into the next device would deny it the retries it has not used. An attach event that tore
+    // down this enumeration is such a fresh start, and needs no retry of its own: the handler that
+    // set the flag goes on to enumerate the device that has just arrived.
+    root_retry_count = 0;
+  } else {
+    // A device behind a hub gets another chance from the next port status change, but nothing ever
+    // retries the root port: the host stays dead until reboot. Re-post the attach so the port is
+    // reset and enumerated again, e.g. after the controller dropped it on a bus error.
+    if (root_retry_count < USBH_ENUM_ROOT_RETRY_MAX) {
+      root_retry_count++;
+      TU_LOG_USBH("Retry root port enumeration %u/%u\r\n", root_retry_count, USBH_ENUM_ROOT_RETRY_MAX);
+      hcd_event_device_attach(rhport, false);
+    } else {
+      root_retry_count = 0; // give up on this attach, but allow a later one to retry again
+    }
+  }
 }
 
 #endif

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -1583,15 +1583,24 @@ bool tuh_interface_set(uint8_t daddr, uint8_t itf_num, uint8_t itf_alt,
 
 // process detach event from rhport:hub_addr:hub_port
 static void process_remove_event(hcd_event_t *event) {
-  if (_usbh_data.enumerating_daddr == 0 &&
-      event->rhport == _usbh_data.dev0_bus.rhport &&
-      event->connection.hub_addr == _usbh_data.dev0_bus.hub_addr &&
-      event->connection.hub_port == _usbh_data.dev0_bus.hub_port) {
+  const tuh_bus_info_t *dev0_bus = &_usbh_data.dev0_bus;
+  const bool dev0_enumerating = (_usbh_data.enumerating_daddr == 0) && (event->rhport == dev0_bus->rhport);
+
+  if (dev0_enumerating &&
+      event->connection.hub_addr == dev0_bus->hub_addr &&
+      event->connection.hub_port == dev0_bus->hub_port) {
     // dev0 is unplugged while enumerating (not yet assigned an address)
-    usbh_device_close(_usbh_data.dev0_bus.rhport, 0);
-  } else {
-    remove_device_tree(event->rhport, event->connection.hub_addr, event->connection.hub_port);
+    usbh_device_close(dev0_bus->rhport, 0);
+    return;
   }
+
+  // hub_addr = 0 is the whole roothub port: dev0 goes with it even if it sits behind a downstream
+  // hub. Without this, enumerating_daddr stays 0 forever and every later attach is deferred.
+  if (dev0_enumerating && event->connection.hub_addr == 0 && event->connection.hub_port == 0) {
+    usbh_device_close(dev0_bus->rhport, 0);
+  }
+
+  remove_device_tree(event->rhport, event->connection.hub_addr, event->connection.hub_port);
 }
 
 // remove a device at rhport:hub_addr:hub_port and all of its downstream

--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -1858,15 +1858,10 @@ static void handle_hprt_irq(uint8_t rhport, bool in_isr) {
       // Port enable
       const tusb_speed_t speed = hprt_speed_get(dwc2);
       port0_enable(dwc2, speed);
-    } else {
-      // Port disabled by the core (port error e.g babble). SOF generation stops, so no transfer
-      // on this bus can ever complete again. Tear down the tree; if something is still connected
-      // re-attach so the port is reset and devices are enumerated again.
-      if (hprt_bm.conn_status == 1u) {
-        hcd_event_device_attach(rhport, in_isr);
-      } else {
-        hcd_event_device_remove(rhport, in_isr);
-      }
+    } else if (hprt_bm.conn_status == 1u && hprt_bm.conn_detected == 0u) {
+      // The core disabled a still-connected port. Reuse attach handling
+      // to tear down the stale device tree and restart enumeration.
+      hcd_event_device_attach(rhport, in_isr);
     }
   }
 

--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -176,6 +176,83 @@ TU_ATTR_ALWAYS_INLINE static inline bool channel_is_periodic(uint32_t hcchar) {
   return hcchar_bm.ep_type == HCCHAR_EPTYPE_INTERRUPT || hcchar_bm.ep_type == HCCHAR_EPTYPE_ISOCHRONOUS;
 }
 
+#if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
+// The FS core cannot run two low-speed transactions in the same frame: a low-speed device behind a
+// full-speed hub is addressed with a preamble packet, and a second one in the same frame makes the
+// core clear HPRT.PENA, which kills the whole root port. ESP-IDF works around this in hcd_dwc.c with
+// a 1 ms delay per low-speed control stage (espressif/esp-idf#15683). Reserve one frame per
+// low-speed transaction instead, which also covers the periodic IN of a second low-speed device.
+// Directly attached low-speed devices use no preamble and are not affected.
+#define DWC2_LS_ONE_XACT_PER_FRAME 1
+#else
+#define DWC2_LS_ONE_XACT_PER_FRAME 0
+#endif
+
+#if DWC2_LS_ONE_XACT_PER_FRAME
+#define DWC2_LS_FRAME_MASK     0x3FFFu // FrNum counts 0..0x3FFF
+#define DWC2_LS_FRAME_SPIN_MAX 200000u // covers a frame, but never spins forever if SOFs have stopped
+
+static uint32_t _ls_frame_end = 0; // last frame claimed by a low-speed transaction
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t ls_frame_now(const dwc2_regs_t* dwc2) {
+  return dwc2->hfnum & DWC2_LS_FRAME_MASK;
+}
+
+TU_ATTR_ALWAYS_INLINE static inline int32_t ls_frame_diff(uint32_t a, uint32_t b) {
+  const uint32_t d = (a - b) & DWC2_LS_FRAME_MASK;
+  return (int32_t)(d << 18) >> 18; // sign-extend 14-bit so the FrNum wrap compares correctly
+}
+
+// A transaction is free to run once the frames claimed by the previous one have passed. offset is
+// where this channel would start: periodic channels are armed for the next frame (odd_frame),
+// non-periodic ones go out in the current frame.
+TU_ATTR_ALWAYS_INLINE static inline bool ls_frame_free(const dwc2_regs_t* dwc2, uint32_t offset) {
+  return ls_frame_diff(ls_frame_now(dwc2) + offset, _ls_frame_end) > 0;
+}
+
+TU_ATTR_ALWAYS_INLINE static inline bool ls_needs_preamble(const dwc2_regs_t* dwc2, uint32_t hcchar, uint32_t hcsplt) {
+  const dwc2_channel_char_t char_bm = {.value = hcchar};
+  const dwc2_channel_split_t splt_bm = {.value = hcsplt};
+  const dwc2_hprt_t hprt = {.value = dwc2->hprt};
+  // high/full speed device, split transaction or low-speed root port: no preamble, nothing to space out
+  return char_bm.low_speed_dev && !splt_bm.split_en && hprt.speed == HPRT_SPEED_FULL;
+}
+
+// Claim the frames this channel's transaction will occupy, waiting out the ones a previous low-speed
+// transaction still holds. Must be called on every path that enables a low-speed channel, including
+// the NAK retries that re-issue an IN token without going through channel_xfer_start(), and always
+// before a caller masks interrupts: this can wait out a whole frame.
+static void ls_frame_reserve(const dwc2_regs_t* dwc2, dwc2_channel_t* channel) {
+  if (!ls_needs_preamble(dwc2, channel->hcchar, channel->hcsplt)) {
+    return;
+  }
+
+  const bool is_period = channel_is_periodic(channel->hcchar);
+  const dwc2_channel_tsize_t hctsiz = {.value = channel->hctsiz};
+  const uint32_t offset = is_period ? 1u : 0u;
+  // the core runs the packets of a multi-packet transfer back-to-back, which at low speed can spill
+  // past the end of the frame it started in
+  const uint32_t span = (!is_period && hctsiz.packet_count > 1) ? 1u : 0u;
+
+  uint32_t spin = DWC2_LS_FRAME_SPIN_MAX;
+  while (spin-- && !ls_frame_free(dwc2, offset)) {}
+
+  const uint32_t now = ls_frame_now(dwc2);
+  if (is_period) {
+    dwc2_channel_char_t rearm = {.value = channel->hcchar};
+    rearm.odd_frame = 1 - (now & 1); // waiting may have crossed a frame boundary
+    channel->hcchar = rearm.value;   // channel_enable() re-picks the frame when it selects one itself
+  }
+  _ls_frame_end = (now + offset + span) & DWC2_LS_FRAME_MASK;
+}
+
+// Periodic low-speed IN armed from the SOF interrupt: defer to the next frame rather than spin, the
+// endpoint already has a retry path for that.
+TU_ATTR_ALWAYS_INLINE static inline bool ls_edpt_deferred(const dwc2_regs_t* dwc2, const hcd_endpoint_t* edpt) {
+  return ls_needs_preamble(dwc2, edpt->hcchar, edpt->hcsplt) && !ls_frame_free(dwc2, 1);
+}
+#endif
+
 TU_ATTR_ALWAYS_INLINE static inline uint8_t req_queue_avail(const dwc2_regs_t* dwc2, bool is_period) {
   if (is_period) {
     const dwc2_hptxsts_t hptxsts = {.value = dwc2->hptxsts};
@@ -292,6 +369,11 @@ TU_ATTR_ALWAYS_INLINE static inline uint16_t channel_send_in_token(dwc2_regs_t* 
   while (0 == req_queue_avail(dwc2, channel_is_periodic(channel->hcchar))) {
     // blocking wait for request queue available
   }
+#if DWC2_LS_ONE_XACT_PER_FRAME
+  // after the queue wait, not before: a wait that spans a frame boundary would leave the
+  // reservation naming a frame this channel no longer starts in
+  ls_frame_reserve(dwc2, channel);
+#endif
   return channel_enable(dwc2, channel, next_periodic_frame);
 }
 
@@ -760,6 +842,9 @@ static bool channel_xfer_start(dwc2_regs_t* dwc2, uint8_t ch_id, bool defer_peri
       periodic_frame = channel_send_in_token(dwc2, channel, is_period);
     } else {
       hcd_dcache_clean(edpt->buffer, edpt->buflen);
+#if DWC2_LS_ONE_XACT_PER_FRAME
+      ls_frame_reserve(dwc2, channel); // IN is covered inside channel_send_in_token()
+#endif
       periodic_frame = channel_enable(dwc2, channel, is_period);
     }
   }
@@ -789,6 +874,13 @@ static bool channel_xfer_start(dwc2_regs_t* dwc2, uint8_t ch_id, bool defer_peri
     if (hcchar_bm->ep_dir == TUSB_DIR_IN) {
       periodic_frame = channel_send_in_token(dwc2, channel, is_period);
     } else {
+#if DWC2_LS_ONE_XACT_PER_FRAME
+      // the path taken whenever host DMA is off, which is the default: every low-speed OUT and SETUP
+      // goes out here, including the control stages of a device enumerating next to a live low-speed
+      // interrupt IN. Before the masked region below, since waiting out a frame with the controller's
+      // interrupt disabled would hold off every other channel too.
+      ls_frame_reserve(dwc2, channel);
+#endif
       // The final FIFO word creates the OUT request. Keep CHENA and that write
       // atomic with respect to this controller's ISR.
       // This region never waits for FIFO or queue space.
@@ -1666,8 +1758,12 @@ static bool handle_sof_irq(uint8_t rhport, bool in_isr) {
           edpt->uframe_countdown -= tu_min32(ucount, edpt->uframe_countdown);
         }
         if (edpt->uframe_countdown == 0) {
-          if (!edpt_xfer_kickoff(dwc2, ep_id)) {
-            edpt->uframe_countdown = ucount; // failed to start, try again next frame
+          bool deferred = false;
+#if DWC2_LS_ONE_XACT_PER_FRAME
+          deferred = ls_edpt_deferred(dwc2, edpt);
+#endif
+          if (deferred || !edpt_xfer_kickoff(dwc2, ep_id)) {
+            edpt->uframe_countdown = ucount; // busy low-speed frame or failed to start: try next frame
           }
         }
 
@@ -1763,7 +1859,14 @@ static void handle_hprt_irq(uint8_t rhport, bool in_isr) {
       const tusb_speed_t speed = hprt_speed_get(dwc2);
       port0_enable(dwc2, speed);
     } else {
-      // TU_ASSERT(false, );
+      // Port disabled by the core (port error e.g babble). SOF generation stops, so no transfer
+      // on this bus can ever complete again. Tear down the tree; if something is still connected
+      // re-attach so the port is reset and devices are enumerated again.
+      if (hprt_bm.conn_status == 1u) {
+        hcd_event_device_attach(rhport, in_isr);
+      } else {
+        hcd_event_device_remove(rhport, in_isr);
+      }
     }
   }
 


### PR DESCRIPTION
Depends on #3815, now merged. That PR keeps the hub status transfer alive, so the hub watchdog commit is gone.

Three leftover fixes from a full-speed DWC2 host dying when an LS mouse and LS keyboard share one FS hub.

### host: close dev0 when the whole roothub port goes away

A remove for `hub_addr = 0, hub_port = 0` covers everything below the root port, but `process_remove_event()` only closed dev0 when the event named the exact bus address it was enumerating on. Mid-enumeration behind a downstream hub then left `enumerating_daddr` at 0 and deferred every later attach.

### host: retry enumeration of the roothub port after a failed attach

`enum_full_complete()` already closes the failed device (#3815). Nothing retries the root port: the host sits idle until reboot. Re-post the attach up to `USBH_ENUM_ROOT_RETRY_MAX` times while the port still reports a connection. Budget is per port and given back when the attachment ends, including when an attach event tears down an in-flight enumeration. `tuh_umount_cb()` only runs for a device that reached `tuh_mounted()`.

### dwc2: space low-speed transactions one per frame on esp32s2/s3

ESP32-S2/S3 cannot run two preamble transactions in the same 1 ms frame. A second one clears `HPRT.PENA` and the bus stays down. Not an errata and not a `GHWCFG` bit — ESP-IDF hits the same limit (IDF-12986 / espressif/esp-idf#15683). Gated at runtime by `ls_needs_preamble()` (FS port + LS device, no split), compiled in only for those MCUs.

Reservation hooks through `channel_enable()` from #3815, after the request-queue wait and outside the interrupt-masked window. Periodic INs from SOF defer a frame rather than spin. A port the core disables on its own now posts attach or remove; that used to hit a commented-out `TU_ASSERT(false, )` and stay dead.

## Testing

| Device | VID:PID | Speed |
| --- | --- | --- |
| Keyboard | `03f0:034a` | LS |
| Mouse | `413c:301a` | LS |
| Flash drive | `058f:6387` | FS |

ESP32-S3 and ESP32-P4, all three on one hub. Cold boot and unplug/replug of each, including the drive, on #3815 plus these three commits. P4 compiles the frame gate out and exercises the two generic commits on HS.