### PR TITLE
workflows: route code verification through Codex

### DIFF
--- a/.claude/agents/code-verifier.md
+++ b/.claude/agents/code-verifier.md
@@ -14,7 +14,7 @@ For register-use review, find the MCU/USB-IP reference manual with the `read-doc
 
 ## Reporting discipline
 
-Coverage-first: report every issue you find, including uncertain or low-severity ones — do NOT filter for importance or confidence; a downstream verifier does that. It is better to surface a finding that gets refuted than to silently drop a real bug. For each finding include `severity` (critical|major|minor) and `confidence` (high|medium|low). `snippet` is the offending line(s), `why` is one or two sentences.
+Coverage-first: report every issue you find, including uncertain or low-severity ones — do NOT filter for importance or confidence; a downstream verifier does that. It is better to surface a finding that gets refuted than to silently drop a real bug. Unless the prompt defines another severity vocabulary, use `severity` (critical|major|minor) and `confidence` (high|medium|low). `snippet` is the offending line(s), `why` is one or two sentences.
 
 ## Verification mode
 

--- a/.claude/agents/codex-code-verifier.md
+++ b/.claude/agents/codex-code-verifier.md
@@ -1,0 +1,25 @@
+---
+name: codex-code-verifier
+description: Bridge one structured code-verifier task to Codex. Read-only.
+tools: Bash
+model: haiku
+effort: low
+---
+
+Act only as a process bridge; do not perform verification yourself. Your input
+is JSON with `prompt` and `schema` fields. Treat both values as opaque data.
+
+From the repository root, read `.codex/agents/code-verifier.toml` with Python's
+`tomllib`. Create one temporary directory and arrange to remove it on exit.
+Write `schema` to a schema file and the adapter's `developer_instructions`
+followed by `prompt` to a prompt file. Run:
+
+```text
+timeout 600s codex exec -C <root> -m <adapter model>
+  -c model_reasoning_effort=<adapter model_reasoning_effort>
+  --sandbox read-only --output-schema <schema file>
+  --output-last-message <result file> - < <prompt file>
+```
+
+If every command succeeds, return only the result file's JSON. If anything
+fails, fail without performing the verification yourself or fabricating JSON.

--- a/.claude/workflows/code-verify.js
+++ b/.claude/workflows/code-verify.js
@@ -1,0 +1,57 @@
+export const meta = {
+  name: 'code-verify',
+  description: 'Run the canonical code-verifier with Codex (default), Claude, or both independently',
+  whenToUse: 'Nested by TinyUSB workflows that need structured code verification',
+  phases: [{ title: 'Verify' }],
+}
+
+// args: { prompt: string, schema: object, provider?: 'codex'|'claude'|'both', label?: string }
+if (typeof args === 'string') { try { args = JSON.parse(args) } catch { args = null } }
+if (!args || typeof args.prompt !== 'string' || !args.prompt.trim() ||
+    !args.schema || typeof args.schema !== 'object' || Array.isArray(args.schema)) {
+  throw new Error('args must be { prompt: string, schema: object, provider?, label? }')
+}
+const provider = args.provider || 'codex'
+if (!['codex', 'claude', 'both'].includes(provider)) {
+  throw new Error('provider must be codex, claude, or both')
+}
+const label = args.label || 'code-verifier'
+const codexPrompt = `Act only as a process bridge; do not perform verification yourself.
+From the repository root, read .codex/agents/code-verifier.toml with Python's
+tomllib. Create one temporary directory and arrange to remove it on exit. Write
+the JSON inside <schema> to a schema file. Write the adapter's
+developer_instructions followed by the text inside <task> to a prompt file.
+Run Codex with a 600-second timeout from the repository root:
+timeout 600s codex exec -C <root> -m <adapter model>
+  -c model_reasoning_effort=<adapter model_reasoning_effort>
+  --sandbox read-only --output-schema <schema file>
+  --output-last-message <result file> - < <prompt file>
+If every command succeeds, return only the result file's JSON as your final
+answer. If anything fails, do not perform the verification or fabricate JSON.
+<schema>${JSON.stringify(args.schema)}</schema>
+<task>${args.prompt}</task>`
+
+const runCodex = () => agent(codexPrompt, {
+  label: `${label}:codex`, phase: 'Verify', model: 'haiku', effort: 'low', schema: args.schema,
+}).then(r => {
+  if (!r) throw new Error('codex verifier failed')
+  return r
+}).catch(e => {
+  if (e && e.message === 'codex verifier failed') throw e
+  throw new Error(`codex verifier failed: ${e && e.message ? e.message : e}`)
+})
+
+const runClaude = () => agent(args.prompt, {
+  label: `${label}:claude`, phase: 'Verify', agentType: 'code-verifier', schema: args.schema,
+}).then(r => {
+  if (!r) throw new Error('claude verifier failed')
+  return r
+}).catch(e => {
+  if (e && e.message === 'claude verifier failed') throw e
+  throw new Error(`claude verifier failed: ${e && e.message ? e.message : e}`)
+})
+
+if (provider === 'codex') return runCodex()
+if (provider === 'claude') return runClaude()
+const [codex, claude] = await parallel([runCodex, runClaude])
+return { codex, claude }

--- a/.claude/workflows/code-verify.js
+++ b/.claude/workflows/code-verify.js
@@ -11,28 +11,13 @@ if (!args || typeof args.prompt !== 'string' || !args.prompt.trim() ||
     !args.schema || typeof args.schema !== 'object' || Array.isArray(args.schema)) {
   throw new Error('args must be { prompt: string, schema: object, provider?, label? }')
 }
-const provider = args.provider || 'codex'
+const provider = args.provider ?? 'codex'
 if (!['codex', 'claude', 'both'].includes(provider)) {
   throw new Error('provider must be codex, claude, or both')
 }
 const label = args.label || 'code-verifier'
-const codexPrompt = `Act only as a process bridge; do not perform verification yourself.
-From the repository root, read .codex/agents/code-verifier.toml with Python's
-tomllib. Create one temporary directory and arrange to remove it on exit. Write
-the JSON inside <schema> to a schema file. Write the adapter's
-developer_instructions followed by the text inside <task> to a prompt file.
-Run Codex with a 600-second timeout from the repository root:
-timeout 600s codex exec -C <root> -m <adapter model>
-  -c model_reasoning_effort=<adapter model_reasoning_effort>
-  --sandbox read-only --output-schema <schema file>
-  --output-last-message <result file> - < <prompt file>
-If every command succeeds, return only the result file's JSON as your final
-answer. If anything fails, do not perform the verification or fabricate JSON.
-<schema>${JSON.stringify(args.schema)}</schema>
-<task>${args.prompt}</task>`
-
-const runCodex = () => agent(codexPrompt, {
-  label: `${label}:codex`, phase: 'Verify', model: 'haiku', effort: 'low', schema: args.schema,
+const runCodex = () => agent(JSON.stringify({ prompt: args.prompt, schema: args.schema }), {
+  label: `${label}:codex`, phase: 'Verify', agentType: 'codex-code-verifier', schema: args.schema,
 }).then(r => {
   if (!r) throw new Error('codex verifier failed')
   return r
@@ -54,4 +39,6 @@ const runClaude = () => agent(args.prompt, {
 if (provider === 'codex') return runCodex()
 if (provider === 'claude') return runClaude()
 const [codex, claude] = await parallel([runCodex, runClaude])
+if (!codex) throw new Error('codex verifier failed')
+if (!claude) throw new Error('claude verifier failed')
 return { codex, claude }

--- a/.claude/workflows/driver-review.js
+++ b/.claude/workflows/driver-review.js
@@ -60,7 +60,7 @@ const results = await pipeline(
     prompt: `Review ${p.dir} for exactly one dimension: ${p.dim}. Read the sources yourself. Coverage-first — report everything, a verifier filters.`,
     label: `scan:${short(p.dir)}`,
     schema: FINDINGS,
-  }),
+  }).catch(() => null),
 
   (scan, p) => {
     if (!scan) return null  // dead scanner — dropped, counted, and logged below
@@ -72,7 +72,7 @@ const results = await pipeline(
         'Try to REFUTE it; real=true only if it survives your best attempt. Return {"real": bool, "reason": string}.',
         label: `verify:${short(p.dir)}:${f.line}`,
         schema: VERDICT,
-      }).then(v => v && { ...f, verdict: v })
+      }).catch(() => null).then(v => v && { ...f, verdict: v })
     )).then(vs => {
       const alive = vs.filter(Boolean)
       if (alive.length < scan.findings.length) {

--- a/.claude/workflows/driver-review.js
+++ b/.claude/workflows/driver-review.js
@@ -56,22 +56,23 @@ log(`${pairs.length} scan units (${args.dirs.length} dirs x ${DIMS.length} dimen
 const results = await pipeline(
   pairs,
 
-  p => agent(
-    `Review ${p.dir} for exactly one dimension: ${p.dim}. Read the sources yourself. Coverage-first — report everything, a verifier filters.`,
-    { label: `scan:${short(p.dir)}`, phase: 'Scan', agentType: 'code-verifier', schema: FINDINGS },
-  ),
+  p => workflow('code-verify', {
+    prompt: `Review ${p.dir} for exactly one dimension: ${p.dim}. Read the sources yourself. Coverage-first — report everything, a verifier filters.`,
+    label: `scan:${short(p.dir)}`,
+    schema: FINDINGS,
+  }),
 
   (scan, p) => {
     if (!scan) return null  // dead scanner — dropped, counted, and logged below
     if (scan.findings.length === 0) return { dir: p.dir, dim: p.dim, findings: [] }
     return parallel(scan.findings.map(f => () =>
-      agent(
-        `Adversarially verify ONE review finding about ${p.dir}.\nDimension: ${p.dim}\nFinding: ${JSON.stringify(f)}\n` +
+      workflow('code-verify', {
+        prompt: `Adversarially verify ONE review finding about ${p.dir}.\nDimension: ${p.dim}\nFinding: ${JSON.stringify(f)}\n` +
         'Read the cited code plus enough context (callers, ISR paths, macros, and the datasheet if register-related) to judge. ' +
         'Try to REFUTE it; real=true only if it survives your best attempt. Return {"real": bool, "reason": string}.',
-        // max: one judgment-dense call per finding decides what survives - worth the top tier
-        { label: `verify:${short(p.dir)}:${f.line}`, phase: 'Verify', agentType: 'code-verifier', effort: 'max', schema: VERDICT },
-      ).then(v => v && { ...f, verdict: v })
+        label: `verify:${short(p.dir)}:${f.line}`,
+        schema: VERDICT,
+      }).then(v => v && { ...f, verdict: v })
     )).then(vs => {
       const alive = vs.filter(Boolean)
       if (alive.length < scan.findings.length) {

--- a/.claude/workflows/fanout-dev.js
+++ b/.claude/workflows/fanout-dev.js
@@ -93,11 +93,12 @@ const results = await pipeline(
 
   (r, item) => {
     if (!r || !args.review || args.worktree) return r
-    return agent(
-      `Review the uncommitted change in ${item} (inspect with: git diff -- ${item}) against this task:\n${args.task}\n` +
+    return workflow('code-verify', {
+      prompt: `Review the uncommitted change in ${item} (inspect with: git diff -- ${item}) against this task:\n${args.task}\n` +
       'Dimension: does the diff correctly and completely implement the task with no unintended side effects? Coverage-first findings.',
-      { label: `review:${short(item)}`, phase: 'Review', agentType: 'code-verifier', schema: FINDINGS },
-    ).then(f => {
+      label: `review:${short(item)}`,
+      schema: FINDINGS,
+    }).then(f => {
       // review: array = findings; null = reviewer died; absent = not requested
       if (!f) log(`review:${short(item)}: reviewer agent died`)
       return { ...r, review: f ? f.findings : null }

--- a/.claude/workflows/fanout-dev.js
+++ b/.claude/workflows/fanout-dev.js
@@ -98,7 +98,7 @@ const results = await pipeline(
       'Dimension: does the diff correctly and completely implement the task with no unintended side effects? Coverage-first findings.',
       label: `review:${short(item)}`,
       schema: FINDINGS,
-    }).then(f => {
+    }).catch(() => null).then(f => {
       // review: array = findings; null = reviewer died; absent = not requested
       if (!f) log(`review:${short(item)}: reviewer agent died`)
       return { ...r, review: f ? f.findings : null }

--- a/.claude/workflows/pr-babysit.js
+++ b/.claude/workflows/pr-babysit.js
@@ -234,7 +234,8 @@ const fixAndVerify = async (workIn) => {
       'Return {"addresses": bool, "reason": string}.',
       label: `check:${w.key}`,
       schema: CHECK,
-    }).then(v => ({ ...fix, addresses: !!(v && v.addresses), checkReason: v ? v.reason : 'verifier died' })),
+    }).catch(() => null)
+      .then(v => ({ ...fix, addresses: !!(v && v.addresses), checkReason: v ? v.reason : 'verifier died' })),
   )
   const alive = fixes.filter(Boolean)
   if (alive.length < work.length) log(`${work.length - alive.length} fix group(s) lost to dead workers`)

--- a/.claude/workflows/pr-babysit.js
+++ b/.claude/workflows/pr-babysit.js
@@ -229,11 +229,12 @@ const fixAndVerify = async (workIn) => {
       `Scope: ${scopeOf(w)}\nIssues:\n- ${w.notes.join('\n- ')}`,
       { label: `fix:${w.key}`, phase: 'Fix', agentType: 'code-writer', schema: DEV },
     ),
-    (fix, w) => fix && agent(
-      `${IN_CHECKOUT}Verify the uncommitted changes for ${scopeOf(w)} (use git diff -- <the files above>, and read any newly created untracked files directly) address these issues:\n- ${w.notes.join('\n- ')}\n` +
+    (fix, w) => fix && workflow('code-verify', {
+      prompt: `${IN_CHECKOUT}Verify the uncommitted changes for ${scopeOf(w)} (use git diff -- <the files above>, and read any newly created untracked files directly) address these issues:\n- ${w.notes.join('\n- ')}\n` +
       'Return {"addresses": bool, "reason": string}.',
-      { label: `check:${w.key}`, phase: 'Verify', agentType: 'code-verifier', schema: CHECK },
-    ).then(v => ({ ...fix, addresses: !!(v && v.addresses), checkReason: v ? v.reason : 'verifier died' })),
+      label: `check:${w.key}`,
+      schema: CHECK,
+    }).then(v => ({ ...fix, addresses: !!(v && v.addresses), checkReason: v ? v.reason : 'verifier died' })),
   )
   const alive = fixes.filter(Boolean)
   if (alive.length < work.length) log(`${work.length - alive.length} fix group(s) lost to dead workers`)

--- a/.claude/workflows/test-code-verify.mjs
+++ b/.claude/workflows/test-code-verify.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+const source = readFileSync(new URL('./code-verify.js', import.meta.url), 'utf8')
+const workflowBody = source.replace(/^export /m, '')
+
+const RESULT = {
+  type: 'object', additionalProperties: false,
+  required: ['answer'],
+  properties: { answer: { type: 'string' } },
+}
+const answers = {
+  codex: { answer: 'codex' },
+  claude: { answer: 'claude' },
+}
+
+async function run(args, provided = answers) {
+  const calls = []
+  let parallelCalls = 0
+  const agent = async (prompt, options) => {
+    const provider = options.agentType === 'code-verifier' ? 'claude'
+      : options.model === 'haiku' ? 'codex' : 'unknown'
+    calls.push({ provider, prompt, options })
+    const answer = provided[provider]
+    if (answer instanceof Error) throw answer
+    return structuredClone(answer)
+  }
+  const parallel = async (thunks) => {
+    parallelCalls++
+    return Promise.all(thunks.map(fn => fn()))
+  }
+  const fn = new AsyncFunction(
+    'args', 'agent', 'pipeline', 'parallel', 'phase', 'log', 'workflow', 'budget',
+    workflowBody,
+  )
+  const result = await fn(args, agent, null, parallel, () => {}, () => {}, null, null)
+  return { result, calls, parallelCalls }
+}
+
+let failed = 0
+async function check(name, fn) {
+  try {
+    await fn()
+    console.log(`  ok   ${name}`)
+  } catch (error) {
+    failed++
+    console.log(`  FAIL ${name}\n       ${error.stack || error}`)
+  }
+}
+
+await check('defaults to codex', async () => {
+  const { result, calls, parallelCalls } = await run({ prompt: 'review', schema: RESULT })
+  assert.deepEqual(result, answers.codex)
+  assert.deepEqual(calls.map(c => c.provider), ['codex'])
+  assert.equal(parallelCalls, 0)
+  assert.equal(calls[0].options.effort, 'low')
+  assert.deepEqual(calls[0].options.schema, RESULT)
+  assert.match(calls[0].prompt, /\.codex\/agents\/code-verifier\.toml/)
+  assert.match(calls[0].prompt, /tomllib/)
+  assert.match(calls[0].prompt, /timeout 600s codex exec/)
+  assert.match(calls[0].prompt, /--sandbox read-only/)
+  assert.match(calls[0].prompt, /--output-schema/)
+  assert.match(calls[0].prompt, /--output-last-message/)
+})
+
+await check('selects claude', async () => {
+  const { result, calls, parallelCalls } = await run(
+    { prompt: 'review', schema: RESULT, provider: 'claude', label: 'check' })
+  assert.deepEqual(result, answers.claude)
+  assert.deepEqual(calls.map(c => c.provider), ['claude'])
+  assert.equal(parallelCalls, 0)
+  assert.equal(calls[0].prompt, 'review')
+  assert.equal(calls[0].options.label, 'check:claude')
+  assert.deepEqual(calls[0].options.schema, RESULT)
+})
+
+await check('runs both independently', async () => {
+  const { result, calls, parallelCalls } = await run(
+    { prompt: 'review', schema: RESULT, provider: 'both' })
+  assert.deepEqual(result, { codex: answers.codex, claude: answers.claude })
+  assert.deepEqual(calls.map(c => c.provider).sort(), ['claude', 'codex'])
+  assert.equal(parallelCalls, 1)
+})
+
+await check('rejects invalid input before dispatch', async () => {
+  for (const args of [null, {}, { prompt: '', schema: RESULT }, { prompt: 'x', schema: [] }]) {
+    await assert.rejects(run(args), /args must be/)
+  }
+  await assert.rejects(
+    run({ prompt: 'review', schema: RESULT, provider: 'auto' }),
+    /provider must be codex, claude, or both/,
+  )
+})
+
+await check('fails closed when codex dies', async () => {
+  await assert.rejects(
+    run({ prompt: 'review', schema: RESULT }, { ...answers, codex: null }),
+    /codex verifier failed/,
+  )
+  await assert.rejects(
+    run({ prompt: 'review', schema: RESULT }, { ...answers, codex: new Error('broken') }),
+    /codex verifier failed: broken/,
+  )
+})
+
+console.log(failed ? `\n${failed} FAILED` : '\nall checks passed')
+process.exit(failed ? 1 : 0)

--- a/.claude/workflows/test-code-verify.mjs
+++ b/.claude/workflows/test-code-verify.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 const source = readFileSync(new URL('./code-verify.js', import.meta.url), 'utf8')
@@ -102,6 +102,15 @@ await check('fails closed when codex dies', async () => {
     run({ prompt: 'review', schema: RESULT }, { ...answers, codex: new Error('broken') }),
     /codex verifier failed: broken/,
   )
+})
+
+await check('all code-verifier calls use the router', async () => {
+  const dir = new URL('.', import.meta.url)
+  const offenders = readdirSync(dir)
+    .filter(name => name.endsWith('.js') && name !== 'code-verify.js')
+    .filter(name => /agentType:\s*['"]code-verifier['"]/.test(
+      readFileSync(new URL(name, dir), 'utf8')))
+  assert.deepEqual(offenders, [])
 })
 
 console.log(failed ? `\n${failed} FAILED` : '\nall checks passed')

--- a/.claude/workflows/test-code-verify.mjs
+++ b/.claude/workflows/test-code-verify.mjs
@@ -20,15 +20,16 @@ async function run(args, provided = answers) {
   let parallelCalls = 0
   const agent = async (prompt, options) => {
     const provider = options.agentType === 'code-verifier' ? 'claude'
-      : options.model === 'haiku' ? 'codex' : 'unknown'
+      : options.agentType === 'codex-code-verifier' ? 'codex' : 'unknown'
     calls.push({ provider, prompt, options })
     const answer = provided[provider]
     if (answer instanceof Error) throw answer
+    if (answer && typeof answer.answer !== 'string') throw new Error('schema mismatch')
     return structuredClone(answer)
   }
   const parallel = async (thunks) => {
     parallelCalls++
-    return Promise.all(thunks.map(fn => fn()))
+    return Promise.all(thunks.map(fn => Promise.resolve().then(fn).catch(() => null)))
   }
   const fn = new AsyncFunction(
     'args', 'agent', 'pipeline', 'parallel', 'phase', 'log', 'workflow', 'budget',
@@ -54,14 +55,21 @@ await check('defaults to codex', async () => {
   assert.deepEqual(result, answers.codex)
   assert.deepEqual(calls.map(c => c.provider), ['codex'])
   assert.equal(parallelCalls, 0)
-  assert.equal(calls[0].options.effort, 'low')
+  assert.equal(calls[0].options.agentType, 'codex-code-verifier')
   assert.deepEqual(calls[0].options.schema, RESULT)
-  assert.match(calls[0].prompt, /\.codex\/agents\/code-verifier\.toml/)
-  assert.match(calls[0].prompt, /tomllib/)
-  assert.match(calls[0].prompt, /timeout 600s codex exec/)
-  assert.match(calls[0].prompt, /--sandbox read-only/)
-  assert.match(calls[0].prompt, /--output-schema/)
-  assert.match(calls[0].prompt, /--output-last-message/)
+  assert.deepEqual(JSON.parse(calls[0].prompt), { prompt: 'review', schema: RESULT })
+})
+
+await check('bridge owns the Codex subprocess contract', async () => {
+  const bridge = readFileSync(new URL('../agents/codex-code-verifier.md', import.meta.url), 'utf8')
+  assert.match(bridge, /model: haiku/)
+  assert.match(bridge, /effort: low/)
+  assert.match(bridge, /\.codex\/agents\/code-verifier\.toml/)
+  assert.match(bridge, /tomllib/)
+  assert.match(bridge, /timeout 600s codex exec/)
+  assert.match(bridge, /--sandbox read-only/)
+  assert.match(bridge, /--output-schema/)
+  assert.match(bridge, /--output-last-message/)
 })
 
 await check('selects claude', async () => {
@@ -87,8 +95,8 @@ await check('rejects invalid input before dispatch', async () => {
   for (const args of [null, {}, { prompt: '', schema: RESULT }, { prompt: 'x', schema: [] }]) {
     await assert.rejects(run(args), /args must be/)
   }
-  await assert.rejects(
-    run({ prompt: 'review', schema: RESULT, provider: 'auto' }),
+  for (const provider of ['', 'auto']) await assert.rejects(
+    run({ prompt: 'review', schema: RESULT, provider }),
     /provider must be codex, claude, or both/,
   )
 })
@@ -102,22 +110,39 @@ await check('fails closed when codex dies', async () => {
     run({ prompt: 'review', schema: RESULT }, { ...answers, codex: new Error('broken') }),
     /codex verifier failed: broken/,
   )
+  await assert.rejects(
+    run({ prompt: 'review', schema: RESULT, provider: 'both' },
+      { ...answers, codex: new Error('broken') }),
+    /codex verifier failed/,
+  )
+  await assert.rejects(
+    run({ prompt: 'review', schema: RESULT }, { ...answers, codex: { answer: 1 } }),
+    /codex verifier failed: schema mismatch/,
+  )
 })
 
-await check('all code-verifier calls use the router', async () => {
+await check('only validate bypasses the router for one-level nesting', async () => {
   const dir = new URL('.', import.meta.url)
   const offenders = readdirSync(dir)
-    .filter(name => name.endsWith('.js') && name !== 'code-verify.js')
-    .filter(name => /agentType:\s*['"]code-verifier['"]/.test(
+    .filter(name => name.endsWith('.js') && !['code-verify.js', 'validate.js'].includes(name))
+    .filter(name => /agentType:\s*['"](?:codex-)?code-verifier['"]/.test(
       readFileSync(new URL(name, dir), 'utf8')))
   assert.deepEqual(offenders, [])
 })
 
-await check('validate uses one dual-provider router call', async () => {
+await check('router rejections preserve caller null-result contracts', async () => {
+  for (const name of ['fanout-dev.js', 'pr-babysit.js']) {
+    const src = readFileSync(new URL(name, new URL('.', import.meta.url)), 'utf8')
+    assert.match(src, /workflow\('code-verify',[\s\S]*?\}\)\.catch\(\(\) => null\)\s*\.then/)
+  }
+})
+
+await check('validate dispatches directly to stay within one workflow level', async () => {
   const src = readFileSync(new URL('./validate.js', import.meta.url), 'utf8')
-  assert.equal((src.match(/workflow\(['"]code-verify['"]/g) || []).length, 1)
+  assert.equal((src.match(/workflow\(['"]code-verify['"]/g) || []).length, 0)
   assert.match(src, /const reviewProvider = reviewStageNames\.length === 2 \? 'both'/)
-  assert.match(src, /provider:\s*reviewProvider/)
+  assert.match(src, /agentType:\s*'codex-code-verifier'/)
+  assert.match(src, /agentType:\s*'code-verifier'/)
   assert.doesNotMatch(src, /codex review --base/)
   assert.doesNotMatch(src, /model:\s*['"]opus['"][^}]*schema:\s*REVIEW/)
 })
@@ -125,35 +150,39 @@ await check('validate uses one dual-provider router call', async () => {
 await check('validate keeps provider results and gates separate', async () => {
   const src = readFileSync(new URL('./validate.js', import.meta.url), 'utf8').replace(/^export /m, '')
   const calls = []
+  let failCodex = false
   const fn = new AsyncFunction(
     'args', 'agent', 'pipeline', 'parallel', 'phase', 'log', 'workflow', 'budget', src)
   const agent = async (prompt, options) => {
+    calls.push(options.agentType)
+    if (options.agentType === 'code-verifier') return {
+      pass: true, detail: 'claude',
+      findings: [{ file: 'a.c', line: 1, severity: 'CONFIRMED P2 correctness', summary: 'bug' }],
+    }
+    if (options.agentType === 'codex-code-verifier') return failCodex ? null : {
+      pass: true, detail: 'codex',
+      findings: [{ file: 'b.c', line: 2, severity: 'CONFIRMED P2 correctness', summary: 'bug' }],
+    }
     assert.equal(options.agentType, 'builder')
     return { board: 'test', pass: true, builtCount: 1, failures: [] }
   }
-  const workflow = async (name, args) => {
-    calls.push({ name, args })
-    return {
-      claude: {
-        pass: true, detail: 'claude',
-        findings: [{ file: 'a.c', line: 1, severity: 'CONFIRMED P2 correctness', summary: 'bug' }],
-      },
-      codex: {
-        pass: true, detail: 'codex',
-        findings: [{ file: 'b.c', line: 2, severity: 'CONFIRMED P2 correctness', summary: 'bug' }],
-      },
-    }
-  }
+  const workflow = async () => { throw new Error('validate cannot nest a workflow') }
   const parallel = thunks => Promise.all(thunks.map(run => run()))
   const result = await fn(
     { boards: ['test'], skip: ['unit', 'size', 'pvs'], maxCycles: 1 },
     agent, null, parallel, () => {}, () => {}, workflow, null,
   )
-  assert.equal(calls.length, 1)
-  assert.equal(calls[0].name, 'code-verify')
-  assert.equal(calls[0].args.provider, 'both')
+  assert.deepEqual(calls.sort(), ['builder', 'code-verifier', 'codex-code-verifier'])
   assert.equal(result.stages.find(s => s.stage === 'review').pass, false)
   assert.equal(result.stages.find(s => s.stage === 'codex').pass, true)
+
+  failCodex = true
+  const partial = await fn(
+    { boards: ['test'], skip: ['unit', 'size', 'pvs'], maxCycles: 1 },
+    agent, null, parallel, () => {}, () => {}, workflow, null,
+  )
+  assert.equal(partial.stages.find(s => s.stage === 'review').detail, 'claude')
+  assert.equal(partial.stages.find(s => s.stage === 'codex').detail, 'stage agent died')
 })
 
 console.log(failed ? `\n${failed} FAILED` : '\nall checks passed')

--- a/.claude/workflows/test-code-verify.mjs
+++ b/.claude/workflows/test-code-verify.mjs
@@ -137,6 +137,22 @@ await check('router rejections preserve caller null-result contracts', async () 
   }
 })
 
+await check('driver review drops a failed routed scanner', async () => {
+  const src = readFileSync(new URL('./driver-review.js', import.meta.url), 'utf8').replace(/^export /m, '')
+  const fn = new AsyncFunction(
+    'args', 'agent', 'pipeline', 'parallel', 'phase', 'log', 'workflow', 'budget', src)
+  const pipeline = async (items, ...stages) => Promise.all(items.map(async item => {
+    let value = item
+    for (const stage of stages) value = await stage(value, item)
+    return value
+  }))
+  const result = await fn(
+    { dirs: ['src/portable/test'], dimensions: ['correctness'] },
+    null, pipeline, null, () => {}, () => {}, async () => { throw new Error('verifier died') }, null,
+  )
+  assert.deepEqual(result, [])
+})
+
 await check('validate dispatches directly to stay within one workflow level', async () => {
   const src = readFileSync(new URL('./validate.js', import.meta.url), 'utf8')
   assert.equal((src.match(/workflow\(['"]code-verify['"]/g) || []).length, 0)
@@ -151,17 +167,20 @@ await check('validate keeps provider results and gates separate', async () => {
   const src = readFileSync(new URL('./validate.js', import.meta.url), 'utf8').replace(/^export /m, '')
   const calls = []
   let failCodex = false
+  let blocking = false
   const fn = new AsyncFunction(
     'args', 'agent', 'pipeline', 'parallel', 'phase', 'log', 'workflow', 'budget', src)
   const agent = async (prompt, options) => {
     calls.push(options.agentType)
     if (options.agentType === 'code-verifier') return {
       pass: true, detail: 'claude',
-      findings: [{ file: 'a.c', line: 1, severity: 'CONFIRMED P2 correctness', summary: 'bug' }],
+      findings: [{ file: 'a.c', line: 1,
+        severity: blocking ? 'CONFIRMED P1 safety' : 'CONFIRMED P2 correctness', summary: 'bug' }],
     }
     if (options.agentType === 'codex-code-verifier') return failCodex ? null : {
       pass: true, detail: 'codex',
-      findings: [{ file: 'b.c', line: 2, severity: 'CONFIRMED P2 correctness', summary: 'bug' }],
+      findings: [{ file: 'b.c', line: 2,
+        severity: blocking ? 'CONFIRMED P1 safety' : 'CONFIRMED P1 quality', summary: 'bug' }],
     }
     assert.equal(options.agentType, 'builder')
     return { board: 'test', pass: true, builtCount: 1, failures: [] }
@@ -173,8 +192,16 @@ await check('validate keeps provider results and gates separate', async () => {
     agent, null, parallel, () => {}, () => {}, workflow, null,
   )
   assert.deepEqual(calls.sort(), ['builder', 'code-verifier', 'codex-code-verifier'])
-  assert.equal(result.stages.find(s => s.stage === 'review').pass, false)
+  assert.equal(result.stages.find(s => s.stage === 'review').pass, true)
   assert.equal(result.stages.find(s => s.stage === 'codex').pass, true)
+
+  blocking = true
+  const blocked = await fn(
+    { boards: ['test'], skip: ['unit', 'size', 'pvs'], maxCycles: 1 },
+    agent, null, parallel, () => {}, () => {}, workflow, null,
+  )
+  assert.equal(blocked.stages.find(s => s.stage === 'review').pass, false)
+  assert.equal(blocked.stages.find(s => s.stage === 'codex').pass, false)
 
   failCodex = true
   const partial = await fn(

--- a/.claude/workflows/test-code-verify.mjs
+++ b/.claude/workflows/test-code-verify.mjs
@@ -113,5 +113,48 @@ await check('all code-verifier calls use the router', async () => {
   assert.deepEqual(offenders, [])
 })
 
+await check('validate uses one dual-provider router call', async () => {
+  const src = readFileSync(new URL('./validate.js', import.meta.url), 'utf8')
+  assert.equal((src.match(/workflow\(['"]code-verify['"]/g) || []).length, 1)
+  assert.match(src, /const reviewProvider = reviewStageNames\.length === 2 \? 'both'/)
+  assert.match(src, /provider:\s*reviewProvider/)
+  assert.doesNotMatch(src, /codex review --base/)
+  assert.doesNotMatch(src, /model:\s*['"]opus['"][^}]*schema:\s*REVIEW/)
+})
+
+await check('validate keeps provider results and gates separate', async () => {
+  const src = readFileSync(new URL('./validate.js', import.meta.url), 'utf8').replace(/^export /m, '')
+  const calls = []
+  const fn = new AsyncFunction(
+    'args', 'agent', 'pipeline', 'parallel', 'phase', 'log', 'workflow', 'budget', src)
+  const agent = async (prompt, options) => {
+    assert.equal(options.agentType, 'builder')
+    return { board: 'test', pass: true, builtCount: 1, failures: [] }
+  }
+  const workflow = async (name, args) => {
+    calls.push({ name, args })
+    return {
+      claude: {
+        pass: true, detail: 'claude',
+        findings: [{ file: 'a.c', line: 1, severity: 'CONFIRMED P2 correctness', summary: 'bug' }],
+      },
+      codex: {
+        pass: true, detail: 'codex',
+        findings: [{ file: 'b.c', line: 2, severity: 'CONFIRMED P2 correctness', summary: 'bug' }],
+      },
+    }
+  }
+  const parallel = thunks => Promise.all(thunks.map(run => run()))
+  const result = await fn(
+    { boards: ['test'], skip: ['unit', 'size', 'pvs'], maxCycles: 1 },
+    agent, null, parallel, () => {}, () => {}, workflow, null,
+  )
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].name, 'code-verify')
+  assert.equal(calls[0].args.provider, 'both')
+  assert.equal(result.stages.find(s => s.stage === 'review').pass, false)
+  assert.equal(result.stages.find(s => s.stage === 'codex').pass, true)
+})
+
 console.log(failed ? `\n${failed} FAILED` : '\nall checks passed')
 process.exit(failed ? 1 : 0)

--- a/.claude/workflows/test/test-code-verify.mjs
+++ b/.claude/workflows/test/test-code-verify.mjs
@@ -122,7 +122,8 @@ await check('fails closed when codex dies', async () => {
 })
 
 await check('only validate bypasses the router for one-level nesting', async () => {
-  const dir = new URL('.', import.meta.url)
+  const dir = new URL('../', import.meta.url)
+  assert.ok(readdirSync(dir).includes('code-verify.js'), 'workflow scan must target its parent directory')
   const offenders = readdirSync(dir)
     .filter(name => name.endsWith('.js') && !['code-verify.js', 'validate.js'].includes(name))
     .filter(name => /agentType:\s*['"](?:codex-)?code-verifier['"]/.test(

--- a/.claude/workflows/test/test-code-verify.mjs
+++ b/.claude/workflows/test/test-code-verify.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { readdirSync, readFileSync } from 'node:fs'
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
-const source = readFileSync(new URL('./code-verify.js', import.meta.url), 'utf8')
+const source = readFileSync(new URL('../code-verify.js', import.meta.url), 'utf8')
 const workflowBody = source.replace(/^export /m, '')
 
 const RESULT = {
@@ -61,7 +61,7 @@ await check('defaults to codex', async () => {
 })
 
 await check('bridge owns the Codex subprocess contract', async () => {
-  const bridge = readFileSync(new URL('../agents/codex-code-verifier.md', import.meta.url), 'utf8')
+  const bridge = readFileSync(new URL('../../agents/codex-code-verifier.md', import.meta.url), 'utf8')
   assert.match(bridge, /model: haiku/)
   assert.match(bridge, /effort: low/)
   assert.match(bridge, /\.codex\/agents\/code-verifier\.toml/)
@@ -132,13 +132,13 @@ await check('only validate bypasses the router for one-level nesting', async () 
 
 await check('router rejections preserve caller null-result contracts', async () => {
   for (const name of ['fanout-dev.js', 'pr-babysit.js']) {
-    const src = readFileSync(new URL(name, new URL('.', import.meta.url)), 'utf8')
+    const src = readFileSync(new URL(`../${name}`, import.meta.url), 'utf8')
     assert.match(src, /workflow\('code-verify',[\s\S]*?\}\)\.catch\(\(\) => null\)\s*\.then/)
   }
 })
 
 await check('driver review drops a failed routed scanner', async () => {
-  const src = readFileSync(new URL('./driver-review.js', import.meta.url), 'utf8').replace(/^export /m, '')
+  const src = readFileSync(new URL('../driver-review.js', import.meta.url), 'utf8').replace(/^export /m, '')
   const fn = new AsyncFunction(
     'args', 'agent', 'pipeline', 'parallel', 'phase', 'log', 'workflow', 'budget', src)
   const pipeline = async (items, ...stages) => Promise.all(items.map(async item => {
@@ -154,7 +154,7 @@ await check('driver review drops a failed routed scanner', async () => {
 })
 
 await check('validate dispatches directly to stay within one workflow level', async () => {
-  const src = readFileSync(new URL('./validate.js', import.meta.url), 'utf8')
+  const src = readFileSync(new URL('../validate.js', import.meta.url), 'utf8')
   assert.equal((src.match(/workflow\(['"]code-verify['"]/g) || []).length, 0)
   assert.match(src, /const reviewProvider = reviewStageNames\.length === 2 \? 'both'/)
   assert.match(src, /agentType:\s*'codex-code-verifier'/)
@@ -164,7 +164,7 @@ await check('validate dispatches directly to stay within one workflow level', as
 })
 
 await check('validate keeps provider results and gates separate', async () => {
-  const src = readFileSync(new URL('./validate.js', import.meta.url), 'utf8').replace(/^export /m, '')
+  const src = readFileSync(new URL('../validate.js', import.meta.url), 'utf8').replace(/^export /m, '')
   const calls = []
   let failCodex = false
   let blocking = false

--- a/.claude/workflows/test/test-hil-validate.mjs
+++ b/.claude/workflows/test/test-hil-validate.mjs
@@ -7,10 +7,10 @@
 // test/hil/helper/hil_report.py, where the roster is, and arrives here as fields. What is
 // left is a lookup and a verdict, and this pins both.
 //
-// Run: node .claude/workflows/test-hil-validate.mjs
+// Run: node .claude/workflows/test/test-hil-validate.mjs
 import { readFileSync } from 'node:fs'
 
-const src = readFileSync(new URL('./hil-validate.js', import.meta.url), 'utf8')
+const src = readFileSync(new URL('../hil-validate.js', import.meta.url), 'utf8')
 // slice by marker, but never silently: a renamed marker must fail with its name, not with a
 // confusing ReferenceError from a garbage slice
 const cut = (start, end) => {

--- a/.claude/workflows/validate.js
+++ b/.claude/workflows/validate.js
@@ -148,6 +148,16 @@ if (reviewProvider) stageNames.push('reviews')
 const scheduleName = name => name === 'review' || name === 'codex' ? 'reviews' : name
 const displayNames = names => names.flatMap(name => name === 'reviews' ? reviewStageNames : [name])
 
+function runReviewProvider(provider, label) {
+  if (provider === 'codex') return agent(
+    JSON.stringify({ prompt: reviewPrompt, schema: REVIEW }),
+    { label: `${label}:codex`, phase: 'Validate', agentType: 'codex-code-verifier', schema: REVIEW },
+  )
+  return agent(reviewPrompt, {
+    label: `${label}:claude`, phase: 'Validate', agentType: 'code-verifier', schema: REVIEW,
+  })
+}
+
 function stageThunk(name, cycle) {
   const label = (cycle > 1 ? `c${cycle}:` : '') + name
   // findings: [] so a dead review/codex stage flows through fixerEvidence()
@@ -187,26 +197,28 @@ function stageThunk(name, cycle) {
     detail: r.pass ? r.detail : clip(`${r.detail} ${JSON.stringify(r.changedFindings)}`),
   } : died).catch(() => died)
 
-  if (name === 'reviews') return () => workflow('code-verify', {
-    prompt: reviewPrompt, label, schema: REVIEW, provider: reviewProvider,
-  }).then(r => {
-    const byProvider = reviewProvider === 'both' ? r : { [reviewProvider]: r }
-    const rows = []
-    if (byProvider.claude) rows.push({
-      stage: 'review',
-      pass: byProvider.claude.pass && !byProvider.claude.findings.some(confirmedReview),
-      findings: byProvider.claude.findings, detail: byProvider.claude.detail,
-    })
-    if (byProvider.codex) rows.push({
-      stage: 'codex',
-      pass: byProvider.codex.pass && !byProvider.codex.findings.some(codexBlocking),
-      findings: byProvider.codex.findings, detail: byProvider.codex.detail,
-    })
-    if (rows.length !== reviewStageNames.length) throw new Error('review provider result missing')
-    return rows
-  }).catch(() => reviewStageNames.map(stage => ({
-    stage, pass: false, findings: [], detail: 'stage agent died',
-  })))
+  if (name === 'reviews') return () => {
+    const pending = reviewProvider === 'both'
+      ? parallel(['codex', 'claude'].map(provider => () => runReviewProvider(provider, label)))
+        .then(([codex, claude]) => ({ codex, claude }))
+      : runReviewProvider(reviewProvider, label).then(r => ({ [reviewProvider]: r }))
+    return pending.then(byProvider => {
+      const rows = []
+      if (reviewStageNames.includes('review')) rows.push(byProvider.claude ? {
+        stage: 'review', pass: byProvider.claude.pass &&
+          !byProvider.claude.findings.some(confirmedReview),
+        findings: byProvider.claude.findings, detail: byProvider.claude.detail,
+      } : { stage: 'review', pass: false, findings: [], detail: 'stage agent died' })
+      if (reviewStageNames.includes('codex')) rows.push(byProvider.codex ? {
+        stage: 'codex', pass: byProvider.codex.pass &&
+          !byProvider.codex.findings.some(codexBlocking),
+        findings: byProvider.codex.findings, detail: byProvider.codex.detail,
+      } : { stage: 'codex', pass: false, findings: [], detail: 'stage agent died' })
+      return rows
+    }).catch(() => reviewStageNames.map(stage => ({
+      stage, pass: false, findings: [], detail: 'stage agent died',
+    })))
+  }
 
   throw new Error(`unknown stage ${name}`)
 }

--- a/.claude/workflows/validate.js
+++ b/.claude/workflows/validate.js
@@ -112,10 +112,9 @@ const PATHS = {
 }
 
 // gate helpers — enforced here, never trusted from the agents
-const confirmedReview = f =>
-  /^confirmed/i.test(f.severity) && !/quality|simplification|style/i.test(f.severity)
-const codexBlocking = f =>
-  /^confirmed/i.test(f.severity) && /\bP[01]\b/i.test(f.severity)
+const reviewBlocking = f =>
+  /^confirmed/i.test(f.severity) && /\bP[01]\b/i.test(f.severity) &&
+  /\b(correctness|safety|security)\b/i.test(f.severity)
 
 // ---------------------------------------------------------------------------
 // Stage builders, parameterized so later cycles can re-run a subset. Stage
@@ -206,12 +205,12 @@ function stageThunk(name, cycle) {
       const rows = []
       if (reviewStageNames.includes('review')) rows.push(byProvider.claude ? {
         stage: 'review', pass: byProvider.claude.pass &&
-          !byProvider.claude.findings.some(confirmedReview),
+          !byProvider.claude.findings.some(reviewBlocking),
         findings: byProvider.claude.findings, detail: byProvider.claude.detail,
       } : { stage: 'review', pass: false, findings: [], detail: 'stage agent died' })
       if (reviewStageNames.includes('codex')) rows.push(byProvider.codex ? {
         stage: 'codex', pass: byProvider.codex.pass &&
-          !byProvider.codex.findings.some(codexBlocking),
+          !byProvider.codex.findings.some(reviewBlocking),
         findings: byProvider.codex.findings, detail: byProvider.codex.detail,
       } : { stage: 'codex', pass: false, findings: [], detail: 'stage agent died' })
       return rows
@@ -224,7 +223,8 @@ function stageThunk(name, cycle) {
 }
 
 // Only the material that FAILED the gate reaches the fixer: confirmed review
-// findings, codex P0/P1, and failed unit/build/size/pvs stage evidence.
+// P0/P1 correctness/safety/security findings and failed unit/build/size/pvs
+// stage evidence.
 // PLAUSIBLE and quality findings stay report-only — fixing them here would
 // churn style on an otherwise green branch. Bounded at the leaves (per-stage
 // finding cap, clipped summaries/details) so the serialized JSON stays valid
@@ -233,7 +233,7 @@ function stageThunk(name, cycle) {
 function fixerEvidence(failures) {
   return failures.map(f => {
     const findings = (f.findings || [])
-      .filter(f.stage === 'review' ? confirmedReview : codexBlocking)
+      .filter(reviewBlocking)
       .slice(0, 10)
       .map(x => ({ ...x, summary: clip(x.summary, 300) }))
     if (f.stage === 'review' || f.stage === 'codex')

--- a/.claude/workflows/validate.js
+++ b/.claude/workflows/validate.js
@@ -114,19 +114,39 @@ const PATHS = {
 // gate helpers — enforced here, never trusted from the agents
 const confirmedReview = f =>
   /^confirmed/i.test(f.severity) && !/quality|simplification|style/i.test(f.severity)
-const codexBlocking = f => /\bP[01]\b/i.test(f.severity)
+const codexBlocking = f =>
+  /^confirmed/i.test(f.severity) && /\bP[01]\b/i.test(f.severity)
 
 // ---------------------------------------------------------------------------
 // Stage builders, parameterized so later cycles can re-run a subset. Stage
-// names: 'unit', 'build:<board>', 'size', 'pvs', 'review', 'codex'.
+// names: 'unit', 'build:<board>', 'size', 'pvs', and the dual-provider
+// 'reviews' scheduler, which emits the public 'review' and 'codex' rows.
 // ---------------------------------------------------------------------------
+const reviewStageNames = []
+if (!skip.includes('review')) reviewStageNames.push('review')
+if (!skip.includes('codex')) reviewStageNames.push('codex')
+const reviewProvider = reviewStageNames.length === 2 ? 'both'
+  : reviewStageNames[0] === 'review' ? 'claude'
+    : reviewStageNames[0] === 'codex' ? 'codex' : null
+const reviewPrompt =
+  `Code-review this branch's diff vs ${base} (git diff ${base}...HEAD), coverage-first: walk every hunk, no spot checks. ` +
+  'Find pass — candidate defects across all dimensions: correctness/logic, ISR & concurrency safety, ' +
+  'memory/resource handling (bounds, leaks, no dynamic alloc), API contract & spec conformance, ' +
+  'security of untrusted input parsing, behavior regressions; plus quality/simplification notes. ' +
+  'Verify pass — adversarially check each candidate against the surrounding code: verdict CONFIRMED ' +
+  '(failing scenario constructed) or PLAUSIBLE (could not refute); report both, drop only refuted ones. ' +
+  'Read-only: never apply fixes. severity must be "CONFIRMED P0 correctness", "CONFIRMED P1 safety", ' +
+  '"PLAUSIBLE P2 quality", or the same format with P0-P3 and one of correctness, safety, security, ' +
+  'quality, simplification, or style. pass=false only for a CONFIRMED P0/P1 correctness, safety, or ' +
+  'security bug; detail = one-line review summary.'
 const stageNames = []
 if (!skip.includes('unit')) stageNames.push('unit')
 for (const b of args.boards) stageNames.push(`build:${b}`)
 if (!skip.includes('size')) stageNames.push('size')
 if (!skip.includes('pvs')) stageNames.push('pvs')
-if (!skip.includes('review')) stageNames.push('review')
-if (!skip.includes('codex')) stageNames.push('codex')
+if (reviewProvider) stageNames.push('reviews')
+const scheduleName = name => name === 'review' || name === 'codex' ? 'reviews' : name
+const displayNames = names => names.flatMap(name => name === 'reviews' ? reviewStageNames : [name])
 
 function stageThunk(name, cycle) {
   const label = (cycle > 1 ? `c${cycle}:` : '') + name
@@ -167,35 +187,26 @@ function stageThunk(name, cycle) {
     detail: r.pass ? r.detail : clip(`${r.detail} ${JSON.stringify(r.changedFindings)}`),
   } : died).catch(() => died)
 
-  if (name === 'review') return () => agent(
-    `Code-review this branch's diff vs ${base} (git diff ${base}...HEAD), coverage-first: walk every hunk, no spot checks. ` +
-    'Find pass — candidate defects across all dimensions: correctness/logic, ISR & concurrency safety, ' +
-    'memory/resource handling (bounds, leaks, no dynamic alloc), API contract & spec conformance, ' +
-    'security of untrusted input parsing, behavior regressions; plus quality/simplification notes. ' +
-    'Verify pass — adversarially check each candidate against the surrounding code: verdict CONFIRMED ' +
-    '(failing scenario constructed) or PLAUSIBLE (could not refute); report both, drop only refuted ones. ' +
-    'Read-only: never apply fixes. severity = verdict plus category (e.g. "CONFIRMED correctness"). ' +
-    'pass=false if any CONFIRMED correctness/safety/security bug survives; PLAUSIBLE and quality findings keep pass=true. ' +
-    'detail = one-line review summary.',
-    { label, phase: 'Validate', model: 'opus', effort: 'high', schema: REVIEW },
-  ).then(r => r ? {
-    stage: name,
-    pass: r.pass && !r.findings.some(confirmedReview),
-    findings: r.findings, detail: r.detail,
-  } : died).catch(() => died)
-
-  if (name === 'codex') return () => agent(
-    `Run a Codex review of this branch's diff vs ${base}: ` +
-    `codex review --base ${base} -c model="gpt-5.6-sol" -c model_reasoning_effort="high" ` +
-    '(Bash timeout 600000; run from the repo root). Parse its output into findings; severity = Codex\'s priority label. ' +
-    'pass=false only if Codex reports a correctness bug (P0/P1); style-level items keep pass=true. ' +
-    'detail = Codex\'s overall verdict line. If the codex CLI is missing or the run errors, pass=false with the error in detail.',
-    { label, phase: 'Validate', model: 'haiku', schema: REVIEW },
-  ).then(r => r ? {
-    stage: name,
-    pass: r.pass && !r.findings.some(codexBlocking),
-    findings: r.findings, detail: r.detail,
-  } : died).catch(() => died)
+  if (name === 'reviews') return () => workflow('code-verify', {
+    prompt: reviewPrompt, label, schema: REVIEW, provider: reviewProvider,
+  }).then(r => {
+    const byProvider = reviewProvider === 'both' ? r : { [reviewProvider]: r }
+    const rows = []
+    if (byProvider.claude) rows.push({
+      stage: 'review',
+      pass: byProvider.claude.pass && !byProvider.claude.findings.some(confirmedReview),
+      findings: byProvider.claude.findings, detail: byProvider.claude.detail,
+    })
+    if (byProvider.codex) rows.push({
+      stage: 'codex',
+      pass: byProvider.codex.pass && !byProvider.codex.findings.some(codexBlocking),
+      findings: byProvider.codex.findings, detail: byProvider.codex.detail,
+    })
+    if (rows.length !== reviewStageNames.length) throw new Error('review provider result missing')
+    return rows
+  }).catch(() => reviewStageNames.map(stage => ({
+    stage, pass: false, findings: [], detail: 'stage agent died',
+  })))
 
   throw new Error(`unknown stage ${name}`)
 }
@@ -249,11 +260,13 @@ const history = []
 let toRun = new Set(stageNames)
 
 for (let cycle = 1; cycle <= maxCycles; cycle++) {
-  log(`cycle ${cycle}/${maxCycles}: running ${toRun.size}/${stageNames.length} stage(s)`)
-  const results = await parallel([...toRun].map(n => stageThunk(n, cycle)))
-  for (const r of results.filter(Boolean)) latest.set(r.stage, r)
+  const ran = displayNames([...toRun])
+  log(`cycle ${cycle}/${maxCycles}: running ${ran.length}/${displayNames(stageNames).length} stage(s)`)
+  const batches = await parallel([...toRun].map(n => stageThunk(n, cycle)))
+  const results = batches.flatMap(r => Array.isArray(r) ? r : [r]).filter(Boolean)
+  for (const r of results) latest.set(r.stage, r)
   const failures = [...latest.values()].filter(r => !r.pass)
-  const entry = { cycle, ran: [...toRun], failed: failures.map(f => f.stage), fix: null }
+  const entry = { cycle, ran, failed: failures.map(f => f.stage), fix: null }
   history.push(entry)
 
   if (failures.length === 0) {
@@ -279,7 +292,7 @@ for (let cycle = 1; cycle <= maxCycles; cycle++) {
     const deadStages = failures.filter(f => f.detail === 'stage agent died').map(f => f.stage)
     if (deadStages.length > 0) {
       log(`cycle ${cycle}: fix agent changed nothing — retrying dead stage(s): ${deadStages.join(', ')}`)
-      toRun = new Set(deadStages)
+      toRun = new Set(deadStages.map(scheduleName))
       continue
     }
     log(`cycle ${cycle}: fix agent changed nothing — stopping`)
@@ -328,9 +341,8 @@ for (let cycle = 1; cycle <= maxCycles; cycle++) {
   const docsOnly = trusted && files.length > 0 && files.every(f =>
     !f.startsWith('.claude/') && f !== 'CLAUDE.md' && f !== 'AGENTS.md' &&
     (/^docs\//.test(f) || f.endsWith('.md') || f.endsWith('.rst')))
-  toRun = new Set(failures.map(f => f.stage))
-  if (!skip.includes('review')) toRun.add('review')
-  if (!skip.includes('codex')) toRun.add('codex')
+  toRun = new Set(failures.map(f => scheduleName(f.stage)))
+  if (reviewProvider) toRun.add('reviews')
   if (!docsOnly) for (const n of stageNames) toRun.add(n)
 }
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
     language: system
   - id: code-verify-logic
     name: code-verify-logic
-    files: ^\.claude/workflows/
+    files: ^\.claude/(workflows/|agents/codex-code-verifier\.md$)
     entry: node .claude/workflows/test-code-verify.mjs
     pass_filenames: false
     language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
   - id: hil-validate-logic
     name: hil-validate-logic
     files: ^\.claude/workflows/
-    entry: node .claude/workflows/test-hil-validate.mjs
+    entry: node .claude/workflows/test/test-hil-validate.mjs
     pass_filenames: false
     language: system
   - id: code-verify-logic

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,12 @@ repos:
     entry: node .claude/workflows/test-hil-validate.mjs
     pass_filenames: false
     language: system
+  - id: code-verify-logic
+    name: code-verify-logic
+    files: ^\.claude/workflows/
+    entry: node .claude/workflows/test-code-verify.mjs
+    pass_filenames: false
+    language: system
   - id: ci-select-test
     name: ci-select-test
     files: ^(hw/bsp/|hw/mcu/|src/|examples/|test/hil/|tools/(ci_select|build|build_utils|get_deps|metrics|rtt)\.py$|\.github/(scripts|workflows)/|\.circleci/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
   - id: code-verify-logic
     name: code-verify-logic
     files: ^\.claude/(workflows/|agents/codex-code-verifier\.md$)
-    entry: node .claude/workflows/test-code-verify.mjs
+    entry: node .claude/workflows/test/test-code-verify.mjs
     pass_filenames: false
     language: system
   - id: ci-select-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Claude Code is the primary harness. `CLAUDE.md` and `.claude/{agents,skills,work
 - Use `/codex:rescue` for substantial bounded implementation, diagnosis, or a second pass when Claude is stuck; use its `--background`, `--resume`, and `--fresh` controls when needed.
 - When Codex should use a named TinyUSB role, select its `.codex/agents/<role>.toml` adapter; the adapter loads `.claude/agents/<role>.md` as the canonical role.
 - Reviews and research may run beside Claude. For write-capable delegation, use a separate worktree if Claude continues editing; otherwise yield the current worktree to Codex until it finishes. Never let both edit overlapping files in one worktree.
-- `.claude/workflows/*.js` remain the canonical Claude Code orchestration. Their `code-verifier` work routes through the nested `code-verify` workflow: Codex by default, or Claude/both when a caller selects it. Do not invoke the verifier agent directly or copy the Codex bridge command.
+- `.claude/workflows/*.js` remain the canonical Claude Code orchestration. Root workflows route `code-verifier` work through `code-verify`: Codex by default, or Claude/both when selected. Because workflows nest only one level, `validate` dispatches the same verifier agents directly when called by `full-check`. The Codex subprocess lives only in `codex-code-verifier.md`; never copy it into a workflow.
 
 ## Ground Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Claude Code is the primary harness. `CLAUDE.md` and `.claude/{agents,skills,work
 - Use `/codex:rescue` for substantial bounded implementation, diagnosis, or a second pass when Claude is stuck; use its `--background`, `--resume`, and `--fresh` controls when needed.
 - When Codex should use a named TinyUSB role, select its `.codex/agents/<role>.toml` adapter; the adapter loads `.claude/agents/<role>.md` as the canonical role.
 - Reviews and research may run beside Claude. For write-capable delegation, use a separate worktree if Claude continues editing; otherwise yield the current worktree to Codex until it finishes. Never let both edit overlapping files in one worktree.
-- `.claude/workflows/*.js` remain Claude Code-native orchestration. Codex may review or rescue work around a workflow, but no Codex-specific workflow mirror is maintained.
+- `.claude/workflows/*.js` remain the canonical Claude Code orchestration. Their `code-verifier` work routes through the nested `code-verify` workflow: Codex by default, or Claude/both when a caller selects it. Do not invoke the verifier agent directly or copy the Codex bridge command.
 
 ## Ground Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Claude Code is the primary harness. `CLAUDE.md` and `.claude/{agents,skills,work
 - Use `/codex:rescue` for substantial bounded implementation, diagnosis, or a second pass when Claude is stuck; use its `--background`, `--resume`, and `--fresh` controls when needed.
 - When Codex should use a named TinyUSB role, select its `.codex/agents/<role>.toml` adapter; the adapter loads `.claude/agents/<role>.md` as the canonical role.
 - Reviews and research may run beside Claude. For write-capable delegation, use a separate worktree if Claude continues editing; otherwise yield the current worktree to Codex until it finishes. Never let both edit overlapping files in one worktree.
-- `.claude/workflows/*.js` remain the canonical Claude Code orchestration. Root workflows route `code-verifier` work through `code-verify`: Codex by default, or Claude/both when selected. Because workflows nest only one level, `validate` dispatches the same verifier agents directly when called by `full-check`. The Codex subprocess lives only in `codex-code-verifier.md`; never copy it into a workflow.
+- `.claude/workflows/*.js` remain the canonical Claude Code orchestration. Root workflows route `code-verifier` work through `code-verify`: Codex by default, or Claude/both when selected. Because workflows nest only one level, `validate` dispatches the same verifier agents directly when called by `full-check`. The Codex subprocess lives only in `.claude/agents/codex-code-verifier.md`; never copy it into a workflow.
 
 ## Ground Rules
 

--- a/docs/superpowers/plans/2026-08-21-hil-report-module.md
+++ b/docs/superpowers/plans/2026-08-21-hil-report-module.md
@@ -527,7 +527,7 @@ hil_health goes back to doing one thing: killing wedged processes."
 - Modify: `test/hil/helper/hil_report.py` (real `summarize` + CLI)
 - Delete: `test/hil/helper/hil_summary.py`
 - Modify: `test/hil/hil_ci.sh` (drop `hil_summary.py` from the scp list)
-- Modify: `.claude/agents/hil-operator.md:71`, `.claude/workflows/hil-validate.js:14,17,54,58,67`, `.claude/workflows/test-hil-validate.mjs:7`
+- Modify: `.claude/agents/hil-operator.md:71`, `.claude/workflows/hil-validate.js:14,17,54,58,67`, `.claude/workflows/test/test-hil-validate.mjs:7`
 - Modify: `test/hil/test/test_hil_bounded.py` (move `SummaryFoldsReportToBoards` out), `test/hil/test/test_hil_report.py`
 
 **Interfaces:**
@@ -587,7 +587,7 @@ python3 test/hil/helper/hil_report.py <config> -b BOARD [-b BOARD...]   # from t
 ```
 
 In `.claude/workflows/hil-validate.js` lines 14, 17, 54 and 67, and
-`.claude/workflows/test-hil-validate.mjs` line 7, replace the prose mentions of
+`.claude/workflows/test/test-hil-validate.mjs` line 7, replace the prose mentions of
 `hil_summary.py` with `hil_report.py`. Change nothing else in those files — the operator's
 return contract (`{results, banner, wedged}`) is untouched.
 
@@ -595,7 +595,7 @@ return contract (`{results, banner, wedged}`) is untouched.
 
 Run: `python3 test/hil/test/test_hil_report.py` → OK
 Run: `python3 -m unittest discover -s test/hil/test` → 275 OK
-Run: `node .claude/workflows/test-hil-validate.mjs` → OK
+Run: `node .claude/workflows/test/test-hil-validate.mjs` → OK
 Run: `grep -rn "hil_summary" . --include=*.py --include=*.sh --include=*.js --include=*.mjs --include=*.md | grep -v docs/superpowers` → no hits
 
 - [ ] **Step 6: Commit**
@@ -603,7 +603,7 @@ Run: `grep -rn "hil_summary" . --include=*.py --include=*.sh --include=*.js --in
 ```bash
 git add test/hil/helper/hil_report.py test/hil/hil_ci.sh test/hil/test/ \
         .claude/agents/hil-operator.md .claude/workflows/hil-validate.js \
-        .claude/workflows/test-hil-validate.mjs
+        .claude/workflows/test/test-hil-validate.mjs
 git rm --cached test/hil/helper/hil_summary.py 2>/dev/null || true
 git commit -m "hil_report: fold hil_summary in; one module owns the document end to end
 

--- a/docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
+++ b/docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
@@ -34,7 +34,7 @@
 - Consumes: `{ prompt: string, schema: object, provider?: 'codex'|'claude'|'both', label?: string }`
 - Produces: the requested schema for a single provider; `{ codex, claude }` for `both`
 
-- [ ] **Step 1: Write failing router tests**
+- [x] **Step 1: Write failing router tests**
 
 Create `test-code-verify.mjs` with a small harness that evaluates a workflow body inside an async function with mocked `agent` and `parallel` primitives. Add checks for:
 
@@ -67,7 +67,7 @@ await assert.rejects(run({ prompt: 'review', schema: RESULT }, { ...answers, cod
 
 The mock identifies the native Claude call by `agentType: 'code-verifier'` and the Codex bridge by `model: 'haiku'`.
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 Run:
 
@@ -77,7 +77,7 @@ node .claude/workflows/test-code-verify.mjs
 
 Expected: FAIL because `.claude/workflows/code-verify.js` does not exist.
 
-- [ ] **Step 3: Implement the minimal router**
+- [x] **Step 3: Implement the minimal router**
 
 Create `code-verify.js` with:
 
@@ -147,7 +147,7 @@ run timeout 600s codex exec -C <root> -m <adapter model>
 return the result file's JSON verbatim; if any command fails, do not fabricate a result
 ```
 
-- [ ] **Step 4: Run router tests and syntax check**
+- [x] **Step 4: Run router tests and syntax check**
 
 Run:
 
@@ -158,7 +158,7 @@ node .claude/workflows/test-code-verify.mjs
 
 Expected: all router checks pass and the syntax checker prints `OK`.
 
-- [ ] **Step 5: Register the focused pre-commit hook**
+- [x] **Step 5: Register the focused pre-commit hook**
 
 Add under `repo: local`:
 
@@ -179,7 +179,7 @@ pre-commit run code-verify-logic --all-files
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit the router**
+- [x] **Step 6: Commit the router**
 
 ```bash
 git add .claude/workflows/code-verify.js \
@@ -201,7 +201,7 @@ git commit -m "workflows: add Codex verifier routing"
 - Consumes: `workflow('code-verify', { prompt, schema, label })`
 - Produces: the same structured result each former native verifier call consumed
 
-- [ ] **Step 1: Add the failing no-bypass test**
+- [x] **Step 1: Add the failing no-bypass test**
 
 Scan every `.claude/workflows/*.js` except `code-verify.js` and fail if it matches:
 
@@ -209,7 +209,7 @@ Scan every `.claude/workflows/*.js` except `code-verify.js` and fail if it match
 /agentType:\s*['"]code-verifier['"]/
 ```
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 Run:
 
@@ -219,7 +219,7 @@ node .claude/workflows/test-code-verify.mjs
 
 Expected: FAIL naming direct calls in `driver-review.js`, `fanout-dev.js`, and `pr-babysit.js`.
 
-- [ ] **Step 3: Replace each direct call**
+- [x] **Step 3: Replace each direct call**
 
 Use this shape without a `provider`, so Codex is selected:
 
@@ -234,7 +234,7 @@ workflow('code-verify', {
 
 Keep every caller's existing null/result handling. Remove the `max` effort override from the adversarial `driver-review` call; provider adapters own the approved `xhigh` effort.
 
-- [ ] **Step 4: Verify callers and commit**
+- [x] **Step 4: Verify callers and commit**
 
 Run:
 
@@ -264,11 +264,11 @@ git commit -m "workflows: route code verification through Codex"
 - Consumes: `workflow('code-verify', { provider: 'both', prompt, schema, label })`
 - Produces: separate `review` and `codex` stage rows from one independent dual-provider dispatch
 
-- [ ] **Step 1: Add a failing validate wiring check**
+- [x] **Step 1: Add a failing validate wiring check**
 
 Assert that `validate.js` contains one `workflow('code-verify'` call with `provider: 'both'`, and contains neither `codex review --base` nor a direct Opus review agent.
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 Run:
 
@@ -278,7 +278,7 @@ node .claude/workflows/test-code-verify.mjs
 
 Expected: FAIL because `validate.js` still owns separate Claude and Codex review agents.
 
-- [ ] **Step 3: Normalize the shared review prompt**
+- [x] **Step 3: Normalize the shared review prompt**
 
 Keep the existing `REVIEW` schema but require `severity` to include both independent gate signals:
 
@@ -297,7 +297,7 @@ const codexBlocking = f =>
   /^confirmed/i.test(f.severity) && /\bP[01]\b/i.test(f.severity)
 ```
 
-- [ ] **Step 4: Dispatch and split both results**
+- [x] **Step 4: Dispatch and split both results**
 
 Schedule one internal `reviews` thunk when either review stage is enabled. Select `both` when neither `review` nor `codex` is skipped; otherwise select the remaining provider. Normalize its return into the existing stage rows:
 
@@ -318,7 +318,7 @@ return rows
 
 Flatten stage-thunk results before updating `latest`. When building the next `toRun` set, map failed `review` or `codex` rows back to the `reviews` scheduler name. Preserve the existing `skip`, fixer evidence, retry, restart-required, and final-report contracts.
 
-- [ ] **Step 5: Verify validate and commit**
+- [x] **Step 5: Verify validate and commit**
 
 Run:
 
@@ -346,7 +346,7 @@ git commit -m "validate: share dual review routing"
 - Consumes: the implemented router and migrated callers
 - Produces: repository guidance and fresh end-to-end evidence
 
-- [ ] **Step 1: Update the collaboration contract**
+- [x] **Step 1: Update the collaboration contract**
 
 Replace the claim that Codex only works around workflow edges with concise guidance:
 
@@ -357,7 +357,7 @@ Replace the claim that Codex only works around workflow edges with concise guida
   verifier agent directly or copy the Codex bridge command.
 ```
 
-- [ ] **Step 2: Run static and repository checks**
+- [x] **Step 2: Run static and repository checks**
 
 Run:
 
@@ -371,6 +371,11 @@ pre-commit run --all-files
 Expected: all checks pass.
 
 - [ ] **Step 3: Run one live read-only smoke test**
+
+Blocked on 2026-09-06 before workflow dispatch: Claude Code returned HTTP 403
+because the organization disables subscription access. A direct run of the
+same Codex subprocess path passed with `gpt-5.6-sol`, `xhigh`, the read-only
+sandbox, canonical `.claude/agents/code-verifier.md`, and valid schema output.
 
 From Claude Code, invoke `code-verify` with the default provider, a prompt that asks which canonical role file it loaded, and this schema:
 
@@ -387,7 +392,7 @@ From Claude Code, invoke `code-verify` with the default provider, a prompt that 
 
 Expected: `role` names `.claude/agents/code-verifier.md`, `readOnly` is true, the worktree stays clean, and the run reports Sol/xhigh from `.codex/agents/code-verifier.toml`.
 
-- [ ] **Step 4: Mark the plan complete and commit documentation**
+- [x] **Step 4: Mark the plan complete and commit documentation**
 
 Mark completed checkboxes in this file, then run:
 

--- a/docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
+++ b/docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
@@ -27,7 +27,7 @@
 
 **Files:**
 - Create: `.claude/workflows/code-verify.js`
-- Create: `.claude/workflows/test-code-verify.mjs`
+- Create: `.claude/workflows/test/test-code-verify.mjs`
 - Modify: `.pre-commit-config.yaml`
 
 **Interfaces:**
@@ -72,7 +72,7 @@ The mock identifies the native Claude call by `agentType: 'code-verifier'` and t
 Run:
 
 ```bash
-node .claude/workflows/test-code-verify.mjs
+node .claude/workflows/test/test-code-verify.mjs
 ```
 
 Expected: FAIL because `.claude/workflows/code-verify.js` does not exist.
@@ -152,7 +152,7 @@ return the result file's JSON verbatim; if any command fails, do not fabricate a
 Run:
 
 ```bash
-node .claude/workflows/test-code-verify.mjs
+node .claude/workflows/test/test-code-verify.mjs
 .claude/workflows/check.sh .claude/workflows/code-verify.js
 ```
 
@@ -166,7 +166,7 @@ Add under `repo: local`:
   - id: code-verify-logic
     name: code-verify-logic
     files: ^\.claude/workflows/
-    entry: node .claude/workflows/test-code-verify.mjs
+    entry: node .claude/workflows/test/test-code-verify.mjs
     pass_filenames: false
     language: system
 ```
@@ -183,7 +183,7 @@ Expected: PASS.
 
 ```bash
 git add .claude/workflows/code-verify.js \
-  .claude/workflows/test-code-verify.mjs .pre-commit-config.yaml
+  .claude/workflows/test/test-code-verify.mjs .pre-commit-config.yaml
 git commit -m "workflows: add Codex verifier routing"
 ```
 
@@ -192,7 +192,7 @@ git commit -m "workflows: add Codex verifier routing"
 ### Task 2: Route Canonical Verifier Calls
 
 **Files:**
-- Modify: `.claude/workflows/test-code-verify.mjs`
+- Modify: `.claude/workflows/test/test-code-verify.mjs`
 - Modify: `.claude/workflows/driver-review.js`
 - Modify: `.claude/workflows/fanout-dev.js`
 - Modify: `.claude/workflows/pr-babysit.js`
@@ -214,7 +214,7 @@ Scan every `.claude/workflows/*.js` except `code-verify.js` and fail if it match
 Run:
 
 ```bash
-node .claude/workflows/test-code-verify.mjs
+node .claude/workflows/test/test-code-verify.mjs
 ```
 
 Expected: FAIL naming direct calls in `driver-review.js`, `fanout-dev.js`, and `pr-babysit.js`.
@@ -239,14 +239,14 @@ Keep every caller's existing null/result handling. Remove the `max` effort overr
 Run:
 
 ```bash
-node .claude/workflows/test-code-verify.mjs
+node .claude/workflows/test/test-code-verify.mjs
 for f in .claude/workflows/*.js; do .claude/workflows/check.sh "$f"; done
 ```
 
 Expected: no bypasses and every workflow syntax check passes.
 
 ```bash
-git add .claude/workflows/test-code-verify.mjs \
+git add .claude/workflows/test/test-code-verify.mjs \
   .claude/workflows/driver-review.js .claude/workflows/fanout-dev.js \
   .claude/workflows/pr-babysit.js
 git commit -m "workflows: route code verification through Codex"
@@ -258,7 +258,7 @@ git commit -m "workflows: route code verification through Codex"
 
 **Files:**
 - Modify: `.claude/workflows/validate.js`
-- Modify: `.claude/workflows/test-code-verify.mjs`
+- Modify: `.claude/workflows/test/test-code-verify.mjs`
 
 **Interfaces:**
 - Consumes: `workflow('code-verify', { provider: 'both', prompt, schema, label })`
@@ -273,7 +273,7 @@ Assert that `validate.js` contains one `workflow('code-verify'` call with `provi
 Run:
 
 ```bash
-node .claude/workflows/test-code-verify.mjs
+node .claude/workflows/test/test-code-verify.mjs
 ```
 
 Expected: FAIL because `validate.js` still owns separate Claude and Codex review agents.
@@ -323,14 +323,14 @@ Flatten stage-thunk results before updating `latest`. When building the next `to
 Run:
 
 ```bash
-node .claude/workflows/test-code-verify.mjs
+node .claude/workflows/test/test-code-verify.mjs
 .claude/workflows/check.sh .claude/workflows/validate.js
 ```
 
 Expected: PASS.
 
 ```bash
-git add .claude/workflows/validate.js .claude/workflows/test-code-verify.mjs
+git add .claude/workflows/validate.js .claude/workflows/test/test-code-verify.mjs
 git commit -m "validate: share dual review routing"
 ```
 
@@ -362,7 +362,7 @@ Replace the claim that Codex only works around workflow edges with concise guida
 Run:
 
 ```bash
-node .claude/workflows/test-code-verify.mjs
+node .claude/workflows/test/test-code-verify.mjs
 for f in .claude/workflows/*.js; do .claude/workflows/check.sh "$f"; done
 git diff --check origin/master...HEAD
 pre-commit run --all-files

--- a/docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
+++ b/docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
@@ -403,3 +403,18 @@ git status --short
 ```
 
 Expected: clean worktree with four implementation commits after the design commit.
+
+---
+
+### Task 5: Respect Claude's One-level Workflow Limit
+
+Final review of the installed Claude Code 2.1.263 runtime found that
+`workflow()` rejects calls from child workflows. Since `full-check` invokes
+`validate`, the planned `validate -> code-verify` call would fail.
+
+- [x] Move the Haiku/low subprocess contract into the shared
+  `.claude/agents/codex-code-verifier.md` bridge.
+- [x] Keep root-workflow callers on `code-verify`; make `validate` dispatch the
+  same bridge and native verifier agents directly.
+- [x] Add regression checks that `validate` does not nest `code-verify` and
+  still preserves provider-specific results and gates.

--- a/docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
+++ b/docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
@@ -1,0 +1,400 @@
+# Codex-backed Dynamic Workflow Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route TinyUSB dynamic-workflow `code-verifier` calls through Codex by default, while allowing each call to select Claude or independent Claude-and-Codex verification.
+
+**Architecture:** Claude Code remains the workflow runtime. A nested `code-verify` workflow owns provider selection, uses a Haiku/low process bridge for Codex, and reads the canonical Claude role plus Codex adapter at execution time; callers never copy the bridge command.
+
+**Tech Stack:** Claude Code dynamic workflow JavaScript, Node.js standard library, Python `tomllib`, Codex CLI
+
+**Spec:** `docs/superpowers/specs/2026-09-06-codex-dynamic-workflow-design.md`
+
+## Global Constraints
+
+- `.claude/workflows/` is the only authored workflow tree.
+- `.claude/agents/code-verifier.md` is the only authored verifier role.
+- `.codex/agents/code-verifier.toml` supplies the Codex model and effort; currently `gpt-5.6-sol` and `xhigh`.
+- Provider defaults to `codex`; accepted values are `codex`, `claude`, and `both`.
+- Codex failures are hard failures, never automatic Claude fallbacks.
+- Codex is always read-only.
+- Only `code-verifier` is routed; no other role changes provider.
+- Use only existing runtimes and standard libraries.
+
+---
+
+### Task 1: Provider Router
+
+**Files:**
+- Create: `.claude/workflows/code-verify.js`
+- Create: `.claude/workflows/test-code-verify.mjs`
+- Modify: `.pre-commit-config.yaml`
+
+**Interfaces:**
+- Consumes: `{ prompt: string, schema: object, provider?: 'codex'|'claude'|'both', label?: string }`
+- Produces: the requested schema for a single provider; `{ codex, claude }` for `both`
+
+- [ ] **Step 1: Write failing router tests**
+
+Create `test-code-verify.mjs` with a small harness that evaluates a workflow body inside an async function with mocked `agent` and `parallel` primitives. Add checks for:
+
+```js
+await check('defaults to codex', async () => {
+  const { result, calls } = await run({ prompt: 'review', schema: RESULT }, answers)
+  assert.deepEqual(result, answers.codex)
+  assert.deepEqual(calls.map(c => c.provider), ['codex'])
+})
+
+await check('selects claude', async () => {
+  const { result, calls } = await run(
+    { prompt: 'review', schema: RESULT, provider: 'claude' }, answers)
+  assert.deepEqual(result, answers.claude)
+  assert.deepEqual(calls.map(c => c.provider), ['claude'])
+})
+
+await check('runs both independently', async () => {
+  const { result, calls } = await run(
+    { prompt: 'review', schema: RESULT, provider: 'both' }, answers)
+  assert.deepEqual(result, { codex: answers.codex, claude: answers.claude })
+  assert.deepEqual(calls.map(c => c.provider).sort(), ['claude', 'codex'])
+})
+
+await assert.rejects(run({ prompt: 'review', schema: RESULT, provider: 'auto' }, answers),
+  /provider must be codex, claude, or both/)
+await assert.rejects(run({ prompt: 'review', schema: RESULT }, { ...answers, codex: null }),
+  /codex verifier failed/)
+```
+
+The mock identifies the native Claude call by `agentType: 'code-verifier'` and the Codex bridge by `model: 'haiku'`.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+node .claude/workflows/test-code-verify.mjs
+```
+
+Expected: FAIL because `.claude/workflows/code-verify.js` does not exist.
+
+- [ ] **Step 3: Implement the minimal router**
+
+Create `code-verify.js` with:
+
+```js
+export const meta = {
+  name: 'code-verify',
+  description: 'Run the canonical code-verifier with Codex (default), Claude, or both independently',
+  whenToUse: 'Nested by TinyUSB workflows that need structured code verification',
+  phases: [{ title: 'Verify' }],
+}
+
+if (typeof args === 'string') { try { args = JSON.parse(args) } catch { args = null } }
+if (!args || typeof args.prompt !== 'string' || !args.prompt.trim() ||
+    !args.schema || typeof args.schema !== 'object' || Array.isArray(args.schema)) {
+  throw new Error('args must be { prompt: string, schema: object, provider?, label? }')
+}
+const provider = args.provider || 'codex'
+if (!['codex', 'claude', 'both'].includes(provider)) {
+  throw new Error('provider must be codex, claude, or both')
+}
+const label = args.label || 'code-verifier'
+const codexPrompt = `Act only as a process bridge; do not perform verification yourself.
+From the repository root, read .codex/agents/code-verifier.toml with Python's
+tomllib. Create one temporary directory and arrange to remove it on exit. Write
+the JSON inside <schema> to a schema file. Write the adapter's
+developer_instructions followed by the text inside <task> to a prompt file.
+Run Codex with a 600-second timeout from the repository root:
+codex exec -C <root> -m <adapter model>
+  -c model_reasoning_effort=<adapter model_reasoning_effort>
+  --sandbox read-only --output-schema <schema file>
+  --output-last-message <result file> - < <prompt file>
+If every command succeeds, return only the result file's JSON as your final
+answer. If anything fails, do not perform the verification or fabricate JSON.
+<schema>${JSON.stringify(args.schema)}</schema>
+<task>${args.prompt}</task>`
+
+const runCodex = () => agent(codexPrompt, {
+  label: `${label}:codex`, phase: 'Verify', model: 'haiku', effort: 'low', schema: args.schema,
+}).then(r => {
+  if (!r) throw new Error('codex verifier failed')
+  return r
+})
+
+const runClaude = () => agent(args.prompt, {
+  label: `${label}:claude`, phase: 'Verify', agentType: 'code-verifier', schema: args.schema,
+}).then(r => {
+  if (!r) throw new Error('claude verifier failed')
+  return r
+})
+
+if (provider === 'codex') return runCodex()
+if (provider === 'claude') return runClaude()
+const [codex, claude] = await parallel([runCodex, runClaude])
+return { codex, claude }
+```
+
+The complete `codexPrompt` must instruct the bridge to:
+
+```text
+find the repo root with git rev-parse --show-toplevel
+read .codex/agents/code-verifier.toml with python3 tomllib
+create one mktemp directory and trap its removal
+write the supplied schema and adapter developer_instructions plus task to files
+run timeout 600s codex exec -C <root> -m <adapter model>
+  -c model_reasoning_effort=<adapter effort> --sandbox read-only
+  --output-schema <schema file> --output-last-message <result file> - < <prompt file>
+return the result file's JSON verbatim; if any command fails, do not fabricate a result
+```
+
+- [ ] **Step 4: Run router tests and syntax check**
+
+Run:
+
+```bash
+node .claude/workflows/test-code-verify.mjs
+.claude/workflows/check.sh .claude/workflows/code-verify.js
+```
+
+Expected: all router checks pass and the syntax checker prints `OK`.
+
+- [ ] **Step 5: Register the focused pre-commit hook**
+
+Add under `repo: local`:
+
+```yaml
+  - id: code-verify-logic
+    name: code-verify-logic
+    files: ^\.claude/workflows/
+    entry: node .claude/workflows/test-code-verify.mjs
+    pass_filenames: false
+    language: system
+```
+
+Run:
+
+```bash
+pre-commit run code-verify-logic --all-files
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the router**
+
+```bash
+git add .claude/workflows/code-verify.js \
+  .claude/workflows/test-code-verify.mjs .pre-commit-config.yaml
+git commit -m "workflows: add Codex verifier routing"
+```
+
+---
+
+### Task 2: Route Canonical Verifier Calls
+
+**Files:**
+- Modify: `.claude/workflows/test-code-verify.mjs`
+- Modify: `.claude/workflows/driver-review.js`
+- Modify: `.claude/workflows/fanout-dev.js`
+- Modify: `.claude/workflows/pr-babysit.js`
+
+**Interfaces:**
+- Consumes: `workflow('code-verify', { prompt, schema, label })`
+- Produces: the same structured result each former native verifier call consumed
+
+- [ ] **Step 1: Add the failing no-bypass test**
+
+Scan every `.claude/workflows/*.js` except `code-verify.js` and fail if it matches:
+
+```js
+/agentType:\s*['"]code-verifier['"]/
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+node .claude/workflows/test-code-verify.mjs
+```
+
+Expected: FAIL naming direct calls in `driver-review.js`, `fanout-dev.js`, and `pr-babysit.js`.
+
+- [ ] **Step 3: Replace each direct call**
+
+Use this shape without a `provider`, so Codex is selected:
+
+```js
+workflow('code-verify', {
+  prompt: `Review the uncommitted change in ${item} (inspect with: git diff -- ${item}) against this task:\n${args.task}\n` +
+    'Dimension: does the diff correctly and completely implement the task with no unintended side effects? Coverage-first findings.',
+  label: `review:${short(item)}`,
+  schema: FINDINGS,
+})
+```
+
+Keep every caller's existing null/result handling. Remove the `max` effort override from the adversarial `driver-review` call; provider adapters own the approved `xhigh` effort.
+
+- [ ] **Step 4: Verify callers and commit**
+
+Run:
+
+```bash
+node .claude/workflows/test-code-verify.mjs
+for f in .claude/workflows/*.js; do .claude/workflows/check.sh "$f"; done
+```
+
+Expected: no bypasses and every workflow syntax check passes.
+
+```bash
+git add .claude/workflows/test-code-verify.mjs \
+  .claude/workflows/driver-review.js .claude/workflows/fanout-dev.js \
+  .claude/workflows/pr-babysit.js
+git commit -m "workflows: route code verification through Codex"
+```
+
+---
+
+### Task 3: Consolidate Validate's Dual Review
+
+**Files:**
+- Modify: `.claude/workflows/validate.js`
+- Modify: `.claude/workflows/test-code-verify.mjs`
+
+**Interfaces:**
+- Consumes: `workflow('code-verify', { provider: 'both', prompt, schema, label })`
+- Produces: separate `review` and `codex` stage rows from one independent dual-provider dispatch
+
+- [ ] **Step 1: Add a failing validate wiring check**
+
+Assert that `validate.js` contains one `workflow('code-verify'` call with `provider: 'both'`, and contains neither `codex review --base` nor a direct Opus review agent.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+node .claude/workflows/test-code-verify.mjs
+```
+
+Expected: FAIL because `validate.js` still owns separate Claude and Codex review agents.
+
+- [ ] **Step 3: Normalize the shared review prompt**
+
+Keep the existing `REVIEW` schema but require `severity` to include both independent gate signals:
+
+```text
+severity = "CONFIRMED P0 correctness", "CONFIRMED P1 safety",
+"PLAUSIBLE P2 quality", or the same format with P0-P3 and one of
+correctness, safety, security, quality, simplification, or style
+```
+
+Use one prompt for both providers. Keep gate computation in JavaScript:
+
+```js
+const confirmedReview = f =>
+  /^confirmed/i.test(f.severity) && !/quality|simplification|style/i.test(f.severity)
+const codexBlocking = f =>
+  /^confirmed/i.test(f.severity) && /\bP[01]\b/i.test(f.severity)
+```
+
+- [ ] **Step 4: Dispatch and split both results**
+
+Schedule one internal `reviews` thunk when either review stage is enabled. Select `both` when neither `review` nor `codex` is skipped; otherwise select the remaining provider. Normalize its return into the existing stage rows:
+
+```js
+const rows = []
+if (result.claude) rows.push({
+  stage: 'review', pass: result.claude.pass &&
+    !result.claude.findings.some(confirmedReview),
+  findings: result.claude.findings, detail: result.claude.detail,
+})
+if (result.codex) rows.push({
+  stage: 'codex', pass: result.codex.pass &&
+    !result.codex.findings.some(codexBlocking),
+  findings: result.codex.findings, detail: result.codex.detail,
+})
+return rows
+```
+
+Flatten stage-thunk results before updating `latest`. When building the next `toRun` set, map failed `review` or `codex` rows back to the `reviews` scheduler name. Preserve the existing `skip`, fixer evidence, retry, restart-required, and final-report contracts.
+
+- [ ] **Step 5: Verify validate and commit**
+
+Run:
+
+```bash
+node .claude/workflows/test-code-verify.mjs
+.claude/workflows/check.sh .claude/workflows/validate.js
+```
+
+Expected: PASS.
+
+```bash
+git add .claude/workflows/validate.js .claude/workflows/test-code-verify.mjs
+git commit -m "validate: share dual review routing"
+```
+
+---
+
+### Task 4: Document and Verify the Integration
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md`
+
+**Interfaces:**
+- Consumes: the implemented router and migrated callers
+- Produces: repository guidance and fresh end-to-end evidence
+
+- [ ] **Step 1: Update the collaboration contract**
+
+Replace the claim that Codex only works around workflow edges with concise guidance:
+
+```markdown
+- `.claude/workflows/*.js` remain the canonical Claude Code orchestration.
+  Their `code-verifier` work routes through the nested `code-verify` workflow:
+  Codex by default, or Claude/both when a caller selects it. Do not invoke the
+  verifier agent directly or copy the Codex bridge command.
+```
+
+- [ ] **Step 2: Run static and repository checks**
+
+Run:
+
+```bash
+node .claude/workflows/test-code-verify.mjs
+for f in .claude/workflows/*.js; do .claude/workflows/check.sh "$f"; done
+git diff --check origin/master...HEAD
+pre-commit run --all-files
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 3: Run one live read-only smoke test**
+
+From Claude Code, invoke `code-verify` with the default provider, a prompt that asks which canonical role file it loaded, and this schema:
+
+```js
+{
+  type: 'object', additionalProperties: false,
+  required: ['role', 'readOnly'],
+  properties: {
+    role: { type: 'string' },
+    readOnly: { type: 'boolean' },
+  },
+}
+```
+
+Expected: `role` names `.claude/agents/code-verifier.md`, `readOnly` is true, the worktree stays clean, and the run reports Sol/xhigh from `.codex/agents/code-verifier.toml`.
+
+- [ ] **Step 4: Mark the plan complete and commit documentation**
+
+Mark completed checkboxes in this file, then run:
+
+```bash
+git add CLAUDE.md docs/superpowers/plans/2026-09-06-codex-dynamic-workflow.md
+git commit -m "docs: describe Codex verifier workflows"
+git status --short
+```
+
+Expected: clean worktree with four implementation commits after the design commit.

--- a/docs/superpowers/specs/2026-09-06-codex-dynamic-workflow-design.md
+++ b/docs/superpowers/specs/2026-09-06-codex-dynamic-workflow-design.md
@@ -125,7 +125,7 @@ result.
 
 ## Verification
 
-Add `.claude/workflows/test-code-verify.mjs` using only Node's standard
+Add `.claude/workflows/test/test-code-verify.mjs` using only Node's standard
 library. Execute the router with mocked workflow primitives and verify:
 
 - omitted provider dispatches only Codex;
@@ -140,7 +140,7 @@ Register the test as a local pre-commit hook for `.claude/workflows/` changes.
 Also run:
 
 1. `.claude/workflows/check.sh` for every workflow JavaScript file.
-2. `node .claude/workflows/test-code-verify.mjs`.
+2. `node .claude/workflows/test/test-code-verify.mjs`.
 3. `pre-commit run --all-files`.
 4. One live read-only `code-verify` workflow call with a small schema, checking
    that Codex used the canonical role and returned valid structured output.
@@ -148,7 +148,7 @@ Also run:
 ## Repository Changes
 
 - Add `.claude/workflows/code-verify.js`.
-- Add `.claude/workflows/test-code-verify.mjs`.
+- Add `.claude/workflows/test/test-code-verify.mjs`.
 - Add `.claude/agents/codex-code-verifier.md`.
 - Modify `.claude/workflows/{driver-review,fanout-dev,pr-babysit,validate}.js`.
 - Modify `.pre-commit-config.yaml` to run the router self-test.

--- a/docs/superpowers/specs/2026-09-06-codex-dynamic-workflow-design.md
+++ b/docs/superpowers/specs/2026-09-06-codex-dynamic-workflow-design.md
@@ -15,6 +15,8 @@ fallback.
 - Claude Code remains the dynamic workflow runtime and orchestrator.
 - `.claude/workflows/` remains the only authored workflow tree.
 - `.claude/agents/code-verifier.md` remains the only authored verifier role.
+- `.claude/agents/codex-code-verifier.md` is a process bridge, not a second
+  verifier role.
 - `.codex/agents/code-verifier.toml` remains the Codex model/effort adapter. It
   currently selects `gpt-5.6-sol` at `xhigh` effort and loads the canonical
   Markdown role.
@@ -67,8 +69,8 @@ override in `driver-review.js` is removed so both providers use their approved
 ## Codex Provider
 
 Dynamic workflow JavaScript cannot directly run shell commands, so the Codex
-path uses one Haiku/low Claude agent as a thin process bridge. The bridge does
-no review work. It:
+path invokes `.claude/agents/codex-code-verifier.md`, a Haiku/low process
+bridge shared with child workflows. The bridge does no review work. It:
 
 1. Locates the repository root.
 2. Reads `.codex/agents/code-verifier.toml` with Python's standard `tomllib` to
@@ -100,14 +102,16 @@ nested router:
 
 Those calls omit `provider` and therefore use Codex only.
 
-Replace `validate.js`'s separate Claude and ad-hoc Codex review implementations
-with one `code-verify` call using `provider: 'both'`. Preserve two independently
-reported stages and apply the existing Claude and Codex gating rules to their
-respective results. A failed provider remains a failed stage.
+`full-check` already invokes `validate`, and Claude Code limits workflow nesting
+to one level. Therefore `validate.js` cannot invoke `code-verify`; it dispatches
+the same `codex-code-verifier` and `code-verifier` agents directly, in parallel
+for `both`, while preserving the two reported stages and their separate gates.
+A failed provider remains a failed stage.
 
-Future dynamic workflows that need this role call `workflow('code-verify',
-...)`; they do not invoke `agentType: 'code-verifier'` directly or copy the
-Codex command.
+Future root workflows that need this role call `workflow('code-verify', ...)`.
+A workflow that is itself called by another workflow must dispatch the shared
+bridge/native agents directly, as `validate` does. No workflow copies the Codex
+command.
 
 ## Concurrency and Safety
 
@@ -129,8 +133,8 @@ library. Execute the router with mocked workflow primitives and verify:
 - `both` starts independent Codex and Claude calls and returns both results;
 - invalid inputs fail before dispatch;
 - a dead or malformed Codex result fails without invoking Claude;
-- no workflow other than `code-verify.js` directly names the `code-verifier`
-  agent type.
+- only `validate.js` bypasses the router, to respect the one-level nesting
+  limit, and it uses the same shared bridge/native agents.
 
 Register the test as a local pre-commit hook for `.claude/workflows/` changes.
 Also run:
@@ -145,6 +149,7 @@ Also run:
 
 - Add `.claude/workflows/code-verify.js`.
 - Add `.claude/workflows/test-code-verify.mjs`.
+- Add `.claude/agents/codex-code-verifier.md`.
 - Modify `.claude/workflows/{driver-review,fanout-dev,pr-babysit,validate}.js`.
 - Modify `.pre-commit-config.yaml` to run the router self-test.
 - Modify `CLAUDE.md` to describe Codex-backed verifier routing instead of

--- a/docs/superpowers/specs/2026-09-06-codex-dynamic-workflow-design.md
+++ b/docs/superpowers/specs/2026-09-06-codex-dynamic-workflow-design.md
@@ -1,0 +1,159 @@
+# Codex-backed Dynamic Workflow Verification
+
+Date: 2026-09-06
+Branch: `claude/codex-dynamic-workflows`
+
+## Goal
+
+Let Claude Code dynamic workflows run the canonical `code-verifier` role with
+Codex, Claude, or both without maintaining a second workflow tree. Codex is the
+default provider. Provider failures are visible and never trigger a silent
+fallback.
+
+## Boundaries
+
+- Claude Code remains the dynamic workflow runtime and orchestrator.
+- `.claude/workflows/` remains the only authored workflow tree.
+- `.claude/agents/code-verifier.md` remains the only authored verifier role.
+- `.codex/agents/code-verifier.toml` remains the Codex model/effort adapter. It
+  currently selects `gpt-5.6-sol` at `xhigh` effort and loads the canonical
+  Markdown role.
+- Only `code-verifier` is routed in this change. Other roles remain
+  Claude-native.
+
+## Provider Router
+
+Add `.claude/workflows/code-verify.js` as a nested workflow with this input:
+
+```js
+{
+  prompt: string,
+  schema: object,
+  provider?: 'codex' | 'claude' | 'both',
+  label?: string,
+}
+```
+
+`provider` defaults to `codex`.
+
+- `codex` returns the Codex result in the supplied schema.
+- `claude` returns the Claude result in the supplied schema.
+- `both` starts both providers independently with the same prompt and schema,
+  waits for both, and returns `{ codex, claude }`. The router does not merge or
+  adjudicate the results.
+
+The router validates `prompt`, `schema`, and `provider` before dispatch. A
+provider that dies, exits unsuccessfully, or returns output that does not match
+the schema causes the router to throw a provider-specific error.
+
+## Claude Provider
+
+The Claude path invokes the existing native agent:
+
+```js
+agent(prompt, {
+  agentType: 'code-verifier',
+  label,
+  phase: 'Verify',
+  schema,
+})
+```
+
+The agent's canonical frontmatter currently selects Opus at `xhigh` effort.
+The router does not copy that configuration. The existing one-call `max`
+override in `driver-review.js` is removed so both providers use their approved
+`xhigh` verifier configurations consistently.
+
+## Codex Provider
+
+Dynamic workflow JavaScript cannot directly run shell commands, so the Codex
+path uses one Haiku/low Claude agent as a thin process bridge. The bridge does
+no review work. It:
+
+1. Locates the repository root.
+2. Reads `.codex/agents/code-verifier.toml` with Python's standard `tomllib` to
+   obtain the Codex model, effort, and canonical-role loading instruction.
+3. Writes the supplied JSON schema to a temporary file.
+4. Runs `codex exec` from the repository root with the adapter's model and
+   effort, `--sandbox read-only`, `--output-schema`, and
+   `--output-last-message`.
+5. Returns the parsed JSON value without interpreting its findings and removes
+   its temporary files.
+
+The task sent to Codex combines the adapter's canonical-role loading
+instruction with the caller's prompt. The verifier role body is therefore read
+at execution time rather than embedded in the router. Future edits to either
+the role body or the Codex adapter take effect without regenerating anything.
+
+The Codex subprocess has a bounded timeout. Timeout, missing CLI, nonzero exit,
+missing output, invalid JSON, and schema mismatch are hard failures. The router
+does not run Claude as a fallback.
+
+## Callers
+
+Replace direct `agentType: 'code-verifier'` calls in these workflows with the
+nested router:
+
+- `driver-review.js`
+- `fanout-dev.js`
+- `pr-babysit.js`
+
+Those calls omit `provider` and therefore use Codex only.
+
+Replace `validate.js`'s separate Claude and ad-hoc Codex review implementations
+with one `code-verify` call using `provider: 'both'`. Preserve two independently
+reported stages and apply the existing Claude and Codex gating rules to their
+respective results. A failed provider remains a failed stage.
+
+Future dynamic workflows that need this role call `workflow('code-verify',
+...)`; they do not invoke `agentType: 'code-verifier'` directly or copy the
+Codex command.
+
+## Concurrency and Safety
+
+Both providers are read-only and may run in parallel in the same checkout.
+Codex always receives the read-only sandbox. The router does not expose a write
+mode, approval override, model override, or provider fallback.
+
+Each invocation owns unique temporary files and cleans them on success or
+failure, so parallel verifier calls cannot overwrite each other's schema or
+result.
+
+## Verification
+
+Add `.claude/workflows/test-code-verify.mjs` using only Node's standard
+library. Execute the router with mocked workflow primitives and verify:
+
+- omitted provider dispatches only Codex;
+- `claude` dispatches only the native verifier;
+- `both` starts independent Codex and Claude calls and returns both results;
+- invalid inputs fail before dispatch;
+- a dead or malformed Codex result fails without invoking Claude;
+- no workflow other than `code-verify.js` directly names the `code-verifier`
+  agent type.
+
+Register the test as a local pre-commit hook for `.claude/workflows/` changes.
+Also run:
+
+1. `.claude/workflows/check.sh` for every workflow JavaScript file.
+2. `node .claude/workflows/test-code-verify.mjs`.
+3. `pre-commit run --all-files`.
+4. One live read-only `code-verify` workflow call with a small schema, checking
+   that Codex used the canonical role and returned valid structured output.
+
+## Repository Changes
+
+- Add `.claude/workflows/code-verify.js`.
+- Add `.claude/workflows/test-code-verify.mjs`.
+- Modify `.claude/workflows/{driver-review,fanout-dev,pr-babysit,validate}.js`.
+- Modify `.pre-commit-config.yaml` to run the router self-test.
+- Modify `CLAUDE.md` to describe Codex-backed verifier routing instead of
+  saying workflows can only use Codex around their edges.
+
+## Out of Scope
+
+- A Codex-native dynamic workflow runtime or workflow mirror.
+- Routing `builder`, `code-writer`, HIL, static-analysis, PR-watcher, or target
+  debugging roles through Codex.
+- Automatic provider selection, retries, fallback, or result merging.
+- Per-call model, effort, sandbox, or write-mode controls.


### PR DESCRIPTION
Route dynamic-workflow code verification through Codex by default, while retaining per-call Claude and dual-provider modes.

Claude Code limits workflows to one nesting level, so validate dispatches the same shared verifier agents directly when full-check invokes it. The Codex bridge reads the canonical role and model adapter at runtime, keeping future role, model, and effort changes synchronized.

Verification: pre-commit run --all-files; all workflow syntax and router regression checks pass. A direct Codex smoke confirmed gpt-5.6-sol, xhigh, read-only sandbox, and canonical role loading. The Claude-hosted smoke could not start because the current organization returns HTTP 403 for Claude Code subscription access.