### PR TITLE
ci: one Claude review per PR at a time, effort high, Opus 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,10 @@ on:
     # those. Same-repo branches (yours or write-access contributors) auto-review.
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Skip drafts, and skip fork PRs (no secrets -> would only fail noisily)
@@ -50,9 +54,6 @@ jobs:
           # --comment makes the code-review command post its findings to the PR.
           # Without it the command only prints the review to the Actions log.
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
-          # TEMPORARY: expose the full Claude transcript in the Actions log for
-          # debugging. Revert to remove once done.
-          show_full_output: true
           # The headless review was blocked on two tools: compound Bash pipelines
           # (sed/python/grep) and Write (it dropped a check_headings.py helper to
           # inspect the diff). Default permission mode gates both; Read/Grep/Glob/
@@ -62,6 +63,6 @@ jobs:
           claude_args: |
             --max-turns 50
             --model claude-opus-4-8
-            --effort max
+            --effort high
             --allowedTools Bash,Write
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,7 +62,7 @@ jobs:
           # token, so any write is ephemeral and nothing can be pushed.
           claude_args: |
             --max-turns 50
-            --model claude-opus-4-8
+            --model claude-opus-5
             --effort high
             --allowedTools Bash,Write
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,4 +65,4 @@ jobs:
           # command allowlist can safely contain it. Claude still edits files and
           # the action commits/opens the PR; the resulting commit is verified by the
           # repo's CircleCI matrix. --max-turns gives room to investigate + fix.
-          claude_args: '--max-turns 30'
+          claude_args: '--max-turns 30 --model claude-opus-5'


### PR DESCRIPTION
- `concurrency` keyed on the PR number with `cancel-in-progress`: a new push cancels the stale in-flight review instead of stacking a second run on the same PR. The review posts its comment only at the end, so a cancelled run leaves nothing half-posted.
- `--effort max` to `--effort high`: the routine per-push review was the only job running the top setting; `high` is the documented default and Opus-tier review precision holds at lower effort.
- `claude-opus-4-8` to `claude-opus-5` on the review job; the @claude job now passes `--model claude-opus-5` explicitly instead of inheriting the action's default.
- Drop the transcript dump that was marked temporary.

This PR's own review run exercises the new configuration.
