### PR TITLE
dcd/samx7x: fix ZLP being dropped on DMA-capable IN endpoints

### DIFF
--- a/src/portable/microchip/samx7x/dcd_samx7x.c
+++ b/src/portable/microchip/samx7x/dcd_samx7x.c
@@ -531,10 +531,11 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t to
   } else {
     if (dir == TUSB_DIR_OUT) {
       USB_REG->DEVEPTIER[epnum] = DEVEPTIER_RXOUTES;
-    } else if (total_bytes == 0 && epnum != 0) {
-      // A ZLP is typically submitted from the completion of a DMA transfer, whose END_BUFF interrupt only
-      // means DPRAM was written: the last bank is usually still being transmitted. Clearing FIFOCON on a busy
-      // bank is a no-op that would swallow the ZLP, so let the TXINI handler validate it once the bank is free
+    } else if (total_bytes == 0 && EP_DMA_SUPPORT(epnum)) {
+      // Such a ZLP is submitted from the completion of a DMA transfer, whose END_BUFF interrupt only means
+      // DPRAM was written: the last bank is usually still being transmitted. Clearing FIFOCON on a busy bank
+      // is a no-op that would swallow the ZLP, so let the TXINI handler validate it once the bank is free.
+      // Endpoints without DMA complete from TXINI with the bank already free and can send the ZLP right away
       xfer->zlp_pending         = true;
       USB_REG->DEVEPTIER[epnum] = DEVEPTIER_TXINES;
     } else {

--- a/src/portable/microchip/samx7x/dcd_samx7x.c
+++ b/src/portable/microchip/samx7x/dcd_samx7x.c
@@ -38,6 +38,7 @@ typedef struct {
   uint16_t   queued_len;
   uint16_t   max_packet_size;
   uint8_t    interval;
+  bool       zlp_pending;
   tu_fifo_t *fifo;
 } xfer_ctl_t;
 
@@ -268,7 +269,11 @@ static void dcd_ep_handler(uint8_t ep_ix) {
     if (int_status & DEVEPTISR_TXINI) {
       // Acknowledge the interrupt
       USB_REG->DEVEPTICR[ep_ix] = DEVEPTICR_TXINIC;
-      if ((xfer->total_len != xfer->queued_len)) {
+      if (xfer->zlp_pending) {
+        // TXINI means the bank is free, so validating it now actually sends the ZLP
+        xfer->zlp_pending         = false;
+        USB_REG->DEVEPTIDR[ep_ix] = DEVEPTIDR_FIFOCONC;
+      } else if ((xfer->total_len != xfer->queued_len)) {
         // TX not complete
         dcd_transmit_packet(xfer, ep_ix);
       } else {
@@ -505,10 +510,11 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t to
 
   xfer_ctl_t *xfer = &xfer_status[epnum];
 
-  xfer->buffer     = buffer;
-  xfer->total_len  = total_bytes;
-  xfer->queued_len = 0;
-  xfer->fifo       = NULL;
+  xfer->buffer      = buffer;
+  xfer->total_len   = total_bytes;
+  xfer->queued_len  = 0;
+  xfer->zlp_pending = false;
+  xfer->fifo        = NULL;
 
   if (EP_DMA_SUPPORT(epnum) && total_bytes != 0) {
     uint32_t udd_dma_ctrl = total_bytes << DEVDMACONTROL_BUFF_LENGTH_Pos;
@@ -525,6 +531,12 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t to
   } else {
     if (dir == TUSB_DIR_OUT) {
       USB_REG->DEVEPTIER[epnum] = DEVEPTIER_RXOUTES;
+    } else if (total_bytes == 0 && epnum != 0) {
+      // A ZLP is typically submitted from the completion of a DMA transfer, whose END_BUFF interrupt only
+      // means DPRAM was written: the last bank is usually still being transmitted. Clearing FIFOCON on a busy
+      // bank is a no-op that would swallow the ZLP, so let the TXINI handler validate it once the bank is free
+      xfer->zlp_pending         = true;
+      USB_REG->DEVEPTIER[epnum] = DEVEPTIER_TXINES;
     } else {
       dcd_transmit_packet(xfer, epnum);
     }
@@ -544,10 +556,11 @@ bool dcd_edpt_xfer_fifo(uint8_t rhport, uint8_t ep_addr, tu_fifo_t *ff, uint16_t
 
   xfer_ctl_t *xfer = &xfer_status[epnum];
 
-  xfer->buffer     = NULL;
-  xfer->total_len  = total_bytes;
-  xfer->queued_len = 0;
-  xfer->fifo       = ff;
+  xfer->buffer      = NULL;
+  xfer->total_len   = total_bytes;
+  xfer->queued_len  = 0;
+  xfer->zlp_pending = false;
+  xfer->fifo        = ff;
 
   if (dir == TUSB_DIR_OUT) {
     USB_REG->DEVEPTIER[epnum] = DEVEPTIER_RXOUTES;

--- a/src/portable/microchip/samx7x/dcd_samx7x.c
+++ b/src/portable/microchip/samx7x/dcd_samx7x.c
@@ -531,13 +531,18 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t to
   } else {
     if (dir == TUSB_DIR_OUT) {
       USB_REG->DEVEPTIER[epnum] = DEVEPTIER_RXOUTES;
-    } else if (total_bytes == 0 && EP_DMA_SUPPORT(epnum)) {
-      // Such a ZLP is submitted from the completion of a DMA transfer, whose END_BUFF interrupt only means
-      // DPRAM was written: the last bank is usually still being transmitted. Clearing FIFOCON on a busy bank
-      // is a no-op that would swallow the ZLP, so let the TXINI handler validate it once the bank is free.
-      // Endpoints without DMA complete from TXINI with the bank already free and can send the ZLP right away
-      xfer->zlp_pending         = true;
-      USB_REG->DEVEPTIER[epnum] = DEVEPTIER_TXINES;
+    } else if (total_bytes == 0 && epnum != 0) {
+      // TXINI is sticky: every bank freed while it was masked (DMA transfers run with it masked) leaves it
+      // set, so acknowledge it first. Only then does NBUSYBK say whether the empty bank can be validated
+      // right away or whether that has to wait for the next TXINI, because clearing FIFOCON on a busy bank
+      // is a no-op that swallows the ZLP
+      USB_REG->DEVEPTICR[epnum] = DEVEPTICR_TXINIC;
+      if (USB_REG->DEVEPTISR[epnum] & DEVEPTISR_NBUSYBK) {
+        xfer->zlp_pending         = true;
+        USB_REG->DEVEPTIER[epnum] = DEVEPTIER_TXINES;
+      } else {
+        dcd_transmit_packet(xfer, epnum);
+      }
     } else {
       dcd_transmit_packet(xfer, epnum);
     }

--- a/src/portable/microchip/samx7x/dcd_samx7x.c
+++ b/src/portable/microchip/samx7x/dcd_samx7x.c
@@ -532,17 +532,16 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t *buffer, uint16_t to
     if (dir == TUSB_DIR_OUT) {
       USB_REG->DEVEPTIER[epnum] = DEVEPTIER_RXOUTES;
     } else if (total_bytes == 0 && epnum != 0) {
-      // TXINI is sticky: every bank freed while it was masked (DMA transfers run with it masked) leaves it
-      // set, so acknowledge it first. Only then does NBUSYBK say whether the empty bank can be validated
-      // right away or whether that has to wait for the next TXINI, because clearing FIFOCON on a busy bank
-      // is a no-op that swallows the ZLP
+      // Clearing FIFOCON on a busy bank is a no-op that swallows the ZLP, so the empty bank is validated
+      // from the TXINI handler, where it is guaranteed free. TXINI is sticky and every bank freed while it
+      // was masked (DMA transfers run with it masked) leaves it set, so acknowledge it first; if a bank is
+      // writable already, raise the interrupt by hand like the ASF driver does
+      xfer->zlp_pending         = true;
       USB_REG->DEVEPTICR[epnum] = DEVEPTICR_TXINIC;
-      if (USB_REG->DEVEPTISR[epnum] & DEVEPTISR_NBUSYBK) {
-        xfer->zlp_pending         = true;
-        USB_REG->DEVEPTIER[epnum] = DEVEPTIER_TXINES;
-      } else {
-        dcd_transmit_packet(xfer, epnum);
+      if (USB_REG->DEVEPTISR[epnum] & DEVEPTISR_RWALL) {
+        USB_REG->DEVEPTIFR[epnum] = DEVEPTIFR_TXINIS;
       }
+      USB_REG->DEVEPTIER[epnum] = DEVEPTIER_TXINES;
     } else {
       dcd_transmit_packet(xfer, epnum);
     }


### PR DESCRIPTION
First of all, thank you for this project!

On SAM E70/S70/V70 the terminating zero-length packet of a bulk IN transfer is silently discarded, so a transfer whose length is an exact multiple of the endpoint size is never terminated on the bus. With a Linux host the data sits in a partially filled cdc-acm URB and is not handed to userspace until something else arrives, which usually looks like a hung or truncated connection.

## Why

`dcd_edpt_xfer()` with `total_bytes == 0` falls through to `dcd_transmit_packet()`, which clears FIFOCON right away to hand the bank to the controller. That is fine when the previous packet completed via TXINI, because TXINI means a bank is free. It is not fine when the previous transfer went through DMA: the END_BUFF interrupt that completes a DMA transfer only says DPRAM was written, and the last bank is normally still being transmitted. Clearing FIFOCON on a busy bank does nothing, and the next TXINI then takes the "TX complete" path and reports the ZLP as sent although it never went out.

The stack hits this on its own, no application code required. `cdcd_xfer_cb()` calls `tu_edpt_stream_write_zlp_if_needed()` from the completion of the preceding data transfer, which is exactly the DMA completion described above. The same applies to the other class drivers that terminate with a ZLP (MIDI, printer, NCM, ECM/RNDIS, MTP).

## Proposed fix

A zero-length IN transfer on a non-control endpoint no longer touches FIFOCON at submit time. It sets `zlp_pending` and enables TXINES, and the TXINI handler validates the empty bank when the bank is guaranteed to be free. The transfer then completes on the following TXINI as before. EP0 is unaffected, it does not use FIFOCON and keeps the existing path.

## Verification

The fix was developed against an older master snapshot in our fork, where the affected code is the same, and verified on a SAME70Q20B at high speed with usbmon on the host. Before the change, CDC writes of an odd multiple of 512 bytes deterministically stalled the link within seconds. After it, 6/6 transfers of exactly 2560 bytes were delivered intact, and normal traffic was unaffected over longer runs.

The port to current master in this PR is compile-tested only, since the surrounding file has been reformatted and reworked since that snapshot.
