### PR TITLE
hil: source ESP-IDF environment for pool checks

### DIFF
--- a/.claude/skills/hil-pool-check/SKILL.md
+++ b/.claude/skills/hil-pool-check/SKILL.md
@@ -40,12 +40,14 @@ ssh ci.lan 'bash -lc "cd ~/code/tinyusb && python3 test/hil/helper/hil_pool_chec
 
 Missing firmware is **built on the spot** — never skipped (`--no-build` opts out; those boards
 then report `flash-failed`). Builds need the family env, referenced by its OFFICIAL variable so the docs hold on any
-rig: `PICO_SDK_PATH` for rp2040/rp2350, `IDF_PATH` for espressif — activated explicitly as
-`. "$IDF_PATH/export.sh"`, never as `get-idf` (an interactive alias; aliases are not expanded
-in non-interactive shells, so scripts get `get-idf: command not found` even under `bash -lc`).
-Each host exports both vars in `~/.bashrc` ABOVE the interactive early-return, which is what
-makes a plain non-interactive `ssh <rig> 'cmd'` see them (verified on ci; where the checkouts
-live is that host's business, not this file's). It also
+rig: `PICO_SDK_PATH` for rp2040/rp2350, `IDF_PATH` for espressif. For espressif boards the tool
+sources `. "$IDF_PATH/export.sh"` itself, scoped to that one build's subprocess (`bash -c`) so it
+never leaks PATH/venv changes into the parent process or sibling threads' concurrent ARM/RISC-V
+builds — it only needs `IDF_PATH` set in the environment, not `idf.py` already on `PATH`. If
+`IDF_PATH` itself is unset, that board still reports `ESP-IDF env missing`.
+Each host exports `IDF_PATH`/`PICO_SDK_PATH` in `~/.bashrc` ABOVE the interactive early-return,
+which is what makes a plain non-interactive `ssh <rig> 'cmd'` see them (verified on ci; where the
+checkouts live is that host's business, not this file's). It also
 needs `esptool` on PATH (pip's
 `~/.local/bin/esptool`; a non-login shell may lack it — run via `bash -lc`). An explicit `-B` is
 searched exclusively for *existing* firmware; builds still land in `cmake-build/` and are noted

--- a/test/hil/helper/hil_pool_check.py
+++ b/test/hil/helper/hil_pool_check.py
@@ -467,8 +467,9 @@ def build_example(board: dict, variant: str, example: str) -> int:
     variants = board.get('variant') or [{'name': name}]
     vcfg = next((v for v in variants if v['name'] == variant), variants[0])
     if board['flasher']['name'].lower() == 'esptool':
-        if not shutil.which('idf.py'):
-            return 127  # ESP-IDF env not sourced in this shell
+        idf_path = os.environ.get('IDF_PATH')
+        if not idf_path and not shutil.which('idf.py'):
+            return 127  # ESP-IDF env not sourced in this shell and IDF_PATH unset
         # -B keyed off the VARIANT so ensure_fw's post-build lookup finds it
         cmd = ['idf.py', '-C', f'examples/{example}',
                '-B', f'cmake-build/cmake-build-{vcfg["name"]}/{example}',
@@ -477,11 +478,17 @@ def build_example(board: dict, variant: str, example: str) -> int:
             cmd.insert(-1, f'-D{d}')
         if vcfg.get('flags'):
             cmd.insert(-1, f'-DCFLAGS_CLI={vcfg["flags"]}')
+        # source export.sh in THIS subprocess only, via bash -c: it mutates PATH/venv
+        # (idf.py, xtensa/riscv toolchain, IDF's own python) which must not leak into
+        # the parent process or sibling threads' concurrent ARM/RISC-V builds
+        if idf_path and not shutil.which('idf.py'):
+            cmd = ['bash', '-c',
+                   f'. "{idf_path}/export.sh" >/dev/null && {shlex.join(cmd)}']
         # the IDF component manager writes examples/<ex>/dependencies.lock in the
         # SOURCE tree (idf.py -B relocates only the build dir), so concurrent esp
         # builds of one example for different targets corrupt each other's solve
         with _esp_lock, _build_sem:
-            return hil_util.run_cmd(shlex.join(cmd), cwd=str(hil_util.TINYUSB_ROOT),
+            return hil_util.run_cmd(cmd, cwd=str(hil_util.TINYUSB_ROOT),
                                     timeout=600).returncode
     cmd = [sys.executable, str(hil_util.TINYUSB_ROOT / 'tools' / 'build.py'),
            '-b', name, '-T', Path(example).name,

--- a/test/hil/helper/hil_pool_check.py
+++ b/test/hil/helper/hil_pool_check.py
@@ -468,8 +468,9 @@ def build_example(board: dict, variant: str, example: str) -> int:
     vcfg = next((v for v in variants if v['name'] == variant), variants[0])
     if board['flasher']['name'].lower() == 'esptool':
         idf_path = os.environ.get('IDF_PATH')
-        if not idf_path and not shutil.which('idf.py'):
-            return 127  # ESP-IDF env not sourced in this shell and IDF_PATH unset
+        idf_py = shutil.which('idf.py')
+        if not idf_py and (not idf_path or not (Path(idf_path) / 'export.sh').is_file()):
+            return 127  # ESP-IDF env is unavailable in this shell
         # -B keyed off the VARIANT so ensure_fw's post-build lookup finds it
         cmd = ['idf.py', '-C', f'examples/{example}',
                '-B', f'cmake-build/cmake-build-{vcfg["name"]}/{example}',
@@ -481,9 +482,9 @@ def build_example(board: dict, variant: str, example: str) -> int:
         # source export.sh in THIS subprocess only, via bash -c: it mutates PATH/venv
         # (idf.py, xtensa/riscv toolchain, IDF's own python) which must not leak into
         # the parent process or sibling threads' concurrent ARM/RISC-V builds
-        if idf_path and not shutil.which('idf.py'):
-            cmd = ['bash', '-c',
-                   f'. "{idf_path}/export.sh" >/dev/null && {shlex.join(cmd)}']
+        if idf_path and not idf_py:
+            cmd = ['bash', '-c', '. "$1/export.sh" >/dev/null && exec "$@"',
+                   'bash', idf_path, *cmd]
         # the IDF component manager writes examples/<ex>/dependencies.lock in the
         # SOURCE tree (idf.py -B relocates only the build dir), so concurrent esp
         # builds of one example for different targets corrupt each other's solve

--- a/test/hil/helper/hil_pool_check.py
+++ b/test/hil/helper/hil_pool_check.py
@@ -483,7 +483,7 @@ def build_example(board: dict, variant: str, example: str) -> int:
         # (idf.py, xtensa/riscv toolchain, IDF's own python) which must not leak into
         # the parent process or sibling threads' concurrent ARM/RISC-V builds
         if idf_path and not idf_py:
-            cmd = ['bash', '-c', '. "$1/export.sh" >/dev/null && exec "$@"',
+            cmd = ['bash', '-c', '. "$1/export.sh" >/dev/null && shift && exec "$@"',
                    'bash', idf_path, *cmd]
         # the IDF component manager writes examples/<ex>/dependencies.lock in the
         # SOURCE tree (idf.py -B relocates only the build dir), so concurrent esp

--- a/test/hil/helper/hil_pool_check.py
+++ b/test/hil/helper/hil_pool_check.py
@@ -483,8 +483,8 @@ def build_example(board: dict, variant: str, example: str) -> int:
         # (idf.py, xtensa/riscv toolchain, IDF's own python) which must not leak into
         # the parent process or sibling threads' concurrent ARM/RISC-V builds
         if idf_path and not idf_py:
-            cmd = ['env', f'IDF_PATH={idf_path}', 'bash', '-c',
-                   '. "$IDF_PATH/export.sh" >/dev/null && exec "$@"', 'bash', *cmd]
+            script = f'. "$IDF_PATH/export.sh" >/dev/null && {shlex.join(cmd)}'
+            cmd = ['env', f'IDF_PATH={idf_path}', 'bash', '-c', script]
         # the IDF component manager writes examples/<ex>/dependencies.lock in the
         # SOURCE tree (idf.py -B relocates only the build dir), so concurrent esp
         # builds of one example for different targets corrupt each other's solve

--- a/test/hil/helper/hil_pool_check.py
+++ b/test/hil/helper/hil_pool_check.py
@@ -483,8 +483,8 @@ def build_example(board: dict, variant: str, example: str) -> int:
         # (idf.py, xtensa/riscv toolchain, IDF's own python) which must not leak into
         # the parent process or sibling threads' concurrent ARM/RISC-V builds
         if idf_path and not idf_py:
-            cmd = ['bash', '-c', '. "$1/export.sh" >/dev/null && shift && exec "$@"',
-                   'bash', idf_path, *cmd]
+            cmd = ['env', f'IDF_PATH={idf_path}', 'bash', '-c',
+                   '. "$IDF_PATH/export.sh" >/dev/null && exec "$@"', 'bash', *cmd]
         # the IDF component manager writes examples/<ex>/dependencies.lock in the
         # SOURCE tree (idf.py -B relocates only the build dir), so concurrent esp
         # builds of one example for different targets corrupt each other's solve

--- a/test/hil/test/test_hil_util.py
+++ b/test/hil/test/test_hil_util.py
@@ -468,7 +468,7 @@ class PoolCheckEspIdfBuild(unittest.TestCase):
         os.environ['IDF_PATH'] = '/definitely/missing/esp-idf'
         self.assertEqual(self.pool_check.build_example(self.board, 'esp32s3', self.example), 127)
 
-    def test_idf_path_is_passed_in_the_child_environment(self):
+    def test_idf_command_is_shell_quoted_without_argument_forwarding(self):
         with TemporaryDirectory(prefix='idf $path ') as td:
             Path(td, 'export.sh').touch()
             os.environ['IDF_PATH'] = td
@@ -481,9 +481,9 @@ class PoolCheckEspIdfBuild(unittest.TestCase):
             self.pool_check.hil_util.run_cmd = fake_run_cmd
             self.assertEqual(self.pool_check.build_example(self.board, 'esp32s3', self.example), 0)
             cmd, kwargs = calls[0]
-            self.assertEqual(cmd[:7], ['env', f'IDF_PATH={td}', 'bash', '-c',
-                                       '. "$IDF_PATH/export.sh" >/dev/null && exec "$@"',
-                                       'bash', 'idf.py'])
+            self.assertEqual(cmd[:4], ['env', f'IDF_PATH={td}', 'bash', '-c'])
+            self.assertTrue(cmd[4].startswith('. "$IDF_PATH/export.sh" >/dev/null && idf.py '))
+            self.assertNotIn('$@', cmd[4])
             self.assertEqual(kwargs['timeout'], 600)
 
 

--- a/test/hil/test/test_hil_util.py
+++ b/test/hil/test/test_hil_util.py
@@ -482,7 +482,7 @@ class PoolCheckEspIdfBuild(unittest.TestCase):
             self.assertEqual(self.pool_check.build_example(self.board, 'esp32s3', self.example), 0)
             cmd, kwargs = calls[0]
             self.assertEqual(cmd[:5], ['bash', '-c',
-                                       '. "$1/export.sh" >/dev/null && exec "$@"',
+                                       '. "$1/export.sh" >/dev/null && shift && exec "$@"',
                                        'bash', td])
             self.assertEqual(cmd[5], 'idf.py')
             self.assertEqual(kwargs['timeout'], 600)

--- a/test/hil/test/test_hil_util.py
+++ b/test/hil/test/test_hil_util.py
@@ -468,7 +468,7 @@ class PoolCheckEspIdfBuild(unittest.TestCase):
         os.environ['IDF_PATH'] = '/definitely/missing/esp-idf'
         self.assertEqual(self.pool_check.build_example(self.board, 'esp32s3', self.example), 127)
 
-    def test_idf_path_is_passed_as_a_bash_argument(self):
+    def test_idf_path_is_passed_in_the_child_environment(self):
         with TemporaryDirectory(prefix='idf $path ') as td:
             Path(td, 'export.sh').touch()
             os.environ['IDF_PATH'] = td
@@ -481,10 +481,9 @@ class PoolCheckEspIdfBuild(unittest.TestCase):
             self.pool_check.hil_util.run_cmd = fake_run_cmd
             self.assertEqual(self.pool_check.build_example(self.board, 'esp32s3', self.example), 0)
             cmd, kwargs = calls[0]
-            self.assertEqual(cmd[:5], ['bash', '-c',
-                                       '. "$1/export.sh" >/dev/null && shift && exec "$@"',
-                                       'bash', td])
-            self.assertEqual(cmd[5], 'idf.py')
+            self.assertEqual(cmd[:7], ['env', f'IDF_PATH={td}', 'bash', '-c',
+                                       '. "$IDF_PATH/export.sh" >/dev/null && exec "$@"',
+                                       'bash', 'idf.py'])
             self.assertEqual(kwargs['timeout'], 600)
 
 

--- a/test/hil/test/test_hil_util.py
+++ b/test/hil/test/test_hil_util.py
@@ -444,5 +444,49 @@ class BoundedReadForGuardlessCallers(unittest.TestCase):
         self.assertIsNone(self.hil_util.read_sysfs(os.path.join(self.td.name, 'nope')))
 
 
+class PoolCheckEspIdfBuild(unittest.TestCase):
+    def setUp(self):
+        from helper import hil_pool_check
+        self.pool_check = hil_pool_check
+        self.board = {'name': 'esp32s3', 'flasher': {'name': 'esptool'}}
+        self.example = 'device/cdc_msc_freertos'
+        self.old_idf_path = os.environ.get('IDF_PATH')
+        self.addCleanup(self._restore_idf_path)
+        self.old_which = self.pool_check.shutil.which
+        self.addCleanup(setattr, self.pool_check.shutil, 'which', self.old_which)
+        self.old_run_cmd = self.pool_check.hil_util.run_cmd
+        self.addCleanup(setattr, self.pool_check.hil_util, 'run_cmd', self.old_run_cmd)
+        self.pool_check.shutil.which = lambda _: None
+
+    def _restore_idf_path(self):
+        if self.old_idf_path is None:
+            os.environ.pop('IDF_PATH', None)
+        else:
+            os.environ['IDF_PATH'] = self.old_idf_path
+
+    def test_missing_export_script_reports_missing_idf_environment(self):
+        os.environ['IDF_PATH'] = '/definitely/missing/esp-idf'
+        self.assertEqual(self.pool_check.build_example(self.board, 'esp32s3', self.example), 127)
+
+    def test_idf_path_is_passed_as_a_bash_argument(self):
+        with TemporaryDirectory(prefix='idf $path ') as td:
+            Path(td, 'export.sh').touch()
+            os.environ['IDF_PATH'] = td
+            calls = []
+
+            def fake_run_cmd(cmd, **kwargs):
+                calls.append((cmd, kwargs))
+                return type('Result', (), {'returncode': 0})()
+
+            self.pool_check.hil_util.run_cmd = fake_run_cmd
+            self.assertEqual(self.pool_check.build_example(self.board, 'esp32s3', self.example), 0)
+            cmd, kwargs = calls[0]
+            self.assertEqual(cmd[:5], ['bash', '-c',
+                                       '. "$1/export.sh" >/dev/null && exec "$@"',
+                                       'bash', td])
+            self.assertEqual(cmd[5], 'idf.py')
+            self.assertEqual(kwargs['timeout'], 600)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The pool checker now sources `$IDF_PATH/export.sh` within an ESP-IDF build subprocess when `idf.py` is unavailable in the caller environment. This preserves the parent process and concurrent non-Espressif builds.

Validation:
- `PYTHONPATH=test/hil python3 -m unittest discover -s test/hil/test -p 'test_hil_util.py' -q`
- Full example builds: `stm32f407disco`, `raspberry_pi_pico`
- Pool check: both boards passed flash and re-enumeration.
- HIL: `stm32f407disco` passed 14/14 cells. `raspberry_pi_pico` passed device coverage, but its four host-fixture cells (`cdc_msc_hid`, `device_info`, `msc_file_explorer`, `msc_file_explorer_freertos`) failed after the prescribed verbose retry.