### PR TITLE
ucpd: Add "attached" state callback for CC state changes

### DIFF
--- a/src/typec/usbc.c
+++ b/src/typec/usbc.c
@@ -57,6 +57,11 @@ TU_ATTR_WEAK bool tuc_pd_control_received_cb(uint8_t rhport, pd_header_t const* 
   return false;
 }
 
+TU_ATTR_WEAK void tuc_attach_changed_cb(uint8_t rhport, bool attached) {
+  (void) rhport;
+  (void) attached;
+}
+
 TU_ATTR_WEAK void tcd_connect(uint8_t rhport) {
   (void) rhport;
 }
@@ -124,8 +129,11 @@ void tuc_task_ext(uint32_t timeout_ms, bool in_isr) {
     if (!osal_queue_receive(_usbc_q, &event, timeout_ms)) return;
 
     switch (event.event_id) {
-      case TCD_EVENT_CC_CHANGED:
+      case TCD_EVENT_CC_CHANGED: {
+        bool const attached = event.cc_changed.cc_state[0] != 0 || event.cc_changed.cc_state[1] != 0;
+        tuc_attach_changed_cb(event.rhport, attached);
         break;
+      }
 
       case TCD_EVENT_RX_COMPLETE:
         // TODO process message here in ISR, move to thread later

--- a/src/typec/usbc.c
+++ b/src/typec/usbc.c
@@ -31,6 +31,7 @@ static bool _usbc_inited = false;
 
 // if port is initialized
 static bool _port_inited[TUP_TYPEC_RHPORTS_NUM];
+static bool _port_attached[TUP_TYPEC_RHPORTS_NUM];
 
 // Max possible PD size is 262 bytes
 static uint8_t _rx_buf[64] TU_ATTR_ALIGNED(4);
@@ -95,6 +96,7 @@ bool tuc_init(uint8_t rhport, uint32_t port_type) {
   // Initialize stack
   if (!_usbc_inited) {
     tu_memclr(_port_inited, sizeof(_port_inited));
+    tu_memclr(_port_attached, sizeof(_port_attached));
 
     _usbc_q = osal_queue_create(&_usbc_qdef);
     TU_ASSERT(_usbc_q != NULL);
@@ -131,7 +133,10 @@ void tuc_task_ext(uint32_t timeout_ms, bool in_isr) {
     switch (event.event_id) {
       case TCD_EVENT_CC_CHANGED: {
         bool const attached = event.cc_changed.cc_state[0] != 0 || event.cc_changed.cc_state[1] != 0;
-        tuc_attach_changed_cb(event.rhport, attached);
+        if (_port_attached[event.rhport] != attached) {
+          _port_attached[event.rhport] = attached;
+          tuc_attach_changed_cb(event.rhport, attached);
+        }
         break;
       }
 

--- a/src/typec/usbc.h
+++ b/src/typec/usbc.h
@@ -65,6 +65,7 @@ extern void tcd_int_handler(uint8_t rhport);
 
 bool tuc_pd_data_received_cb(uint8_t rhport, pd_header_t const* header, uint8_t const* dobj, uint8_t const* p_end);
 bool tuc_pd_control_received_cb(uint8_t rhport, pd_header_t const* header);
+void tuc_attach_changed_cb(uint8_t rhport, bool attached);
 
 //--------------------------------------------------------------------+
 //

--- a/src/typec/usbc.h
+++ b/src/typec/usbc.h
@@ -65,6 +65,7 @@ extern void tcd_int_handler(uint8_t rhport);
 
 bool tuc_pd_data_received_cb(uint8_t rhport, pd_header_t const* header, uint8_t const* dobj, uint8_t const* p_end);
 bool tuc_pd_control_received_cb(uint8_t rhport, pd_header_t const* header);
+// Invoked from tuc_task() only when the derived attachment state changes.
 void tuc_attach_changed_cb(uint8_t rhport, bool attached);
 
 //--------------------------------------------------------------------+

--- a/src/typec/usbc.h
+++ b/src/typec/usbc.h
@@ -65,7 +65,6 @@ extern void tcd_int_handler(uint8_t rhport);
 
 bool tuc_pd_data_received_cb(uint8_t rhport, pd_header_t const* header, uint8_t const* dobj, uint8_t const* p_end);
 bool tuc_pd_control_received_cb(uint8_t rhport, pd_header_t const* header);
-// Invoked from tuc_task() only when the derived attachment state changes.
 void tuc_attach_changed_cb(uint8_t rhport, bool attached);
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
This is a simple change to define a new callback in the USB-C sink implementation, so that the user application can know when attach state of the cable changes. This was needed in my application to track PD events.