### PR TITLE
audio: validate feature-unit channel number (wValue low byte) before indexing mute/volume in uac2 examples

### DIFF
--- a/examples/device/audio_4_channel_mic/src/main.c
+++ b/examples/device/audio_4_channel_mic/src/main.c
@@ -224,6 +224,10 @@ bool tud_audio_set_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 
   // If request is for our feature unit
   if (entityID == 2) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Request uses format layout 1
@@ -322,6 +326,10 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 
   // Feature unit
   if (entityID == 2) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Audio control mute cur parameter block consists of only one byte - we thus can send it right away

--- a/examples/device/audio_4_channel_mic_freertos/src/main.c
+++ b/examples/device/audio_4_channel_mic_freertos/src/main.c
@@ -296,6 +296,10 @@ bool tud_audio_set_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 
   // If request is for our feature unit
   if (entityID == 2) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Request uses format layout 1
@@ -391,6 +395,10 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 
   // Feature unit
   if (entityID == 2) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Audio control mute cur parameter block consists of only one byte - we thus can send it right away

--- a/examples/device/audio_test/src/main.c
+++ b/examples/device/audio_test/src/main.c
@@ -210,6 +210,10 @@ bool tud_audio_set_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 
   // If request is for our feature unit
   if (entityID == 2) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Request uses format layout 1
@@ -308,6 +312,10 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 
   // Feature unit
   if (entityID == 2) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Audio control mute cur parameter block consists of only one byte - we thus can send it right away

--- a/examples/device/audio_test_freertos/src/main.c
+++ b/examples/device/audio_test_freertos/src/main.c
@@ -282,6 +282,10 @@ bool tud_audio_set_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 
   // If request is for our feature unit
   if (entityID == 2) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Request uses format layout 1
@@ -377,6 +381,10 @@ bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_request_t const *p
 
   // Feature unit
   if (entityID == 2) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Audio control mute cur parameter block consists of only one byte - we thus can send it right away

--- a/examples/device/audio_test_multi_rate/src/main.c
+++ b/examples/device/audio_test_multi_rate/src/main.c
@@ -234,6 +234,10 @@ static bool audio10_set_req_entity(tusb_control_request_t const *p_request, uint
 
   // If request is for our feature unit (ID defined in usbd.h)
   if (entityID == 0x02) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO10_FU_CTRL_MUTE:
         switch (p_request->bRequest) {
@@ -282,6 +286,10 @@ static bool audio10_get_req_entity(uint8_t rhport, tusb_control_request_t const 
 
   // If request is for our feature unit (ID defined in usbd.h)
   if (entityID == 0x02) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO10_FU_CTRL_MUTE:
         // Audio control mute cur parameter block consists of only one byte - we thus can send it right away
@@ -355,6 +363,10 @@ static bool audio20_set_req_entity(tusb_control_request_t const *p_request, uint
 
   // If request is for our feature unit
   if (entityID == UAC2_ENTITY_FEATURE_UNIT) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Request uses format layout 1
@@ -435,6 +447,10 @@ static bool audio20_get_req_entity(uint8_t rhport, tusb_control_request_t const 
 
   // Feature unit
   if (entityID == UAC2_ENTITY_FEATURE_UNIT) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX) return false;
+
     switch (ctrlSel) {
       case AUDIO20_FU_CTRL_MUTE:
         // Audio control mute cur parameter block consists of only one byte - we thus can send it right away

--- a/examples/device/cdc_uac2/src/uac2_app.c
+++ b/examples/device/cdc_uac2/src/uac2_app.c
@@ -157,6 +157,9 @@ static bool tud_audio_feature_unit_get_request(uint8_t rhport, tusb_control_requ
 {
   uint8_t const ctrl_sel    = TU_U16_HIGH(p_request->wValue);
   uint8_t const channel_num = TU_U16_LOW(p_request->wValue);
+  // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+  // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+  if (channel_num > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
 
   if (ctrl_sel == AUDIO20_FU_CTRL_MUTE && p_request->bRequest == AUDIO20_CS_REQ_CUR)
   {
@@ -196,6 +199,9 @@ static bool tud_audio_feature_unit_set_request(uint8_t rhport, tusb_control_requ
 
   uint8_t const ctrl_sel    = TU_U16_HIGH(p_request->wValue);
   uint8_t const channel_num = TU_U16_LOW(p_request->wValue);
+  // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+  // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+  if (channel_num > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
 
   TU_VERIFY(p_request->bRequest == AUDIO20_CS_REQ_CUR);
 

--- a/examples/device/uac2_headset/src/main.c
+++ b/examples/device/uac2_headset/src/main.c
@@ -207,6 +207,10 @@ static bool audio10_set_req_entity(tusb_control_request_t const *p_request, uint
 
   // If request is for our speaker feature unit
   if (entityID == UAC1_ENTITY_SPK_FEATURE_UNIT) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
+
     switch (ctrlSel) {
       case AUDIO10_FU_CTRL_MUTE:
         switch (p_request->bRequest) {
@@ -255,6 +259,10 @@ static bool audio10_get_req_entity(uint8_t rhport, tusb_control_request_t const 
 
   // If request is for our speaker feature unit
   if (entityID == UAC1_ENTITY_SPK_FEATURE_UNIT) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
+
     switch (ctrlSel) {
       case AUDIO10_FU_CTRL_MUTE:
         // Audio control mute cur parameter block consists of only one byte - we thus can send it right away
@@ -381,6 +389,10 @@ static bool audio20_feature_unit_get_request(uint8_t rhport, tusb_control_reques
   uint8_t const ctrl_sel    = TU_U16_HIGH(p_request->wValue);
   uint8_t const channel_num = TU_U16_LOW(p_request->wValue);
 
+  // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+  // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+  if (channel_num > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
+
   if (ctrl_sel == AUDIO20_FU_CTRL_MUTE && p_request->bRequest == AUDIO20_CS_REQ_CUR) {
     audio20_control_cur_1_t mute1 = {.bCur = mute[channel_num]};
     TU_LOG1("Get channel %u mute %d\r\n", channel_num, mute1.bCur);
@@ -411,6 +423,10 @@ static bool audio20_feature_unit_set_request(uint8_t rhport, tusb_control_reques
 
   uint8_t const ctrl_sel    = TU_U16_HIGH(p_request->wValue);
   uint8_t const channel_num = TU_U16_LOW(p_request->wValue);
+
+  // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+  // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+  if (channel_num > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
 
   TU_VERIFY(p_request->bRequest == AUDIO20_CS_REQ_CUR);
 

--- a/examples/device/uac2_speaker_fb/src/main.c
+++ b/examples/device/uac2_speaker_fb/src/main.c
@@ -201,6 +201,10 @@ static bool audio10_set_req_entity(tusb_control_request_t const *p_request, uint
 
   // If request is for our feature unit
   if (entityID == UAC1_ENTITY_FEATURE_UNIT) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
+
     switch (ctrlSel) {
       case AUDIO10_FU_CTRL_MUTE:
         switch (p_request->bRequest) {
@@ -249,6 +253,10 @@ static bool audio10_get_req_entity(uint8_t rhport, tusb_control_request_t const 
 
   // If request is for our feature unit
   if (entityID == UAC1_ENTITY_FEATURE_UNIT) {
+    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
+
     switch (ctrlSel) {
       case AUDIO10_FU_CTRL_MUTE:
         // Audio control mute cur parameter block consists of only one byte - we thus can send it right away
@@ -373,6 +381,10 @@ static bool audio20_feature_unit_get_request(uint8_t rhport, tusb_control_reques
   uint8_t const ctrl_sel    = TU_U16_HIGH(p_request->wValue);
   uint8_t const channel_num = TU_U16_LOW(p_request->wValue);
 
+  // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+  // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+  if (channel_num > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
+
   if (ctrl_sel == AUDIO20_FU_CTRL_MUTE && p_request->bRequest == AUDIO20_CS_REQ_CUR) {
     audio20_control_cur_1_t mute1 = {.bCur = mute[channel_num]};
     TU_LOG1("Get channel %u mute %d\r\n", channel_num, mute1.bCur);
@@ -400,6 +412,10 @@ static bool audio20_feature_unit_get_request(uint8_t rhport, tusb_control_reques
 static bool audio20_feature_unit_set_request(tusb_control_request_t const *p_request, uint8_t const *buf) {
   uint8_t const ctrl_sel    = TU_U16_HIGH(p_request->wValue);
   uint8_t const channel_num = TU_U16_LOW(p_request->wValue);
+
+  // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
+  // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
+  if (channel_num > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
 
   TU_VERIFY(p_request->bRequest == AUDIO20_CS_REQ_CUR);
 


### PR DESCRIPTION
Note upfront: I am new to embedded programming, and this analysis and this patch were prepared with AI assistance. The code excerpts were checked against current master (2026-09-09), and the guard is hardware-verified on my side on a firmware built from a component that inherited these handlers (details at the end). Happy to make any changes the reviewers require.

Fixes #3908

### What this fixes

The feature-unit request handlers in `uac2_headset` and `uac2_speaker_fb` index `mute[]` / `volume[]` (sized `CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1`, i.e. 3 entries for the stereo speaker: 0 = master, 1 = L, 2 = R) with the channel number taken straight from the control request's wValue low byte — a fully host-controlled SETUP value in the range 0..255 — and never validate it. The entity ID is checked in these handlers; the channel number is not, on either the UAC1 (`audio10_*_req_entity`) or the UAC2 (`audio20_feature_unit_*_request`) path, in either example. Representative sites (uac2_headset, current master line numbers; speaker_fb is the same code):

```c
// lines 76-77
uint8_t mute[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1];   // +1 for master channel 0
int16_t volume[CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1];// +1 for master channel 0
...
// audio10_set_req_entity(), line 217 — OOB write when ch > N
mute[channelNum] = pBuff[0];
...
// audio10_get_req_entity(), line 263 — OOB read, result sent to the host
return tud_audio_buffer_and_schedule_control_xfer(rhport, p_request, &mute[channelNum], 1);
```

Concretely, a control transfer that any host can send (SET_CUR MUTE, wValue = `(0x01 << 8) | 200`, wIndex = `(FU_ID << 8) | AC_itf`, wLength = 1) makes the stock examples write 1 byte at `mute[200]` — ~197 entries past a 3-entry array — and return success to the host. The GET_CUR forms read 1-2 bytes from past the arrays and transmit them back. Both are undefined behaviour with zero diagnostics on either side of the link. `audio_device.c` deliberately does not validate the channel number (it verifies the entity and forwards the request to the `tud_audio_*_req_entity_cb` callback — ~lines 1296/1389), so validation belongs exactly where this patch puts it.

Conforming hosts only address channels declared in the feature unit's `bmaControls` bitmap (0..N), so no existing functional behaviour changes: the guard only converts previously-undefined (silently out-of-bounds) requests into
a proper STALL. The impact of the unfixed state is largest for downstream users: these examples are the canonical reference for UAC request handlers, and at least one widely distributed component (esp-iot-solution `usb_device_uac`, via the ESP Component Registry) inherited the exact pattern — there the arrays live in a heap struct followed by buffers and callback pointers, so the same unchecked index is a heap OOB read/write. A matching report is being filed there: https://github.com/espressif/esp-iot-solution/issues/781 https://github.com/espressif/esp-iot-solution/pull/782

### Changes

Twenty-two identical guard insertions — one at the head of each feature-unit handler path in all eight device audio examples; no other edits:

```c
    // Channel number is host-controlled (0..255) but mute[]/volume[] hold only
    // CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX + 1 entries - reject out-of-range (STALL)
    if (channelNum > CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX) return false;
```

(`channel_num` in the audio20 handlers; indentation follows each site.)

- In the `audio10_*` handlers the guard sits inside the feature-unit branch, so requests routed to other entities are untouched; in the `audio20_feature_unit_*` handlers it sits at function entry after `channel_num` is computed.
- Boundary is `>` (not `>=`): valid indices are 0..N because the arrays hold N+1 entries — `>=` would wrongly STALL the highest real channel (R = 2).
- Returning `false` is the documented STALL mechanism for entity callbacks — the same one the "not supported" returns of these very handlers already use, so the host sees a protocol-level rejection, not a timeout.
- **Correction (2026-09-09):** `audio_test` *is* affected — its entity handlers index `mute[]`/`volume[]` the same way (the `(void) channelNum` casts I had checked are in the EP/ITF handlers). Re-scanning the tree, six more examples carry the same pattern: `audio_test_freertos`, `audio_test_multi_rate` (UAC1 + UAC2 paths), `audio_4_channel_mic`, `audio_4_channel_mic_freertos`, and `cdc_uac2` (handlers in `src/uac2_app.c` — easy to miss because they are not in `main.c`). This PR now guards **all eight** device audio examples — 22 insertions total, still nothing else. In the `audio_test*` / `audio_4_channel_mic*` examples the bound is `CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX` because their arrays are TX (microphone) sized; `uac2_headset`, `uac2_speaker_fb`, and `cdc_uac2` use `_RX`.

### Testing

- **No behavioural change for conforming hosts — hardware verified on my side.**  My firmware (ESP32-S3 + PCM5102A, built on the esp-iot-solution component that inherits these handlers, with the identical guard added) enumerates normally on Linux; volume GET_CUR/SET_CUR/RANGE for ch=1/ch=2, mute, and 48k↔96k switching behave identically to the unguarded build (side-by-side monitor logs; zero rejected requests in normal operation — a conforming host never sends out-of-range channels).
- **Rejection probe** (pyusb, from the linked issue): SET_CUR MUTE ch=200 → stock example completes the transfer silently; patched example raises `usb.core.USBError` (STALL). One command, ready to re-run against a stock example build — transcript on request.
- The examples build for ESP32-S3 with the patch applied (no new warnings); the diff is mechanically identical at all 8 sites, so review should be quick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

###Update on the cdc_uac2 example (2026-09-13)

Reviewing the automated-review findings against master surfaced a pre-existing descriptor/state mismatch in cdc_uac2, so the "no behavioural change for conforming hosts" statement above needs one exception:

- CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_RX is 1 and mute[]/volume[] hold N+1 = 2 entries (master + ch1, src/uac2_app.c), but the speaker Input Terminal declares 2 logical channels and the Feature Unit advertises RW mute+volume for master/ch1/ch2 (src/usb_descriptors.h). The mismatch is present in the 0.21.0 tag as well, so it predates this PR.
- In the stock example, a conforming host addressing the advertised ch2 was already reading/writing one entry past the arrays — the OOB this PR exists to prevent. With the guards, that request now STALLs, so for this one example the PR does change behaviour for a conforming host.
- The reconciliation is being prepared as a separate follow-up PR (#3915): mono — the descriptors aligned with the AS bNrChannels = 1, RX = 1 and the existing 2-entry arrays, leaving the advertised stream format and EP size unchanged. Once it lands, the guards reject only channels that are neither advertised nor backed by state, in every example.

The other 7 examples advertise control sets consistent with their state arrays, so the statement holds for them as-is.

* **Bug Fixes**
  * USB audio devices now consistently reject requests containing invalid or unsupported channel numbers.
  * Prevented out-of-range channel requests from accessing unavailable mute and volume controls.
  * Improved request failure handling across UAC1 and UAC2 audio examples, including multi-channel, multi-rate, headset, speaker, microphone, and combined audio configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->