### PR TITLE
tools: support RTT capture lifecycle on Windows

### DIFF
--- a/test/hil/test/test_hil_rtt.py
+++ b/test/hil/test/test_hil_rtt.py
@@ -12,6 +12,7 @@ import time
 import unittest
 from contextlib import suppress as contextlib_suppress
 from pathlib import Path
+from unittest import mock
 
 # the module under test lives in the parent dir's helper/ package
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -77,6 +78,68 @@ for line in sys.stdin:
 '''
 
 BOARD = {'flasher': {'uid': '000', 'args': '-device FAKE'}}
+
+
+class RttPlatformLifecycle(unittest.TestCase):
+    def test_cli_missing_jlink_is_a_clean_error_on_this_platform(self):
+        env = dict(os.environ, RTT_JLINK_EXE='definitely-not-a-jlink-tool')
+        r = subprocess.run([sys.executable, str(CLI), '--backend', 'jlink',
+                            '--probe', '000', '--device', 'FAKE', '--seconds', '0.1'],
+                           env=env, capture_output=True, timeout=15)
+        self.assertEqual(r.returncode, 1, r.stderr)
+        self.assertIn(b'not on PATH', r.stderr)
+        self.assertNotIn(b'Traceback', r.stderr)
+
+    def test_process_group_creation_matches_platform(self):
+        options = hil_util._rtt._popen_group_options()
+        if os.name == 'nt':
+            self.assertEqual(options, {'creationflags': subprocess.CREATE_NEW_PROCESS_GROUP})
+        else:
+            self.assertEqual(options, {'start_new_session': True})
+
+    def test_windows_termination_uses_process_api_and_taskkill(self):
+        class FakeProc:
+            pid = 123
+
+            def __init__(self):
+                self.terminated = False
+                self.killed = False
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                self.killed = True
+
+        proc = FakeProc()
+        with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', True):
+            hil_util._rtt._terminate_process_group(proc, force=False)
+            self.assertTrue(proc.terminated)
+            with mock.patch.object(hil_util._rtt.subprocess, 'run') as taskkill:
+                hil_util._rtt._terminate_process_group(proc, force=True)
+        taskkill.assert_called_once()
+        self.assertEqual(taskkill.call_args.args[0][:4], ['taskkill', '/PID', '123', '/T'])
+        self.assertTrue(proc.killed)
+
+    def test_windows_defaults_to_jlink_exe(self):
+        with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', True), \
+             mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(hil_util._rtt._tool_exe('RTT_JLINK_EXE', 'JLinkExe', 'JLink.exe'),
+                             'JLink.exe')
+
+    def test_cli_rejects_an_existing_stop_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stop_file = Path(temp_dir) / 'capture.stop'
+            stop_file.touch()
+            r = subprocess.run(
+                [sys.executable, str(CLI), '--backend', 'jlink', '--probe', '000',
+                 '--device', 'FAKE', '--stop-file', str(stop_file)],
+                capture_output=True, timeout=20)
+        self.assertEqual(r.returncode, 2)
+        self.assertIn(b'already exists', r.stderr)
 
 
 @unittest.skipIf(os.name == 'nt', 'POSIX PATH/exec semantics')
@@ -195,6 +258,21 @@ class JlinkRttFakeProbe(unittest.TestCase):
         self.assertEqual(r.returncode, 1)
         self.assertIn(b'hello from target', r.stdout)
         self.assertIn(b'server closed', r.stderr)
+
+    def test_cli_stop_file_closes_a_continuous_capture(self):
+        env = dict(os.environ, PATH=self._path, FAKE_JLINK_MODE='tick')
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stop_file = Path(temp_dir) / 'capture.stop'
+            proc = subprocess.Popen(
+                [sys.executable, str(CLI), '--backend', 'jlink', '--probe', '000',
+                 '--device', 'FAKE', '--seconds', '0', '--stop-file', str(stop_file)],
+                env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            time.sleep(0.5)
+            stop_file.touch()
+            stdout, stderr = proc.communicate(timeout=20)
+        self.assertEqual(proc.returncode, 0, stderr)
+        self.assertIn(b'hello from target', stdout)
+        self.assertIn(b'tick', stdout)
 
     def test_peer_reset_latches_eof(self):
         # a killed server closes with RST when bytes are unread; the read side must

--- a/test/hil/test/test_hil_rtt.py
+++ b/test/hil/test/test_hil_rtt.py
@@ -326,7 +326,7 @@ class RttPlatformLifecycle(unittest.TestCase):
             self.assertEqual(hil_util._rtt._tool_exe('RTT_JLINK_EXE', 'JLinkExe', 'JLink.exe'),
                              'JLink.exe')
 
-    def test_cli_rejects_an_existing_stop_file(self):
+    def test_cli_accepts_an_existing_stop_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             stop_file = Path(temp_dir) / 'capture.stop'
             stop_file.touch()
@@ -334,8 +334,22 @@ class RttPlatformLifecycle(unittest.TestCase):
                 [sys.executable, str(CLI), '--backend', 'jlink', '--probe', '000',
                  '--device', 'FAKE', '--stop-file', str(stop_file)],
                 capture_output=True, timeout=20)
-        self.assertEqual(r.returncode, 2)
-        self.assertIn(b'already exists', r.stderr)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_cli_accepts_a_stop_file_created_immediately_after_spawn(self):
+        env = dict(os.environ, RTT_JLINK_EXE='definitely-not-a-jlink-tool')
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stop_file = Path(temp_dir) / 'capture.stop'
+            for _ in range(5):
+                with contextlib_suppress(FileNotFoundError):
+                    stop_file.unlink()
+                proc = subprocess.Popen(
+                    [sys.executable, str(CLI), '--backend', 'jlink', '--probe', '000',
+                     '--device', 'FAKE', '--stop-file', str(stop_file)],
+                    env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                stop_file.touch()
+                _, stderr = proc.communicate(timeout=20)
+                self.assertEqual(proc.returncode, 0, stderr)
 
     def test_cli_stop_file_cancels_connection_setup(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/test/hil/test/test_hil_rtt.py
+++ b/test/hil/test/test_hil_rtt.py
@@ -249,6 +249,24 @@ class RttPlatformLifecycle(unittest.TestCase):
         con.close()
         self.assertFalse(os.path.exists(log_name))
 
+    def test_posix_server_log_keeps_automatic_deletion(self):
+        class DoneProc:
+            stdin = None
+            stdout = None
+
+            def poll(self):
+                return 0
+
+        con = hil_util._rtt._SocketRtt()
+        named_temporary_file = tempfile.NamedTemporaryFile
+        with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', False), \
+             mock.patch.object(hil_util._rtt.tempfile, 'NamedTemporaryFile',
+                               wraps=named_temporary_file) as named_log, \
+             mock.patch.object(hil_util._rtt.subprocess, 'Popen', return_value=DoneProc()):
+            con._spawn(['fake-server'])
+        self.assertTrue(named_log.call_args.kwargs['delete'])
+        con.close()
+
     def test_connect_honors_a_stop_request_during_setup(self):
         class FakeProc:
             def poll(self):
@@ -273,6 +291,34 @@ class RttPlatformLifecycle(unittest.TestCase):
             with self.assertRaises(hil_util._rtt._StopCapture):
                 hil_util._rtt.nm_rtt_addr(str(fake_nm), nm=sys.executable, stop=stop)
         self.assertLess(time.monotonic() - started, 2)
+
+    def test_symbol_lookup_reaps_nm_when_interrupted(self):
+        class InterruptedNm:
+            returncode = None
+
+            def __init__(self):
+                self.terminated = False
+                self.reaped = False
+
+            def communicate(self, timeout=None):
+                if not self.terminated:
+                    raise KeyboardInterrupt
+                self.reaped = True
+                self.returncode = -1
+                return '', ''
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                self.terminated = True
+
+        proc = InterruptedNm()
+        with mock.patch.object(hil_util._rtt.subprocess, 'Popen', return_value=proc), \
+             self.assertRaises(KeyboardInterrupt):
+            hil_util._rtt.nm_rtt_addr('fake.elf', nm='fake-nm', stop=lambda: False)
+        self.assertTrue(proc.terminated)
+        self.assertTrue(proc.reaped)
 
     def test_windows_defaults_to_jlink_exe(self):
         with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', True), \

--- a/test/hil/test/test_hil_rtt.py
+++ b/test/hil/test/test_hil_rtt.py
@@ -5,6 +5,7 @@
 # hil-test hook can run this on GitHub's bare runner. Run directly:
 #   python3 test/hil/test/test_hil_rtt.py
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -115,14 +116,163 @@ class RttPlatformLifecycle(unittest.TestCase):
                 self.killed = True
 
         proc = FakeProc()
-        with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', True):
+        with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', True), \
+             mock.patch.object(hil_util._rtt.subprocess, 'run') as taskkill:
             hil_util._rtt._terminate_process_group(proc, force=False)
-            self.assertTrue(proc.terminated)
-            with mock.patch.object(hil_util._rtt.subprocess, 'run') as taskkill:
-                hil_util._rtt._terminate_process_group(proc, force=True)
         taskkill.assert_called_once()
         self.assertEqual(taskkill.call_args.args[0][:4], ['taskkill', '/PID', '123', '/T'])
+        self.assertIn('/F', taskkill.call_args.args[0])
+        self.assertTrue(proc.terminated)
+
+        proc = FakeProc()
+        with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', True), \
+             mock.patch.object(hil_util._rtt.subprocess, 'run') as taskkill:
+            hil_util._rtt._terminate_process_group(proc, force=True)
+        self.assertIn('/F', taskkill.call_args.args[0])
         self.assertTrue(proc.killed)
+
+    def test_windows_close_stops_the_tree_before_the_parent_can_exit(self):
+        class FakeProc:
+            pid = 123
+            stdin = None
+            stdout = None
+
+            def __init__(self):
+                self.alive = True
+
+            def poll(self):
+                return None if self.alive else 0
+
+            def wait(self, timeout):
+                if self.alive:
+                    raise subprocess.TimeoutExpired('fake', timeout)
+                return 0
+
+        class FakeConsole(hil_util._rtt._SocketRtt):
+            def __init__(self, proc):
+                super().__init__()
+                self._proc = proc
+                self.gentle_called = False
+
+            def _gentle_stop(self, proc):
+                self.gentle_called = True
+                proc.alive = False
+
+        proc = FakeProc()
+        con = FakeConsole(proc)
+
+        def stop_tree(stopped_proc, force):
+            self.assertIs(stopped_proc, proc)
+            self.assertFalse(force)
+            stopped_proc.alive = False
+
+        with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', True), \
+             mock.patch.object(hil_util._rtt, '_terminate_process_group', side_effect=stop_tree) as stop:
+            con.close()
+        stop.assert_called_once_with(proc, force=False)
+        self.assertFalse(con.gentle_called)
+
+    @unittest.skipUnless(os.name == 'nt', 'Windows process-tree semantics')
+    def test_windows_close_reaps_a_real_child_process(self):
+        import ctypes
+
+        def pid_exists(pid):
+            handle = ctypes.windll.kernel32.OpenProcess(0x1000, False, pid)
+            if not handle:
+                return False
+            try:
+                exit_code = ctypes.c_ulong()
+                if not ctypes.windll.kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                    return False
+                return exit_code.value == 259  # STILL_ACTIVE
+            finally:
+                ctypes.windll.kernel32.CloseHandle(handle)
+
+        child_code = 'import time; time.sleep(60)'
+        parent_code = ('import subprocess, sys, time; '
+                       f'p = subprocess.Popen([sys.executable, "-c", {child_code!r}]); '
+                       'print(p.pid, flush=True); time.sleep(60)')
+        con = hil_util._rtt._SocketRtt()
+        con._spawn([sys.executable, '-c', parent_code])
+        proc = con._proc
+        child_pid = None
+        try:
+            deadline = time.monotonic() + 5
+            while child_pid is None and time.monotonic() < deadline:
+                match = re.search(r'\d+', con._server_tail())
+                if match:
+                    child_pid = int(match.group())
+                    break
+                time.sleep(0.05)
+            self.assertIsNotNone(child_pid, 'child PID was not written to the server log')
+            taskkill_results = []
+            real_run = subprocess.run
+
+            def run_taskkill(cmd, **kwargs):
+                kwargs['stdout'] = subprocess.PIPE
+                kwargs['stderr'] = subprocess.PIPE
+                result = real_run(cmd, **kwargs)
+                taskkill_results.append(result)
+                return result
+
+            with mock.patch.object(hil_util._rtt.subprocess, 'run', side_effect=run_taskkill):
+                con.close()
+            self.assertEqual(taskkill_results[0].returncode, 0, taskkill_results[0].stderr)
+            self.assertIsNotNone(proc.poll())
+            deadline = time.monotonic() + 2
+            while pid_exists(child_pid) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            self.assertFalse(pid_exists(child_pid))
+        finally:
+            con.close()
+            for pid in (proc.pid, child_pid):
+                if pid and pid_exists(pid):
+                    subprocess.run(['taskkill', '/PID', str(pid), '/T', '/F'],
+                                   capture_output=True, check=False)
+
+    @unittest.skipUnless(os.name == 'nt', 'Windows temporary-file sharing semantics')
+    def test_server_log_can_be_reopened_and_is_removed(self):
+        class DoneProc:
+            stdin = None
+            stdout = None
+
+            def poll(self):
+                return 0
+
+        con = hil_util._rtt._SocketRtt()
+        with mock.patch.object(hil_util._rtt.subprocess, 'Popen', return_value=DoneProc()):
+            con._spawn(['fake-server'])
+        log_name = con._log.name
+        con._log.write(b'useful server failure')
+        con._log.flush()
+        self.assertIn('useful server failure', con._server_tail())
+        con.close()
+        self.assertFalse(os.path.exists(log_name))
+
+    def test_connect_honors_a_stop_request_during_setup(self):
+        class FakeProc:
+            def poll(self):
+                return None
+
+        con = hil_util._rtt._SocketRtt()
+        con._proc = FakeProc()
+        con.close = mock.Mock()
+        stop = mock.Mock(side_effect=(False, True))
+        with mock.patch.object(hil_util._rtt.socket, 'create_connection', side_effect=OSError), \
+             mock.patch.object(hil_util._rtt.time, 'sleep'), \
+             self.assertRaises(hil_util._rtt._StopCapture):
+            con._connect(1234, stop=stop)
+        con.close.assert_called_once()
+
+    def test_symbol_lookup_honors_a_stop_request(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_nm = Path(temp_dir) / 'slow_nm.py'
+            fake_nm.write_text('import time\ntime.sleep(30)\n')
+            stop = mock.Mock(side_effect=(False, False, True))
+            started = time.monotonic()
+            with self.assertRaises(hil_util._rtt._StopCapture):
+                hil_util._rtt.nm_rtt_addr(str(fake_nm), nm=sys.executable, stop=stop)
+        self.assertLess(time.monotonic() - started, 2)
 
     def test_windows_defaults_to_jlink_exe(self):
         with mock.patch.object(hil_util._rtt, 'IS_WINDOWS', True), \
@@ -140,6 +290,37 @@ class RttPlatformLifecycle(unittest.TestCase):
                 capture_output=True, timeout=20)
         self.assertEqual(r.returncode, 2)
         self.assertIn(b'already exists', r.stderr)
+
+    def test_cli_stop_file_cancels_connection_setup(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stop_file = Path(temp_dir) / 'capture.stop'
+
+            def start_console(*_args, **kwargs):
+                stop_file.touch()
+                self.assertTrue(kwargs['stop']())
+                raise hil_util._rtt._StopCapture
+
+            argv = [str(CLI), '--backend', 'jlink', '--probe', '000', '--device', 'FAKE',
+                    '--stop-file', str(stop_file)]
+            with mock.patch.object(sys, 'argv', argv), \
+                 mock.patch.object(hil_util._rtt, 'JlinkRtt', side_effect=start_console):
+                self.assertEqual(hil_util._rtt.main(), 0)
+
+    def test_cli_stop_file_cancels_symbol_lookup(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stop_file = Path(temp_dir) / 'capture.stop'
+
+            def find_symbol(_elf, nm=None, stop=None):
+                self.assertIsNone(nm)
+                stop_file.touch()
+                self.assertTrue(stop())
+                raise hil_util._rtt._StopCapture
+
+            argv = [str(CLI), '--backend', 'openocd', '--probe', '000', '--cfg', '-f fake.cfg',
+                    '--elf', 'fake.elf', '--stop-file', str(stop_file)]
+            with mock.patch.object(sys, 'argv', argv), \
+                 mock.patch.object(hil_util._rtt, 'nm_rtt_addr', side_effect=find_symbol):
+                self.assertEqual(hil_util._rtt.main(), 0)
 
 
 @unittest.skipIf(os.name == 'nt', 'POSIX PATH/exec semantics')

--- a/tools/rtt.py
+++ b/tools/rtt.py
@@ -183,27 +183,32 @@ def nm_rtt_addr(elf: str, nm: str = None, stop=None) -> int:
             if stop():
                 raise _StopCapture
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            deadline = time.monotonic() + 30
-            while True:
-                if stop():
-                    proc.terminate()
+            try:
+                deadline = time.monotonic() + 30
+                while True:
+                    if stop():
+                        raise _StopCapture
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise subprocess.TimeoutExpired(cmd, 30)
                     try:
-                        proc.communicate(timeout=2)
+                        stdout, stderr = proc.communicate(timeout=min(0.1, remaining))
+                        r = subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+                        break
                     except subprocess.TimeoutExpired:
-                        proc.kill()
-                        proc.communicate()
-                    raise _StopCapture
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    proc.kill()
-                    stdout, stderr = proc.communicate()
-                    raise subprocess.TimeoutExpired(cmd, 30, output=stdout, stderr=stderr)
+                        pass
+            except BaseException:
+                # Signals and stop-file cancellation must not strand nm after main()
+                # returns. Reap it before preserving the original exception.
+                with contextlib.suppress(OSError):
+                    proc.terminate()
                 try:
-                    stdout, stderr = proc.communicate(timeout=min(0.1, remaining))
-                    r = subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
-                    break
+                    proc.communicate(timeout=2)
                 except subprocess.TimeoutExpired:
-                    pass
+                    with contextlib.suppress(OSError):
+                        proc.kill()
+                    proc.communicate()
+                raise
             if stop():
                 raise _StopCapture
     except FileNotFoundError:
@@ -248,10 +253,10 @@ class _SocketRtt:
         # single-threaded server once 64 KiB of log accumulates (openocd at
         # polling_interval 1 against a resetting target fills that in minutes) and
         # the console goes silent with no error; the file also feeds _server_tail
-        # delete=False lets _server_tail() reopen the live file on Windows, where an
-        # auto-delete NamedTemporaryFile otherwise denies the second open. close()
-        # unlinks it explicitly on every platform.
-        self._log = tempfile.NamedTemporaryFile(prefix='rtt-server-', suffix='.log', delete=False)
+        # Windows needs delete=False so _server_tail() can reopen the live file.
+        # POSIX keeps NamedTemporaryFile's automatic close/finalizer cleanup.
+        self._log = tempfile.NamedTemporaryFile(prefix='rtt-server-', suffix='.log',
+                                                delete=not IS_WINDOWS)
         try:
             self._proc = subprocess.Popen(cmd, stdin=stdin, stdout=self._log,
                                           stderr=subprocess.STDOUT, **_popen_group_options())

--- a/tools/rtt.py
+++ b/tools/rtt.py
@@ -43,6 +43,53 @@ import threading
 import time
 
 
+IS_WINDOWS = os.name == 'nt'
+
+
+def _tool_exe(env_name: str, posix_name: str, windows_name: str = None) -> str:
+    """Return an overridable executable name without invoking a shell."""
+    return os.environ.get(env_name, windows_name if IS_WINDOWS and windows_name else posix_name)
+
+
+def _popen_group_options() -> dict:
+    """Put each server in an independently terminable process group/session."""
+    if IS_WINDOWS:
+        return {'creationflags': subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {'start_new_session': True}
+
+
+def _termination_signals() -> tuple:
+    """Signals that exist on this host and can request an orderly CLI stop."""
+    names = ('SIGTERM', 'SIGHUP')
+    return tuple(getattr(signal, name) for name in names if hasattr(signal, name))
+
+
+def _terminate_process_group(proc, force: bool) -> None:
+    """Stop the server and anything it spawned, on POSIX or Windows."""
+    if proc.poll() is not None:
+        return
+    if IS_WINDOWS:
+        if force:
+            # TerminateProcess reaches only the direct child. taskkill /T also
+            # retires helpers a debug server may have spawned and is present on
+            # supported Windows hosts. Fall back to Popen.kill() if it fails.
+            with contextlib.suppress(OSError, subprocess.SubprocessError):
+                subprocess.run(['taskkill', '/PID', str(proc.pid), '/T', '/F'],
+                               stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                               stderr=subprocess.DEVNULL, timeout=10, check=False)
+            if proc.poll() is None:
+                with contextlib.suppress(OSError):
+                    proc.kill()
+        else:
+            with contextlib.suppress(OSError):
+                proc.terminate()
+        return
+
+    sig = signal.SIGKILL if force else signal.SIGTERM
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(proc.pid, sig)
+
+
 class RttError(RuntimeError):
     """Every way a console can break: stall, closed, dead or reset server.
 
@@ -170,7 +217,7 @@ class _SocketRtt:
         self._log = tempfile.NamedTemporaryFile(prefix='rtt-server-', suffix='.log')
         try:
             self._proc = subprocess.Popen(cmd, stdin=stdin, stdout=self._log,
-                                          stderr=subprocess.STDOUT, start_new_session=True)
+                                          stderr=subprocess.STDOUT, **_popen_group_options())
         except FileNotFoundError as e:
             self.close()
             raise RttError(f'RTT console: {e.filename or cmd[0]} not on PATH') from e
@@ -336,19 +383,16 @@ class _SocketRtt:
                 with contextlib.suppress(subprocess.TimeoutExpired):
                     proc.wait(timeout=5)
         if proc and proc.poll() is None:
-            # own session (start_new_session), so the group takedown gets the server and
-            # anything it spawned; leaving one alive would hold the probe for the next test
-            try:
-                os.killpg(proc.pid, signal.SIGTERM)
+            # The server owns a separate POSIX session or Windows process group.
+            # Retire it before returning so it cannot hold the probe for the next run.
+            _terminate_process_group(proc, force=False)
+            with contextlib.suppress(subprocess.TimeoutExpired):
                 proc.wait(timeout=5)
-            except (ProcessLookupError, PermissionError):
-                pass
-            except subprocess.TimeoutExpired:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.killpg(proc.pid, signal.SIGKILL)
-                # reap, or the server stays a zombie for the caller's lifetime
-                with contextlib.suppress(subprocess.TimeoutExpired):
-                    proc.wait(timeout=2)
+        if proc and proc.poll() is None:
+            _terminate_process_group(proc, force=True)
+            # Reap, or the server stays a zombie for the caller's lifetime.
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=2)
         if proc:
             for pipe in (proc.stdin, proc.stdout):
                 if pipe:
@@ -406,7 +450,8 @@ class JlinkRtt(_SocketRtt):
         # roster ever carries such args. -ExitOnError makes a failed target connect
         # EXIT Commander
         # (a clean error with the log tail) instead of leaving a banner-only console
-        cmd = ['JLinkExe', '-USB', str(flasher['uid']), '-if', 'swd',
+        cmd = [_tool_exe('RTT_JLINK_EXE', 'JLinkExe', 'JLink.exe'),
+               '-USB', str(flasher['uid']), '-if', 'swd',
                '-JTAGConf', '-1,-1', '-speed', 'auto', '-NoGui', '1',
                '-ExitOnError', '1', '-AutoConnect', '1',
                *args, '-RTTTelnetPort', str(port)]
@@ -445,7 +490,8 @@ class OpenocdRtt(_SocketRtt):
         # argv, never a shell string: cfg/serial/vid_pid come from roster JSON and the
         # command line, and a '$', backtick or quote in any of them would otherwise be
         # substituted by the shell or break out of it
-        cmd = ['openocd', '-c', 'tcl_port disabled', '-c', 'gdb_port disabled',
+        cmd = [_tool_exe('RTT_OPENOCD_EXE', 'openocd'),
+               '-c', 'tcl_port disabled', '-c', 'gdb_port disabled',
                '-c', 'telnet_port disabled']
         # probe pin: vid_pid keeps discovery from opening foreign usbfs nodes (a
         # wedged one hangs the open), serial disambiguates same-model probes —
@@ -485,8 +531,7 @@ class OpenocdRtt(_SocketRtt):
         # no stdin channel to ask openocd to exit, and it keeps its listener up after
         # the client disconnects: go straight to the group takedown instead of blocking
         # the base class's 5 s wait on a process that has no reason to leave
-        with contextlib.suppress(ProcessLookupError, PermissionError):
-            os.killpg(proc.pid, signal.SIGTERM)
+        _terminate_process_group(proc, force=False)
 
 
 def dump_ring(probe: str, device: str, addr: int, out_path: str, channel: int = 0) -> int:
@@ -503,7 +548,8 @@ def dump_ring(probe: str, device: str, addr: int, out_path: str, channel: int = 
     # each ring 6 words {sName, pBuffer, SizeOfBuffer, WrOff, RdOff, Flags}. Read the
     # counts with the descriptor so an out-of-range channel is rejected instead of
     # reading whatever RAM follows the array.
-    jlink = ['JLinkExe', '-USB', probe, '-device', device, '-if', 'swd',
+    jlink = [_tool_exe('RTT_JLINK_EXE', 'JLinkExe', 'JLink.exe'),
+             '-USB', probe, '-device', device, '-if', 'swd',
              '-speed', '4000', '-NoGui', '1', '-AutoConnect', '1']
 
     def _jlink_run(script: str):
@@ -512,9 +558,9 @@ def dump_ring(probe: str, device: str, addr: int, out_path: str, channel: int = 
         try:
             return subprocess.run(jlink, input=script, capture_output=True, text=True, timeout=60)
         except FileNotFoundError:
-            raise SystemExit('JLinkExe not on PATH — the --dump route needs J-Link Commander')
+            raise SystemExit(f'{jlink[0]} not on PATH — the --dump route needs J-Link Commander')
         except subprocess.TimeoutExpired:
-            raise SystemExit('JLinkExe did not finish in 60 s — probe wedged or target unreachable?')
+            raise SystemExit(f'{jlink[0]} did not finish in 60 s — probe wedged or target unreachable?')
 
     script = f'mem32 {addr + 0x10:#x}, 2\nmem32 {addr + 0x18 + channel * 24:#x}, 6\nexit\n'
     r = _jlink_run(script)
@@ -573,6 +619,7 @@ def main() -> int:
     ap.add_argument('--addr', help='SEGGER RTT control block address (hex), instead of --elf')
     ap.add_argument('--channel', type=int, default=0, help='up-buffer index (0 console, 1 SysView)')
     ap.add_argument('--seconds', type=float, default=0, help='capture duration; 0 = until Ctrl-C/EOF')
+    ap.add_argument('--stop-file', help='exit successfully when this path appears')
     ap.add_argument('-i', '--interactive', action='store_true', help='forward stdin to the target')
     ap.add_argument('--reset-before-attach', action='store_true',
                     help='openocd: reset the target inside the capture session so the '
@@ -588,6 +635,8 @@ def main() -> int:
         # a negative index would walk backwards off aUp[] into the control-block
         # header and read garbage as a descriptor
         ap.error(f'--channel must be >= 0, got {args.channel}')
+    if args.stop_file and os.path.exists(args.stop_file):
+        ap.error(f'--stop-file already exists: {args.stop_file}')
 
     def rtt_addr():
         if args.addr:
@@ -615,6 +664,8 @@ def main() -> int:
         ap.error('the openocd backend needs --probe and/or --vid-pid')
 
     if args.dump:
+        if args.stop_file:
+            ap.error('--stop-file is not valid with --dump')
         if args.backend != 'jlink':
             ap.error('--dump uses the jlink backend (debug-AP reads via JLinkExe)')
         return dump_ring(args.probe, args.device, rtt_addr(), args.dump, args.channel)
@@ -625,7 +676,7 @@ def main() -> int:
     # stdin EOF; openocd has no such channel and its own session shields it)
     def _terminate(signum, _frame):
         raise KeyboardInterrupt
-    for _sig in (signal.SIGTERM, signal.SIGHUP):
+    for _sig in _termination_signals():
         with contextlib.suppress(ValueError, OSError):
             signal.signal(_sig, _terminate)
 
@@ -674,7 +725,8 @@ def main() -> int:
     rc = 0
     seen = b''   # pre-release accumulator for the banner check only
     try:
-        while deadline is None or time.monotonic() < deadline:
+        while ((deadline is None or time.monotonic() < deadline) and
+               not (args.stop_file and os.path.exists(args.stop_file))):
             try:
                 chunk = con.read(con.in_waiting or 1)
             except RttError as e:
@@ -716,7 +768,7 @@ def main() -> int:
             print('rtt: no target output within the window', file=sys.stderr)
         # a late TERM landing during the up-to-12 s teardown must not skip the kill
         # escalation and orphan the server -- cleanup is committed at this point
-        for _sig in (signal.SIGTERM, signal.SIGHUP):
+        for _sig in _termination_signals():
             with contextlib.suppress(ValueError, OSError):
                 signal.signal(_sig, signal.SIG_IGN)
         con.close()

--- a/tools/rtt.py
+++ b/tools/rtt.py
@@ -690,7 +690,7 @@ def main() -> int:
         # header and read garbage as a descriptor
         ap.error(f'--channel must be >= 0, got {args.channel}')
     if args.stop_file and os.path.exists(args.stop_file):
-        ap.error(f'--stop-file already exists: {args.stop_file}')
+        return 0
 
     def stop_requested():
         return bool(args.stop_file and os.path.exists(args.stop_file))

--- a/tools/rtt.py
+++ b/tools/rtt.py
@@ -66,25 +66,26 @@ def _termination_signals() -> tuple:
 
 def _terminate_process_group(proc, force: bool) -> None:
     """Stop the server and anything it spawned, on POSIX or Windows."""
-    if proc.poll() is not None:
-        return
     if IS_WINDOWS:
-        if force:
-            # TerminateProcess reaches only the direct child. taskkill /T also
-            # retires helpers a debug server may have spawned and is present on
-            # supported Windows hosts. Fall back to Popen.kill() if it fails.
-            with contextlib.suppress(OSError, subprocess.SubprocessError):
-                subprocess.run(['taskkill', '/PID', str(proc.pid), '/T', '/F'],
-                               stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
-                               stderr=subprocess.DEVNULL, timeout=10, check=False)
-            if proc.poll() is None:
-                with contextlib.suppress(OSError):
-                    proc.kill()
-        else:
+        if proc.poll() is not None:
+            return
+        # Enumerate and stop the tree while the parent still exists. TerminateProcess
+        # (Popen.terminate/kill) reaches only the direct child, and taskkill cannot find
+        # the descendants by their former parent after that process has exited.
+        # /F is required for console children: without it taskkill can retire the
+        # parent first and leave its child alive, after which /PID can no longer find
+        # the tree. POSIX retains its graceful-then-force ladder below.
+        cmd = ['taskkill', '/PID', str(proc.pid), '/T', '/F']
+        with contextlib.suppress(OSError, subprocess.SubprocessError):
+            subprocess.run(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL, timeout=10, check=False)
+        if proc.poll() is None:
             with contextlib.suppress(OSError):
-                proc.terminate()
+                (proc.kill if force else proc.terminate)()
         return
 
+    if proc.poll() is not None:
+        return
     sig = signal.SIGKILL if force else signal.SIGTERM
     with contextlib.suppress(ProcessLookupError, PermissionError):
         os.killpg(proc.pid, sig)
@@ -97,6 +98,10 @@ class RttError(RuntimeError):
     but named so the harness can tell a console failure from an unrelated
     NotImplementedError / 'dictionary changed size during iteration' and stop
     reporting harness bugs as board failures."""
+
+
+class _StopCapture(Exception):
+    """The CLI stop marker appeared while the RTT console was starting."""
 
 
 def _pos_float_env(name: str, default: float) -> float:
@@ -166,12 +171,41 @@ def free_ports(count: int) -> list:
             s.close()
 
 
-def nm_rtt_addr(elf: str, nm: str = None) -> int:
+def nm_rtt_addr(elf: str, nm: str = None, stop=None) -> int:
     """Control-block address from the FLASHED elf's symbol table. --addr is the way
     out when nm cannot read the file (another architecture, no toolchain)."""
     nm = nm or os.environ.get('RTT_NM', 'arm-none-eabi-nm')
     try:
-        r = subprocess.run([nm, elf], capture_output=True, text=True, timeout=30)
+        cmd = [nm, elf]
+        if stop is None:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        else:
+            if stop():
+                raise _StopCapture
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            deadline = time.monotonic() + 30
+            while True:
+                if stop():
+                    proc.terminate()
+                    try:
+                        proc.communicate(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        proc.communicate()
+                    raise _StopCapture
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    proc.kill()
+                    stdout, stderr = proc.communicate()
+                    raise subprocess.TimeoutExpired(cmd, 30, output=stdout, stderr=stderr)
+                try:
+                    stdout, stderr = proc.communicate(timeout=min(0.1, remaining))
+                    r = subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+                    break
+                except subprocess.TimeoutExpired:
+                    pass
+            if stop():
+                raise _StopCapture
     except FileNotFoundError:
         raise SystemExit(f'{nm} not on PATH — set RTT_NM=<your-nm>, or pass --addr')
     except subprocess.TimeoutExpired:
@@ -214,7 +248,10 @@ class _SocketRtt:
         # single-threaded server once 64 KiB of log accumulates (openocd at
         # polling_interval 1 against a resetting target fills that in minutes) and
         # the console goes silent with no error; the file also feeds _server_tail
-        self._log = tempfile.NamedTemporaryFile(prefix='rtt-server-', suffix='.log')
+        # delete=False lets _server_tail() reopen the live file on Windows, where an
+        # auto-delete NamedTemporaryFile otherwise denies the second open. close()
+        # unlinks it explicitly on every platform.
+        self._log = tempfile.NamedTemporaryFile(prefix='rtt-server-', suffix='.log', delete=False)
         try:
             self._proc = subprocess.Popen(cmd, stdin=stdin, stdout=self._log,
                                           stderr=subprocess.STDOUT, **_popen_group_options())
@@ -226,10 +263,12 @@ class _SocketRtt:
             self.close()
             raise
 
-    def _connect(self, port: int) -> None:
+    def _connect(self, port: int, stop=None) -> None:
         try:
             deadline = time.monotonic() + 15
             while time.monotonic() < deadline:
+                if stop and stop():
+                    raise _StopCapture
                 try:
                     self._sock = socket.create_connection(('127.0.0.1', port), timeout=2)
                     break
@@ -237,6 +276,8 @@ class _SocketRtt:
                     if self._proc.poll() is not None:
                         break
                     time.sleep(0.2)
+            if stop and stop():
+                raise _StopCapture
             if self._sock is None:
                 tail = self._server_tail()
                 self.close()
@@ -247,7 +288,7 @@ class _SocketRtt:
                 self.close()
                 raise RttError(f'RTT console: {self.server} died after connect (port {port} hijacked?)')
             self._sock.setblocking(False)
-        except (KeyboardInterrupt, SystemExit):
+        except (KeyboardInterrupt, SystemExit, _StopCapture):
             # a signal mid-construction must not orphan the server we just spawned
             self.close()
             raise
@@ -379,7 +420,11 @@ class _SocketRtt:
         proc = getattr(self, '_proc', None)
         if proc:
             if proc.poll() is None:
-                self._gentle_stop(proc)
+                if IS_WINDOWS:
+                    # taskkill must see the live parent to enumerate its descendants.
+                    _terminate_process_group(proc, force=False)
+                else:
+                    self._gentle_stop(proc)
                 with contextlib.suppress(subprocess.TimeoutExpired):
                     proc.wait(timeout=5)
         if proc and proc.poll() is None:
@@ -402,8 +447,11 @@ class _SocketRtt:
         # grows it while alive -- GC is not a release policy on a rig
         log = getattr(self, '_log', None)
         if log:
+            log_name = log.name
             with contextlib.suppress(OSError, ValueError):
                 log.close()
+            with contextlib.suppress(OSError):
+                os.unlink(log_name)
             self._log = None
 
     # a console dropped without close() must not hold the probe for the process's life
@@ -434,7 +482,7 @@ class JlinkRtt(_SocketRtt):
 
     server = 'JLinkExe'
 
-    def __init__(self, board: dict, timeout: float = 0.1):
+    def __init__(self, board: dict, timeout: float = 0.1, stop=None):
         super().__init__(timeout)
         flasher = board['flasher']
         args = shlex.split(flasher.get('args', ''))
@@ -458,7 +506,7 @@ class JlinkRtt(_SocketRtt):
         # stdin stays open: Commander exits when it runs out of input; close() writes
         # 'exit' there.
         self._spawn(cmd, stdin=subprocess.PIPE)
-        self._connect(port)
+        self._connect(port, stop=stop)
 
     def _gentle_stop(self, proc) -> None:
         with contextlib.suppress(OSError, ValueError):
@@ -484,7 +532,8 @@ class OpenocdRtt(_SocketRtt):
     server = 'openocd'
 
     def __init__(self, cfg: str, addr: int, channel: int, serial_no: str = None,
-                 vid_pid: str = None, timeout: float = 0.1, reset_before_attach: bool = False):
+                 vid_pid: str = None, timeout: float = 0.1, reset_before_attach: bool = False,
+                 stop=None):
         super().__init__(timeout)
         port = free_ports(1)[0]
         # argv, never a shell string: cfg/serial/vid_pid come from roster JSON and the
@@ -525,7 +574,7 @@ class OpenocdRtt(_SocketRtt):
                 '-c', 'rtt polling_interval 1', '-c', 'rtt start',
                 '-c', f'rtt server start {port} {channel}']
         self._spawn(cmd)
-        self._connect(port)
+        self._connect(port, stop=stop)
 
     def _gentle_stop(self, proc) -> None:
         # no stdin channel to ask openocd to exit, and it keeps its listener up after
@@ -638,6 +687,9 @@ def main() -> int:
     if args.stop_file and os.path.exists(args.stop_file):
         ap.error(f'--stop-file already exists: {args.stop_file}')
 
+    def stop_requested():
+        return bool(args.stop_file and os.path.exists(args.stop_file))
+
     def rtt_addr():
         if args.addr:
             try:
@@ -645,7 +697,7 @@ def main() -> int:
             except ValueError:
                 ap.error(f'--addr must be hex, got {args.addr!r}')
         if args.elf:
-            return nm_rtt_addr(args.elf)
+            return nm_rtt_addr(args.elf, stop=stop_requested)
         ap.error('need --elf (flashed elf, address via nm) or --addr')
 
     if args.backend == 'jlink':
@@ -686,11 +738,16 @@ def main() -> int:
                 ap.error('--backend openocd needs --cfg')
             con = OpenocdRtt(args.cfg, rtt_addr(), args.channel,
                              serial_no=args.probe, vid_pid=args.vid_pid,
-                             reset_before_attach=args.reset_before_attach)
+                             reset_before_attach=args.reset_before_attach,
+                             stop=stop_requested)
         else:
             con = JlinkRtt({'flasher': {'uid': args.probe, 'args': f'-device {args.device}'}},
-                           timeout=0.1)
+                           timeout=0.1, stop=stop_requested)
+    except _StopCapture:
+        return 0
     except RttError as e:
+        if stop_requested():
+            return 0
         print(e, file=sys.stderr)
         return 1
     except KeyboardInterrupt:
@@ -725,8 +782,7 @@ def main() -> int:
     rc = 0
     seen = b''   # pre-release accumulator for the banner check only
     try:
-        while ((deadline is None or time.monotonic() < deadline) and
-               not (args.stop_file and os.path.exists(args.stop_file))):
+        while ((deadline is None or time.monotonic() < deadline) and not stop_requested()):
             try:
                 chunk = con.read(con.in_waiting or 1)
             except RttError as e:


### PR DESCRIPTION
Use platform-specific process group creation and termination so J-Link, OpenOCD, and dump helpers are retired reliably on Windows as well as POSIX. Resolve Windows executable names while preserving environment overrides and report missing tools cleanly.

Add an optional stop file for ending indefinite captures from automation without signals. Cover executable selection, process cleanup, and stop-file handling in the RTT HIL tests.