### PR TITLE
bsp: flash AT32 boards with probe-rs

### DIFF
--- a/hw/bsp/at32f402_405/family.cmake
+++ b/hw/bsp/at32f402_405/family.cmake
@@ -117,4 +117,6 @@ function(family_configure_example TARGET RTOS)
   # Flashing
   family_add_bin_hex(${TARGET})
   family_flash_jlink(${TARGET})
+  set(PROBE_RS_CHIP ${MCU_VARIANT})
+  family_flash_probe_rs(${TARGET})
 endfunction()

--- a/hw/bsp/at32f402_405/family.mk
+++ b/hw/bsp/at32f402_405/family.mk
@@ -62,4 +62,5 @@ LD_FILE ?= ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/linker/${MCU_LIN
 # For freeRTOS port source
 FREERTOS_PORTABLE_SRC = $(FREERTOS_PORTABLE_PATH)/ARM_CM4F
 
-flash: flash-atlink
+PROBE_RS_CHIP = ${MCU_VARIANT}
+flash: flash-probe-rs

--- a/hw/bsp/at32f403a_407/family.cmake
+++ b/hw/bsp/at32f403a_407/family.cmake
@@ -92,4 +92,6 @@ function(family_configure_example TARGET RTOS)
   # Flashing
   family_add_bin_hex(${TARGET})
   family_flash_jlink(${TARGET})
+  set(PROBE_RS_CHIP ${MCU_VARIANT})
+  family_flash_probe_rs(${TARGET})
 endfunction()

--- a/hw/bsp/at32f403a_407/family.mk
+++ b/hw/bsp/at32f403a_407/family.mk
@@ -37,4 +37,5 @@ LD_FILE ?= ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/linker/${MCU_LIN
 # For freeRTOS port source
 FREERTOS_PORTABLE_SRC = $(FREERTOS_PORTABLE_PATH)/ARM_CM4F
 
-flash: flash-atlink
+PROBE_RS_CHIP = ${MCU_VARIANT}
+flash: flash-probe-rs

--- a/hw/bsp/at32f413/family.cmake
+++ b/hw/bsp/at32f413/family.cmake
@@ -93,4 +93,6 @@ function(family_configure_example TARGET RTOS)
   # Flashing
   family_add_bin_hex(${TARGET})
   family_flash_jlink(${TARGET})
+  set(PROBE_RS_CHIP ${MCU_VARIANT})
+  family_flash_probe_rs(${TARGET})
 endfunction()

--- a/hw/bsp/at32f413/family.mk
+++ b/hw/bsp/at32f413/family.mk
@@ -37,4 +37,5 @@ LD_FILE ?= ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/linker/${MCU_LIN
 # For freeRTOS port source
 FREERTOS_PORTABLE_SRC = $(FREERTOS_PORTABLE_PATH)/ARM_CM4F
 
-flash: flash-atlink
+PROBE_RS_CHIP = ${MCU_VARIANT}
+flash: flash-probe-rs

--- a/hw/bsp/at32f415/family.cmake
+++ b/hw/bsp/at32f415/family.cmake
@@ -92,4 +92,6 @@ function(family_configure_example TARGET RTOS)
   # Flashing
   family_add_bin_hex(${TARGET})
   family_flash_jlink(${TARGET})
+  set(PROBE_RS_CHIP ${MCU_VARIANT})
+  family_flash_probe_rs(${TARGET})
 endfunction()

--- a/hw/bsp/at32f415/family.mk
+++ b/hw/bsp/at32f415/family.mk
@@ -34,4 +34,5 @@ SRC_S += ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/startup_${AT32_FAM
 
 LD_FILE ?= ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/linker/${MCU_LINKER_NAME}_FLASH.ld
 
-flash: flash-atlink
+PROBE_RS_CHIP = ${MCU_VARIANT}
+flash: flash-probe-rs

--- a/hw/bsp/at32f423/family.cmake
+++ b/hw/bsp/at32f423/family.cmake
@@ -94,4 +94,6 @@ function(family_configure_example TARGET RTOS)
   # Flashing
   family_add_bin_hex(${TARGET})
   family_flash_jlink(${TARGET})
+  set(PROBE_RS_CHIP ${MCU_VARIANT})
+  family_flash_probe_rs(${TARGET})
 endfunction()

--- a/hw/bsp/at32f423/family.mk
+++ b/hw/bsp/at32f423/family.mk
@@ -35,4 +35,5 @@ SRC_S += ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/startup_${AT32_FAM
 
 LD_FILE ?= ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/linker/${MCU_LINKER_NAME}_FLASH.ld
 
-flash: flash-atlink
+PROBE_RS_CHIP = ${MCU_VARIANT}
+flash: flash-probe-rs

--- a/hw/bsp/at32f425/family.cmake
+++ b/hw/bsp/at32f425/family.cmake
@@ -92,4 +92,6 @@ function(family_configure_example TARGET RTOS)
   # Flashing
   family_add_bin_hex(${TARGET})
   family_flash_jlink(${TARGET})
+  set(PROBE_RS_CHIP ${MCU_VARIANT})
+  family_flash_probe_rs(${TARGET})
 endfunction()

--- a/hw/bsp/at32f425/family.mk
+++ b/hw/bsp/at32f425/family.mk
@@ -34,4 +34,5 @@ SRC_S += ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/startup_${AT32_FAM
 
 LD_FILE ?= ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/linker/${MCU_LINKER_NAME}_FLASH.ld
 
-flash: flash-atlink
+PROBE_RS_CHIP = ${MCU_VARIANT}
+flash: flash-probe-rs

--- a/hw/bsp/at32f435_437/family.cmake
+++ b/hw/bsp/at32f435_437/family.cmake
@@ -101,4 +101,6 @@ function(family_configure_example TARGET RTOS)
   # Flashing
   family_add_bin_hex(${TARGET})
   family_flash_jlink(${TARGET})
+  set(PROBE_RS_CHIP ${MCU_VARIANT})
+  family_flash_probe_rs(${TARGET})
 endfunction()

--- a/hw/bsp/at32f435_437/family.mk
+++ b/hw/bsp/at32f435_437/family.mk
@@ -40,4 +40,5 @@ SRC_S += ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/startup_${AT32_FAM
 
 LD_FILE ?= ${AT32_SDK_LIB}/cmsis/cm4/device_support/startup/gcc/linker/${MCU_LINKER_NAME}_FLASH.ld
 
-flash: flash-atlink
+PROBE_RS_CHIP = ${MCU_VARIANT}
+flash: flash-probe-rs

--- a/hw/bsp/family_rules.mk
+++ b/hw/bsp/family_rules.mk
@@ -137,6 +137,13 @@ OPENOCD_OPTION ?=
 flash-openocd: $(BUILD)/$(PROJECT).elf
 	$(OPENOCD) $(OPENOCD_OPTION) -c "program $< verify reset exit"
 
+# --------------- probe-rs -----------------
+# flash with https://probe-rs.rs
+PROBE_RS ?= probe-rs
+PROBE_RS_OPTION ?=
+flash-probe-rs: $(BUILD)/$(PROJECT).elf
+	$(PROBE_RS) download --chip $(PROBE_RS_CHIP) $(PROBE_RS_OPTION) --verify --reset $<
+
 # --------------- openocd-wch -----------------
 # WCH parts need an openocd built with the wlinke adapter. The image is written
 # without verify: WCH code flash is not readable back over the debug bus.

--- a/hw/bsp/family_support.cmake
+++ b/hw/bsp/family_support.cmake
@@ -778,6 +778,24 @@ function(family_flash_pyocd TARGET)
 endfunction()
 
 
+# Add flash with https://probe-rs.rs
+function(family_flash_probe_rs TARGET)
+  if (NOT DEFINED PROBE_RS)
+    set(PROBE_RS probe-rs)
+  endif ()
+
+  separate_arguments(OPTION_LIST UNIX_COMMAND ${PROBE_RS_OPTION})
+
+  add_custom_target(${TARGET}-probe-rs
+    DEPENDS ${TARGET}
+    COMMAND ${PROBE_RS} download --chip ${PROBE_RS_CHIP} ${OPTION_LIST} --verify --reset $<TARGET_FILE:${TARGET}>
+    VERBATIM
+    )
+
+  #set_property(TARGET ${TARGET}-probe-rs PROPERTY FOLDER ${TARGET}-group)
+endfunction()
+
+
 # Flash with UF2
 function(family_flash_uf2 TARGET FAMILY_ID)
   add_custom_target(${TARGET}-uf2


### PR DESCRIPTION
## What
Add `flash-probe-rs` and point seven AT32 families at it. `flash-atlink` was never defined, so `make flash` fails on every AT32 board.

## Why not openocd or jlink
Mainline's artery driver rejects F402/F405 and G/M-density PIDs. AT-START boards carry AT-Link-EZ (CMSIS-DAP), not J-Link.

## Tested
at_start_f435, device/cdc_msc, probe-rs 0.32.0, Linux host with ten probes. CDC echo and MSC mount OK.

```
$ make -C examples/device/cdc_msc BOARD=at_start_f435 PROBE_RS_OPTION="--probe 2e3c:f000" flash
probe-rs download --chip AT32F435ZMT7 --probe 2e3c:f000 --verify --reset _build/at_start_f435/cdc_msc.elf
     Finished in 1.54s
 WARN probe_rs::session: Could not clear all hardware breakpoints: An ARM specific error occurred.
$ lsusb -d cafe:
Bus 003 Device 084: ID cafe:4007 TinyUSB TinyUSB Device
```

`PROBE_RS_OPTION="--probe VID:PID"` is needed on a host with more than one probe; without it probe-rs prompts and exits. The breakpoint warning appears after reset and does not affect the flash.

## Not tested
Other ten AT-START boards, no hardware. Only the F435/437 flash algorithm is exercised; the other series use different flash register blocks in probe-rs. at32f45x unchanged: probe-rs has no AT32F455/456/457.

## AI assistance
Claude drafted the rule and audited the diff. I verified the chip list, flashed the board and captured the log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added probe-rs flashing support for supported AT32 board families.
  * Flashing automatically selects the target chip variant, verifies programming, and resets the device.
  * Added configurable probe-rs command and option settings for customized flashing workflows.

* **Changes**
  * Updated AT32 board flashing workflows to use probe-rs instead of the previous flasher.
  * Probe-rs flashing is now available through both Make and CMake-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
