### PR TITLE
audio_test_freertos: prime and hold the EP IN FIFO at its threshold

### DIFF
--- a/docs/superpowers/followup/pr3851-audiod-short-fifo-read.md
+++ b/docs/superpowers/followup/pr3851-audiod-short-fifo-read.md
@@ -1,0 +1,33 @@
+# audio device: short EP IN FIFO read replays stale bytes
+
+Split out of PR #3851 (found by the hfp HIL rig on stm32f746disco-DMA
+audio_test_freertos: "Audio mismatch at sample 8702: expected 8702, got 8696").
+
+## Established
+
+- `src/class/audio/audio_device.c` `audiod_tx_xfer_isr()` (~line 527): the return
+  of `tu_fifo_read_n(ff, lin_buf_in, n_bytes_tx)` is ignored and
+  `usbd_edpt_xfer()` still submits `n_bytes_tx`. When the SW FIFO holds fewer
+  bytes than the flow-control packet size, the tail of `lin_buf_in` is the
+  previous packet's data — the host hears a replayed fragment, offset by exactly
+  one packet (6 samples at HS 48 kHz mono 16-bit: "expected 8702, got 8696").
+- Reproduced whenever the producer lets the FIFO underrun; the example was fixed
+  to hold the FIFO at threshold (PR #3851, `20ff2b498`), but any application
+  with >~2 ms producer starvation can still hit the driver bug.
+- A naive short-write is not a fix: sending fewer bytes than the flow-control
+  size is legal ISO behavior, but a 1-byte pad would byte-misalign the stream —
+  the packet must shrink to the bytes actually read (sample-aligned).
+
+## Remains
+
+- In `audiod_tx_xfer_isr()`, submit the number of bytes `tu_fifo_read_n()`
+  actually returned (rounded down to a whole sample frame), not `n_bytes_tx`;
+  audit the flow-control accounting (`ctrl_blackout`, byte budget) for the
+  shrunken packet so long-term rate stays correct.
+- Coverage: hfp rig audio_test_freertos with a deliberately starved producer;
+  unit test on the FIFO-short path if feasible.
+
+## Why split
+
+PR #3851 is a board/clock PR; this is an audio class-driver correctness fix
+with its own review and test surface.

--- a/docs/superpowers/followup/pr3851-audiod-short-fifo-read.md
+++ b/docs/superpowers/followup/pr3851-audiod-short-fifo-read.md
@@ -12,8 +12,8 @@ audio_test_freertos: "Audio mismatch at sample 8702: expected 8702, got 8696").
   previous packet's data — the host hears a replayed fragment, offset by exactly
   one packet (6 samples at HS 48 kHz mono 16-bit: "expected 8702, got 8696").
 - Reproduced whenever the producer lets the FIFO underrun; the example was fixed
-  to hold the FIFO at threshold (PR #3851, `20ff2b498`), but any application
-  with >~2 ms producer starvation can still hit the driver bug.
+  to hold the FIFO at threshold (this PR, #3866), but any application with
+  >~2 ms producer starvation can still hit the driver bug.
 - A naive short-write is not a fix: sending fewer bytes than the flow-control
   size is legal ISO behavior, but a 1-byte pad would byte-misalign the stream —
   the packet must shrink to the bytes actually read (sample-aligned).

--- a/examples/device/audio_test_freertos/src/main.c
+++ b/examples/device/audio_test_freertos/src/main.c
@@ -214,10 +214,24 @@ void audio_isr_task(void *param) {
   (void) param;
   while (1) {
     vTaskDelay(1);
-    for (size_t cnt = 0; cnt < sizeof(test_buffer_audio) / 2; cnt++) {
-      test_buffer_audio[cnt] = startVal++;
+    tu_fifo_t *ep_in_ff = tud_audio_get_ep_in_ff();
+    if (ep_in_ff == NULL) {
+      continue;
     }
-    tud_audio_write((uint8_t *) test_buffer_audio, sizeof(test_buffer_audio));
+    // Our 1 ms tick and the host SOF are independent clocks, so keep the EP IN FIFO at the
+    // level the driver's flow control aims for instead of writing one frame per tick.
+    // Letting it get there by draining alone keeps the FIFO within a frame of empty for
+    // ~150 ms, and an underrun repeats the tail of the previous packet. Overflow is just as
+    // bad: the FIFO is overwritable and drops the oldest samples.
+    const uint16_t target = tud_audio_get_ep_in_fifo_threshold();
+    for (uint16_t level = tu_fifo_count(ep_in_ff);
+         level < target && tu_fifo_remaining(ep_in_ff) >= sizeof(test_buffer_audio);
+         level += sizeof(test_buffer_audio)) {
+      for (size_t cnt = 0; cnt < sizeof(test_buffer_audio) / 2; cnt++) {
+        test_buffer_audio[cnt] = startVal++;
+      }
+      tud_audio_write((uint8_t *) test_buffer_audio, sizeof(test_buffer_audio));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- The example's 1 ms producer tick and the host SOF are independent clocks. Writing one frame per tick from stream open leaves the EP IN FIFO within a frame of empty for ~180 ms, and on underrun the audio driver replays the previous packet's tail — caught by the hfp HIL rig on stm32f746disco-DMA as "Audio mismatch at sample 8702: expected 8702, got 8696" (exactly one 6-sample HS packet back). Intermittent by nature: it needs tick-vs-SOF jitter to align inside the startup window, which is why some runs pass.
- Fix: hold the FIFO at the driver's own flow-control threshold — primed at stream open, topped up each tick, every write still requiring a full frame of room so the overwritable FIFO never drops samples (overflow and underrun both covered). Filling above threshold is deliberately avoided: flow control then sends max-size packets (~48.73 kHz) and overruns the host capture.
- Verified by simulating the driver's flow-control law over the 2 s capture (zero underruns at ±400 µs producer jitter, vs 3 events for the old producer) plus warning-free builds of the failing DMA variant.
- The driver-side half — `audiod_tx_xfer_isr()` ignoring a short `tu_fifo_read_n()` and submitting stale bytes — is a separate correctness fix; handoff in `docs/superpowers/followup/pr3851-audiod-short-fifo-read.md`.

## Testing

- Builds: stm32f746disco audio_test_freertos (default + `-DCFG_TUD_DWC2_DMA_ENABLE=1`, the failing HIL variant)
- Split out of #3851, where the hfp failure was root-caused