### PR TITLE
lpc40: make USB host work on ea4088_quickstart

### DIFF
--- a/docs/reference/hil_boards.md
+++ b/docs/reference/hil_boards.md
@@ -2,7 +2,7 @@
 
 ### ci rig
 
-27 boards, from `test/hil/tinyusb.json`.
+28 boards, from `test/hil/tinyusb.json`.
 
 | Board                    | Roles              | Flasher   | Variants                                               | Note                                                                                                                                                                   |
 |--------------------------|--------------------|-----------|--------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -14,6 +14,7 @@
 | max32666fthr             | device             | openocd   |                                                        |                                                                                                                                                                        |
 | metro_m4_express         | device, dual       | jlink     | metro_m4_express                                       | pl23x; audio_test_freertos skipped: samd51 iso-IN capture fails (arecord EIO)                                                                                          |
 | lpcxpresso11u37          | device             | jlink     |                                                        |                                                                                                                                                                        |
+| ea4088_quickstart        | device, host, dual | jlink     | ea4088_quickstart                                      | console is the LPC-Link2's RTT channel: this probe has no VCOM (rtt skill)                                                                                             |
 | lpcxpresso55s28          | device             | jlink     |                                                        |                                                                                                                                                                        |
 | ra4m1_ek                 | device             | jlink     |                                                        |                                                                                                                                                                        |
 | raspberry_pi_pico        | device, host, dual | openocd   | raspberry_pi_pico                                      |                                                                                                                                                                        |

--- a/docs/superpowers/followup/pr3853-rtt-harness-adoption.md
+++ b/docs/superpowers/followup/pr3853-rtt-harness-adoption.md
@@ -12,36 +12,26 @@ src-level `board_putchar` asymmetry this work surfaced has its own handoff
   ea4088_quickstart runs its host suite over RTT (16 passed / 0 failed / 3
   skipped, the 'hil: read the host console over RTT when the probe has no VCOM' commit), and the `rtt` skill's boards.md carries the
   validated matrix.
-- `test_host_device_info` honors `"logger": "rtt"` (hil_test.py, `test_host_device_info`; the eof fail-fast assert sits in its read loop):
-  in RTT mode it resets via the flasher BEFORE opening the console (which
-  then owns the probe; Commander delivers the buffered boot burst) and its
-  read loop fails fast on `JlinkRtt.eof` instead of blaming the board.
+- All three host tests honor `"logger": "rtt"`: `test_host_device_info`,
+  `test_host_cdc_msc_hid` and `test_host_msc_file_explorer` open through
+  `open_console_reset()` (hil_test.py), which does the per-console reset
+  ordering — RTT resets via the flasher BEFORE opening (the console owns the
+  probe; Commander delivers the buffered boot burst), VCOM resets after — and
+  each read loop fails fast on `JlinkRtt.eof` instead of blaming the board.
+  Landed with the ea4088_quickstart roster entry; the interim load-time gate
+  that rejected `logger: rtt` + `is_cdc`/`is_msc` is gone.
 
 ## Remaining gaps
 
-1. **`test_host_cdc_msc_hid` and `test_host_msc_file_explorer` (hil_test.py) still call `hil_util.get_serial_dev(flasher["uid"], ...)`
-   directly** — on a `logger: rtt` board with `is_cdc`/`is_msc` fixtures they
-   would fail with the same "No serial device found" the console work fixed
-   for device_info (an interim load-time gate in `hil_test.py` now rejects
-   that combination up front; delete the gate when this lands). Fix: route
-   both through `open_board_console(board)` — but design the conversion
-   reset-aware rather than hand-copying device_info's dual branch: hoist a
-   `reset=` parameter into `open_board_console` that does the per-console
-   ordering itself (RTT: reset via flasher BEFORE opening — the console owns
-   the probe; VCOM: reset after open to catch the banner), and REMOVE the
-   existing post-open `# reset device to catch mount messages` blocks in both
-   tests (grep the marker — line numbers churn) — kept as-is on an RTT board they reset
-   while the console holds the probe. `JlinkRtt` carries input for their
-   menus and implements the `reset_input_buffer()` those tests call.
-2. **`hil_pool_check.check_host_serial` carries its own inline RTT branch**
+1. **`hil_pool_check.check_host_serial` carries its own inline RTT branch**
    (reset → `JlinkRtt` → poll through `hil_util.strip_banner`) — RTT boards
    ARE health-checkable today, but the console-opening logic now lives in
-   two places (`open_board_console` in hil_test.py and this branch), each
-   with its own reset-ordering. Fix: hoist `open_board_console()` into
-   `hil_util.py` with the `reset=` parameter from item 1 and collapse
-   pool_check's branch onto it; keep the `do_reset` flush semantics for the
-   VCOM path intact.
-3. **OpenOCD console backend in the harness**: the skill's CLI
+   two places (`open_console_reset` in hil_test.py and this branch), each
+   with its own reset-ordering. Fix: hoist `open_console_reset()` into
+   `hil_util.py` next to `open_board_console()` and collapse pool_check's
+   branch onto it; keep the `do_reset` flush semantics for the VCOM path
+   intact.
+2. **OpenOCD console backend in the harness**: the skill's CLI
    (`tools/rtt.py --backend openocd`, class
    `OpenocdRtt` in the same module) is built, deduplicated behind a shared
    base class next to `JlinkRtt` in `tools/rtt.py`, re-exported by
@@ -55,8 +45,6 @@ src-level `board_putchar` asymmetry this work surfaced has its own handoff
 
 ## Validation for this follow-up
 
-Run the ea4088 local host suite (a board with a `is_cdc`+`is_msc` capable
-device attached to J3, or the rig's frdm_k64f/mimxrt1064 with a temporary
-`logger: rtt` entry) so cdc_msc_hid and msc_file_explorer actually execute
-over RTT; then a `hil_pool_check.py` pass on a no-VCOM board. Delete this doc
-when the follow-up PR lands.
+A `hil_pool_check.py` pass on a no-VCOM board (ea4088_quickstart), plus the
+ea4088 host suite to show the collapse did not change the reset ordering the
+three tests depend on. Delete this doc when the follow-up PR lands.

--- a/examples/dual/host_info_to_device_cdc/only.txt
+++ b/examples/dual/host_info_to_device_cdc/only.txt
@@ -9,3 +9,4 @@ mcu:STM32F4
 mcu:STM32F7
 mcu:STM32H7
 mcu:ESP32P4
+mcu:LPC40XX

--- a/examples/dual/host_info_to_device_cdc/src/main.c
+++ b/examples/dual/host_info_to_device_cdc/src/main.c
@@ -234,10 +234,10 @@ void cdc_task(void) {
 // Host Get device information
 //--------------------------------------------------------------------+
 static void print_device_info(uint8_t daddr, const tusb_desc_device_t* desc_device) {
-  // Get String descriptor using Sync API
-  uint16_t serial[64];
-  uint16_t buf[128];
-  (void) buf;
+  // Get String descriptor using Sync API. The buffers are written by the host controller,
+  // so they must sit in memory it can reach (and be cache-line aligned where dcache is on).
+  static CFG_TUH_MEM_SECTION CFG_TUH_MEM_ALIGN uint16_t serial[64];
+  static CFG_TUH_MEM_SECTION CFG_TUH_MEM_ALIGN uint16_t buf[128];
 
   cdc_printf("Device %u: ID %04x:%04x SN ", daddr, desc_device->idVendor, desc_device->idProduct);
   uint8_t xfer_result = tuh_descriptor_get_serial_string_sync(daddr, LANGUAGE_ID, serial, sizeof(serial));

--- a/examples/dual/host_info_to_device_cdc/src/main.c
+++ b/examples/dual/host_info_to_device_cdc/src/main.c
@@ -72,6 +72,11 @@ static uint32_t blink_interval_ms = BLINK_NOT_MOUNTED;
 static bool               is_printable[CFG_TUH_DEVICE_MAX + 1] = {0};
 static tusb_desc_device_t descriptor_device[CFG_TUH_DEVICE_MAX+1];
 
+CFG_TUH_MEM_SECTION struct {
+  TUH_EPBUF_DEF(serial, 64*sizeof(uint16_t));
+  TUH_EPBUF_DEF(buf, 128*sizeof(uint16_t));
+} desc;
+
 static void print_utf16(uint16_t *temp_buf, size_t buf_len);
 static void print_device_info(uint8_t daddr, const tusb_desc_device_t* desc_device);
 
@@ -234,19 +239,18 @@ void cdc_task(void) {
 // Host Get device information
 //--------------------------------------------------------------------+
 static void print_device_info(uint8_t daddr, const tusb_desc_device_t* desc_device) {
-  // Get String descriptor using Sync API. The buffers are written by the host controller,
-  // so they must sit in memory it can reach (and be cache-line aligned where dcache is on).
-  static CFG_TUH_MEM_SECTION CFG_TUH_MEM_ALIGN uint16_t serial[64];
-  static CFG_TUH_MEM_SECTION CFG_TUH_MEM_ALIGN uint16_t buf[128];
-
   cdc_printf("Device %u: ID %04x:%04x SN ", daddr, desc_device->idVendor, desc_device->idProduct);
-  uint8_t xfer_result = tuh_descriptor_get_serial_string_sync(daddr, LANGUAGE_ID, serial, sizeof(serial));
+  uint8_t xfer_result = XFER_RESULT_FAILED;
+  if (desc_device->iSerialNumber != 0) {
+    xfer_result = tuh_descriptor_get_serial_string_sync(daddr, LANGUAGE_ID, desc.serial, sizeof(desc.serial));
+  }
   if (XFER_RESULT_SUCCESS != xfer_result) {
+    uint16_t *serial = (uint16_t *)(uintptr_t)desc.serial;
     serial[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * 1 + 2));
     serial[1] = '0';
     serial[2] = 0;
   }
-  print_utf16(serial, TU_ARRAY_SIZE(serial));
+  print_utf16((uint16_t *)(uintptr_t)desc.serial, sizeof(desc.serial) / 2);
   cdc_printf("\r\n");
 
   cdc_printf("Device Descriptor:\r\n");
@@ -262,27 +266,31 @@ static void print_device_info(uint8_t daddr, const tusb_desc_device_t* desc_devi
   cdc_printf("  bcdDevice           %04x\r\n"   , desc_device->bcdDevice);
 
   cdc_printf("  iManufacturer       %u     "     , desc_device->iManufacturer);
-  xfer_result = tuh_descriptor_get_manufacturer_string_sync(daddr, LANGUAGE_ID, buf, sizeof(buf));
-  if (XFER_RESULT_SUCCESS == xfer_result) {
-    print_utf16(buf, TU_ARRAY_SIZE(buf));
+  if (desc_device->iManufacturer != 0) {
+    if (XFER_RESULT_SUCCESS ==
+        tuh_descriptor_get_manufacturer_string_sync(daddr, LANGUAGE_ID, desc.buf, sizeof(desc.buf))) {
+      print_utf16((uint16_t *)(uintptr_t)desc.buf, sizeof(desc.buf) / 2);
+    }
   }
   cdc_printf("\r\n");
 
   cdc_printf("  iProduct            %u     "     , desc_device->iProduct);
-  xfer_result = tuh_descriptor_get_product_string_sync(daddr, LANGUAGE_ID, buf, sizeof(buf));
-  if (XFER_RESULT_SUCCESS == xfer_result) {
-    print_utf16(buf, TU_ARRAY_SIZE(buf));
+  if (desc_device->iProduct != 0) {
+    if (XFER_RESULT_SUCCESS == tuh_descriptor_get_product_string_sync(daddr, LANGUAGE_ID, desc.buf, sizeof(desc.buf))) {
+      print_utf16((uint16_t *)(uintptr_t)desc.buf, sizeof(desc.buf) / 2);
+    }
   }
   cdc_printf("\r\n");
 
   cdc_printf("  iSerialNumber       %u     "     , desc_device->iSerialNumber);
-  cdc_printf("%s \r\n", (char*)serial); // serial is already to UTF-8
+  cdc_printf("%s \r\n", (char *)desc.serial); // serial is already to UTF-8
   cdc_printf("  bNumConfigurations  %u\r\n"     , desc_device->bNumConfigurations);
 }
 
 void tuh_enum_descriptor_device_cb(uint8_t daddr, tusb_desc_device_t const* desc_device) {
-  (void) daddr;
-  descriptor_device[daddr] = *desc_device; // save device descriptor
+  if (daddr <= CFG_TUH_DEVICE_MAX) {
+    descriptor_device[daddr] = *desc_device; // save device descriptor
+  }
 }
 
 void tuh_mount_cb(uint8_t daddr) {

--- a/examples/host/cdc_msc_hid/src/cdc_app.c
+++ b/examples/host/cdc_msc_hid/src/cdc_app.c
@@ -42,11 +42,24 @@ static size_t console_read(uint8_t *buf, size_t bufsize) {
   return count;
 }
 
-static size_t console_write(const uint8_t *buf, size_t bufsize) {
+// Give up forwarding to the console after this long without progress. Not every board's
+// board_uart_write() reports "no console here" the same way, so the loop below cannot rely
+// on the return value alone to know when to stop.
+enum { CONSOLE_STALL_MS = 10 };
+
+// Returns bytes written, 0 if the console cannot take them right now, negative if this
+// board has no console at all.
+static int console_write(const uint8_t *buf, size_t bufsize) {
+#if defined(LOGGER_RTT)
+  // The console is the debug probe, not a UART: board_uart_write() is a stub on those
+  // boards. NO_BLOCK_SKIP writes all or nothing, so 0 means the probe has not drained the
+  // up-buffer yet.
+  return (int) SEGGER_RTT_Write(0, buf, (unsigned) bufsize);
+#else
   // Use board_uart_write directly for non-blocking behavior.
   // board_putchar -> sys_write has a blocking retry loop that causes UART RX overrun.
-  int wr = board_uart_write(buf, (int) bufsize);
-  return (wr > 0) ? (size_t) wr : 0;
+  return board_uart_write(buf, (int) bufsize);
+#endif
 }
 
 // forward from console to usbh
@@ -70,11 +83,23 @@ void cdc_app_task(void) {
   uint8_t  buf[64];
   uint32_t count = tuh_cdc_read(idx, buf, sizeof(buf));
   uint32_t wr    = 0;
+  uint32_t progress_ms = tusb_time_millis_api();
 
   do {
-    // uart write is slow, while waiting forward uart -> usbh else uart rx can be overflow
+    // console write is slow, while waiting forward console -> usbh else its rx can overflow
     if (count) {
-      wr += console_write(buf + wr, count - wr);
+      const int written = console_write(buf + wr, count - wr);
+      if (written < 0) {
+        break; // no console on this board at all
+      }
+      if (written > 0) {
+        wr += (uint32_t) written;
+        progress_ms = tusb_time_millis_api();
+      } else if (tusb_time_millis_api() - progress_ms > CONSOLE_STALL_MS) {
+        // a TX FIFO or an RTT up-buffer is only ever transiently full: nothing draining it
+        // must not stall the host task, so drop the rest
+        break;
+      }
     }
     console_to_usbh(idx);
   } while (wr < count);

--- a/examples/host/device_info/src/main.c
+++ b/examples/host/device_info/src/main.c
@@ -66,10 +66,11 @@ static uint32_t blink_interval_ms = BLINK_NOT_MOUNTED;
 // Declare for buffer for usb transfer, may need to be in USB/DMA section and
 // multiple of dcache line size if dcache is enabled (for some ports).
 CFG_TUH_MEM_SECTION struct {
-  TUH_EPBUF_TYPE_DEF(tusb_desc_device_t, device);
   TUH_EPBUF_DEF(serial, 64*sizeof(uint16_t));
   TUH_EPBUF_DEF(buf, 128*sizeof(uint16_t));
 } desc;
+
+static tusb_desc_device_t descriptor_device[CFG_TUH_DEVICE_MAX + 1];
 
 void led_blinking_task(void* param);
 void print_devinfo_task(void* param);
@@ -117,6 +118,12 @@ int main(void) {
 
 /*------------- TinyUSB Callbacks -------------*/
 
+void tuh_enum_descriptor_device_cb(uint8_t daddr, const tusb_desc_device_t *desc_device) {
+  if (daddr <= CFG_TUH_DEVICE_MAX) {
+    descriptor_device[daddr] = *desc_device;
+  }
+}
+
 // Invoked when device is mounted (configured). Runs in the host task — keep
 // it minimal. The actual descriptor fetching/printing happens in
 // print_devinfo_task() below, which runs in a different context (main loop
@@ -144,18 +151,11 @@ void tuh_umount_cb(uint8_t daddr) {
 // OS_NONE / dedicated FreeRTOS task on RTOS).
 //--------------------------------------------------------------------+
 
-static void print_one_device(uint8_t daddr) {
-  // Get Device Descriptor
-  uint8_t xfer_result = tuh_descriptor_get_device_sync(daddr, &desc.device, 18);
-  if (XFER_RESULT_SUCCESS != xfer_result) {
-    printf("Failed to get device descriptor\r\n");
-    return;
-  }
+static void print_one_device(uint8_t daddr, const tusb_desc_device_t *desc_device) {
+  printf("Device %u: ID %04x:%04x SN ", daddr, desc_device->idVendor, desc_device->idProduct);
 
-  printf("Device %u: ID %04x:%04x SN ", daddr, desc.device.idVendor, desc.device.idProduct);
-
-  xfer_result = XFER_RESULT_FAILED;
-  if (desc.device.iSerialNumber != 0) {
+  uint8_t xfer_result = XFER_RESULT_FAILED;
+  if (desc_device->iSerialNumber != 0) {
     xfer_result = tuh_descriptor_get_serial_string_sync(daddr, LANGUAGE_ID, desc.serial, sizeof(desc.serial));
   }
   if (XFER_RESULT_SUCCESS != xfer_result) {
@@ -168,36 +168,36 @@ static void print_one_device(uint8_t daddr) {
   printf("\r\n");
 
   printf("Device Descriptor:\r\n");
-  printf("  bLength             %u\r\n", desc.device.bLength);
-  printf("  bDescriptorType     %u\r\n", desc.device.bDescriptorType);
-  printf("  bcdUSB              %04x\r\n", desc.device.bcdUSB);
-  printf("  bDeviceClass        %u\r\n", desc.device.bDeviceClass);
-  printf("  bDeviceSubClass     %u\r\n", desc.device.bDeviceSubClass);
-  printf("  bDeviceProtocol     %u\r\n", desc.device.bDeviceProtocol);
-  printf("  bMaxPacketSize0     %u\r\n", desc.device.bMaxPacketSize0);
-  printf("  idVendor            0x%04x\r\n", desc.device.idVendor);
-  printf("  idProduct           0x%04x\r\n", desc.device.idProduct);
-  printf("  bcdDevice           %04x\r\n", desc.device.bcdDevice);
+  printf("  bLength             %u\r\n", desc_device->bLength);
+  printf("  bDescriptorType     %u\r\n", desc_device->bDescriptorType);
+  printf("  bcdUSB              %04x\r\n", desc_device->bcdUSB);
+  printf("  bDeviceClass        %u\r\n", desc_device->bDeviceClass);
+  printf("  bDeviceSubClass     %u\r\n", desc_device->bDeviceSubClass);
+  printf("  bDeviceProtocol     %u\r\n", desc_device->bDeviceProtocol);
+  printf("  bMaxPacketSize0     %u\r\n", desc_device->bMaxPacketSize0);
+  printf("  idVendor            0x%04x\r\n", desc_device->idVendor);
+  printf("  idProduct           0x%04x\r\n", desc_device->idProduct);
+  printf("  bcdDevice           %04x\r\n", desc_device->bcdDevice);
 
-  printf("  iManufacturer       %u     ", desc.device.iManufacturer);
-  if (desc.device.iManufacturer != 0) {
+  printf("  iManufacturer       %u     ", desc_device->iManufacturer);
+  if (desc_device->iManufacturer != 0) {
     if (XFER_RESULT_SUCCESS == tuh_descriptor_get_manufacturer_string_sync(daddr, LANGUAGE_ID, desc.buf, sizeof(desc.buf))) {
       print_utf16((uint16_t*)(uintptr_t) desc.buf, sizeof(desc.buf)/2);
     }
   }
   printf("\r\n");
 
-  printf("  iProduct            %u     ", desc.device.iProduct);
-  if (desc.device.iProduct != 0) {
+  printf("  iProduct            %u     ", desc_device->iProduct);
+  if (desc_device->iProduct != 0) {
     if (XFER_RESULT_SUCCESS == tuh_descriptor_get_product_string_sync(daddr, LANGUAGE_ID, desc.buf, sizeof(desc.buf))) {
       print_utf16((uint16_t*)(uintptr_t) desc.buf, sizeof(desc.buf)/2);
     }
   }
   printf("\r\n");
 
-  printf("  iSerialNumber       %u     ", desc.device.iSerialNumber);
+  printf("  iSerialNumber       %u     ", desc_device->iSerialNumber);
   printf("%s\r\n", (char*)desc.serial); // serial is already UTF-8
-  printf("  bNumConfigurations  %u\r\n", desc.device.bNumConfigurations);
+  printf("  bNumConfigurations  %u\r\n", desc_device->bNumConfigurations);
 }
 
 void print_devinfo_task(void* param) {
@@ -209,7 +209,7 @@ void print_devinfo_task(void* param) {
     for (uint8_t daddr = 1; daddr < TU_ARRAY_SIZE(need_devinfo); daddr++) {
       if (need_devinfo[daddr]) {
         need_devinfo[daddr] = false;
-        print_one_device(daddr);
+        print_one_device(daddr, &descriptor_device[daddr]);
       }
     }
 #if CFG_TUSB_OS == OPT_OS_FREERTOS

--- a/hw/bsp/board_api.h
+++ b/hw/bsp/board_api.h
@@ -39,6 +39,10 @@ extern "C" {
 
 #include "tusb.h"
 
+#if defined(LOGGER_RTT)
+#include "SEGGER_RTT.h"
+#endif
+
 #if CFG_TUSB_OS == OPT_OS_ZEPHYR
   #include <zephyr/kernel.h>
 #elif CFG_TUSB_OS == OPT_OS_FREERTOS

--- a/hw/bsp/lpc40/boards/ea4088_quickstart/board.h
+++ b/hw/bsp/lpc40/boards/ea4088_quickstart/board.h
@@ -59,9 +59,10 @@ static const PINMUX_GRP_T pinmuxing[] = {
     { 0, 29, (IOCON_FUNC1 | IOCON_MODE_INACT) }, // D+1
     { 0, 30, (IOCON_FUNC1 | IOCON_MODE_INACT) }, // D-1
     { 1, 18, (IOCON_FUNC1 | IOCON_MODE_INACT) }, // UP LED1
-    { 1, 19, (IOCON_FUNC2 | IOCON_MODE_INACT) }, // PPWR1
-//  {2, 14, (IOCON_FUNC2 | IOCON_MODE_INACT)}, // VBUS1
-//  {2, 15, (IOCON_FUNC2 | IOCON_MODE_INACT)}, // OVRCR1
+    // U7 (STMPS2171) enables VBUS on a HIGH level, but USB_PPWR1 asserts LOW, so the port
+    // never gets power while the peripheral function drives this pin. Keep it a GPIO and
+    // drive it high in board_init() instead.
+    { 1, 19, (IOCON_FUNC0 | IOCON_MODE_INACT) }, // VBUS1 enable (active high)
 
     // USB2 as Device
     { 0, 31, (IOCON_FUNC1 | IOCON_MODE_INACT) }, // D+2

--- a/hw/bsp/lpc40/family.c
+++ b/hw/bsp/lpc40/family.c
@@ -121,6 +121,11 @@ void board_init(void) {
 
   // set portfunc: USB1 = host, USB2 = device
   LPC_USB->StCtrl = 0x3;
+
+  // VBUS on the USB1 host connector, see the P1.19 note in board.h. Driven either way:
+  // left as an input it would float the switch enable in a device-only build.
+  Chip_GPIO_SetPinState(LPC_GPIO, 1, 19, CFG_TUH_ENABLED);
+  Chip_GPIO_SetPinDIROutput(LPC_GPIO, 1, 19);
 }
 
 //--------------------------------------------------------------------+

--- a/hw/bsp/lpc40/family.cmake
+++ b/hw/bsp/lpc40/family.cmake
@@ -33,6 +33,8 @@ function(family_add_board BOARD_TARGET)
     __USE_LPCOPEN
     CORE_M4
     CFG_TUSB_MEM_SECTION=__attribute__\(\(section\(\".data.$RAM2\"\)\)\)
+    CFG_TUD_MEM_SECTION=__attribute__\(\(section\(\".data.$RAM2\"\)\)\)
+    CFG_TUH_MEM_SECTION=__attribute__\(\(section\(\".data.$RAM2\"\)\)\)
     )
   target_include_directories(${BOARD_TARGET} PUBLIC
     ${SDK_DIR}/inc

--- a/hw/bsp/lpc40/family.cmake
+++ b/hw/bsp/lpc40/family.cmake
@@ -35,6 +35,8 @@ function(family_add_board BOARD_TARGET)
     CFG_TUSB_MEM_SECTION=__attribute__\(\(section\(\".data.$RAM2\"\)\)\)
     CFG_TUD_MEM_SECTION=__attribute__\(\(section\(\".data.$RAM2\"\)\)\)
     CFG_TUH_MEM_SECTION=__attribute__\(\(section\(\".data.$RAM2\"\)\)\)
+    # host is on root-hub port index 0; the dual examples would otherwise default it to 1
+    BOARD_TUH_RHPORT=0
     )
   target_include_directories(${BOARD_TARGET} PUBLIC
     ${SDK_DIR}/inc

--- a/hw/bsp/lpc40/family.mk
+++ b/hw/bsp/lpc40/family.mk
@@ -10,6 +10,7 @@ CFLAGS += \
   -DCFG_TUSB_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
   -DCFG_TUD_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
   -DCFG_TUH_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
+  -DBOARD_TUH_RHPORT=0 \
   -DCFG_TUSB_MCU=OPT_MCU_LPC40XX
 
 # mcu driver cause following warnings

--- a/hw/bsp/lpc40/family.mk
+++ b/hw/bsp/lpc40/family.mk
@@ -8,6 +8,8 @@ CFLAGS += \
   -DCORE_M4 \
   -D__USE_LPCOPEN \
   -DCFG_TUSB_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
+  -DCFG_TUD_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
+  -DCFG_TUH_MEM_SECTION='__attribute__((section(".data.$$RAM2")))' \
   -DCFG_TUSB_MCU=OPT_MCU_LPC40XX
 
 # mcu driver cause following warnings

--- a/src/portable/ohci/ohci.c
+++ b/src/portable/ohci/ohci.c
@@ -232,6 +232,18 @@ bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
 
   tusb_time_delay_ms_api(OHCI_REG->rh_descriptorA_bit.power_on_to_good_time * 2); // Wait POTG after power up
 
+  // A device attached before this point sets the port's connect status change, but the RHSC
+  // interrupt that went with it was cleared above and no new edge will follow. Scan the ports
+  // once so an already-connected device is still enumerated.
+  for (uint8_t i = 0; i < TUP_OHCI_RHPORTS; i++) {
+    if (OHCI_REG->rhport_status_bit[i].current_connect_status) {
+      // one write does both: w1c the stale ConnectStatusChange, else the next RHSC reports
+      // this device again, and w1s PortReset to reset the port the way the RHSC path does
+      OHCI_REG->rhport_status[i] = RHPORT_CONNECT_STATUS_CHANGE_MASK | RHPORT_PORT_RESET_STATUS_MASK;
+      hcd_event_device_attach(i, false);
+    }
+  }
+
   return true;
 }
 

--- a/test/hil/hil_test.py
+++ b/test/hil/hil_test.py
@@ -316,6 +316,28 @@ def open_board_console(board: Board):
     return ser
 
 
+def open_console_reset(board: Board):
+    """Open the board's console and reset it, ordered so the boot output survives.
+
+    The RTT console owns the probe, so the reset has to happen BEFORE it opens and the
+    ring keeps the boot burst for it; a VCOM survives the reset, so resetting after open
+    is what catches the banner. Both orders are needed because the lines the host tests
+    match on (mount messages, enumeration) print exactly once per boot.
+    """
+    flasher = board['flasher']
+
+    def _reset():
+        ret = getattr(hil_flash, f'reset_{flasher["name"].lower()}')(board)
+        assert ret.returncode == 0, 'Failed to reset device'
+
+    if board.get('logger') == 'rtt':
+        _reset()
+        return open_board_console(board)
+    ser = open_board_console(board)
+    _reset()
+    return ser
+
+
 def serial_write_all(ser: serial.Serial, data: bytes):
     # write_timeout is a deadline for the whole call. A timeout means the device stopped
     # draining, and it is fatal: pyserial loses the partial-write count on raise, so
@@ -560,24 +582,10 @@ def test_dual_host_info_to_device_cdc(board):
 # Tests: host
 # -------------------------------------------------------------
 def test_host_device_info(board):
-    flasher = board['flasher']
     declared_devs = [f'{d["vid_pid"]}_{d["serial"]}' for d in board['tests']['dev_attached']]
 
-    if board.get('logger') == 'rtt':
-        # The RTT console owns the probe, so reset BEFORE opening it (Commander then
-        # delivers the buffered boot burst). Unconditional, not only under --skip-flash:
-        # a previous run's console drained the ring, and the enumeration lines print
-        # only once — without this a re-run on unchanged firmware reads an empty ring.
-        ret = getattr(hil_flash, f'reset_{flasher["name"].lower()}')(board)
-        assert ret.returncode == 0, 'Failed to reset device'
-    ser = open_board_console(board)
+    ser = open_console_reset(board)
     try:
-        if board.get('logger') != 'rtt':
-            # reset device since we can miss the first line; on the VCOM the console
-            # survives the reset, so resetting after open catches the boot banner.
-            ret = getattr(hil_flash, f'reset_{flasher["name"].lower()}')(board)
-            assert ret.returncode == 0, 'Failed to reset device'
-
         data = b''
         timeout = enum_timeout()
         while timeout > 0:
@@ -652,172 +660,172 @@ def check_msc_info(lines, msc_devs):
 
 
 def test_host_cdc_msc_hid(board):
-    flasher = board['flasher']
     dev_attached = board['tests'].get('dev_attached', [])
     cdc_devs = [d for d in dev_attached if d.get('is_cdc')]
     msc_devs = [d for d in dev_attached if d.get('is_msc')]
     if not cdc_devs and not msc_devs:
         return 'skipped'
 
-    port = hil_util.get_serial_dev(flasher["uid"], None, None, 0)
-    ser = open_serial_dev(port)
-    ser.timeout = 0.1
+    # console + reset, in the order this board's console needs
+    ser = open_console_reset(board)
+    try:
 
-    # reset device to catch mount messages
-    ret = getattr(hil_flash, f'reset_{flasher["name"].lower()}')(board)
-    assert ret.returncode == 0, 'Failed to reset device'
+        data = b''
+        timeout = enum_timeout()
+        wait_cdc = len(cdc_devs) > 0
+        wait_msc = len(msc_devs) > 0
+        while timeout > 0:
+            # infra death is not a board failure: without this a dead JLinkExe/probe
+            # would burn the whole timeout and report as a mount failure
+            assert not getattr(ser, 'eof', False), \
+                'RTT console died (its server exited or the probe dropped off USB)'
+            new_data = ser.read(ser.in_waiting or 1)
+            if new_data:
+                data += new_data
+                cdc_ok = (not wait_cdc) or (b'CDC Interface is mounted' in data)
+                msc_ok = (not wait_msc) or (b'Disk Size' in data)
+                if cdc_ok and msc_ok:
+                    break
+            time.sleep(0.1)
+            timeout -= 0.1
 
-    data = b''
-    timeout = enum_timeout()
-    wait_cdc = len(cdc_devs) > 0
-    wait_msc = len(msc_devs) > 0
-    while timeout > 0:
-        new_data = ser.read(ser.in_waiting or 1)
-        if new_data:
-            data += new_data
-            cdc_ok = (not wait_cdc) or (b'CDC Interface is mounted' in data)
-            msc_ok = (not wait_msc) or (b'Disk Size' in data)
-            if cdc_ok and msc_ok:
-                break
-        time.sleep(0.1)
-        timeout -= 0.1
+        vid_pid_name = {
+            '0403_6001': 'FTDI', '0403_6010': 'FTDI', '0403_6011': 'FTDI', '0403_6014': 'FTDI',
+            '10c4_ea60': 'CP210x', '10c4_ea70': 'CP210x',
+            '067b_2303': 'PL2303', '067b_23a3': 'PL2303',
+            '1a86_7523': 'CH340', '1a86_7522': 'CH340',
+            '1a86_55d3': 'CH9102', '1a86_55d4': 'CH9102',
+        }
 
-    vid_pid_name = {
-        '0403_6001': 'FTDI', '0403_6010': 'FTDI', '0403_6011': 'FTDI', '0403_6014': 'FTDI',
-        '10c4_ea60': 'CP210x', '10c4_ea70': 'CP210x',
-        '067b_2303': 'PL2303', '067b_23a3': 'PL2303',
-        '1a86_7523': 'CH340', '1a86_7522': 'CH340',
-        '1a86_55d3': 'CH9102', '1a86_55d4': 'CH9102',
-    }
+        lines = data.decode('utf-8', errors='ignore').splitlines()
 
-    lines = data.decode('utf-8', errors='ignore').splitlines()
+        if cdc_devs:
+            assert b'CDC Interface is mounted' in data, 'CDC device not mounted on host'
+            dev = cdc_devs[0]
+            chip_name = vid_pid_name.get(dev['vid_pid'], dev['vid_pid'])
+            for l in lines:
+                if 'CDC Interface is mounted' in l:
+                    print(f'\r\n  {chip_name}: {l} ', end='')
 
-    if cdc_devs:
-        assert b'CDC Interface is mounted' in data, 'CDC device not mounted on host'
-        dev = cdc_devs[0]
-        chip_name = vid_pid_name.get(dev['vid_pid'], dev['vid_pid'])
-        for l in lines:
-            if 'CDC Interface is mounted' in l:
-                print(f'\r\n  {chip_name}: {l} ', end='')
+        if msc_devs:
+            assert b'MassStorage device is mounted' in data, 'MSC device not mounted on host'
+            assert b'Disk Size' in data, 'MSC Disk Size not reported'
+            check_msc_info(lines, msc_devs)
 
-    if msc_devs:
-        assert b'MassStorage device is mounted' in data, 'MSC device not mounted on host'
-        assert b'Disk Size' in data, 'MSC Disk Size not reported'
-        check_msc_info(lines, msc_devs)
+        # CDC echo test via flasher serial
+        if not cdc_devs:
+            return
 
-    # CDC echo test via flasher serial
-    if not cdc_devs:
+        time.sleep(2)
+        ser.read(ser.in_waiting)
+        ser.reset_input_buffer()
+
+        def rand_ascii(length):
+            return "".join(random.choices(string.ascii_letters + string.digits, k=length)).encode("ascii")
+
+        packet_size = 64
+
+        echo_len = 1024
+        echo_data = rand_ascii(echo_len)
+        ser.reset_input_buffer()
+        offset = 0
+        while offset < echo_len:
+            chunk_size = min(random.randint(1, packet_size), echo_len - offset)
+            serial_write_all(ser, echo_data[offset:offset + chunk_size])
+            echo = b''
+            t_end = time.monotonic() + 1.0
+            while time.monotonic() < t_end and len(echo) < chunk_size:
+                rd = ser.read(chunk_size - len(echo))
+                if rd:
+                    echo += rd
+            expected = echo_data[offset:offset + chunk_size]
+            assert echo == expected, (f'CDC echo mismatch at offset {offset} ({chunk_size} bytes):\n'
+                                      f'  expected: {expected}\n  received: {echo}')
+            offset += chunk_size
+
+    finally:
         ser.close()
-        return
-
-    time.sleep(2)
-    ser.read(ser.in_waiting)
-    ser.reset_input_buffer()
-
-    def rand_ascii(length):
-        return "".join(random.choices(string.ascii_letters + string.digits, k=length)).encode("ascii")
-
-    packet_size = 64
-
-    echo_len = 1024
-    echo_data = rand_ascii(echo_len)
-    ser.reset_input_buffer()
-    offset = 0
-    while offset < echo_len:
-        chunk_size = min(random.randint(1, packet_size), echo_len - offset)
-        serial_write_all(ser, echo_data[offset:offset + chunk_size])
-        echo = b''
-        t_end = time.monotonic() + 1.0
-        while time.monotonic() < t_end and len(echo) < chunk_size:
-            rd = ser.read(chunk_size - len(echo))
-            if rd:
-                echo += rd
-        expected = echo_data[offset:offset + chunk_size]
-        assert echo == expected, (f'CDC echo mismatch at offset {offset} ({chunk_size} bytes):\n'
-                                  f'  expected: {expected}\n  received: {echo}')
-        offset += chunk_size
-
-    ser.close()
 
 
 def test_host_msc_file_explorer(board):
-    flasher = board['flasher']
     msc_devs = [d for d in board['tests'].get('dev_attached', []) if d.get('is_msc')]
     if not msc_devs:
         return 'skipped'
 
-    port = hil_util.get_serial_dev(flasher["uid"], None, None, 0)
-    ser = open_serial_dev(port)
-    ser.timeout = 0.1
+    # console + reset, in the order this board's console needs
+    ser = open_console_reset(board)
+    try:
 
-    # reset device to catch mount messages
-    ret = getattr(hil_flash, f'reset_{flasher["name"].lower()}')(board)
-    assert ret.returncode == 0, 'Failed to reset device'
+        data = b''
+        timeout = enum_timeout()
+        while timeout > 0:
+            # infra death is not a board failure: without this a dead JLinkExe/probe
+            # would burn the whole timeout and report as a mount failure
+            assert not getattr(ser, 'eof', False), \
+                'RTT console died (its server exited or the probe dropped off USB)'
+            new_data = ser.read(ser.in_waiting or 1)
+            if new_data:
+                data += new_data
+                if b'Disk Size' in data:
+                    break
+            time.sleep(0.1)
+            timeout -= 0.1
+        assert b'Disk Size' in data, 'MSC device not mounted'
+        lines = data.decode('utf-8', errors='ignore').splitlines()
+        check_msc_info(lines, msc_devs)
 
-    data = b''
-    timeout = enum_timeout()
-    while timeout > 0:
-        new_data = ser.read(ser.in_waiting or 1)
-        if new_data:
-            data += new_data
-            if b'Disk Size' in data:
+        # Send "cat README.TXT" and check response (optional — file may not exist on all drives)
+        time.sleep(1)
+        ser.reset_input_buffer()
+        for ch in 'cat README.TXT\r':
+            serial_write_all(ser, ch.encode())
+            time.sleep(0.002)
+
+        resp = b''
+        t = 10.0
+        while t > 0:
+            rd = ser.read(max(1, ser.in_waiting))
+            if rd:
+                resp += rd
+            if b'>' in resp and resp.rstrip().endswith(b'>'):
                 break
-        time.sleep(0.1)
-        timeout -= 0.1
-    assert b'Disk Size' in data, 'MSC device not mounted'
-    lines = data.decode('utf-8', errors='ignore').splitlines()
-    check_msc_info(lines, msc_devs)
+            time.sleep(0.05)
+            t -= 0.05
 
-    # Send "cat README.TXT" and check response (optional — file may not exist on all drives)
-    time.sleep(1)
-    ser.reset_input_buffer()
-    for ch in 'cat README.TXT\r':
-        serial_write_all(ser, ch.encode())
-        time.sleep(0.002)
+        resp_text = resp.decode('utf-8', errors='ignore')
+        if MSC_README_TXT.decode() in resp_text:
+            print('README.TXT matched ', end='')
 
-    resp = b''
-    t = 10.0
-    while t > 0:
-        rd = ser.read(max(1, ser.in_waiting))
-        if rd:
-            resp += rd
-        if b'>' in resp and resp.rstrip().endswith(b'>'):
-            break
-        time.sleep(0.05)
-        t -= 0.05
+        time.sleep(0.5)
+        ser.reset_input_buffer()
+        for ch in 'dd 1024\r':
+            serial_write_all(ser, ch.encode())
+            time.sleep(0.002)
 
-    resp_text = resp.decode('utf-8', errors='ignore')
-    if MSC_README_TXT.decode() in resp_text:
-        print('README.TXT matched ', end='')
+        resp = b''
+        t = 30.0
+        while t > 0:
+            rd = ser.read(max(1, ser.in_waiting))
+            if rd:
+                resp += rd
+            if b'KB/s' in resp and b'>' in resp:
+                break
+            time.sleep(0.05)
+            t -= 0.05
 
-    time.sleep(0.5)
-    ser.reset_input_buffer()
-    for ch in 'dd 1024\r':
-        serial_write_all(ser, ch.encode())
-        time.sleep(0.002)
+        resp_text = resp.decode('utf-8', errors='ignore')
+        speed = None
+        for line in resp_text.splitlines():
+            if 'KB/s' in line:
+                print(f'{line.strip()} ', end='')
+                m = re.search(r'([\d.]+)\s*([KMG]B/s)', line)  # MSC read speed for the report cell
+                if m:
+                    speed = f'{m.group(1)} {m.group(2)}'
+                break
 
-    resp = b''
-    t = 30.0
-    while t > 0:
-        rd = ser.read(max(1, ser.in_waiting))
-        if rd:
-            resp += rd
-        if b'KB/s' in resp and b'>' in resp:
-            break
-        time.sleep(0.05)
-        t -= 0.05
+    finally:
+        ser.close()
 
-    resp_text = resp.decode('utf-8', errors='ignore')
-    speed = None
-    for line in resp_text.splitlines():
-        if 'KB/s' in line:
-            print(f'{line.strip()} ', end='')
-            m = re.search(r'([\d.]+)\s*([KMG]B/s)', line)  # MSC read speed for the report cell
-            if m:
-                speed = f'{m.group(1)} {m.group(2)}'
-            break
-
-    ser.close()
     assert speed is not None, 'MSC read produced no speed report (dd stalled or failed)'
     return speed
 
@@ -2461,17 +2469,6 @@ def main() -> None:
                               f'configured RTT console')
         print(f'warning: {msg} -- fine for prebuilt example sets, wrong for --build/CI '
               f'builds', flush=True)
-    rtt_fixture = [e['name'] for e in config_boards
-                   if e.get('logger') == 'rtt'
-                   and any(d.get('is_cdc') or d.get('is_msc')
-                           for d in e.get('tests', {}).get('dev_attached', []))]
-    if rtt_fixture:
-        # interim guard, removed when the followup lands: cdc_msc_hid/msc_file_explorer
-        # still open the flasher VCOM directly and would die mid-run on an rtt board
-        _rtt_config_abort(f'"logger": "rtt" boards cannot carry is_cdc/is_msc fixtures yet '
-                          f'(host cdc/msc tests bypass the RTT console — see '
-                          f'the rtt harness-adoption doc in docs/superpowers/followup/): {", ".join(rtt_fixture)}')
-
     if not config_boards:
         # same reason the unknown -b board exits 1: 'No tests were run.' with rc 0 reads as
         # a green HIL leg, so a roster edit emptying a leg's filter stops testing silently

--- a/test/hil/tinyusb.json
+++ b/test/hil/tinyusb.json
@@ -200,6 +200,42 @@
             }
         },
         {
+            "name": "ea4088_quickstart",
+            "uid": "22150C0C1508595343E1857B060000F5",
+            "comment": "console is the LPC-Link2's RTT channel: this probe has no VCOM (rtt skill)",
+            "logger": "rtt",
+            "variant": [
+                { "name": "ea4088_quickstart", "defines": ["LOGGER=rtt"], "flags": "-DBUFFER_SIZE_DOWN=128" }
+            ],
+            "tests": {
+                "device": true,
+                "host": true,
+                "dual": true,
+                "dev_attached": [
+                    {
+                        "vid_pid": "1a86_7523",
+                        "serial": "0",
+                        "is_cdc": true,
+                        "comment": "CH340 USB-serial behind the hub on USB-A J3, TX-RX shorted for the cdc echo half"
+                    },
+                    {
+                        "vid_pid": "346d_5678",
+                        "serial": "6265011211829708393",
+                        "is_msc": true,
+                        "block_size": 512,
+                        "block_count": 3891200,
+                        "msc_inquiry": "VendorCo ProductCode      2.00",
+                        "comment": "USB Disk 2.0 thumbdrive behind the same hub"
+                    }
+                ]
+            },
+            "flasher": {
+                "name": "jlink",
+                "uid": "611000000",
+                "args": "-device LPC4088"
+            }
+        },
+        {
             "name": "lpcxpresso55s28",
             "uid": "2BF1839A7D51F553A15AB03FD08F70AB",
             "tests": {


### PR DESCRIPTION
The EA LPC4088 QuickStart has both USB ports wired — U1 to the Type-A host
connector, U2 to the micro-B — but the host side had never worked. Four
things were in the way, one of them in shared OHCI code.

- **DMA placement.** The family passed only `CFG_TUSB_MEM_SECTION`, while every
  example's `tusb_config.h` pre-defines `CFG_TUD_MEM_SECTION`/`CFG_TUH_MEM_SECTION`
  as empty, so `tusb_option.h`'s fallback never applied and `ohci_data` landed in
  main SRAM. The USB AHB master cannot reach it: the controller latched
  `HcInterruptStatus.UE` and never wrote the HCCA.
- **VBUS polarity.** The host port's switch (STMPS2171) enables on a HIGH level,
  but `USB_PPWR1` asserts LOW, so muxing P1.19 to its peripheral function held the
  switch off. NXP's own lpcusblib HAL muxes it the same way, which is why the
  vendor host example fails on this board too.
- **A missed connect in `ohci.c`** — affects every OHCI user, not just this board.
  `hcd_init()` clears all pending interrupt flags before enabling its own set,
  which drops the RHSC that went with an already-present device while the root hub
  keeps ConnectStatusChange set. No new edge follows, so the port sits at CCS=1,
  CSC=1, PES=0 forever. Host-only builds mostly got away with it; a dual build
  initialises the device stack first, which moves detection into the cleared
  window. `hcd_init()` now scans the root-hub ports once and raises the attach
  itself.
- **Stack-allocated string buffers** in `dual/host_info_to_device_cdc`, written by
  the host controller, so on this family they came back as garbage.

`host/cdc_msc_hid` also could not run here: it writes the attached device's
output to the console via `board_uart_write()`, which is a stub on a board whose
console is the debug probe. It now goes through RTT on `LOGGER_RTT` builds, and
the forwarding loop is bounded by elapsed time rather than by the write's return
value — the stubs disagree on how they report "no console here" (`lpc40` returns
-1, `apm32f0xx` returns 0), so the return value alone cannot say when to stop.

Last commit adds the board to the HIL roster with `"logger": "rtt"` and routes
the two remaining host tests through the console abstraction, retiring the
load-time gate that rejected `is_cdc`/`is_msc` fixtures on RTT boards.

## Test

On the rig: **19 passed, 0 failed, 0 skipped** across device, host and dual.
usbtest 30/30, host MSC reads 682 KB/s, device CDC/MSC ~510 kB/s (full speed
behind the rig's hub).

Builds: all examples for `ea4088_quickstart` (43) and `lpcxpresso1769` (42, the
other OHCI user) — clean. `host/cdc_msc_hid` additionally built for
`stm32f407disco` to cover the real-UART console path. Unit tests 63/63,
`pre-commit run --all-files` clean.
