### PR TITLE
Fix DWC2 DMA data toggle mismatch in IN-transfers

### DIFF
--- a/src/portable/synopsys/dwc2/hcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/hcd_dwc2.c
@@ -1129,6 +1129,10 @@ static bool handle_channel_in_dma(dwc2_regs_t* dwc2, uint8_t ch_id, uint32_t hci
         channel_send_in_token(dwc2, channel);
       }
     } else if (hcint & (HCINT_XFER_COMPLETE | HCINT_STALL | HCINT_BABBLE_ERR)) {
+      if (edpt->hcchar_bm.ep_num != 0 && (hcint & HCINT_XFER_COMPLETE)) {
+        edpt->next_pid = hctsiz.pid; // save pid (already toggled)
+      }
+
       const uint16_t remain_bytes = (uint16_t) hctsiz.xfer_size;
       const uint16_t remain_packets = hctsiz.packet_count;
       const uint16_t actual_len = edpt->buflen - remain_bytes;


### PR DESCRIPTION
In the DWC2 driver, when an IN transfer completes in non-DMA mode, the driver correctly reads the updated `pid` and saves it to `next_pid`:

```c
static bool handle_channel_in_slave(dwc2_regs_t* dwc2, uint8_t ch_id, uint32_t hcint) {
  // ...
  if (hcint & HCINT_XFER_COMPLETE) {
    if (edpt->hcchar_bm.ep_num != 0) {
      edpt->next_pid = hctsiz.pid; // save pid (already toggled)
    }
  // ...
}
```

However, the handler for DMA mode (`handle_channel_in_dma`) was missing this logic. If the expected number of packets was not received, then for all subsequent transfers the driver would program the wrong DATA0/DATA1 pid for their initial packets.

With this patch the DMA handler now matches the non-DMA handler.

The issue was observed when interfacing with a LAN9500. After some time, ethernet frames would start missing their first 64 bytes, because the first USB packet in each transfer was discarded due to the DATA0/DATA1 mismatch.

