### PR TITLE
class/mtp: a short OUT packet ends the data phase when the length is …

### DIFF
--- a/src/class/mtp/mtp_device.c
+++ b/src/class/mtp/mtp_device.c
@@ -432,6 +432,12 @@ bool mtpd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
         // OUT completion: reaching total_len or ZLP only. A short packet does NOT end the phase
         // (an early short packet before total_len is the cancel case, not normal completion).
         is_complete = (p_mtp->xferred_len >= p_mtp->total_len) || ((xferred_bytes == 0 && p_mtp->xferred_len > 0));
+        // Unknown length (total_len = 0xFFFFFFFF, as the container Length field is when the host does
+        // not declare a size): there is no total_len to reach, and the host only sends a ZLP when its
+        // data happens to be a multiple of the packet size, so the short packet is the terminator.
+        if (p_mtp->total_len == UINT32_MAX && xferred_bytes > 0 && xferred_bytes < threshold) {
+          is_complete = true;
+        }
       }
 
       TU_LOG_DRV("  MTP Data %s CB: xferred_bytes=%lu, xferred_len/total_len=%lu/%lu, is_complete=%d\r\n",

--- a/src/class/mtp/mtp_device.h
+++ b/src/class/mtp/mtp_device.h
@@ -82,7 +82,9 @@ bool tud_mtp_mounted(void);
 // send data phase
 bool tud_mtp_data_send(mtp_container_info_t* p_container);
 
-// receive data phase
+// receive data phase. On the first call, header->len is the expected total length of the data block
+// (header + payload); set it to 0xFFFFFFFF when the host did not declare a size (e.g. SendObject after
+// an ObjectInfo with ObjectCompressedSize 0 or 0xFFFFFFFF), then a short packet ends the phase.
 bool tud_mtp_data_receive(mtp_container_info_t* p_container);
 
 // send response


### PR DESCRIPTION
…unknown

An OUT data phase currently completes only on reaching total_len or on a ZLP.  When the host does not declare a size (SendObject after an ObjectInfo with ObjectCompressedSize 0 or 0xFFFFFFFF) the application has no total_len to give tud_mtp_data_receive(), so it passes 0xFFFFFFFF - the value the MTP container Length field itself carries for an unknown length.  That can then only be satisfied by a ZLP, which the host sends only when its data happens to be a whole number of packets.  For every other length the transfer simply stops: the application stops re-arming, no ZLP arrives, tud_mtp_data_complete_cb() never fires and no response is sent, so the operation hangs with the object half-written until the host cancels or closes the session.

For an unknown length the short packet is the terminator, so accept it as one; declared lengths keep the existing rule (an early short packet is still the cancel case).  Document the 0xFFFFFFFF convention on tud_mtp_data_receive().

Found by review of the completion rule while using the driver on a BCM2835 (dwc2) device; declared-length transfers either side of the packet boundary read back unchanged with the fix in place.


Claude-Session: https://claude.ai/code/session_01MdrRaYqJFVTfAMTBLJAKSx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MTP data transfers with an unspecified length now complete correctly when a short packet indicates the end of the transfer.
  - Object receiving now detects storage overflow and reports `STORE_FULL`; successful and failed transfers are reported distinctly.

- **Documentation**
  - Clarified MTP receive behavior for transfers without a declared data size, including initial call requirements, short-packet termination, and large-transfer limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->