### PR TITLE
docs: document STM32F7 low-speed hub limitation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,9 @@ Supported CPUs
 |              |    +------------------------+--------+------+-----------+------------------------+--------------------+
 |              |    | 105, 107               | ✅     | ✅   | ❌        | dwc2                   |                    |
 |              +----+------------------------+--------+------+-----------+------------------------+--------------------+
-|              | F2, F4, F7, H7, H7RS        | ✅     | ✅   | ✅        | dwc2                   |                    |
+|              | F2, F4, H7, H7RS            | ✅     | ✅   | ✅        | dwc2                   |                    |
+|              +-----------------------------+--------+------+-----------+------------------------+--------------------+
+|              | F7                          | ✅     | ✅   | ✅        | dwc2                   | LS hub issue [3]_  |
 |              +-----------------------------+--------+------+-----------+------------------------+--------------------+
 |              | C0, C5, G0, H5, U3          | ✅     | ✅   | ❌        | stm32_fsdev            | 2KB USB RAM        |
 |              +-----------------------------+--------+------+-----------+------------------------+--------------------+
@@ -328,6 +330,7 @@ Table Legend
 
 .. [1] NRND (Not Recommended for New Design), see `NXP LPC54600 issues <docs/reference/device_issues.rst#nxp-lpc54600>`_
 .. [2] ISO data loss, see `WCH CH32F20x/CH32V20x/CH32V30x issues <docs/reference/device_issues.rst#wch-ch32f20x-ch32v20x-ch32v30x>`_
+.. [3] Low-speed device through hub limitation, see `STM32F7 issues <docs/reference/device_issues.rst#stmicroelectronics-stm32f7>`_
 
 Development Tools
 -----------------

--- a/docs/reference/device_issues.rst
+++ b/docs/reference/device_issues.rst
@@ -65,6 +65,29 @@ USB.5: An isochronous IN endpoint sending a 1024-byte maximum-packet-size packet
 interrupt and its command/status entry is not updated. Workaround: cap the isochronous IN maximum
 packet size at 1023 bytes in the descriptor.
 
+STMicroelectronics STM32F7
+---------------------------------
+**Severity: High** when a low-speed device is connected through a hub to an internal full-speed interface
+
+Reference: `STM32F76xxx/77xxx Errata Sheet`_ OTG_FS 2.19.2 and OTG_HS 2.20.2
+
+.. _STM32F76xxx/77xxx Errata Sheet: https://www.st.com/resource/en/errata_sheet/es0334-stm32f76xxx-and-stm32f77xxx-device-errata-stmicroelectronics.pdf
+
+The transmitter state machine may hang when the host connects to a low-speed device through a hub using
+the full-speed interface. After a timeout, the controller disables the still-connected root port and raises
+a port interrupt. ST documents this for the STM32F76xxx/77xxx OTG_FS peripheral and for the OTG_HS
+peripheral when it uses its internal full-speed interface.
+
+TinyUSB hardware testing reproduced the same behavior on an STM32F723ZE, although the
+`STM32F72xxx/73xxx Errata Sheet`_ does not list this limitation. Treat the STM32F723 result as an observed
+silicon limitation rather than an official ST erratum.
+
+.. _STM32F72xxx/73xxx Errata Sheet: https://www.st.com/resource/en/errata_sheet/es0360-stm32f72xxx-and-stm32f73xxx-device-limitations-stmicroelectronics.pdf
+
+There is no software workaround. Connect the low-speed device directly, or use a high-speed root
+connection and a high-speed hub so the controller uses split transactions instead of low-speed preambles.
+ST notes that adding capacitance to the data lines may reduce the occurrence, but does not eliminate it.
+
 WCH CH32F20x/CH32V20x/CH32V30x
 ---------------------------------
 **Severity: Medium**


### PR DESCRIPTION
## Summary

- document the STM32F76xxx/77xxx transmitter hang when a low-speed device is reached through a hub over an internal full-speed interface
- record the equivalent STM32F723ZE behavior observed during hardware diagnosis while noting that ES0360 does not list it
- document direct attachment and high-speed split transactions as topology workarounds
- link the narrow limitation from the README support table while retaining full F7 support status

This is a documentation-only follow-up to the PR #3864 investigation. The STM32F723 wording deliberately identifies the result as observed behavior rather than an official ST erratum.

## Validation

- `python -m docutils --writer=html5 --halt=warning --report=warning README.rst NUL`
- `python -m docutils --writer=html5 --halt=warning --report=warning docs/reference/device_issues.rst NUL`
- `pre-commit run --files README.rst docs/reference/device_issues.rst`
- `python tools/build_doc.py -c -W` could not start because `myst_parser` is not installed; no dependency was downloaded for this worktree